### PR TITLE
Search: record a back/forward step when opening a note from a search match

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -606,7 +606,7 @@
   // module reads / writes pending search + preview anchor, view mode, and the
   // alias map via ctx — those `$state` decls stay in App.
   const {
-    recordCurrentPosition, handleNavBack, handleNavForward, handleFileSelect, handleNavigate, handleOpenAtOffset,
+    recordCurrentPosition, handleNavBack, handleNavForward, handleFileSelect, handleNavigate, handleOpenAtOffset, handleJumpToMatch,
     handleSourceDeleted, handleOpenSource, handleOpenPdf, handleShowMarkdownFromPdf, handleOpenExcerpt,
   } = createNavView({
     getEditorComponent: () => editorComponent,
@@ -1355,10 +1355,7 @@
   {#if findInNotesMode}
     <FindInNotesDialog
       initialMode={findInNotesMode}
-      onJumpTo={async (rel, line, col) => {
-        await editor.openFile(rel);
-        requestAnimationFrame(() => editorComponent?.gotoLineColumn(line, col + 1));
-      }}
+      onJumpTo={handleJumpToMatch}
       onClose={() => { findInNotesMode = null; }}
     />
   {/if}

--- a/src/renderer/lib/app/nav-view.ts
+++ b/src/renderer/lib/app/nav-view.ts
@@ -12,7 +12,7 @@ import { getEditorStore } from '../stores/editor.svelte';
 import { getNotebaseStore } from '../stores/notebase.svelte';
 import { getNavigationStore, type NavPosition } from '../stores/navigation.svelte';
 import { flattenNoteFiles, resolveWikiLinkTarget } from '../wiki-link-resolver';
-import { findAnchorOffset } from './text-helpers';
+import { findAnchorOffset, lineColToOffset } from './text-helpers';
 import { getPreferredSourceView, setPreferredSourceView } from '../source-view-preference';
 import { tick } from 'svelte';
 
@@ -91,6 +91,23 @@ export function createNavView(ctx: NavViewCtx) {
     await editor.openFile(relativePath);
     await tick();
     requestAnimationFrame(() => ctx.getEditorComponent()?.restorePosition(offset));
+    nav.record({ type: 'note', relativePath, offset });
+  }
+
+  /**
+   * Open a note at a full-text search match and record the jump. A search result
+   * was the one open path that skipped nav history, so Back stepped past it;
+   * this puts it on the back/forward stack like sidebar / Quick Switch opens.
+   * `line` is 1-based and `col` 0-based (the FindInNotes match coordinates), and
+   * both the landing jump and the recorded position use the same offset so Back
+   * returns to the match.
+   */
+  async function handleJumpToMatch(relativePath: string, line: number, col: number) {
+    recordCurrentPosition();
+    await editor.openFile(relativePath);
+    const offset = lineColToOffset(editor.content, line, col);
+    await tick();
+    requestAnimationFrame(() => ctx.getEditorComponent()?.gotoOffset(offset));
     nav.record({ type: 'note', relativePath, offset });
   }
 
@@ -195,7 +212,7 @@ export function createNavView(ctx: NavViewCtx) {
 
   return {
     recordCurrentPosition, handleNavBack, handleNavForward, handleFileSelect, handleNavigate,
-    handleOpenAtOffset,
+    handleOpenAtOffset, handleJumpToMatch,
     handleSourceDeleted, handleOpenSource, handleOpenPdf, handleShowMarkdownFromPdf, handleOpenExcerpt,
   };
 }

--- a/src/renderer/lib/app/text-helpers.ts
+++ b/src/renderer/lib/app/text-helpers.ts
@@ -41,6 +41,15 @@ export function offsetToLineCol(text: string, offset: number): { line: number; c
   return { line, col };
 }
 
+/** Byte offset for a 1-based line + 0-based column — the inverse of
+ *  `offsetToLineCol`. Used to place a search match on the nav stack. */
+export function lineColToOffset(text: string, line: number, col: number): number {
+  const lines = text.split('\n');
+  let offset = 0;
+  for (let i = 0; i < line - 1 && i < lines.length; i++) offset += lines[i]!.length + 1;
+  return offset + col;
+}
+
 /**
  * Display name for a line bookmark (#756): the trimmed text of the line the
  * offset sits on, truncated, or `Line N` when that line is blank. Gives the

--- a/tests/renderer/app/nav-view.test.ts
+++ b/tests/renderer/app/nav-view.test.ts
@@ -130,6 +130,23 @@ describe('handleOpenExcerpt', () => {
   });
 });
 
+describe('handleJumpToMatch', () => {
+  it('records the departure position and the search-match landing on the nav stack', async () => {
+    h.editor.content = 'line one\nline two\nline three';
+    h.editor.activeTab = { type: 'note' };
+    h.editor.activeFilePath = 'from.md';
+    ctx.getEditorComponent = () => ({ getOffset: () => 4, gotoOffset: vi.fn(), restorePosition: vi.fn() });
+
+    await view.handleJumpToMatch('hit.md', 2, 5); // line 2 (1-based), col 5 (0-based)
+
+    expect(h.editor.openFile).toHaveBeenCalledWith('hit.md');
+    // Departure: where we left from, at its cursor offset.
+    expect(h.nav.record).toHaveBeenCalledWith({ type: 'note', relativePath: 'from.md', offset: 4 });
+    // Arrival: offset of (line 2, col 5) = len("line one") + 1 newline + 5 = 14.
+    expect(h.nav.record).toHaveBeenCalledWith({ type: 'note', relativePath: 'hit.md', offset: 14 });
+  });
+});
+
 describe('handleNavBack', () => {
   it('opens the note position returned by goBack', async () => {
     h.nav.goBack.mockReturnValue({ type: 'note', relativePath: 'a.md', offset: 5 });

--- a/tests/renderer/app/text-helpers.test.ts
+++ b/tests/renderer/app/text-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   slugifyForPath,
   findAnchorOffset,
   offsetToLineCol,
+  lineColToOffset,
   lineBookmarkName,
   flattenNotePaths,
   countNotes,
@@ -58,6 +59,21 @@ describe('offsetToLineCol', () => {
     expect(offsetToLineCol(text, 2)).toEqual({ line: 1, col: 2 });
     expect(offsetToLineCol(text, 4)).toEqual({ line: 2, col: 0 });
     expect(offsetToLineCol(text, 7)).toEqual({ line: 3, col: 0 });
+  });
+});
+
+describe('lineColToOffset', () => {
+  it('is the inverse of offsetToLineCol', () => {
+    const text = 'abc\nde\nf';
+    expect(lineColToOffset(text, 1, 0)).toBe(0);
+    expect(lineColToOffset(text, 1, 2)).toBe(2);
+    expect(lineColToOffset(text, 2, 0)).toBe(4);
+    expect(lineColToOffset(text, 3, 0)).toBe(7);
+    // round-trip a few offsets through both directions
+    for (const off of [0, 2, 4, 5, 7]) {
+      const { line, col } = offsetToLineCol(text, off);
+      expect(lineColToOffset(text, line, col)).toBe(off);
+    }
   });
 });
 

--- a/website/docs/navigation-back-forward.html
+++ b/website/docs/navigation-back-forward.html
@@ -125,7 +125,7 @@
       </div>
       <div class="row">
         <div class="k">A <a href="navigation-search.html">search</a> result</div>
-        <div class="v"><b>Not remembered.</b> Jumping straight to a search match doesn't add a step, so Back skips past it.</div>
+        <div class="v"><b>Remembered.</b> Jumping to a search match records a step, so Back returns you to where you were before the search.</div>
       </div>
       <div class="row">
         <div class="k">Back and forward themselves</div>


### PR DESCRIPTION
## Problem

Selecting a full-text search result jumped straight to the note via `editor.openFile` **without recording a back/forward history step** — so pressing Back stepped right past it. Every other way of opening a note (sidebar click, Quick Switch) records a step; search was the lone exception. The docs even described this as expected behavior, but it's a bug.

## Fix

Route the `FindInNotesDialog` `onJumpTo` through a new `nav-view` handler, `handleJumpToMatch`, that mirrors the other open paths (`handleFileSelect` / `handleOpenAtOffset`):

1. `recordCurrentPosition()` — record where you're leaving from.
2. `editor.openFile(...)`.
3. jump to the match and `nav.record(...)` the landing.

The landing offset is derived from the match's `line`/`col` via a new pure helper `lineColToOffset` (the inverse of the existing `offsetToLineCol`), and the *same* offset drives both the visual jump (`gotoOffset`) and the recorded position — so Back returns you to where you were before the search, and Forward returns to the match.

## Also

- Updated **Navigation → Back/forward** docs: a search result is now "Remembered."
- Unit tests: `handleJumpToMatch` (records departure + arrival with the correct offset) and `lineColToOffset` (round-trips with `offsetToLineCol`).

Lint + affected tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)