### PR TITLE
Website: fix empty docs links (point to the docs site)

### DIFF
--- a/website/about.html
+++ b/website/about.html
@@ -125,7 +125,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="#">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/features.html
+++ b/website/features.html
@@ -400,7 +400,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="#">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -89,7 +89,7 @@
     <p class="eyebrow">Where to go next</p>
     <h2>Once you're in</h2>
     <div class="grid">
-      <div class="card"><span class="em">📖</span><h3>Read the docs</h3><p>Keyboard shortcuts, skills, query syntax, import and export. <a href="#">Open the documentation →</a></p></div>
+      <div class="card"><span class="em">📖</span><h3>Read the docs</h3><p>Keyboard shortcuts, skills, query syntax, import and export. <a href="docs/index.html">Open the documentation →</a></p></div>
       <div class="card"><span class="em">🧰</span><h3>Explore the features</h3><p>The editor, the knowledge graph, sources, and the full skills library. <a href="features.html">See features →</a></p></div>
       <div class="card"><span class="em">✍️</span><h3>Follow along</h3><p>Notes on building Minerva and thinking with AI, on the Dancing with Robots Substack. <a href="#">Read the blog →</a></p></div>
     </div>
@@ -104,7 +104,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="https://github.com/dgriffith/ide-for-thought/releases/latest/download/Minerva-mac-arm64.dmg">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="#">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/index.html
+++ b/website/index.html
@@ -204,7 +204,7 @@
         <h4>Learn</h4>
         <a href="about.html">About</a>
         <a href="privacy.html">Privacy</a>
-        <a href="#">Docs</a>
+        <a href="docs/index.html">Docs</a>
         <a href="#">Dancing with Robots</a>
       </div>
       <div class="col">

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -101,7 +101,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="#">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>


### PR DESCRIPTION
## Problem

On the marketing site, the link to the documentation was an empty placeholder — `<a href="#">` — so clicking it did nothing. The docs site itself has already shipped at `website/docs/index.html`; nothing linked to it.

## Fix

Point every docs link at `docs/index.html` (the correct relative path from the root-level pages — the docs pages already reach back with `../`):

- The **"Open the documentation →"** CTA card on `getting-started.html`
- The footer **"Docs"** link in the *Learn* column on all five root pages (`index`, `about`, `features`, `privacy`, `getting-started`)

Unrelated placeholder links on the site (the "Dancing with Robots" blog, "build it from source") are intentionally left alone — this PR only fixes the docs links.

## Verification

- Grep confirms zero remaining `href="#"` docs links; all six now resolve to `docs/index.html`, which exists.
- Static HTML change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)