### PR TITLE
Compute: make the trust gate a real boundary + fix propose_compute bypass (#1411)

### DIFF
--- a/src/main/compute/trust.ts
+++ b/src/main/compute/trust.ts
@@ -1,0 +1,30 @@
+/**
+ * Compute-trust enforcement boundary (#1411).
+ *
+ * The per-project "run compute cells" consent used to be a renderer-only UX
+ * prompt (`runCellWithTrust`) — main's executor ran unconditionally, so any code
+ * path that reached the IPC (notably `propose_compute`'s Run) executed with no
+ * gate at all. This moves the CHECK into main: every renderer-reachable
+ * execution entry point calls this first, so the renderer prompt now *grants*
+ * trust rather than *being* the gate. A caller that forgets to prompt is
+ * refused, not silently run.
+ *
+ * This does not reduce capability (that's the sandbox, #1329) — it makes the
+ * existing consent a real boundary and closes the AI-authored-cell bypass.
+ */
+import { getPythonTrust } from '../project-config';
+import type { CellResult } from '../../shared/compute/types';
+
+const UNTRUSTED_ERROR =
+  'Compute is not trusted for this thoughtbase. Run a cell from the editor and approve the ' +
+  'prompt (or enable it in Settings → Compute) before running code here.';
+
+/**
+ * Guard a compute execution: returns an error `CellResult` to short-circuit the
+ * caller when the project has not granted compute trust, or `null` when it's
+ * trusted and execution may proceed.
+ */
+export function computeTrustGuard(rootPath: string): CellResult | null {
+  if (getPythonTrust(rootPath)) return null;
+  return { ok: false, error: UNTRUSTED_ERROR };
+}

--- a/src/main/ipc/register-compute.ts
+++ b/src/main/ipc/register-compute.ts
@@ -3,6 +3,7 @@ import { Channels } from '../../shared/channels';
 import { handle } from './typed-ipc';
 import { getPythonTrust, setPythonTrust } from '../project-config';
 import { runCell as runComputeCell, registeredLanguages as computeLanguages } from '../compute/registry';
+import { computeTrustGuard } from '../compute/trust';
 import { restartKernel as restartPythonKernel, interruptKernel as interruptPythonKernel } from '../compute/python-kernel';
 import {
   getPythonSettings,
@@ -25,6 +26,10 @@ export {
 
 export function registerCompute(): void {
   handle(Channels.COMPUTE_RUN_CELL, withRootPath(async (rootPath, language: string, code: string, notePath?: string) => {
+    // Enforcement boundary (#1411): refuse to execute an untrusted project even
+    // if a caller reached the IPC without the renderer trust prompt.
+    const guard = computeTrustGuard(rootPath);
+    if (guard) return guard;
     return await runComputeCell(language, code, { rootPath, ...(notePath !== undefined ? { notePath } : {}) });
   }));
 

--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -10,6 +10,7 @@ import { privilegedFetch } from '../privileged-sites';
 import { ttlString } from '../sources/source-meta-write';
 import { fileSourceProperties } from '../llm/source-properties';
 import { runCell as runComputeCell } from '../compute/registry';
+import { computeTrustGuard } from '../compute/trust';
 import { buildExcerptTtl } from '../sources/create-excerpt';
 import { slugify } from '../../shared/slug';
 import { applyPropertyUpdates } from '../llm/set-properties';
@@ -792,6 +793,10 @@ export function registerConversation(): void {
       const codeToRun = editedCode ?? draft.code;
       console.log(`[conv] RUN_COMPUTE_DRAFT lang=${draft.language} draftId=${draft.draftId}`);
       const ctx = projectContext(rootPath);
+      // Enforcement boundary (#1411): an AI-drafted cell must not run in an
+      // untrusted project — the renderer grants trust before reaching here.
+      const guard = computeTrustGuard(rootPath);
+      if (guard) return { result: guard };
       const result = await runComputeCell(draft.language, codeToRun, { rootPath });
       // Append the result to the conversation log as a user-role
       // message so the LLM's next turn sees it as context. Format

--- a/src/renderer/lib/compute/run-cell-with-trust.ts
+++ b/src/renderer/lib/compute/run-cell-with-trust.ts
@@ -73,29 +73,40 @@ export interface TrustGateDeps {
  * through the per-project trust prompt (#1325). Non-executable
  * languages pass through unchanged.
  */
+/**
+ * Ensure the project has granted compute trust before an executable cell runs
+ * (#1325, #1411). Returns true when execution may proceed (non-gated language,
+ * already trusted, or the user just approved the prompt) and false when the user
+ * declined. Shared by every run entry point — the editor's ▶ gutter AND the
+ * conversation's propose_compute Run — so AI-drafted cells hit the same gate.
+ * Main independently refuses an untrusted run (see compute/trust.ts), so this is
+ * the consent/UX half of a real boundary, not the boundary itself.
+ */
+export async function ensureComputeTrust(language: string, deps: TrustGateDeps): Promise<boolean> {
+  if (!TRUST_GATED_LANGUAGES.has(language.toLowerCase())) return true;
+  if (await api.compute.getPythonTrust()) return true;
+  const confirmed = await deps.showConfirm(
+    COMPUTE_TRUST_PROMPT,
+    CONFIRM_KEYS.pythonTrust,
+    'Run',
+    { hideDontAskAgain: true },
+  );
+  if (!confirmed) return false;
+  await api.compute.setPythonTrust(true);
+  return true;
+}
+
 export async function runCellWithTrust(
   language: string,
   code: string,
   notePath: string | undefined,
   deps: TrustGateDeps,
 ): Promise<CellResult> {
-  if (TRUST_GATED_LANGUAGES.has(language.toLowerCase())) {
-    const trusted = await api.compute.getPythonTrust();
-    if (!trusted) {
-      const confirmed = await deps.showConfirm(
-        COMPUTE_TRUST_PROMPT,
-        CONFIRM_KEYS.pythonTrust,
-        'Run',
-        { hideDontAskAgain: true },
-      );
-      if (!confirmed) {
-        return {
-          ok: false,
-          error: 'Compute execution declined for this thoughtbase. Open Settings → Compute or re-run a cell to be prompted again.',
-        };
-      }
-      await api.compute.setPythonTrust(true);
-    }
+  if (!(await ensureComputeTrust(language, deps))) {
+    return {
+      ok: false,
+      error: 'Compute execution declined for this thoughtbase. Open Settings → Compute or re-run a cell to be prompted again.',
+    };
   }
   return api.compute.runCell(language, code, notePath);
 }

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -1,5 +1,7 @@
 import { api } from '../ipc/client';
 import { getConversationsSettings } from '../conversations/settings';
+import { ensureComputeTrust } from '../compute/run-cell-with-trust';
+import { getDialogStore } from './dialogs.svelte';
 import type {
   Conversation,
   ContextBundle,
@@ -969,6 +971,13 @@ async function runComputeDraft(
 ): Promise<void> {
   const tab = findTab(tabId);
   if (!tab) return;
+  // Trust gate (#1411): an AI-drafted cell must clear the same per-project
+  // consent prompt as an editor cell before it runs. Main independently refuses
+  // an untrusted run, but prompt here so the user gets the dialog instead of a
+  // bare refusal error. Declining leaves the draft un-run.
+  if (!(await ensureComputeTrust(draft.language, { showConfirm: getDialogStore().showConfirm }))) {
+    return;
+  }
   const state = tab.computeDraftState[draft.draftId];
   if (state) {
     // Mark in-flight so the panel can render a spinner + disable buttons.

--- a/tests/main/compute/trust-guard.test.ts
+++ b/tests/main/compute/trust-guard.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Compute-trust enforcement boundary (#1411).
+ *
+ * The trust check now lives in MAIN, so an execution entry point that reaches
+ * the IPC without the renderer prompt is refused — not silently run. This is
+ * what makes the consent an actual boundary rather than renderer UX (and what
+ * closes the propose_compute Run bypass).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { computeTrustGuard } from '../../../src/main/compute/trust';
+import { getPythonTrust, setPythonTrust } from '../../../src/main/project-config';
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-compute-trust-'));
+});
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('computeTrustGuard (#1411)', () => {
+  it('an untrusted project defaults to refused (getPythonTrust is false)', () => {
+    expect(getPythonTrust(root)).toBe(false);
+    const guard = computeTrustGuard(root);
+    expect(guard).not.toBeNull();
+    expect(guard?.ok).toBe(false);
+    if (guard && !guard.ok) expect(guard.error).toMatch(/not trusted/i);
+  });
+
+  it('once trust is granted, the guard lets execution proceed (returns null)', () => {
+    setPythonTrust(root, true);
+    expect(computeTrustGuard(root)).toBeNull();
+  });
+
+  it('revoking trust re-arms the guard', () => {
+    setPythonTrust(root, true);
+    expect(computeTrustGuard(root)).toBeNull();
+    setPythonTrust(root, false);
+    expect(computeTrustGuard(root)).not.toBeNull();
+  });
+});

--- a/tests/renderer/run-cell-with-trust.test.ts
+++ b/tests/renderer/run-cell-with-trust.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { runCellWithTrust } from '../../src/renderer/lib/compute/run-cell-with-trust';
+import { runCellWithTrust, ensureComputeTrust } from '../../src/renderer/lib/compute/run-cell-with-trust';
 import { CONFIRM_KEYS } from '../../src/renderer/lib/confirm-keys';
 
 const trustState = { trusted: false };
@@ -149,5 +149,43 @@ describe('runCellWithTrust (#373, #1325)', () => {
     await runCellWithTrust('python', 'b = 2', 'note.md', { showConfirm });
     expect(showConfirm).toHaveBeenCalledTimes(1);
     expect(calls.runCell).toHaveLength(2);
+  });
+});
+
+/**
+ * ensureComputeTrust is the shared consent gate the propose_compute Run path now
+ * routes through (#1411), so an AI-drafted cell hits the same per-project prompt
+ * as an editor cell rather than executing unprompted.
+ */
+describe('ensureComputeTrust (#1411 — the conversation Run gate)', () => {
+  it('untrusted python prompts; Run grants trust and clears to proceed', async () => {
+    const showConfirm = vi.fn(() => Promise.resolve(true));
+    const ok = await ensureComputeTrust('python', { showConfirm });
+    expect(ok).toBe(true);
+    expect(showConfirm).toHaveBeenCalledTimes(1);
+    expect(calls.setTrust).toEqual([true]);
+  });
+
+  it('untrusted python + Cancel returns false and grants nothing', async () => {
+    const showConfirm = vi.fn(() => Promise.resolve(false));
+    const ok = await ensureComputeTrust('python', { showConfirm });
+    expect(ok).toBe(false);
+    expect(calls.setTrust).toEqual([]);
+  });
+
+  it('already-trusted proceeds without prompting', async () => {
+    trustState.trusted = true;
+    const showConfirm = vi.fn(() => Promise.resolve(true));
+    const ok = await ensureComputeTrust('python', { showConfirm });
+    expect(ok).toBe(true);
+    expect(showConfirm).not.toHaveBeenCalled();
+  });
+
+  it('a non-executable language is never gated', async () => {
+    const showConfirm = vi.fn(() => Promise.resolve(true));
+    const ok = await ensureComputeTrust('mermaid', { showConfirm });
+    expect(ok).toBe(true);
+    expect(showConfirm).not.toHaveBeenCalled();
+    expect(calls.getTrust).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #1411. First near-term step of the #1329 sequencing — the cheap, clearly-correct one. This is **consent enforcement only**; it does not reduce capability (that's the OS sandbox, #1329).

## The gap
The per-project compute-trust prompt (`runCellWithTrust`) was a **renderer-side UX gate, not a boundary**: `src/main`'s `runComputeCell` executed unconditionally for any IPC caller, and **`propose_compute`'s Run path bypassed the gate entirely** — an AI-drafted cell ran with *no* prompt, not even the sticky per-project one.

## The fix
Move the check into **main**, so the renderer prompt *grants* trust rather than *being* it:

- **`src/main/compute/trust.ts`** — `computeTrustGuard(rootPath)` returns an error `CellResult` when the project hasn't granted compute trust, else `null`.
- **`COMPUTE_RUN_CELL`** (editor) and **`CONVERSATION_RUN_COMPUTE_DRAFT`** (propose_compute Run) both call the guard before executing — every renderer-reachable path is refused when untrusted. (Enforced at the IPC handlers, not inside the pure `runCell` executor, so direct/internal callers and tests are unaffected.)
- **`run-cell-with-trust.ts`** — extracted `ensureComputeTrust` (the prompt + grant), now shared by the editor's ▶ gutter **and** the conversation Run path.
- **conversations store `runComputeDraft`** — routes through `ensureComputeTrust` (via the dialogs store's `showConfirm`), so an AI-drafted cell hits the same per-project prompt as an editor cell; declining leaves it un-run (and main would refuse it anyway).

## Verification
- `computeTrustGuard`: untrusted → refused, granted → allowed, re-arms on revoke.
- `ensureComputeTrust`: prompts when untrusted, grants on Run, returns false on Cancel, skips non-executable languages.
- Existing `runCellWithTrust` suite still green (it now delegates to `ensureComputeTrust`).
- `pnpm lint` clean; `pnpm test` — **4409 tests**.

Follow-ups tracked separately: provenance/eyes-on-code consent (#1412), trust UX + fresh/shared detection + network-off (#1413), and the OS sandbox endgame (#1329).