### PR TITLE
grep_notes: exact / regex search over notes, for the conversation agent and MCP

### DIFF
--- a/src/cli/engine.ts
+++ b/src/cli/engine.ts
@@ -26,9 +26,21 @@ import type { ChunkEmbedder } from '../main/embeddings/vector-store';
 import { getSharedEmbedder } from '../main/embeddings/shared-embedder';
 import * as approval from '../main/llm/approval';
 import { readFile } from '../main/notebase/fs';
+import { searchInNotes } from '../main/notebase/search-in-notes';
 import type { ProjectContext } from '../main/project-context-types';
 
 export type ExecResult = { ok: true; data: unknown } | { ok: false; error: string };
+
+export interface GrepOptions {
+  regex?: boolean | undefined;
+  caseSensitive?: boolean | undefined;
+  limit?: number | undefined;
+}
+
+/** Default / hard caps on grep match lines, so a broad pattern can't flood the
+ *  agent's context; the result still reports the true `total`. */
+const GREP_DEFAULT_LIMIT = 50;
+const GREP_MAX_LIMIT = 200;
 
 export interface ProposeNoteInput {
   relativePath: string;
@@ -44,6 +56,11 @@ export interface Engine {
   sql(sql: string): Promise<ExecResult>;
   search(text: string, limit?: number): Promise<ExecResult>;
   semantic(text: string, limit?: number): Promise<ExecResult>;
+  /** Exact literal / regex search over raw note text (like grep) — matches
+   *  grounded with note path + line number. Complements `search` (word-based
+   *  full-text) and `semantic` (meaning); the tool for exact strings, symbols,
+   *  and structural patterns. */
+  grep(pattern: string, opts?: GrepOptions): Promise<ExecResult>;
   read(relativePath: string): Promise<ExecResult>;
   /** Assemble a task-relevant slice of the thoughtbase for a topic: the matching
    *  notes plus their link neighborhood and full content, as one bundle an
@@ -124,6 +141,31 @@ export function createEngine(ctx: ProjectContext, opts: EngineOptions = {}): Eng
       const data: Record<string, unknown> = { query: text, hits };
       if (hits.length === 0) data.note = SEMANTIC_EMPTY_NOTE;
       return { ok: true, data };
+    },
+    async grep(pattern, opts = {}) {
+      if (typeof pattern !== 'string' || pattern.trim() === '') {
+        return { ok: false, error: 'pattern is required' };
+      }
+      const regex = opts.regex === true;
+      const caseSensitive = opts.caseSensitive === true;
+      const cap = Math.min(
+        opts.limit && opts.limit > 0 ? Math.floor(opts.limit) : GREP_DEFAULT_LIMIT,
+        GREP_MAX_LIMIT,
+      );
+      // searchInNotes reads the vault directly (no index), so no ensure* step.
+      const files = await searchInNotes(ctx.rootPath, { pattern, caseSensitive, regex });
+      const total = files.reduce((n, f) => n + f.matches.length, 0);
+      const matches: { path: string; line: number; text: string }[] = [];
+      outer: for (const f of files) {
+        for (const m of f.matches) {
+          if (matches.length >= cap) break outer;
+          matches.push({ path: f.relativePath, line: m.line, text: m.lineText.slice(0, 200) });
+        }
+      }
+      return {
+        ok: true,
+        data: { pattern, regex, caseSensitive, total, truncated: matches.length < total, matches },
+      };
     },
     async read(relativePath) {
       try {

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -109,6 +109,34 @@ export const MCP_TOOLS: McpTool[] = [
     run: (engine, args) => engine.search(str(args.text), num(args.limit)),
   },
   {
+    name: 'grep_notes',
+    description:
+      'Exact literal or regular-expression search over the raw text of every note, like ' +
+      '`grep`. Matches are grounded with note path and line number. Unlike search_notes ' +
+      '(ranked, word-based) and semantic_search (meaning-based), this matches the exact ' +
+      'characters — punctuation, symbols, code, casing, structure — and finds every ' +
+      'occurrence, so use it for a known string, a structural pattern (unfinished tasks ' +
+      '"- [ ]", "[[wiki-links]]", a "status:" property, TODO/FIXME), or to verify whether ' +
+      'something literally appears. Literal substring by default; set regex:true for a ' +
+      'JavaScript regular expression.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'Text to find. Literal substring unless regex is true.' },
+        regex: { type: 'boolean', description: 'Treat pattern as a JavaScript regular expression. Default false.' },
+        case_sensitive: { type: 'boolean', description: 'Match case exactly. Default false.' },
+        limit: { type: 'number', description: 'Max match lines (default 50, max 200).' },
+      },
+      required: ['pattern'],
+    },
+    run: (engine, args) =>
+      engine.grep(str(args.pattern), {
+        regex: args.regex === true,
+        caseSensitive: args.case_sensitive === true,
+        limit: num(args.limit),
+      }),
+  },
+  {
     name: 'semantic_search',
     description:
       'Semantic (embeddings) search over notes — finds conceptually related content, not ' +

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -50,6 +50,8 @@ Commands:
   query <sparql>        Run a SPARQL query against the knowledge graph.
   sql <sql>             Run a DuckDB SQL query over the vault's CSV tables.
   search <text>         Full-text search over notes.        [--limit <n>]
+  grep <pattern>        Exact literal / regex search over raw note text; matches
+                        grounded with path + line.  [--regex] [--case-sensitive] [--limit <n>]
   semantic <text>       Semantic (embeddings) search over notes.  [--limit <n>]
   read <relative-path>  Print a note's raw markdown.
   context <topic>       Assemble a relevant slice — matching notes + their link
@@ -61,7 +63,9 @@ Commands:
 
 Options:
   --project <path>      Thoughtbase root (default: current directory).
-  --limit <n>           Max results for search/semantic (default: 20).
+  --limit <n>           Max results for search/semantic/grep (default: 20).
+  --regex               Treat a grep pattern as a regular expression.
+  --case-sensitive      Match case exactly (grep; default: case-insensitive).
   --by <client-id>      Provenance for propose-note (default: cli).
   --help, -h            Show this help.
 
@@ -75,6 +79,8 @@ interface ParsedArgs {
   project: string | undefined;
   limit: number | undefined;
   by: string | undefined;
+  regex: boolean;
+  caseSensitive: boolean;
   help: boolean;
 }
 
@@ -86,6 +92,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let project: string | undefined;
   let limit: number | undefined;
   let by: string | undefined;
+  let regex = false;
+  let caseSensitive = false;
   let help = false;
 
   for (let i = 0; i < argv.length; i++) {
@@ -104,12 +112,16 @@ export function parseArgs(argv: string[]): ParsedArgs {
       by = argv[++i];
     } else if (arg.startsWith('--by=')) {
       by = arg.slice('--by='.length);
+    } else if (arg === '--regex') {
+      regex = true;
+    } else if (arg === '--case-sensitive') {
+      caseSensitive = true;
     } else {
       positionals.push(arg);
     }
   }
 
-  return { command: positionals.shift(), positionals, project, limit, by, help };
+  return { command: positionals.shift(), positionals, project, limit, by, regex, caseSensitive, help };
 }
 
 function json(value: unknown): string {
@@ -184,6 +196,12 @@ export async function runCli(argv: string[], opts: RunOptions): Promise<CliResul
       case 'search':
         if (!rest.trim()) throw new UsageError('search: a query string is required.');
         return format(await engine.search(rest, args.limit), 'Error');
+      case 'grep':
+        if (!rest.trim()) throw new UsageError('grep: a search pattern is required.');
+        return format(
+          await engine.grep(rest, { regex: args.regex, caseSensitive: args.caseSensitive, limit: args.limit }),
+          'Error',
+        );
       case 'semantic':
         if (!rest.trim()) throw new UsageError('semantic: a query string is required.');
         return format(await engine.semantic(rest, args.limit), 'Error');

--- a/src/main/llm/format-tool-call.ts
+++ b/src/main/llm/format-tool-call.ts
@@ -27,6 +27,10 @@ export function formatToolCall(name: string, input: unknown): string {
       const q = pickString(i, 'query');
       return q ? `🔎 Searching notes for **${truncate(q, MAX_SNIPPET)}**` : '🔎 Searching notes';
     }
+    case 'grep_notes': {
+      const p = pickString(i, 'pattern');
+      return p ? `🔦 Grepping notes for **${truncate(p, MAX_SNIPPET)}**` : '🔦 Grepping notes';
+    }
     case 'search_help': {
       const q = pickString(i, 'query');
       return q ? `📖 Checking the docs for **${truncate(q, MAX_SNIPPET)}**` : '📖 Checking the docs';

--- a/src/main/llm/tools/grep-notes.ts
+++ b/src/main/llm/tools/grep-notes.ts
@@ -1,0 +1,101 @@
+import { searchInNotes } from '../../notebase/search-in-notes';
+import type { NotebaseTool, ToolContext } from './types';
+
+/** Cap on the number of match lines returned to the model, so a broad pattern
+ *  can't flood the context. The header reports the true total when truncated. */
+const DEFAULT_MAX = 50;
+const HARD_MAX = 200;
+/** Trim absurdly long lines (minified data, base64) to keep output readable. */
+const MAX_LINE = 200;
+
+interface GrepInput {
+  pattern?: unknown;
+  regex?: unknown;
+  case_sensitive?: unknown;
+  max_matches?: unknown;
+}
+
+async function runGrep(ctx: ToolContext, input: unknown): Promise<string> {
+  const { pattern, regex, case_sensitive, max_matches } = (input ?? {}) as GrepInput;
+  if (typeof pattern !== 'string' || pattern.trim() === '') {
+    throw new Error('pattern is required');
+  }
+  const asRegex = regex === true;
+  const caseSensitive = case_sensitive === true;
+  const cap = Math.min(
+    typeof max_matches === 'number' && Number.isFinite(max_matches) ? Math.max(1, Math.floor(max_matches)) : DEFAULT_MAX,
+    HARD_MAX,
+  );
+
+  const files = await searchInNotes(ctx.rootPath, { pattern, caseSensitive, regex: asRegex });
+
+  const total = files.reduce((n, f) => n + f.matches.length, 0);
+  if (total === 0) {
+    // A regex that fails to compile also yields zero matches (searchInNotes
+    // swallows the error) — call that out so the model can fix its pattern.
+    const hint = asRegex ? ' (if this is an invalid regular expression, no matches are returned)' : '';
+    return `No matches for ${asRegex ? 'regex' : 'literal'} "${pattern}".${hint}`;
+  }
+
+  const flags = [asRegex ? 'regex' : 'literal', caseSensitive ? 'case-sensitive' : 'case-insensitive'].join(', ');
+  const lines: string[] = [];
+  let shown = 0;
+  outer: for (const f of files) {
+    for (const m of f.matches) {
+      if (shown >= cap) break outer;
+      const text = m.lineText.trim().slice(0, MAX_LINE);
+      lines.push(`${f.relativePath}:${m.line}: ${text}`);
+      shown++;
+    }
+  }
+
+  const header =
+    `${total} match${total === 1 ? '' : 'es'} in ${files.length} note${files.length === 1 ? '' : 's'}` +
+    ` for "${pattern}" (${flags})` +
+    (shown < total ? ` — showing the first ${shown}; narrow the pattern to see the rest` : '') +
+    ':';
+  return `${header}\n${lines.join('\n')}`;
+}
+
+export const grepNotes: NotebaseTool = {
+  definition: {
+    name: 'grep_notes',
+    description:
+      'Exact literal or regular-expression search over the raw text of every note ' +
+      'in the thoughtbase, like `grep`. Returns each matching line as ' +
+      '`path:line: text`. Unlike search_notes (ranked, word-based full-text) and ' +
+      'search_related (meaning-based), this matches the exact characters — ' +
+      'including punctuation, symbols, code, casing, and structure — and finds ' +
+      'every occurrence, so it is the tool for a known string (an exact phrase, an ' +
+      'identifier, a URL), a structural pattern (unfinished tasks "- [ ]", ' +
+      '"[[wiki-links]]", a "status:" property, TODO/FIXME), or to verify whether ' +
+      'something literally appears at all. The pattern is a literal substring by ' +
+      'default; set regex:true to use a JavaScript regular expression. Matches are ' +
+      'per line.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        pattern: {
+          type: 'string',
+          description: 'The text to find. A literal substring unless regex is true.',
+        },
+        regex: {
+          type: 'boolean',
+          description: 'Treat pattern as a JavaScript regular expression. Defaults to false (literal).',
+        },
+        case_sensitive: {
+          type: 'boolean',
+          description: 'Match case exactly. Defaults to false (case-insensitive).',
+        },
+        max_matches: {
+          type: 'integer',
+          description: `Maximum match lines to return. Defaults to ${DEFAULT_MAX}, max ${HARD_MAX}.`,
+          minimum: 1,
+          maximum: HARD_MAX,
+        },
+      },
+      required: ['pattern'],
+    },
+  },
+  run: async (ctx, input) => ({ content: await runGrep(ctx, input), isError: false }),
+};

--- a/src/main/llm/tools/registry.ts
+++ b/src/main/llm/tools/registry.ts
@@ -2,6 +2,7 @@ import type { ConversationToolKey } from '../../../shared/conversation-tools';
 import type { ToolSpec } from '../provider/types';
 import type { NotebaseTool, ToolContext, ToolCallbacks, ToolResult } from './types';
 import { searchNotes } from './search-notes';
+import { grepNotes } from './grep-notes';
 import { readNote } from './read-note';
 import { readSource } from './read-source';
 import { searchRelated } from './search-related';
@@ -31,6 +32,7 @@ import { askUser } from './ask-user';
  */
 const DEFAULT_TOOLS: NotebaseTool[] = [
   searchNotes,
+  grepNotes,
   readNote,
   readSource,
   searchRelated,

--- a/tests/cli/mcp.test.ts
+++ b/tests/cli/mcp.test.ts
@@ -51,7 +51,7 @@ describe('handleMcpMessage — handshake & discovery', () => {
     const r = await handleMcpMessage({ jsonrpc: '2.0', id: 2, method: 'tools/list' }, engine());
     const tools = (r?.result as { tools: { name: string; inputSchema: unknown }[] }).tools;
     expect(tools.map((t) => t.name).sort()).toEqual(
-      ['gather_context', 'propose_note', 'query_graph', 'read_note', 'search_notes', 'semantic_search', 'sql_query'],
+      ['gather_context', 'grep_notes', 'propose_note', 'query_graph', 'read_note', 'search_notes', 'semantic_search', 'sql_query'],
     );
     for (const t of tools) expect(t.inputSchema).toHaveProperty('type', 'object');
   });
@@ -96,6 +96,14 @@ describe('handleMcpMessage — tools/call', () => {
     const parsed = JSON.parse((r?.result as { content: { text: string }[] }).content[0].text);
     expect(parsed.path).toBe('photosynthesis.md');
     expect(parsed.content).toContain('chemical energy');
+  });
+
+  it('grep_notes returns exact matches grounded with path + line', async () => {
+    const r = await call('grep_notes', { pattern: 'chemical energy' });
+    const parsed = JSON.parse((r?.result as { content: { text: string }[] }).content[0].text);
+    expect(parsed.total).toBe(1);
+    expect(parsed.matches[0]).toMatchObject({ path: 'photosynthesis.md', line: 5 });
+    expect(parsed.matches[0].text).toContain('chemical energy');
   });
 
   it('a tool failure is an MCP tool result with isError, not a JSON-RPC error', async () => {

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -86,6 +86,14 @@ describe('parseArgs', () => {
     expect(a.command).toBe('query');
     expect(a.positionals).toEqual(['SELECT ?s WHERE { ?s ?p ?o }']);
   });
+
+  it('recognizes the grep boolean flags', () => {
+    const a = parseArgs(['grep', '[[chlorophyll]]', '--regex', '--case-sensitive']);
+    expect(a.command).toBe('grep');
+    expect(a.positionals).toEqual(['[[chlorophyll]]']);
+    expect(a.regex).toBe(true);
+    expect(a.caseSensitive).toBe(true);
+  });
 });
 
 describe('runCli read commands (#1149)', () => {
@@ -115,6 +123,25 @@ describe('runCli read commands (#1149)', () => {
     const r = await runCli(['search', 'photosynthesis', '--limit', '1'], { cwd: root });
     const out = JSON.parse(r.stdout);
     expect(out.hits.length).toBeLessThanOrEqual(1);
+  });
+
+  it('grep finds a literal pattern grounded with path + line (exit 0)', async () => {
+    const r = await runCli(['grep', '[[chlorophyll]]'], { cwd: root });
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.total).toBe(1);
+    expect(out.matches[0]).toMatchObject({ path: 'notes/photosynthesis.md', line: 6 });
+    expect(out.matches[0].text).toContain('[[chlorophyll]]');
+  });
+
+  it('grep supports --regex and --case-sensitive', async () => {
+    const rx = JSON.parse((await runCli(['grep', '^# ', '--regex'], { cwd: root })).stdout);
+    expect(rx.matches.map((m: { path: string }) => m.path)).toEqual(['notes/chlorophyll.md']);
+
+    // Case-sensitive lowercase "photosynthesis" skips the capitalized title/sentence.
+    const cs = JSON.parse((await runCli(['grep', 'photosynthesis', '--case-sensitive'], { cwd: root })).stdout);
+    expect(cs.total).toBe(1);
+    expect(cs.matches[0].path).toBe('notes/chlorophyll.md');
   });
 
   it('sql queries CSV tables and serializes DuckDB BigInt counts (exit 0)', async () => {

--- a/tests/main/llm/format-tool-call.test.ts
+++ b/tests/main/llm/format-tool-call.test.ts
@@ -17,6 +17,11 @@ describe('formatToolCall (#NEW)', () => {
       .toBe('🔎 Searching notes for **sparql**');
   });
 
+  it('shows the pattern for grep_notes', () => {
+    expect(formatToolCall('grep_notes', { pattern: '- [ ]' }))
+      .toBe('🔦 Grepping notes for **- [ ]**');
+  });
+
   it('shows the query for search_help', () => {
     expect(formatToolCall('search_help', { query: 'how do links work' }))
       .toBe('📖 Checking the docs for **how do links work**');

--- a/tests/main/llm/grep-notes-tool.test.ts
+++ b/tests/main/llm/grep-notes-tool.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { executeNotebaseTool, NOTEBASE_TOOLS } from '../../../src/main/llm/tools';
+import { projectContext } from '../../../src/main/project-context-types';
+
+describe('grep_notes tool', () => {
+  let root: string;
+  const ctx = () => projectContext(root);
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-grep-notes-'));
+    await fsp.writeFile(
+      path.join(root, 'alpha.md'),
+      'The mitochondrion is the powerhouse.\nTODO: cite this claim.\n',
+      'utf-8',
+    );
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(
+      path.join(root, 'notes', 'beta.md'),
+      'A MITOCHONDRION reference in Naples.\n- [ ] unfinished task\n',
+      'utf-8',
+    );
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('finds a literal substring case-insensitively across notes, as path:line: text', async () => {
+    const res = await executeNotebaseTool(ctx(), 'grep_notes', { pattern: 'mitochondrion' });
+    expect(res.isError).toBe(false);
+    expect(res.content).toContain('alpha.md:1: The mitochondrion is the powerhouse.');
+    expect(res.content).toContain('notes/beta.md:1: A MITOCHONDRION reference in Naples.');
+    expect(res.content).toMatch(/2 matches in 2 notes/);
+  });
+
+  it('honors case_sensitive', async () => {
+    const res = await executeNotebaseTool(ctx(), 'grep_notes', { pattern: 'MITOCHONDRION', case_sensitive: true });
+    expect(res.content).toContain('notes/beta.md:1:');
+    expect(res.content).not.toContain('alpha.md:1:');
+  });
+
+  it('treats the pattern as a literal (special characters need no escaping)', async () => {
+    const res = await executeNotebaseTool(ctx(), 'grep_notes', { pattern: '- [ ]' });
+    expect(res.content).toContain('notes/beta.md:2: - [ ] unfinished task');
+  });
+
+  it('supports regex when regex:true', async () => {
+    const res = await executeNotebaseTool(ctx(), 'grep_notes', { pattern: '^TODO:', regex: true });
+    expect(res.content).toContain('alpha.md:2: TODO: cite this claim.');
+    expect(res.content).not.toContain('beta.md');
+  });
+
+  it('reports no matches clearly', async () => {
+    const res = await executeNotebaseTool(ctx(), 'grep_notes', { pattern: 'zzz-not-present' });
+    expect(res.isError).toBe(false);
+    expect(res.content).toMatch(/No matches for literal "zzz-not-present"/);
+  });
+
+  it('caps output and reports the true total when truncated', async () => {
+    const res = await executeNotebaseTool(ctx(), 'grep_notes', { pattern: 'e', max_matches: 1 });
+    expect(res.content).toMatch(/showing the first 1/);
+    // header still reports the full count
+    expect(res.content).toMatch(/^\d+ matches in \d+ notes/);
+  });
+
+  it('requires a non-empty pattern', async () => {
+    const res = await executeNotebaseTool(ctx(), 'grep_notes', { pattern: '  ' });
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/pattern is required/);
+  });
+
+  it('is registered in the default conversation toolset', () => {
+    expect(NOTEBASE_TOOLS.map((t) => t.name)).toContain('grep_notes');
+  });
+});


### PR DESCRIPTION
Gives every agent a third, complementary retrieval mode alongside full-text (`search_notes`) and vector/semantic (`search_related` / `semantic_search`): **exact literal and regular-expression search over the raw note text**, like `grep` — across all three agent surfaces (in-app conversation, MCP, and the CLI).

## Why
The full-text index is lowercased, word-token, prefix+fuzzy — blind to case-sensitive matches, substrings, punctuation/symbols (`useEffect(`, `#tag`, `[[link]]`, `status:`), exact phrases, and structural/regex patterns, and it can't guarantee exhaustiveness. Semantic search is about meaning, not strings. `grep_notes` fills that gap — the mode an agent needs to **verify** whether something literally appears, **enumerate** structural matches (`- [ ]` tasks, `[[wiki-links]]`, `TODO`/`FIXME`, a `status:` property), or find a **known string** (an identifier, a URL, an exact quote). Workflow: semantic to discover → grep to pin exact occurrences → read.

## Implementation
One primitive, three surfaces. Wraps the existing `src/main/notebase/search-in-notes.ts` — the engine behind Find/Replace in Notes — as a read-only capability. **No new scanning code**: it inherits the ignore rules (`.git`, `node_modules`, `.minerva`, dotfiles) and path-safety, and stays index-free (always current). Literal by default (no escaping needed); regex opt-in; case-insensitive unless asked; uncompilable regex yields zero matches rather than throwing.

- **Conversation tool** (`src/main/llm/tools/grep-notes.ts`) — in the default toolset; returns `path:line: text`, capped (`max_matches`, default 50 / max 200) with a truncation notice reporting the true total; `🔦 Grepping notes for …` progress label.
- **MCP** (`src/cli/mcp.ts` + `Engine.grep`) — a `grep_notes` read tool returning **grounded JSON** (`{ pattern, total, truncated, matches: [{ path, line, text }] }`) for external fleet agents.
- **CLI** (`src/cli/run.ts`) — `minerva grep <pattern> [--regex] [--case-sensitive] [--limit n]`, same grounded JSON on stdout (pipes into jq). Every read engine method now has a CLI command.

## Tests
- `grep-notes-tool.test.ts` — the conversation tool over a temp vault (literal, case, special-chars `- [ ]`, regex, no-match, truncation cap, empty-pattern error, registration).
- `mcp.test.ts` — `grep_notes` in `tools/list` and a `tools/call` returning path+line-grounded matches.
- `run.test.ts` — `parseArgs` flags and `runCli grep` (literal `[[wiki-link]]` grounded with path+line, `--regex`, `--case-sensitive`).
- `format-tool-call` case. Verified the built CLI live against a real vault. Lint + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)