### PR TITLE
Charts: fit to the note column via Vega width:"container", not CSS squish

### DIFF
--- a/src/renderer/lib/markdown/vega-renderer.ts
+++ b/src/renderer/lib/markdown/vega-renderer.ts
@@ -135,6 +135,31 @@ function buildThemeConfig(): Record<string, unknown> {
 }
 
 /**
+ * Make a chart fit the note column instead of rendering at a fixed pixel size
+ * that CSS then has to squish (which shrinks the axis text too). For a
+ * Vega-Lite spec that hasn't set its own `width`, inject `width: "container"`
+ * so Vega lays the chart out to the available width — labels stay full-size and
+ * axes re-tick. A spec that *does* set an explicit width is left alone: the
+ * author asked for that size, and `.vega-block` scrolls if it's wider than the
+ * column.
+ *
+ * `width: "container"` is only valid on single-view (unit) and layered specs,
+ * not multi-view composites (concat / facet / repeat), so those are skipped —
+ * as are full `vega` specs, which size through a different mechanism.
+ */
+function applyResponsiveWidth(spec: unknown, mode: 'vega' | 'vega-lite'): unknown {
+  if (mode !== 'vega-lite') return spec;
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) return spec;
+  const s = spec as Record<string, unknown>;
+  if ('width' in s) return spec; // author set an explicit size — honor it
+  const isComposite =
+    'hconcat' in s || 'vconcat' in s || 'concat' in s || 'facet' in s || 'repeat' in s;
+  if (isComposite) return spec;
+  if (!('mark' in s) && !('layer' in s)) return spec; // not a sizable single view
+  return { ...s, width: 'container' };
+}
+
+/**
  * Recursively collect every `url` string in the spec. Any present `url` is a
  * remote/file fetch we refuse by default (#829) — inline `data.values` carry
  * no `url`. (#832 will introduce a safe local-vault data form resolved before
@@ -292,6 +317,10 @@ export async function hydrateVegaBlocks(root: HTMLElement, noteContent = ''): Pr
       }
     }
 
+    // Fit the chart to the note column (unless it set its own width). Done last,
+    // after data resolution and the security scans, so it can't affect them.
+    spec = applyResponsiveWidth(spec, mode);
+
     try {
       // No DOMPurify pass here (#1331): vega-embed builds the chart with safe
       // DOM construction (createElementNS/setAttribute via its SVG renderer),
@@ -359,4 +388,4 @@ function escapeHtml(s: string): string {
 
 // Exported for unit tests — the spec-scan and JSON guardrail are the security
 // surface and deserve direct coverage without a DOM/vega-embed round-trip.
-export const __test = { findUrlRefs };
+export const __test = { findUrlRefs, applyResponsiveWidth };

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -393,10 +393,11 @@ mark.hl-orange { background: color-mix(in oklch, var(--hl-orange) 30%, transpare
 .vega-block .vega-embed {
   width: 100%;
 }
-.vega-block svg {
-  max-width: 100%;
-  height: auto;
-}
+/* No `max-width: 100%` on the SVG: that scaled the whole chart down (text and
+ * all) to fit, which is what made wide charts look cramped. Charts without an
+ * explicit width get `width: "container"` from the renderer and lay out to this
+ * column; a chart that sets its own pixel width renders at that size and this
+ * block's `overflow-x: auto` scrolls it. */
 .vega-block[data-vega-rendered="pending"]::before {
   content: 'Rendering chart\2026';
   color: var(--text-muted);

--- a/tests/renderer/markdown/vega-renderer.test.ts
+++ b/tests/renderer/markdown/vega-renderer.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { __test } from '../../../src/renderer/lib/markdown/vega-renderer';
 
-const { findUrlRefs } = __test;
+const { findUrlRefs, applyResponsiveWidth } = __test;
 
 function urls(spec: unknown): string[] {
   const acc: string[] = [];
@@ -92,5 +92,57 @@ describe('findUrlRefs (vega remote-data guardrail)', () => {
     // Depth guard caps recursion at 64; a url below that is simply not reached.
     // The point is it returns without throwing.
     expect(() => urls(deep)).not.toThrow();
+  });
+});
+
+describe('applyResponsiveWidth (fit charts to the note column)', () => {
+  const widthOf = (spec: unknown, mode: 'vega' | 'vega-lite' = 'vega-lite') =>
+    (applyResponsiveWidth(spec, mode) as { width?: unknown }).width;
+
+  it('injects width:"container" into a unit spec with no width', () => {
+    expect(widthOf({ mark: 'bar', encoding: {} })).toBe('container');
+  });
+
+  it('injects width:"container" into a layered spec with no width', () => {
+    expect(widthOf({ layer: [{ mark: 'line' }, { mark: 'point' }] })).toBe('container');
+  });
+
+  it('leaves an explicit numeric width untouched (author intent honored)', () => {
+    const spec = { mark: 'bar', width: 800 };
+    expect(applyResponsiveWidth(spec, 'vega-lite')).toBe(spec); // same reference, unmodified
+    expect(widthOf(spec)).toBe(800);
+  });
+
+  it('leaves an explicit "container" width as-is', () => {
+    expect(widthOf({ mark: 'bar', width: 'container' })).toBe('container');
+  });
+
+  it('does not touch multi-view composites (container is invalid there)', () => {
+    for (const key of ['hconcat', 'vconcat', 'concat', 'facet', 'repeat']) {
+      const spec = { [key]: [{ mark: 'bar' }] };
+      expect(applyResponsiveWidth(spec, 'vega-lite')).toBe(spec);
+      expect((spec as { width?: unknown }).width).toBeUndefined();
+    }
+  });
+
+  it('does not touch a spec that is neither a unit nor a layer', () => {
+    const spec = { data: { values: [] } }; // no mark / layer
+    expect(applyResponsiveWidth(spec, 'vega-lite')).toBe(spec);
+  });
+
+  it('leaves full vega specs alone (different sizing mechanism)', () => {
+    const spec = { marks: [], scales: [] };
+    expect(applyResponsiveWidth(spec, 'vega')).toBe(spec);
+  });
+
+  it('is a no-op on non-object specs', () => {
+    expect(applyResponsiveWidth(null, 'vega-lite')).toBe(null);
+    expect(applyResponsiveWidth([{ mark: 'bar' }], 'vega-lite')).toEqual([{ mark: 'bar' }]);
+  });
+
+  it('does not mutate the input spec', () => {
+    const spec = { mark: 'bar', encoding: { x: {} } };
+    applyResponsiveWidth(spec, 'vega-lite');
+    expect('width' in spec).toBe(false);
   });
 });


### PR DESCRIPTION
## The bug

A chart with no explicit width rendered at Vega's default fixed pixel size, and `.vega-block svg { max-width: 100%; height: auto }` then scaled the **entire SVG — axis text and all — down** to fit the note column. That uniform squish is what made wide charts look cramped: the labels shrank with the bars. It also silently defeated the block's own `overflow-x: auto` (with `max-width: 100%` the content could never overflow, so the scrollbar was dead code — the two CSS rules contradicted each other).

## The fix (adapt to the column)

Let Vega do the sizing instead of CSS:

- **Unsized single-view / layered specs** get Vega-Lite's `width: "container"` injected, so Vega lays the chart out to the available column width — labels stay full-size, axes re-tick, nothing squishes. It's also live-responsive to column/window resize.
- **Specs with an explicit `width`** are left untouched — author intent honored. The CSS down-scaling is removed, so such a chart renders at its real size and the block's `overflow-x: auto` scrolls it when it's wider than the column (now functional).
- **Skipped:** composite specs (concat / facet / repeat), where `width: "container"` is invalid, and full `vega` specs, which size through a different mechanism.

Injection runs *after* data resolution and the remote-data/`usermeta` security scans, so it can't affect them.

## Scope

This is the interactive in-app preview. The **publish/export** path (`vega-render.ts`) pre-renders each chart to a static SVG image at its authored size — there's no container to measure server-side, so `width: "container"` doesn't apply there. Left as-is intentionally.

## Tests

New `applyResponsiveWidth` cases in `vega-renderer.test.ts` (11): container injected for unit + layer specs; explicit width honored (same reference, unmodified); composites/facet/repeat and full-vega skipped; non-object no-ops; input not mutated. Full vega-renderer suite green (19); `pnpm lint` clean.

## Docs

The "scales down to fit" gotcha in `website/docs/notes-charts.html` is rewritten to the new behavior (responsive by default; explicit width honored + scrolls) in the working-tree docs batch, not this code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)