### PR TITLE
Preview: dismiss the hover tooltip on click (stuck after navigating)

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1200,6 +1200,11 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 
     function handleClick(e: MouseEvent) {
         const el = e.target as HTMLElement;
+        // Dismiss any open hover tooltip first. Clicking a wiki-link navigates
+        // the preview and replaces the DOM before a `mouseout` can fire on the
+        // now-destroyed link, which otherwise leaves the tooltip stuck onscreen
+        // over the newly-loaded note. A click means "acting, not hovering".
+        dismissTooltip();
         if (handleTaskCheckboxClick(el)) return;
         for (const [selector, handler] of clickRoutes) {
             const matched = el.closest<HTMLElement>(selector);
@@ -1619,7 +1624,13 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         // relatedTarget can be null when cursor leaves the window — dismiss anyway
         const to = e.relatedTarget as Node | null;
         if (to && leaving.contains(to)) return;
-        hoverToken++; // cancel any in-flight wiki-link fetch (#1132)
+        dismissTooltip();
+    }
+
+    /** Hide the hover tooltip and cancel any in-flight wiki-link fetch (#1132)
+     *  so a late-resolving read can't re-show it. */
+    function dismissTooltip() {
+        hoverToken++;
         tooltipVisible = false;
     }
 


### PR DESCRIPTION
## The bug

In preview mode: hover a wiki-link → a note-preview tooltip appears (title + snippet of the linked note). Click the link → the preview navigates to that note, **but the tooltip stays pinned onscreen** over the newly-loaded note. Edit mode doesn't have this (CodeMirror manages its own hover lifecycle).

## Cause

The tooltip is shown on `mouseover` of a `.wiki-link` and hidden on `mouseout`. Clicking the link navigates the preview, which re-renders and **replaces the DOM** — the `.wiki-link` element the pointer was over is destroyed before any `mouseout` fires on it, so `tooltipVisible` is never set back to `false`.

## Fix

Dismiss the tooltip at the top of `handleClick`, before click routing — any click in the preview means the user is acting, not hovering. Pulled the hide-and-cancel-in-flight-fetch logic into a small `dismissTooltip()` helper shared with `handleMouseOut` (it bumps `hoverToken` too, so a late-resolving note read can't re-show the tooltip after the click).

Because the handler is on the preview container and fires for every click (before routing), it covers wiki-link navigation regardless of how that click is routed.

## Testing

Verified by inspection: these are DOM-event → component-`$state` handlers with no pure seam, and there's no component-mount harness for `Preview.svelte` (its existing tests all cover extracted pure helpers). `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)