### PR TITLE
Graph: materialise nested frontmatter objects as blank nodes

### DIFF
--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -17,7 +17,7 @@ import * as $rdf from 'rdflib';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import path from 'node:path';
-import { parseMarkdown, type ParsedTable, type FrontmatterValue } from './parser';
+import { parseMarkdown, type ParsedTable, type FrontmatterValue, type FrontmatterMap } from './parser';
 import { getLinkType, type LinkType } from '../../shared/link-types';
 import { mapFrontmatterKey, type FrontmatterPredicate } from './frontmatter-predicates';
 import { resolveWikiLinkTarget } from '../../shared/wiki-link-resolver';
@@ -152,7 +152,9 @@ function flattenFrontmatterStrings(value: FrontmatterValue): string[] {
   return [];
 }
 
-type FrontmatterScalarNonNull = Exclude<FrontmatterValue, null | FrontmatterValue[]>;
+// A non-null leaf scalar — excludes lists AND nested maps (maps materialise as
+// blank nodes in emitFrontmatterValue, never as a single edge).
+type FrontmatterScalarNonNull = string | number | boolean | Date;
 
 /**
  * Reconstitute YAML-eaten wiki-link shorthand. The user writes
@@ -184,12 +186,66 @@ function recoverYamlEatenWikiLink(value: FrontmatterValue): FrontmatterValue {
   return value;
 }
 
-/** Flatten nested arrays, dropping nulls. Scalars pass through in typed form. */
-function flattenFrontmatterScalars(value: FrontmatterValue): FrontmatterScalarNonNull[] {
+function isFrontmatterMap(value: FrontmatterValue): value is FrontmatterMap {
+  return typeof value === 'object' && value !== null
+    && !Array.isArray(value) && !(value instanceof Date);
+}
+
+/**
+ * Emit the graph triples for one frontmatter value under `subject` (the note
+ * IRI at the top level, a blank node when recursing into a nested mapping):
+ *
+ *  - scalar / wiki-link → one edge via `frontmatterValueToEdge`
+ *  - list               → one edge per element, all under `keyPredicate`
+ *  - nested mapping      → a fresh blank node linked under `keyPredicate`, with
+ *    the map's own keys becoming `minerva:meta-<subkey>` predicates on that
+ *    blank node (recursively). RDF's idiomatic way to carry structured
+ *    metadata — so `address: { city: … }` is queryable via
+ *    `?note minerva:meta-address/minerva:meta-city ?c` instead of being dropped.
+ *    Nested keys always take the `meta-` form (not canonical mapping): a nested
+ *    structure is opaque user data, so its keys stay predictable rather than
+ *    sometimes resolving to dc:/schema:/… predicates. The blank node is linked
+ *    in only if it received at least one child triple, so an
+ *    all-unmaterialisable map leaves nothing.
+ *
+ * `depth` caps recursion (matches the parser's own sanitise cap).
+ */
+function emitFrontmatterValue(
+  state: GraphState,
+  store: $rdf.IndexedFormula,
+  subject: $rdf.NamedNode | $rdf.BlankNode,
+  keyPredicate: ReturnType<typeof resolveFrontmatterPredicate>,
+  value: FrontmatterValue,
+  graph: $rdf.NamedNode,
+  rc: LinkResolveCtx,
+  depth: number,
+): void {
+  if (depth > 8) return;
   const recovered = recoverYamlEatenWikiLink(value);
-  if (recovered === null || recovered === undefined) return [];
-  if (Array.isArray(recovered)) return recovered.flatMap(flattenFrontmatterScalars);
-  return [recovered];
+  if (recovered === null || recovered === undefined) return;
+  if (Array.isArray(recovered)) {
+    for (const item of recovered) {
+      emitFrontmatterValue(state, store, subject, keyPredicate, item, graph, rc, depth + 1);
+    }
+    return;
+  }
+  if (isFrontmatterMap(recovered)) {
+    const bnode = $rdf.blankNode();
+    let childCount = 0;
+    for (const [subkey, subval] of Object.entries(recovered)) {
+      const before = store.statements.length;
+      // Nested keys are always `meta-<subkey>` — predictable, opaque data
+      // (not run through canonical key mapping like top-level keys are).
+      emitFrontmatterValue(
+        state, store, bnode, MINERVA(`meta-${subkey}`), subval, graph, rc, depth + 1,
+      );
+      if (store.statements.length > before) childCount++;
+    }
+    if (childCount > 0) store.add(subject, keyPredicate, bnode, graph);
+    return;
+  }
+  const edge = frontmatterValueToEdge(recovered, state, keyPredicate, rc);
+  if (edge) store.add(subject, edge.predicate, edge.term, graph);
 }
 
 function resolveFrontmatterPredicate(key: string) {
@@ -230,7 +286,7 @@ const WHOLE_WIKILINK_RE = /^\[\[([^\]\n]+?)\]\]$/;
  * →an IRI node, everything else→a plain string literal.
  */
 function frontmatterValueToEdge(
-  value: Exclude<FrontmatterValue, null | FrontmatterValue[]>,
+  value: FrontmatterScalarNonNull,
   state: GraphState,
   keyPredicate: ReturnType<typeof resolveFrontmatterPredicate>,
   rc: LinkResolveCtx,
@@ -533,13 +589,10 @@ export async function indexNote(
     // publishing directives (#1136) — a publication concern, kept out of the
     // graph (and it's an object, not a materialisable scalar anyway).
     if (key === 'title' || key === 'tags' || key === 'publish') continue;
-    const keyPredicate = resolveFrontmatterPredicate(key);
-    for (const v of flattenFrontmatterScalars(value)) {
-      // A typed wiki-link value (`[[supports::x]]`) overrides keyPredicate with
-      // its own type; everything else stays under the key's predicate.
-      const edge = frontmatterValueToEdge(v, state, keyPredicate, linkCtx);
-      if (edge) store.add(subject, edge.predicate, edge.term, graph);
-    }
+    // A typed wiki-link value (`[[supports::x]]`) overrides keyPredicate with
+    // its own type; a nested mapping materialises as a blank node; everything
+    // else stays a scalar edge under the key's predicate.
+    emitFrontmatterValue(state, store, subject, resolveFrontmatterPredicate(key), value, graph, linkCtx, 0);
   }
 
   // Embedded turtle blocks — parse into the note's named graph

--- a/src/main/graph/parser.ts
+++ b/src/main/graph/parser.ts
@@ -31,7 +31,9 @@ export interface ParsedTable {
 
 /** A frontmatter value after YAML parsing — preserves type info the indexer needs. */
 export type FrontmatterScalar = string | number | boolean | Date | null;
-export type FrontmatterValue = FrontmatterScalar | FrontmatterValue[];
+/** A nested YAML mapping. The indexer materialises it as a blank node. */
+export interface FrontmatterMap { [key: string]: FrontmatterValue }
+export type FrontmatterValue = FrontmatterScalar | FrontmatterValue[] | FrontmatterMap;
 
 export interface ParsedNote {
   title: string | null;
@@ -212,7 +214,11 @@ function extractFrontmatter(content: string): Record<string, FrontmatterValue> {
   return result;
 }
 
-function sanitizeFrontmatterValue(value: unknown): FrontmatterValue | undefined {
+/** Deepest nesting level a frontmatter mapping is materialised to before we
+ *  stop recursing — a guard against pathological / cyclic structures. */
+const MAX_FRONTMATTER_DEPTH = 8;
+
+function sanitizeFrontmatterValue(value: unknown, depth = 0): FrontmatterValue | undefined {
   if (value === null || value === undefined) return null;
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
     return value;
@@ -221,12 +227,23 @@ function sanitizeFrontmatterValue(value: unknown): FrontmatterValue | undefined 
   if (Array.isArray(value)) {
     const items: FrontmatterValue[] = [];
     for (const item of value) {
-      const s = sanitizeFrontmatterValue(item);
+      const s = sanitizeFrontmatterValue(item, depth + 1);
       if (s !== undefined && s !== null) items.push(s);
     }
     return items;
   }
-  // Drop nested objects — they'd require predicate decisions we don't have.
+  // Nested mapping — kept (the indexer materialises it as a blank node with the
+  // sub-keys as its own predicates). Recurse so deeply-nested maps and lists
+  // survive; bail past the depth cap. An empty map (nothing sanitisable inside)
+  // collapses to `undefined` so no dangling blank node is emitted.
+  if (typeof value === 'object' && depth < MAX_FRONTMATTER_DEPTH) {
+    const map: FrontmatterMap = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const s = sanitizeFrontmatterValue(v, depth + 1);
+      if (s !== undefined && k.trim()) map[k.trim()] = s;
+    }
+    return Object.keys(map).length > 0 ? map : undefined;
+  }
   return undefined;
 }
 

--- a/tests/main/graph/frontmatter-indexing.test.ts
+++ b/tests/main/graph/frontmatter-indexing.test.ts
@@ -175,6 +175,109 @@ title: Frontmatter Title
     expect(titles).toEqual(['Frontmatter Title']);
   });
 
+  it('materialises a nested mapping as a blank node with sub-key predicates', async () => {
+    await indexNote(ctx, 'paper.md', `---
+address:
+  city: Paris
+  zip: "75001"
+---
+# Paper
+`);
+    const { results } = await queryGraph(ctx, `
+      SELECT ?city ?zip ?blank WHERE {
+        ?note minerva:relativePath "paper.md" ;
+              minerva:meta-address ?addr .
+        ?addr minerva:meta-city ?city ;
+              minerva:meta-zip ?zip .
+        BIND(isBlank(?addr) AS ?blank)
+      } LIMIT 1
+    `);
+    const row = (results as Array<Record<string, string>>)[0];
+    expect(row.city).toBe('Paris');
+    expect(row.zip).toBe('75001');
+    expect(String(row.blank)).toContain('true'); // the mapping is a blank node
+  });
+
+  it('types nested scalars (a nested integer stays xsd:integer)', async () => {
+    await indexNote(ctx, 'paper.md', `---
+stats:
+  count: 42
+---
+# Paper
+`);
+    const { results } = await queryGraph(ctx, `
+      SELECT ?count WHERE {
+        ?note minerva:relativePath "paper.md" ; minerva:meta-stats/minerva:meta-count ?count .
+      } LIMIT 1
+    `);
+    expect((results as Array<{ count: string }>)[0].count).toBe('42');
+  });
+
+  it('recurses into deeply nested mappings', async () => {
+    await indexNote(ctx, 'paper.md', `---
+meta:
+  geo:
+    lat: "48.8"
+---
+# Paper
+`);
+    const { results } = await queryGraph(ctx, `
+      SELECT ?lat WHERE {
+        ?note minerva:relativePath "paper.md" ;
+              minerva:meta-meta/minerva:meta-geo/minerva:meta-lat ?lat .
+      } LIMIT 1
+    `);
+    expect((results as Array<{ lat: string }>)[0].lat).toBe('48.8');
+  });
+
+  it('emits one blank node per element for a list of mappings', async () => {
+    // `contributors` is a non-canonical key (unlike `authors`, which aliases
+    // dc:creator), so it materialises under minerva:meta-contributors.
+    await indexNote(ctx, 'paper.md', `---
+contributors:
+  - name: Alice
+  - name: Bob
+---
+# Paper
+`);
+    const { results } = await queryGraph(ctx, `
+      SELECT ?name WHERE {
+        ?note minerva:relativePath "paper.md" ; minerva:meta-contributors/minerva:meta-name ?name .
+      } ORDER BY ?name
+    `);
+    expect((results as Array<{ name: string }>).map(r => r.name)).toEqual(['Alice', 'Bob']);
+  });
+
+  it('emits nothing for an empty mapping (no dangling blank node)', async () => {
+    await indexNote(ctx, 'paper.md', `---
+blankish: {}
+---
+# Paper
+`);
+    const { results } = await queryGraph(ctx, `
+      SELECT ?x WHERE { ?note minerva:relativePath "paper.md" ; minerva:meta-blankish ?x . }
+    `);
+    expect(results).toEqual([]);
+  });
+
+  it('does not accumulate blank-node triples across re-index', async () => {
+    const note = `---
+address:
+  city: Paris
+---
+# Paper
+`;
+    await indexNote(ctx, 'paper.md', note);
+    await indexNote(ctx, 'paper.md', note); // re-index the same content
+    const { results } = await queryGraph(ctx, `
+      SELECT ?city WHERE {
+        ?note minerva:relativePath "paper.md" ; minerva:meta-address/minerva:meta-city ?city .
+      }
+    `);
+    // Exactly one — the prior blank node was cleared with the note's named graph.
+    expect((results as Array<{ city: string }>).map(r => r.city)).toEqual(['Paris']);
+  });
+
   it('does NOT materialise the publish: block as a graph predicate (#1136)', async () => {
     await indexNote(ctx, 'card.md', [
       '---', 'title: Card', 'publish:', '  image: https://ex.com/c.png', '  background: "#faf3e0"',

--- a/tests/main/graph/parser.test.ts
+++ b/tests/main/graph/parser.test.ts
@@ -322,9 +322,14 @@ describe('frontmatter extraction', () => {
     expect(result.frontmatter).toEqual({});
   });
 
-  it('drops nested objects (no sensible predicate mapping)', () => {
+  it('preserves a nested object as a map (materialised as a blank node when indexed)', () => {
     const result = parseMarkdown('---\nauthor:\n  name: Ada\n  orcid: 0000\n---');
-    expect(result.frontmatter.author).toBeUndefined();
+    expect(result.frontmatter.author).toEqual({ name: 'Ada', orcid: 0 });
+  });
+
+  it('drops a nested object that has nothing materialisable inside (empty map)', () => {
+    const result = parseMarkdown('---\nempty: {}\n---');
+    expect(result.frontmatter.empty).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## The gotcha, and why it was too picky

A frontmatter value that's a mapping was **dropped at parse time** (`sanitizeFrontmatterValue` returned `undefined`) on the grounds that it had "no obvious predicate to materialize." But RDF's obvious answer is a **blank node** — as you noted. So structured metadata was invisible to the graph for no good reason.

## The fix

Mint a blank node for a nested mapping, link it under the key's predicate, and turn the mapping's own keys into predicates on that node:

```
address:              ?note minerva:meta-address ?a .
  city: Paris     →   ?a    minerva:meta-city    ?c .
  zip: "75001"        ?a    minerva:meta-zip     ?z .
```

Queryable with a property path: `?note minerva:meta-address/minerva:meta-city ?city`.

- **Parser** keeps nested maps (new `FrontmatterMap` type), recursing with a depth cap; an empty / all-unmaterialisable map still collapses to nothing.
- **Indexer** (`emitFrontmatterValue`) recurses: scalars → one edge, lists → one edge per element, maps → a blank node (linked in only if it received ≥1 child triple, so no dangling empties). Lists of mappings emit one blank node per element; nesting recurses.
- **Nested keys always take the `minerva:meta-<key>` form**, not canonical mapping — a nested structure is opaque data, so its keys stay predictable rather than sometimes resolving to `dc:`/`schema:`/… (only top-level keys map canonically). This surfaced while testing: `authors` is a canonical alias for `dc:creator`, so canonical-mapping nested keys would be surprising.
- Blank-node triples live in the note's **named graph**, so a re-index clears them wholesale — no orphan accumulation (there's a test for exactly this).

`publish:` stays excluded (publication directives, not metadata).

## Tests

New cases in `frontmatter-indexing.test.ts`: single nested map → blank node (asserted `isBlank`), nested scalar typing, deep nesting (property path), list-of-maps → one node each, empty map → nothing, and no accumulation across re-index. The parser test that asserted the old drop is flipped to assert preservation. Full suite green except the pre-existing `help-docs-corpus-staleness` snapshot (dirty docs batch, unrelated).

## Docs

The "nested objects don't reach the graph" gotcha is removed and the capability documented in the Custom keys section — in the working-tree docs batch, not this code PR. (The Properties panel still shows nested objects as read-only YAML; that's a separate display concern and unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)