### PR TITLE
Charts: fill the note column instead of rendering narrow (#1395)

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -2651,6 +2651,19 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         display: none;
     }
 
+    /* vega-embed renders in place by adding its own `.vega-embed` class to our
+       `.vega-block` container, and its bundled CSS makes `.vega-embed`
+       `display: inline-block` — which shrinks the container to the chart's
+       default width, so `width: "container"` has nothing to fit to and the
+       chart lays out narrow (#1395). Force the container to fill the note
+       column; vega-embed's inner `.chart-wrapper.fit-x` then measures the full
+       width and the chart sizes to it. Higher specificity than the bundled
+       `.vega-embed` rule, so it wins. */
+    .preview :global(.vega-block) {
+        display: block;
+        width: 100%;
+    }
+
     /* markdown-it-footnote output. The plugin emits a back-of-note
        `<section class="footnotes">` with an ordered list of footnote
        bodies, plus inline `<sup class="footnote-ref">` markers in the


### PR DESCRIPTION
## Problem

`vega-lite` / `vega` charts embedded in a note render at a fixed narrow width (~200–300px), tucked to the left of a full-width cell, instead of fitting the note column — despite the `width: "container"` injection intended by #1391. Mermaid diagrams fill the column fine, so it's Vega-specific.

## Root cause

`vega-embed` renders *in place* by adding its own `vega-embed` class onto our `.vega-block` container. Its bundled stylesheet sets `.vega-embed { display: inline-block }`, which shrinks the container to the chart's default width. The inner `.chart-wrapper.fit-x` is `width: 100%` of that shrunk parent, so `width: "container"` resolves to the tiny default — a circular dependency.

Verified with a live DOM probe: `.fence-body` was a correct **702px**, but `.vega-block.vega-embed` was `display: inline-block` at **157px** around a **97px** SVG.

## Fix

One CSS rule forcing the container to fill the note column:

```css
.preview :global(.vega-block) { display: block; width: 100%; }
```

Higher specificity than vega-embed's bundled `.vega-embed` rule, so the container keeps a definite full width and `.chart-wrapper.fit-x` fits the chart to it. No JS or timing changes; mermaid and the query-block chart path are untouched.

## Verification

Rebuilt the packaged app and rendered a bar chart in a note: it now spans the full column with full-size axis labels (previously ~97px wide, left-aligned).

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)