### PR TITLE
Add a read_source tool so conversations can read source bodies (#1371)

### DIFF
--- a/src/main/llm/tools/read-note.ts
+++ b/src/main/llm/tools/read-note.ts
@@ -17,7 +17,9 @@ export const readNote: NotebaseTool = {
       '(e.g. "notes/topics/llm-trust.md"). Returns the raw markdown including ' +
       'any frontmatter. Use this when you have a path from search_notes, from ' +
       'a wiki-link in another note, or from a graph query, and need the full ' +
-      'text.',
+      'text. This reads plain notes only — for an ingested source (a `[source]` ' +
+      'hit from search_related, identified by a source id rather than a path) ' +
+      'use read_source instead.',
     input_schema: {
       type: 'object',
       properties: {

--- a/src/main/llm/tools/read-source.ts
+++ b/src/main/llm/tools/read-source.ts
@@ -1,0 +1,73 @@
+import * as fs from '../../notebase/fs';
+import { projectContext } from '../../project-context-types';
+import { sourceTitle } from '../../graph/index';
+import type { NotebaseTool, ToolContext } from './types';
+
+/**
+ * Read an ingested source's extracted body (#1371). Sibling of `read_note`:
+ * read-only, main-process, no approval gate and no renderer callback. Where
+ * `read_note` reads a thoughtbase-relative note path, this reads a source's
+ * on-disk body by its source id — `.minerva/sources/<id>/body.md`, the same
+ * file `window-manager.ts` re-reads on a meta change and that `indexSource`
+ * embedded, which is why `search_related` surfaces `[source]` hits at all.
+ */
+async function runRead(ctx: ToolContext, input: unknown): Promise<string> {
+  const { source_id } = input as { source_id?: unknown };
+  if (typeof source_id !== 'string' || !source_id.trim()) {
+    throw new Error('source_id is required');
+  }
+  const id = source_id.trim();
+  // A source id is a flat identifier, never a path. Reject separators / traversal
+  // up front for a clearer message than a deep assertSafePath throw (the fs read
+  // below is also guarded, so this is defence-in-depth, not the only check).
+  if (id.includes('/') || id.includes('\\') || id.includes('..')) {
+    throw new Error(`Invalid source_id "${id}": expected a bare source identifier, not a path.`);
+  }
+
+  let body: string;
+  try {
+    body = await fs.readFile(ctx.rootPath, `.minerva/sources/${id}/body.md`);
+  } catch {
+    throw new Error(
+      `No readable body for source "${id}". Either the id is unknown or its text ` +
+      `was never extracted (a source can have metadata but no body.md). Use ` +
+      `search_related or query_graph to find valid source ids.`,
+    );
+  }
+
+  // Short provenance header so the title travels with the body inline; richer
+  // metadata (authors, URL, date) stays in the graph via query_graph. Falls
+  // back to just the id when the source has no dc:title (or isn't indexed yet).
+  const title = sourceTitle(projectContext(ctx.rootPath), id);
+  const header = title && title !== id ? `[source ${id}] ${title}` : `[source ${id}]`;
+  return `${header}\n\n${body}`;
+}
+
+export const readSource: NotebaseTool = {
+  definition: {
+    name: 'read_source',
+    description:
+      'Read the full extracted text of an ingested source (article, PDF, web ' +
+      'page) by its source id — the identifier search_related surfaces on a ' +
+      '`[source]` hit and that graph queries return. Returns the source body as ' +
+      'markdown with a short provenance header (its title). Use this to ground ' +
+      'an answer in the full text of the user\'s research library rather than ' +
+      'the 240-char snippet search_related shows. For a plain note use ' +
+      'read_note; for a source\'s structured metadata (authors, URL, date) use ' +
+      'query_graph.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        source_id: {
+          type: 'string',
+          description:
+            'The bare source identifier (a `[source]` hit\'s ref from ' +
+            'search_related, or a sourceId from a graph query). Not a path — ' +
+            'separators and traversal (..) are rejected.',
+        },
+      },
+      required: ['source_id'],
+    },
+  },
+  run: async (ctx, input) => ({ content: await runRead(ctx, input), isError: false }),
+};

--- a/src/main/llm/tools/registry.ts
+++ b/src/main/llm/tools/registry.ts
@@ -3,6 +3,7 @@ import type { ToolSpec } from '../provider/types';
 import type { NotebaseTool, ToolContext, ToolCallbacks, ToolResult } from './types';
 import { searchNotes } from './search-notes';
 import { readNote } from './read-note';
+import { readSource } from './read-source';
 import { searchRelated } from './search-related';
 import { searchHelp } from './search-help';
 import { queryGraph } from './query-graph';
@@ -31,6 +32,7 @@ import { askUser } from './ask-user';
 const DEFAULT_TOOLS: NotebaseTool[] = [
   searchNotes,
   readNote,
+  readSource,
   searchRelated,
   searchHelp,
   queryGraph,

--- a/src/main/llm/tools/search-related.ts
+++ b/src/main/llm/tools/search-related.ts
@@ -84,7 +84,9 @@ export const searchRelated: NotebaseTool = {
       'note ("what else is like this one"). Optionally restrict with `kinds` ' +
       '(e.g. ["excerpt"] to mine the research library). Each result names its ' +
       'kind, the matched section, and a similarity score (0–1); a `[source]` / ' +
-      '`[excerpt]` tag marks library hits (use read_note only for plain notes).\n' +
+      '`[excerpt]` tag marks library hits. Read a full hit by kind: `read_source` ' +
+      'for a `[source]`, `read_note` for a plain note (untagged); an `[excerpt]` ' +
+      'is anchored to a source, so read its `[source]` for the surrounding text.\n' +
       'Choosing among the search tools: use search_related for "find things ' +
       'like / about this" by meaning; use search_notes for exact keywords or ' +
       'phrases; use query_graph for structural questions (links, tags, types, ' +

--- a/tests/main/llm/read-source-tool.test.ts
+++ b/tests/main/llm/read-source-tool.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { executeNotebaseTool } from '../../../src/main/llm/tools';
+import { initGraph, indexSource } from '../../../src/main/graph/index';
+import { projectContext } from '../../../src/main/project-context-types';
+
+describe('read_source tool (#1371)', () => {
+  let root: string;
+  const ctx = () => projectContext(root);
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-read-source-'));
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function seedSource(id: string, body: string, meta?: string): Promise<void> {
+    const dir = path.join(root, '.minerva', 'sources', id);
+    await fsp.mkdir(dir, { recursive: true });
+    await fsp.writeFile(path.join(dir, 'body.md'), body, 'utf-8');
+    if (meta) await fsp.writeFile(path.join(dir, 'meta.ttl'), meta, 'utf-8');
+  }
+
+  it('reads a source body by id, with a title provenance header', async () => {
+    await initGraph(ctx());
+    const meta = 'this: a thought:Article ;\n  dc:title "The Trust Paper" .\n';
+    const body = '# Trust\n\nThe full extracted body of the source.\n';
+    await seedSource('trust-2023', body, meta);
+    indexSource(ctx(), 'trust-2023', meta, body); // so sourceTitle resolves the header
+
+    const res = await executeNotebaseTool(ctx(), 'read_source', { source_id: 'trust-2023' });
+    expect(res.isError).toBe(false);
+    expect(res.content).toContain('The full extracted body of the source.');
+    expect(res.content).toContain('[source trust-2023] The Trust Paper');
+  });
+
+  it('falls back to a bare header when the source has no indexed title', async () => {
+    await seedSource('untitled-1', 'body only\n'); // no meta, graph not initialised
+    const res = await executeNotebaseTool(ctx(), 'read_source', { source_id: 'untitled-1' });
+    expect(res.isError).toBe(false);
+    expect(res.content).toContain('[source untitled-1]');
+    expect(res.content).toContain('body only');
+  });
+
+  it('errors clearly for an unknown / bodyless source', async () => {
+    const res = await executeNotebaseTool(ctx(), 'read_source', { source_id: 'nope' });
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/No readable body for source "nope"/);
+  });
+
+  it('rejects a path-traversal source_id', async () => {
+    const res = await executeNotebaseTool(ctx(), 'read_source', { source_id: '../../etc/passwd' });
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/Invalid source_id|not a path/);
+  });
+
+  it('requires a non-empty source_id', async () => {
+    const res = await executeNotebaseTool(ctx(), 'read_source', { source_id: '  ' });
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/source_id is required/);
+  });
+
+  it('is registered in the default conversation toolset', async () => {
+    const { NOTEBASE_TOOLS } = await import('../../../src/main/llm/tools');
+    expect(NOTEBASE_TOOLS.map((t) => t.name)).toContain('read_source');
+  });
+});


### PR DESCRIPTION
Closes #1371.

## What

Conversations could **discover** ingested sources (`search_related` returns `[source]` hits) but had no way to **read** one — `read_note` is notes-only. So answers grounded in the user's research library were capped at a 240-char snippet.

`read_source` mirrors `read_note`: **read-only, main-process, no approval-engine gate, no `TOOL_CALLBACK_KEYS` entry** (it touches no renderer surface).

- **Input:** `source_id` — exactly the ref `search_related` surfaces on a `[source]` hit and that graph queries return.
- **Behavior:** reads `.minerva/sources/<id>/body.md` via `notebaseFs.readFile` (same call `window-manager.ts` uses; `assertSafePath` covers traversal). Prepends a short `[source <id>] <title>` header via the existing `graph.sourceTitle` helper so provenance travels inline; richer metadata (authors, URL, date) stays reachable through `query_graph`.
- **Errors:** a flat source id is required — separators / `..` are rejected up front with a clear message (defence-in-depth on top of `assertSafePath`); an unknown or bodyless id (metadata but a failed extraction) gives an actionable "no readable body" error pointing back at `search_related` / `query_graph`.

## Wiring

- Registered in `DEFAULT_TOOLS` (always-on) → lands in `NOTEBASE_TOOL_REGISTRY` + `DISPATCH`.
- `search_related`'s description now routes hits by kind (`[source]` → `read_source`, untagged → `read_note`, `[excerpt]` → read its source); `read_note`'s description clarifies it's notes-only and points sources at `read_source`.

## Tests

`tests/main/llm/read-source-tool.test.ts`: happy path with an indexed title header, fallback bare header when untitled/unindexed, unknown-id error, path-traversal rejection, empty-id guard, and registry membership. `pnpm lint` + `pnpm test` green (the only failing test is the pre-existing `help-docs-corpus-staleness` snapshot, unrelated — a dirty local docs batch).

## Scope

This is the read tool only. The structured-`Citation[]` half — returning source content as Anthropic citable `search_result` / `document` blocks, extending `collectCitations`, and a renderer surface for local citations — is deliberately **not** here: it changes the plain-string tool-result contract and is bigger/riskier, tracked separately under `epic:citation-authoring` per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)