### PR TITLE
LLM: propose folder moves and deletes (#911 follow-up)

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -429,9 +429,13 @@ export function registerConversation(): void {
     withRootPath(async (rootPath, draft: import('../../shared/conversation-refactor-drafts').ConversationRefactorDraft) => {
       if (!draft?.fromPath || !draft?.toPath) throw new Error('FILE_REFACTOR_DRAFT: draft is missing fromPath/toPath');
       const ctx = projectContext(rootPath);
+      // A folder move (propose_folder_move sets isFolder) files a folder-refactor
+      // payload; a single-note move files note-refactor. Both re-plan at apply.
       const proposal = await approval.proposeWrite(ctx, {
         operationType: 'note_refactor',
-        payloads: [{ kind: 'note-refactor', fromPath: draft.fromPath, toPath: draft.toPath }],
+        payloads: [draft.isFolder
+          ? { kind: 'folder-refactor', fromPath: draft.fromPath, toPath: draft.toPath }
+          : { kind: 'note-refactor', fromPath: draft.fromPath, toPath: draft.toPath }],
         note: draft.note,
         conversationUri: `https://minerva.dev/ontology/thought#conversation/${draft.conversationId}`,
         proposedBy: `llm:conversation:${draft.conversationId}`,
@@ -480,13 +484,18 @@ export function registerConversation(): void {
       draft: import('../../shared/conversation-refactor-drafts').ConversationDeleteDraft,
       selected: string[],
     ) => {
-      if (!Array.isArray(selected) || selected.length === 0) {
+      // A folder delete (propose_folder_delete sets folderPath) is all-or-nothing:
+      // file ONE folder-delete for the whole tree, ignoring per-note selection.
+      // A per-note delete files one note-delete per selected path.
+      const ctx = projectContext(rootPath);
+      if (!draft?.folderPath && (!Array.isArray(selected) || selected.length === 0)) {
         return { proposalUri: null, applied: false };
       }
-      const ctx = projectContext(rootPath);
       const proposal = await approval.proposeWrite(ctx, {
         operationType: 'note_delete',
-        payloads: selected.map((path) => ({ kind: 'note-delete' as const, path })),
+        payloads: draft.folderPath
+          ? [{ kind: 'folder-delete' as const, path: draft.folderPath }]
+          : selected.map((path) => ({ kind: 'note-delete' as const, path })),
         note: draft.note,
         conversationUri: `https://minerva.dev/ontology/thought#conversation/${draft.conversationId}`,
         proposedBy: `llm:conversation:${draft.conversationId}`,

--- a/src/main/llm/apply-dispatch.ts
+++ b/src/main/llm/apply-dispatch.ts
@@ -12,7 +12,8 @@ import * as notebaseFs from '../notebase/fs';
 import * as search from '../search/index';
 import * as vectors from '../embeddings/vector-store';
 import { markPathHandled } from '../notebase/path-dedup';
-import { planRename, renameWithLinkRewrites } from '../notebase/rename';
+import { planRename, planFolderRename, renameWithLinkRewrites, listAllFiles } from '../notebase/rename';
+import { isIndexable } from '../notebase/indexable-files';
 import { setSourceProperties, readMeta, sourceMetaPath, restoreSourceMeta } from '../sources/source-meta-write';
 import type { ProjectContext } from '../project-context-types';
 import type { AppliedRecord, PayloadOf, ProposalPayload } from './proposal-types';
@@ -258,6 +259,98 @@ register<'note-delete'>({
       void vectors.indexNote(ctx, data.path, data.content);
     } catch (err) {
       console.warn(`[approval] note-delete rollback restore failed for ${data.path}:`, err);
+    }
+  },
+});
+
+register<'folder-refactor'>({
+  kind: 'folder-refactor',
+  apply: async (ctx, p): Promise<unknown> => {
+    // Capture pre-images of every note the folder move touches (relocated notes
+    // + inbound-rewritten referrers) BEFORE applying. planFolderRename also runs
+    // the guardrails (collision / into-self / not-a-folder) — it throws on
+    // violation. Assets (images/pdfs) don't need pre-images: rollback moves the
+    // whole folder back with a pure fs rename, relocating them verbatim.
+    const plan = await planFolderRename(ctx.rootPath, p.fromPath, p.toPath);
+    const preImages: Record<string, string> = {};
+    for (const a of plan.affectedNotes) preImages[a.path] = a.before;
+
+    const { transitions, rewrittenPaths } = await renameWithLinkRewrites(ctx.rootPath, p.fromPath, p.toPath, {
+      markPathHandled,
+      reindexHook: (relPath, content) => {
+        if (relPath.endsWith('.md')) { search.indexNote(ctx, relPath, content); void vectors.indexNote(ctx, relPath, content); }
+      },
+      removeHook: (relPath) => { search.removeNote(ctx, relPath); void vectors.removeNote(ctx, relPath); },
+    });
+    return { fromPath: p.fromPath, toPath: p.toPath, preImages, transitions, rewrittenPaths };
+  },
+  rollback: async (ctx, rollbackData) => {
+    const data = rollbackData as {
+      fromPath: string; toPath: string;
+      preImages: Record<string, string>;
+      transitions: { old: string; new: string }[];
+    };
+    // De-index the relocated notes at their new paths, move the whole folder
+    // back with a pure fs rename (no link rewrite — the pre-images below undo
+    // the link edits), then restore every captured pre-image verbatim.
+    for (const t of data.transitions) {
+      graph.removeNote(ctx, t.new); search.removeNote(ctx, t.new); void vectors.removeNote(ctx, t.new);
+    }
+    markPathHandled(data.fromPath);
+    markPathHandled(data.toPath);
+    try {
+      await notebaseFs.rename(ctx.rootPath, data.toPath, data.fromPath);
+    } catch (err) {
+      console.warn(`[approval] folder-refactor rollback move-back failed for ${data.toPath} → ${data.fromPath}:`, err);
+    }
+    for (const [relPath, content] of Object.entries(data.preImages)) {
+      try {
+        markPathHandled(relPath);
+        await notebaseFs.writeFile(ctx.rootPath, relPath, content);
+        await graph.indexNote(ctx, relPath, content);
+        search.indexNote(ctx, relPath, content);
+        void vectors.indexNote(ctx, relPath, content);
+      } catch (err) {
+        console.warn(`[approval] folder-refactor rollback restore failed for ${relPath}:`, err);
+      }
+    }
+  },
+});
+
+register<'folder-delete'>({
+  kind: 'folder-delete',
+  apply: async (ctx, p): Promise<unknown> => {
+    // Capture every file under the folder as bytes (round-trips notes AND
+    // binary assets), de-index its notes, then remove the folder recursively.
+    // The bytes let rollback recreate the whole tree verbatim.
+    const files = await listAllFiles(ctx.rootPath, p.path);
+    const captured: { path: string; bytes: Uint8Array }[] = [];
+    for (const f of files) {
+      captured.push({ path: f, bytes: await notebaseFs.readBinaryFile(ctx.rootPath, f) });
+      markPathHandled(f);
+      if (isIndexable(f)) { graph.removeNote(ctx, f); search.removeNote(ctx, f); void vectors.removeNote(ctx, f); }
+    }
+    markPathHandled(p.path);
+    await notebaseFs.deleteFolder(ctx.rootPath, p.path);
+    return { path: p.path, files: captured };
+  },
+  rollback: async (ctx, rollbackData) => {
+    const data = rollbackData as { path: string; files: { path: string; bytes: Uint8Array }[] };
+    // Recreate each captured file (writeBinaryFile makes parent dirs), then
+    // reindex the notes across graph/search/vectors.
+    for (const f of data.files) {
+      try {
+        markPathHandled(f.path);
+        await notebaseFs.writeBinaryFile(ctx.rootPath, f.path, f.bytes);
+        if (isIndexable(f.path)) {
+          const content = await notebaseFs.readFile(ctx.rootPath, f.path);
+          await graph.indexNote(ctx, f.path, content);
+          search.indexNote(ctx, f.path, content);
+          void vectors.indexNote(ctx, f.path, content);
+        }
+      } catch (err) {
+        console.warn(`[approval] folder-delete rollback restore failed for ${f.path}:`, err);
+      }
     }
   },
 });

--- a/src/main/llm/proposal-types.ts
+++ b/src/main/llm/proposal-types.ts
@@ -103,6 +103,24 @@ export type ProposalPayload =
       path: string;
     }
   | {
+      kind: 'folder-refactor';
+      /** Move/rename a whole folder. Every note under it moves (relative links
+       *  re-relativized) and every inbound wiki-link is rewritten via
+       *  `renameWithLinkRewrites` (already folder-aware); rollback moves the
+       *  folder back and restores captured pre-images (#911 follow-up). */
+      fromPath: string;
+      toPath: string;
+    }
+  | {
+      kind: 'folder-delete';
+      /** Delete a whole folder and everything under it. Apply captures every
+       *  file (notes as text, assets as bytes) as a pre-image so rollback can
+       *  recreate the tree verbatim. Inbound wiki-links from outside are left
+       *  dangling (matching the note-delete / manual-delete stance), with the
+       *  blast radius shown on the review card. */
+      path: string;
+    }
+  | {
       kind: 'note-rewrite';
       /** Overwrite an existing note's full content in place (#936). Apply
        *  captures the prior content as a pre-image so rollback can restore it

--- a/src/main/llm/tools/propose-folder-delete.ts
+++ b/src/main/llm/tools/propose-folder-delete.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from 'node:crypto';
+import nodeFs from 'node:fs/promises';
+import nodePath from 'node:path';
+import * as graph from '../../graph/index';
+import { projectContext } from '../../project-context-types';
+import { listAllFiles } from '../../notebase/rename';
+import type { ConversationDeleteDraft, DeleteDraftItem } from '../../../shared/conversation-refactor-drafts';
+import type { NotebaseTool, ToolContext, ToolCallbacks } from './types';
+
+/**
+ * propose_folder_delete — the folder counterpart to propose_note_delete. A
+ * folder delete is all-or-nothing, so unlike the per-note version it files ONE
+ * `folder-delete` proposal for the whole tree. The review card still lists the
+ * notes inside (with their inbound-link blast radius) + an asset count so the
+ * user sees exactly what's being removed. Never deletes — on Approve the
+ * renderer files + applies the `folder-delete` proposal (recoverable via
+ * rollback / git).
+ */
+async function runProposeFolderDelete(
+  ctx: ToolContext, input: unknown, callbacks: ToolCallbacks,
+): Promise<{ content: string; isError: boolean }> {
+  if (!callbacks.onDeleteDraft) {
+    return { content: 'propose_folder_delete is only available in conversation contexts.', isError: true };
+  }
+  if (!ctx.conversationId) {
+    return { content: 'propose_folder_delete requires a bound conversation id.', isError: true };
+  }
+  const { path: folderPath } = input as { path?: string };
+  if (typeof folderPath !== 'string' || !folderPath.trim()) return { content: 'path is required.', isError: true };
+  const dir = folderPath.trim().replace(/^\/+|\/+$/g, '');
+  if (!dir) return { content: 'Refusing to delete the project root.', isError: true };
+
+  let stat: import('node:fs').Stats;
+  try { stat = await nodeFs.stat(nodePath.join(ctx.rootPath, dir)); }
+  catch { return { content: `No such folder: ${dir}`, isError: true }; }
+  if (!stat.isDirectory()) return { content: `${dir} is a note, not a folder — use propose_note_delete.`, isError: true };
+
+  const allFiles = await listAllFiles(ctx.rootPath, dir);
+  const notes = allFiles.filter((f) => f.endsWith('.md'));
+  const assetCount = allFiles.length - notes.length;
+
+  const pctx = projectContext(ctx.rootPath);
+  // Inbound links from OUTSIDE the folder — these dangle once it's gone.
+  const blockers = graph.findExternalInboundLinks(pctx, notes);
+  const inboundByTarget = new Map<string, { source: string; sourceTitle: string; linkCount: number }[]>();
+  for (const b of blockers) {
+    const list = inboundByTarget.get(b.target) ?? [];
+    list.push({ source: b.source, sourceTitle: b.sourceTitle, linkCount: b.linkCount });
+    inboundByTarget.set(b.target, list);
+  }
+
+  const items: DeleteDraftItem[] = notes.map((p) => ({
+    path: p,
+    title: graph.noteTitle(pctx, p) || (p.split('/').pop() ?? p),
+    inbound: inboundByTarget.get(p) ?? [],
+  }));
+
+  const draft: ConversationDeleteDraft = {
+    draftId: `delete-${randomUUID()}`,
+    conversationId: ctx.conversationId,
+    note: `Delete folder ${dir}`,
+    items,
+    warnings: [],
+    folderPath: dir,
+    assetCount,
+    createdAt: new Date().toISOString(),
+  };
+  callbacks.onDeleteDraft(draft);
+
+  const danglingTotal = items.reduce((n, i) => n + i.inbound.length, 0);
+  return {
+    content: JSON.stringify({
+      status: 'drafted',
+      draftId: draft.draftId,
+      folder: dir,
+      notesInside: items.length,
+      assetsInside: assetCount,
+      notesWithInboundLinks: items.filter((i) => i.inbound.length > 0).length,
+      danglingLinkSources: danglingTotal,
+      hint: 'STOP. The folder deletion is queued for the user to review and approve — nothing has been deleted. ' +
+        'End the turn with one short acknowledgement and do NOT call this tool again this turn.',
+    }),
+    isError: false,
+  };
+}
+
+export const proposeFolderDelete: NotebaseTool = {
+  definition: {
+    name: 'propose_folder_delete',
+    description:
+      'Propose deleting a whole folder and everything inside it (notes AND assets) ' +
+      'for the user to review. Use during a cleanup when an entire folder is ' +
+      'redundant or superseded — deleting notes one-by-one would leave the folder ' +
+      'and its images/attachments behind. The user reviews a card listing the notes ' +
+      'inside, how many other notes link into them (those links will dangle), and ' +
+      'the asset count, then approves or discards. NOTHING is deleted until approved. ' +
+      'Never tell the user to delete a folder by hand — propose it here instead.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'The folder\'s thoughtbase-relative path (e.g. "notes/old-topic").' },
+      },
+      required: ['path'],
+    },
+  },
+  run: (ctx, input, callbacks) => runProposeFolderDelete(ctx, input, callbacks),
+};

--- a/src/main/llm/tools/propose-folder-move.ts
+++ b/src/main/llm/tools/propose-folder-move.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from 'node:crypto';
+import { planFolderRename, RefactorError } from '../../notebase/rename';
+import type { ConversationRefactorDraft } from '../../../shared/conversation-refactor-drafts';
+import type { NotebaseTool, ToolContext, ToolCallbacks } from './types';
+
+/**
+ * propose_folder_move — the folder counterpart to propose_note_move/rename.
+ * Dry-runs the folder move via `planFolderRename` (validates guardrails +
+ * computes the blast radius: every note that relocates + every note whose
+ * inbound links get rewritten), then forwards a refactor draft flagged
+ * `isFolder` for review. Never moves anything — on Approve the renderer files a
+ * `folder-refactor` proposal.
+ */
+async function runProposeFolderMove(
+  ctx: ToolContext, input: unknown, callbacks: ToolCallbacks,
+): Promise<{ content: string; isError: boolean }> {
+  if (!callbacks.onRefactorDraft) {
+    return { content: 'propose_folder_move is only available in conversation contexts.', isError: true };
+  }
+  if (!ctx.conversationId) {
+    return { content: 'propose_folder_move requires a bound conversation id.', isError: true };
+  }
+  const { path: folderPath, newPath } = input as { path?: string; newPath?: string };
+  if (typeof folderPath !== 'string' || !folderPath.trim()) return { content: 'path is required.', isError: true };
+  if (typeof newPath !== 'string' || !newPath.trim()) return { content: 'newPath is required (the folder\'s full destination path).', isError: true };
+  const from = folderPath.trim().replace(/^\/+|\/+$/g, '');
+  const to = newPath.trim().replace(/^\/+|\/+$/g, '');
+
+  let plan: Awaited<ReturnType<typeof planFolderRename>>;
+  try {
+    plan = await planFolderRename(ctx.rootPath, from, to);
+  } catch (e) {
+    if (e instanceof RefactorError) return { content: `Cannot move folder: ${e.message}`, isError: true };
+    throw e;
+  }
+
+  const notesMoved = plan.affectedNotes.filter((a) => a.isMoved).length;
+  const notesWithLinkRewrites = plan.affectedNotes.filter((a) => !a.isMoved).length;
+
+  const draft: ConversationRefactorDraft = {
+    draftId: `refactor-${randomUUID()}`,
+    conversationId: ctx.conversationId,
+    note: `Move folder ${from} → ${to}`,
+    fromPath: from,
+    toPath: to,
+    affectedNotes: plan.affectedNotes.map((a) => ({ path: a.path, before: a.before, after: a.after, isMoved: a.isMoved })),
+    isFolder: true,
+    createdAt: new Date().toISOString(),
+  };
+  callbacks.onRefactorDraft(draft);
+
+  return {
+    content: JSON.stringify({
+      status: 'drafted',
+      draftId: draft.draftId,
+      fromPath: from,
+      toPath: to,
+      notesMoved,
+      notesWithLinkRewrites,
+      hint: 'STOP. The folder move is queued for the user to review and approve — nothing has changed yet. ' +
+        'End the turn with one short acknowledgement and do NOT call this tool again this turn.',
+    }),
+    isError: false,
+  };
+}
+
+export const proposeFolderMove: NotebaseTool = {
+  definition: {
+    name: 'propose_folder_move',
+    description:
+      'Propose moving OR renaming a whole folder (and everything under it) for the ' +
+      'user to review. Use this instead of moving notes one-by-one when a folder ' +
+      'belongs somewhere else or should be renamed. Every note inside relocates and ' +
+      'all inbound wiki-links + relative paths are rewritten automatically on ' +
+      'approval; the user reviews a card showing the destination and the affected ' +
+      'notes. To move, give a `newPath` under a different parent (keep the last ' +
+      'segment); to rename, give a `newPath` with a different last segment. Use ' +
+      'list_notes first to see the folder structure. NOTHING moves until approved.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'The folder\'s current thoughtbase-relative path (e.g. "notes/old-topic").' },
+        newPath: { type: 'string', description: 'The folder\'s full destination path (e.g. "notes/archive/old-topic" to move, or "notes/new-topic" to rename).' },
+      },
+      required: ['path', 'newPath'],
+    },
+  },
+  run: (ctx, input, callbacks) => runProposeFolderMove(ctx, input, callbacks),
+};

--- a/src/main/llm/tools/registry.ts
+++ b/src/main/llm/tools/registry.ts
@@ -13,6 +13,8 @@ import { proposeNoteRename } from './propose-note-rename';
 import { proposeNoteMove } from './propose-note-move';
 import { proposeReorganization } from './propose-reorganization';
 import { proposeNoteDelete } from './propose-note-delete';
+import { proposeFolderMove } from './propose-folder-move';
+import { proposeFolderDelete } from './propose-folder-delete';
 import { proposeNoteBody } from './propose-note-body';
 import { proposeNotes } from './propose-notes';
 import { describeGraphSchema } from './describe-graph-schema';
@@ -43,6 +45,8 @@ const DEFAULT_TOOLS: NotebaseTool[] = [
   proposeNoteMove,
   proposeReorganization,
   proposeNoteDelete,
+  proposeFolderMove,
+  proposeFolderDelete,
   proposeNoteBody,
   proposeNotes,
   describeGraphSchema,

--- a/src/main/notebase/rename.ts
+++ b/src/main/notebase/rename.ts
@@ -35,7 +35,7 @@ async function listIndexableFiles(rootPath: string, relDir: string): Promise<str
  * etc — those need to be in the rewrites map so a sibling note's
  * `![alt](pic.png)` gets re-relativized when the folder moves.
  */
-async function listAllFiles(rootPath: string, relDir: string): Promise<string[]> {
+export async function listAllFiles(rootPath: string, relDir: string): Promise<string[]> {
   const results: string[] = [];
   const absDir = path.join(rootPath, relDir);
   try {
@@ -135,6 +135,80 @@ export async function planRename(rootPath: string, fromPath: string, toPath: str
     }
   }
   return { fromPath, toPath, affectedNotes, warnings: [] };
+}
+
+/**
+ * Folder generalization of {@link planRename} (#911 follow-up): compute what
+ * moving/renaming a whole folder would do — every note that moves (its own
+ * relative links re-relativized) plus every note that links *into* the folder
+ * (inbound wiki-links rewritten) — **without writing anything**. Returns the
+ * same `RenamePlan` shape as `planRename`, so the draft, the review card, and
+ * the proposal's pre-image capture all reuse it unchanged. Uses the same
+ * rewriter helpers + folder rewrite-map construction as
+ * `renameWithLinkRewrites`, so the preview matches the commit.
+ *
+ * Moved notes are always included in `affectedNotes` (even when their content
+ * doesn't change) so the apply can capture every relocated note's pre-image.
+ */
+export async function planFolderRename(rootPath: string, fromDir: string, toDir: string): Promise<RenamePlan> {
+  const from = fromDir.replace(/\/+$/, '');
+  const to = toDir.replace(/\/+$/, '');
+  if (!from) throw new RefactorError('Cannot move the project root.');
+  if (from === to) throw new RefactorError('The source and destination are the same.');
+  if (to.startsWith(`${from}/`)) throw new RefactorError('Cannot move a folder into itself.');
+
+  notebaseFs.assertSafePath(rootPath, from);
+  notebaseFs.assertSafePath(rootPath, to);
+
+  let stat: import('node:fs').Stats;
+  try { stat = await fs.stat(path.join(rootPath, from)); }
+  catch { throw new RefactorError(`The folder to move no longer exists: ${from}`); }
+  if (!stat.isDirectory()) throw new RefactorError('That path is a note, not a folder — use a note move instead.');
+  // Destination must not already exist.
+  let destExists = true;
+  try { await fs.stat(path.join(rootPath, to)); } catch { destExists = false; }
+  if (destExists) throw new RefactorError(`Something already exists at the destination: ${to}`);
+
+  const ctx = projectContext(rootPath);
+
+  // Wiki-link + markdown-link rewrite maps, built exactly as
+  // `renameWithLinkRewrites` does for a directory.
+  const descendants = await listIndexableFiles(rootPath, from);
+  const rewrites = new Map<string, string>();
+  for (const d of descendants) {
+    rewrites.set(normalizeLinkPath(d), normalizeLinkPath(to + d.slice(from.length)));
+  }
+  const mdRewrites = new Map<string, string>();
+  for (const d of await listAllFiles(rootPath, from)) {
+    mdRewrites.set(d, to + d.slice(from.length));
+  }
+
+  const referringNotes = new Set<string>();
+  for (const oldPath of rewrites.keys()) {
+    for (const p of graph.findNotesLinkingTo(ctx, `${oldPath}.md`)) referringNotes.add(p);
+  }
+
+  const movedSet = new Set(descendants);
+  const affectedNotes: AffectedNote[] = [];
+  for (const currentPath of await listIndexableFiles(rootPath, '')) {
+    const isMoved = movedSet.has(currentPath);
+    let content: string;
+    try { content = await notebaseFs.readFile(rootPath, currentPath); } catch { continue; }
+
+    let rewritten = content;
+    if (!isMoved && referringNotes.has(currentPath)) {
+      rewritten = rewriteWikiLinks(rewritten, rewrites);
+    }
+    // A moved note's authored relative links resolve against its OLD location;
+    // the new location is its mapped destination.
+    const newEquivalent = isMoved ? to + currentPath.slice(from.length) : currentPath;
+    rewritten = rewriteRelativeMarkdownLinks(rewritten, currentPath, newEquivalent, mdRewrites);
+
+    if (rewritten !== content || isMoved) {
+      affectedNotes.push({ path: currentPath, before: content, after: rewritten, isMoved });
+    }
+  }
+  return { fromPath: from, toPath: to, affectedNotes, warnings: [] };
 }
 
 export interface RenameWithLinksOptions {

--- a/src/renderer/lib/components/DeleteDraftCard.svelte
+++ b/src/renderer/lib/components/DeleteDraftCard.svelte
@@ -52,9 +52,13 @@
 
 <div class="draft-card">
   <div class="draft-summary">
-    <strong>Delete</strong>
+    <strong>{draft.folderPath ? 'Delete folder' : 'Delete'}</strong>
     <span class="draft-note">
-      {selectedItems.length} of {draft.items.length} note{draft.items.length === 1 ? '' : 's'}
+      {#if draft.folderPath}
+        <span class="path">{draft.folderPath}</span> · {draft.items.length} note{draft.items.length === 1 ? '' : 's'}{#if draft.assetCount}, {draft.assetCount} asset{draft.assetCount === 1 ? '' : 's'}{/if}
+      {:else}
+        {selectedItems.length} of {draft.items.length} note{draft.items.length === 1 ? '' : 's'}
+      {/if}
       {#if danglingSources > 0}
         · {danglingSources} other note{danglingSources === 1 ? '' : 's'} will have dangling links
       {/if}
@@ -69,21 +73,25 @@
     </div>
   {/if}
 
-  <button class="select-all" type="button" onclick={toggleAll}>
-    <Icon name={allSelected ? 'check' : 'dot'} size={11} />
-    {allSelected ? 'Deselect all' : 'Select all'}
-  </button>
+  {#if !draft.folderPath}
+    <button class="select-all" type="button" onclick={toggleAll}>
+      <Icon name={allSelected ? 'check' : 'dot'} size={11} />
+      {allSelected ? 'Deselect all' : 'Select all'}
+    </button>
+  {/if}
 
   <div class="items">
     {#each draft.items as item (item.path)}
-      {@const isSel = selected.has(item.path)}
+      {@const isSel = draft.folderPath ? true : selected.has(item.path)}
       {@const isExp = expanded.has(item.path)}
       {@const links = inboundCount(item)}
       <div class="item" class:deselected={!isSel}>
         <div class="item-row">
+          {#if !draft.folderPath}
           <label class="check">
             <input type="checkbox" checked={isSel} onchange={() => toggle(item.path)} />
           </label>
+          {/if}
           <span class="paths" title={item.path}>
             <span class="title">{item.title}</span>
             <span class="path">{item.path}</span>
@@ -111,8 +119,8 @@
   </div>
 
   <div class="draft-actions">
-    <button type="button" class="draft-btn primary" disabled={selectedItems.length === 0} onclick={approve}>
-      Delete {selectedItems.length}
+    <button type="button" class="draft-btn primary" disabled={!draft.folderPath && selectedItems.length === 0} onclick={approve}>
+      {draft.folderPath ? 'Delete folder' : `Delete ${selectedItems.length}`}
     </button>
     <button type="button" class="draft-btn" onclick={onDiscard}>Discard</button>
   </div>

--- a/src/renderer/lib/components/RefactorDraftCard.svelte
+++ b/src/renderer/lib/components/RefactorDraftCard.svelte
@@ -23,25 +23,35 @@
 
   const verb = $derived(refactorVerb(draft.fromPath, draft.toPath));
   const isRename = $derived(verb === 'Rename');
-  // Other notes whose inbound links get rewritten (excludes the moved note itself).
+  // Other notes whose inbound links get rewritten (excludes the moved note(s) itself).
   const otherNotes = $derived(draft.affectedNotes.filter((a) => !a.isMoved));
+  // Notes that relocate. For a single-note move that's the one note (not always
+  // in affectedNotes); for a folder move it's every note inside.
+  const movedNotes = $derived(draft.affectedNotes.filter((a) => a.isMoved));
+  const subject = $derived(draft.isFolder ? 'folder' : 'note');
 </script>
 
 <DraftCard
-  headline={verb}
+  headline={draft.isFolder ? `${verb} folder` : verb}
   note="{draft.fromPath} → {draft.toPath}"
-  approveLabel={isRename ? 'Approve & rename' : 'Approve & move'}
+  approveLabel={isRename ? `Approve & rename ${draft.isFolder ? 'folder' : ''}`.trim() : `Approve & move ${draft.isFolder ? 'folder' : ''}`.trim()}
   {onApprove}
   {onDiscard}
 >
   <div class="refactor-body">
+    {#if draft.isFolder}
+      <div class="blast">
+        <strong>{movedNotes.length}</strong> note{movedNotes.length === 1 ? '' : 's'} move{movedNotes.length === 1 ? 's' : ''} with the folder{#if otherNotes.length > 0}; <strong>{otherNotes.length}</strong> other note{otherNotes.length === 1 ? '' : 's'} will have links rewritten{/if}.
+      </div>
+    {:else}
     <div class="blast" class:none={otherNotes.length === 0}>
       {#if otherNotes.length === 0}
-        No other notes link here — only the note moves.
+        No other notes link here — only the {subject} moves.
       {:else}
         <strong>{otherNotes.length}</strong> note{otherNotes.length === 1 ? '' : 's'} will have links rewritten.
       {/if}
     </div>
+    {/if}
 
     {#if draft.affectedNotes.length > 0}
       <button class="toggle" type="button" onclick={() => (expanded = !expanded)}>

--- a/src/renderer/lib/components/conversations/DraftCards.svelte
+++ b/src/renderer/lib/components/conversations/DraftCards.svelte
@@ -93,8 +93,9 @@
   async function handleApproveRefactor(tabId: string, draft: ConversationRefactorDraft) {
     try {
       await store.approveRefactorDraft(tabId, draft);
-      // Land the user on the note at its new path.
-      void editor.openFile(draft.toPath);
+      // Land the user on the note at its new path. A folder move has no single
+      // file to open — the file tree refreshes from the watcher instead.
+      if (!draft.isFolder) void editor.openFile(draft.toPath);
     } catch (e) {
       console.error('[conv-panel] approve refactor failed:', e);
     }

--- a/src/shared/conversation-refactor-drafts.ts
+++ b/src/shared/conversation-refactor-drafts.ts
@@ -30,6 +30,10 @@ export interface ConversationRefactorDraft extends ConversationToolDraft {
   toPath: string;
   /** The dry-run blast radius — every note whose links would be rewritten. */
   affectedNotes: RefactorAffectedNote[];
+  /** True when `fromPath`/`toPath` are folders (propose_folder_move) rather than
+   *  a single note. The card labels it "Move folder" and the file handler files
+   *  a `folder-refactor` proposal instead of `note-refactor`. */
+  isFolder?: boolean;
 }
 
 /** One move/rename within a batch reorganization plan (#914). */
@@ -77,5 +81,13 @@ export interface ConversationDeleteDraft extends ConversationToolDraft {
   items: DeleteDraftItem[];
   /** Per-note problems surfaced before apply (missing file, not a note). */
   warnings: string[];
+  /** Set by propose_folder_delete: the folder being deleted whole. `items`
+   *  then lists the notes inside it (for the review card + inbound audit), but
+   *  the delete is all-or-nothing — the file handler files ONE `folder-delete`
+   *  proposal for `folderPath` rather than per-note `note-delete`s. */
+  folderPath?: string;
+  /** Count of non-note assets (images/pdfs/…) inside `folderPath` that will be
+   *  removed with it — surfaced on the card so the user knows. */
+  assetCount?: number;
 }
 

--- a/tests/main/llm/folder-move-delete-proposal.test.ts
+++ b/tests/main/llm/folder-move-delete-proposal.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { proposeWrite, approveProposal } from '../../../src/main/llm/approval';
+import { initGraph, indexNote, disposeProject as disposeGraph } from '../../../src/main/graph/index';
+import { initSearch, indexNote as searchIndex, disposeProject as disposeSearch } from '../../../src/main/search/index';
+import { projectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+const ctx = () => projectContext(root);
+const read = (rel: string) => fsp.readFile(path.join(root, rel), 'utf-8');
+const readBytes = (rel: string) => fsp.readFile(path.join(root, rel));
+const exists = (rel: string) => fs.existsSync(path.join(root, rel));
+
+async function seed(rel: string, body: string): Promise<void> {
+  const abs = path.join(root, rel);
+  await fsp.mkdir(path.dirname(abs), { recursive: true });
+  await fsp.writeFile(abs, body, 'utf-8');
+  await indexNote(ctx(), rel, body);
+  searchIndex(ctx(), rel, body);
+}
+
+/** A non-note binary asset inside the folder (an image) — not indexed. */
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01, 0x02, 0xff]);
+async function seedBinary(rel: string, bytes: Uint8Array): Promise<void> {
+  const abs = path.join(root, rel);
+  await fsp.mkdir(path.dirname(abs), { recursive: true });
+  await fsp.writeFile(abs, bytes);
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-folder-refactor-'));
+  await initGraph(ctx());
+  await initSearch(ctx());
+  // A folder with two linked notes + a binary asset, and an outside note that
+  // links into the folder.
+  await seed('topic/a.md', '# A\n\nSee [[topic/b]]. ![diagram](pic.png)');
+  await seed('topic/b.md', '# B\n\nThe B note.');
+  await seedBinary('topic/pic.png', PNG_BYTES);
+  await seed('outside.md', '# Outside\n\nRefers to [[topic/a]].');
+});
+afterEach(async () => {
+  disposeGraph(ctx());
+  disposeSearch(ctx());
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+describe('folder-refactor proposal (#911 follow-up)', () => {
+  function moveFolder(fromPath: string, toPath: string) {
+    return proposeWrite(ctx(), {
+      operationType: 'note_refactor',
+      payloads: [{ kind: 'folder-refactor', fromPath, toPath }],
+      note: `Move folder ${fromPath} → ${toPath}`,
+      proposedBy: 'unit-test',
+    });
+  }
+
+  it('files as pending — nothing moves until approval', async () => {
+    const p = await moveFolder('topic', 'archive/topic');
+    expect(p.status).toBe('pending');
+    expect(exists('topic/a.md')).toBe(true);
+    expect(exists('archive/topic/a.md')).toBe(false);
+  });
+
+  it('on approval moves the whole folder, its asset, and rewrites links', async () => {
+    const p = await moveFolder('topic', 'archive/topic');
+    expect((await approveProposal(ctx(), p.uri)).ok).toBe(true);
+
+    // Folder + all files relocated.
+    expect(exists('topic')).toBe(false);
+    expect(exists('archive/topic/a.md')).toBe(true);
+    expect(exists('archive/topic/b.md')).toBe(true);
+    expect(await readBytes('archive/topic/pic.png')).toEqual(Buffer.from(PNG_BYTES));
+
+    // Inbound wiki-link from outside rewritten; internal link re-pointed.
+    expect(await read('outside.md')).toContain('[[archive/topic/a]]');
+    expect(await read('outside.md')).not.toContain('[[topic/a]]');
+    expect(await read('archive/topic/a.md')).toContain('[[archive/topic/b]]');
+  });
+
+  it('rolls back exactly when a later payload fails — folder + asset + links verbatim', async () => {
+    const outsideBefore = await read('outside.md');
+    const aBefore = await read('topic/a.md');
+    const p = await proposeWrite(ctx(), {
+      operationType: 'note_refactor',
+      payloads: [
+        { kind: 'folder-refactor', fromPath: 'topic', toPath: 'archive/topic' },
+        { kind: 'graph-triples', turtle: 'this is not valid turtle @@@', affectsNodeUris: [] },
+      ],
+      note: 'folder move + bad triples',
+      proposedBy: 'unit-test',
+    });
+    await expect(approveProposal(ctx(), p.uri)).rejects.toThrow();
+
+    // Everything exactly as before: folder back, destination gone, links + asset verbatim.
+    expect(exists('archive/topic/a.md')).toBe(false);
+    expect(exists('topic/a.md')).toBe(true);
+    expect(await read('outside.md')).toBe(outsideBefore);
+    expect(await read('topic/a.md')).toBe(aBefore);
+    expect(await readBytes('topic/pic.png')).toEqual(Buffer.from(PNG_BYTES));
+  });
+
+  it('rejects a colliding destination at approval time', async () => {
+    await fsp.mkdir(path.join(root, 'archive/topic'), { recursive: true });
+    const p = await moveFolder('topic', 'archive/topic');
+    await expect(approveProposal(ctx(), p.uri)).rejects.toThrow(/already exists/);
+    expect(exists('topic/a.md')).toBe(true);
+  });
+});
+
+describe('folder-delete proposal (#911 follow-up)', () => {
+  function deleteFolder(p: string) {
+    return proposeWrite(ctx(), {
+      operationType: 'note_delete',
+      payloads: [{ kind: 'folder-delete', path: p }],
+      note: `Delete folder ${p}`,
+      proposedBy: 'unit-test',
+    });
+  }
+
+  it('files as pending — nothing deletes until approval', async () => {
+    const p = await deleteFolder('topic');
+    expect(p.status).toBe('pending');
+    expect(exists('topic/a.md')).toBe(true);
+  });
+
+  it('on approval removes the whole folder (notes + assets)', async () => {
+    const p = await deleteFolder('topic');
+    expect((await approveProposal(ctx(), p.uri)).ok).toBe(true);
+    expect(exists('topic')).toBe(false);
+    expect(exists('topic/a.md')).toBe(false);
+    expect(exists('topic/pic.png')).toBe(false);
+    // The outside note survives (its link now dangles — that's expected).
+    expect(exists('outside.md')).toBe(true);
+  });
+
+  it('rolls back exactly — recreates every note and the binary asset', async () => {
+    const aBefore = await read('topic/a.md');
+    const p = await proposeWrite(ctx(), {
+      operationType: 'note_delete',
+      payloads: [
+        { kind: 'folder-delete', path: 'topic' },
+        { kind: 'graph-triples', turtle: 'not valid @@@', affectsNodeUris: [] },
+      ],
+      note: 'folder delete + bad triples',
+      proposedBy: 'unit-test',
+    });
+    await expect(approveProposal(ctx(), p.uri)).rejects.toThrow();
+
+    // The whole tree is restored, including the binary asset byte-for-byte.
+    expect(await read('topic/a.md')).toBe(aBefore);
+    expect(exists('topic/b.md')).toBe(true);
+    expect(await readBytes('topic/pic.png')).toEqual(Buffer.from(PNG_BYTES));
+  });
+});

--- a/website/docs/refactoring-ai-assisted.html
+++ b/website/docs/refactoring-ai-assisted.html
@@ -97,8 +97,8 @@
     <p>Deletion works the same way, with a checkbox for each note. For every note you're about to remove, the card tells you how many other notes still link to it, so you can see the impact before approving. See <a href="refactoring-safe-delete.html">Safe delete &amp; dangling links</a> for more.</p>
 
     <div class="box">
-      <span class="label">Whole folders are done by hand</span>
-      <p>The assistant works on individual notes. To move or rename an entire folder at once, do it yourself by dragging it — see <a href="refactoring-manual.html">Manual rename, move &amp; delete</a>.</p>
+      <span class="label">Whole folders, too</span>
+      <p>The assistant can also propose moving, renaming, or deleting an <em>entire folder</em> at once — the review card shows every note that moves (or every note inside, for a delete), any links that would be rewritten or left dangling, and the count of images and other assets that come along. As always, nothing changes until you approve. Prefer to do it yourself? You still can — just drag it, see <a href="refactoring-manual.html">Manual rename, move &amp; delete</a>.</p>
     </div>
 
     <div class="pager">


### PR DESCRIPTION
Closes the gap you flagged: the AI's approval engine supported **single-note** moves/deletes but not **folder** moves/deletes (the manual drag path could). This adds both, at full parity, reusing the existing refactor/delete draft → review-card → approval flow — so **no new IPC channels** (nothing to add to the typed `ChannelMap` / ratchet).

## What the AI can now do
- `propose_folder_move` — move **or** rename a whole folder; every note inside relocates and all inbound wiki-links + relative paths are rewritten on approval.
- `propose_folder_delete` — delete a whole folder (notes **and** assets); the card lists the notes inside, their dangling-link blast radius, and the asset count.

Both are reviewed and approved exactly like the note versions, and nothing changes until you approve.

## How it works
- **`planFolderRename`** (rename.ts) — a folder generalization of `planRename`: walks the subtree, computes the moved notes + inbound-link rewrites + pre-images, and shares the same rewriter helpers as `renameWithLinkRewrites`, so the preview matches the commit.
- **Apply/rollback** (apply-dispatch.ts):
  - *Folder move* commits via the already-folder-aware `renameWithLinkRewrites`; rollback moves the folder back with a pure fs rename (assets ride along) and restores note pre-images to undo the link edits.
  - *Folder delete* captures **every file as bytes** (notes and binary assets), and its rollback recreates the whole tree verbatim.
- **Reuse**: the tools set `isFolder` / `folderPath` on the existing refactor/delete drafts; the file-draft handlers file `folder-refactor` / `folder-delete` payloads accordingly; the cards relabel for folders and (for the all-or-nothing folder delete) drop the per-note toggles and show the asset count.

Because folder ops go through `proposeWrite`/`approveProposal` like everything else, the trust invariant (LLM writes only via the approval engine) holds.

## Tests
`tests/main/llm/folder-move-delete-proposal.test.ts` (7):
- Files as pending; on approval moves/deletes the whole folder + its asset + rewrites links.
- **Exact rollback** when a later bundle payload fails — folder back, links verbatim, and the **binary asset restored byte-for-byte**.
- Colliding-destination guard.

`pnpm lint` clean; `pnpm test` green — **4409 tests** (7 new).

## Docs
`refactoring-ai-assisted.html` updated — the assistant now handles whole folders (it previously said folders were manual-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)