### PR TITLE
Compute: block network egress from Python cells by default (#1413)

### DIFF
--- a/resources/python/minerva_kernel.py
+++ b/resources/python/minerva_kernel.py
@@ -45,6 +45,71 @@ _project_root = os.environ.get('MINERVA_PROJECT_ROOT')
 if _project_root and _project_root not in sys.path:
     sys.path.insert(1, _project_root)
 
+
+_LOCAL_HOSTS = frozenset({'127.0.0.1', '::1', 'localhost', '', '0.0.0.0'})
+
+
+def _is_local_address(address):
+    """True for addresses the network guard always permits (#1413).
+
+    AF_UNIX addresses are a str/bytes path (not a tuple) — always local; this is
+    how the kernel's own RPC channel to the main process rides, so it must never
+    be blocked. AF_INET/AF_INET6 addresses are a `(host, port, ...)` tuple; we
+    permit loopback only.
+    """
+    if not isinstance(address, tuple) or not address:
+        return True
+    host = address[0]
+    if host in _LOCAL_HOSTS:
+        return True
+    # 127.0.0.0/8 is entirely loopback.
+    return isinstance(host, str) and host.startswith('127.')
+
+
+def install_network_guard():
+    """Block outbound network from user cells unless explicitly allowed (#1413).
+
+    Defense-in-depth, NOT a hard sandbox. A determined cell can still shell out
+    (`subprocess`) or re-enter libc via `ctypes`; real capability containment is
+    the OS sandbox (#1329). But nearly every *accidental* or LLM-authored
+    exfiltration path — `requests`, `urllib`, `http.client`, a raw socket,
+    `pandas.read_csv('https://…')` — funnels through `socket.connect`, so
+    guarding it there makes "phone home" fail by default. Loopback + AF_UNIX
+    stay open so the kernel's RPC channel and localhost dev services keep working.
+
+    Enabled unless MINERVA_ALLOW_NETWORK == '1' (the Settings → Compute toggle).
+    """
+    if os.environ.get('MINERVA_ALLOW_NETWORK') == '1':
+        return
+    import socket
+
+    orig_connect = socket.socket.connect
+    orig_connect_ex = socket.socket.connect_ex
+
+    def _blocked(address):
+        raise OSError(
+            'Network access is disabled for Minerva compute cells. Enable it in '
+            'Settings → Compute if you trust this code (host: {!r}).'.format(
+                address[0] if isinstance(address, tuple) and address else address
+            )
+        )
+
+    def guarded_connect(self, address):
+        if not _is_local_address(address):
+            _blocked(address)
+        return orig_connect(self, address)
+
+    def guarded_connect_ex(self, address):
+        if not _is_local_address(address):
+            _blocked(address)
+        return orig_connect_ex(self, address)
+
+    socket.socket.connect = guarded_connect
+    socket.socket.connect_ex = guarded_connect_ex
+
+
+install_network_guard()
+
 namespaces = {}
 
 

--- a/src/main/compute/python-kernel.ts
+++ b/src/main/compute/python-kernel.ts
@@ -22,7 +22,7 @@ import { app } from 'electron';
 import { randomUUID } from 'node:crypto';
 import type { CellOutput, CellResult, KernelMimeBundle } from '../../shared/compute/types';
 import { startRpcServer, type RpcServer } from './rpc-server';
-import { resolvePythonInterpreter } from './python-settings';
+import { resolvePythonInterpreter, getPythonSettings } from './python-settings';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 
@@ -99,6 +99,9 @@ export function kernelScriptPath(): string {
 
 async function spawnKernel(rootPath: string): Promise<KernelState> {
   const py = await resolvePythonBin();
+  // Network posture is read at spawn time (#1413) — so toggling it in Settings
+  // takes effect on the next kernel start / restart, not mid-session.
+  const { allowNetwork } = await getPythonSettings();
   const script = kernelScriptPath();
   // RPC server up first so the kernel can connect on first import.
   const rpc = await startRpcServer(rootPath);
@@ -123,6 +126,10 @@ async function spawnKernel(rootPath: string): Promise<KernelState> {
       PYTHONPATH: pythonResourcesRoot() + path.delimiter + rootPath,
       MINERVA_IPC_SOCKET: rpc.socketPath,
       MINERVA_PROJECT_ROOT: rootPath,
+      // Network egress off by default (#1413). The kernel bootstrap installs a
+      // socket guard unless this is exactly '1'; the RPC channel + loopback are
+      // always allowed so the guard never severs the kernel's own connection.
+      ...(allowNetwork ? { MINERVA_ALLOW_NETWORK: '1' } : {}),
       // Force matplotlib's non-interactive Agg backend (#243). Without
       // this, importing pyplot on macOS spawns a Cocoa GUI process
       // that bounces in the dock and leaks across app sessions; we

--- a/src/main/compute/python-settings.ts
+++ b/src/main/compute/python-settings.ts
@@ -26,6 +26,14 @@ export interface PythonSettings {
    * PATH lookup in that case.
    */
   pythonPath: string;
+  /**
+   * Allow compute cells to make outbound network connections (#1413).
+   * Off by default: the kernel installs a socket guard that blocks
+   * non-local connections (the common exfiltration path — `requests`,
+   * `urllib`, `pandas.read_csv(url)`) unless this is on. Per-machine,
+   * like `pythonPath`.
+   */
+  allowNetwork: boolean;
 }
 
 export interface PythonProbeResult {
@@ -38,7 +46,7 @@ export interface PythonProbeResult {
   error?: string;
 }
 
-const DEFAULT_SETTINGS: PythonSettings = { pythonPath: '' };
+const DEFAULT_SETTINGS: PythonSettings = { pythonPath: '', allowNetwork: false };
 
 function settingsPath(): string {
   return path.join(app.getPath('userData'), 'python-settings.json');
@@ -50,6 +58,9 @@ export async function getPythonSettings(): Promise<PythonSettings> {
     const parsed = JSON.parse(raw) as Partial<PythonSettings>;
     return {
       pythonPath: typeof parsed.pythonPath === 'string' ? parsed.pythonPath : '',
+      // Default off — only a literal `true` enables network, so a corrupt or
+      // truthy-non-bool value fails closed (matches the consent gate's posture).
+      allowNetwork: parsed.allowNetwork === true,
     };
   } catch {
     return { ...DEFAULT_SETTINGS };
@@ -57,7 +68,11 @@ export async function getPythonSettings(): Promise<PythonSettings> {
 }
 
 export async function setPythonSettings(settings: PythonSettings): Promise<void> {
-  await fs.writeFile(settingsPath(), JSON.stringify(settings, null, 2), 'utf-8');
+  await fs.writeFile(
+    settingsPath(),
+    JSON.stringify({ pythonPath: settings.pythonPath, allowNetwork: settings.allowNetwork === true }, null, 2),
+    'utf-8',
+  );
 }
 
 /**

--- a/src/main/ipc/register-compute.ts
+++ b/src/main/ipc/register-compute.ts
@@ -48,6 +48,7 @@ export function registerCompute(): void {
   handle(Channels.COMPUTE_SET_PYTHON_SETTINGS, async (_e, settings: PythonSettings) => {
     await setPythonSettings({
       pythonPath: typeof settings?.pythonPath === 'string' ? settings.pythonPath : '',
+      allowNetwork: settings?.allowNetwork === true,
     });
   });
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -178,7 +178,7 @@ contextBridge.exposeInMainWorld('api', {
     restartPythonKernel: () => invoke(Channels.COMPUTE_RESTART_PYTHON_KERNEL),
     interruptPythonKernel: () => invoke(Channels.COMPUTE_INTERRUPT_PYTHON),
     getPythonSettings: () => invoke(Channels.COMPUTE_GET_PYTHON_SETTINGS),
-    setPythonSettings: (settings: { pythonPath: string }) =>
+    setPythonSettings: (settings: { pythonPath: string; allowNetwork: boolean }) =>
       invoke(Channels.COMPUTE_SET_PYTHON_SETTINGS, settings),
     probePython: (candidate?: string) =>
       invoke(Channels.COMPUTE_PROBE_PYTHON, candidate),

--- a/src/renderer/lib/components/ComputeSettings.svelte
+++ b/src/renderer/lib/components/ComputeSettings.svelte
@@ -40,12 +40,16 @@
   let pythonPathSaved = $state('');
   let pythonProbe = $state<{ ok: boolean; path: string; version?: string; error?: string } | null>(null);
   let pythonProbing = $state(false);
+  /** Network egress toggle (#1413). Off by default; the kernel blocks non-local
+   *  sockets unless this is on. Applied when the kernel next starts. */
+  let allowNetwork = $state(false);
 
   async function loadComputeSettings(): Promise<void> {
     try {
       const s = await api.compute.getPythonSettings();
       pythonPathInput = s.pythonPath;
       pythonPathSaved = s.pythonPath;
+      allowNetwork = s.allowNetwork;
       // Probe whatever the resolver would currently pick so the status line
       // reflects the live state, not just the override.
       await refreshPythonProbe();
@@ -79,11 +83,23 @@
 
   async function savePythonPath(): Promise<void> {
     try {
-      await settings.setPythonSettings({ pythonPath: pythonPathInput.trim() });
+      await settings.setPythonSettings({ pythonPath: pythonPathInput.trim(), allowNetwork });
       pythonPathSaved = pythonPathInput.trim();
       await refreshPythonProbe();
     } catch (e) {
       pythonProbe = { ok: false, path: pythonPathInput, error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
+  /** Persist the network toggle immediately (#1413). Takes effect when the
+   *  kernel next starts — the hint tells the user to restart to apply now. */
+  async function saveNetworkSetting(): Promise<void> {
+    try {
+      await settings.setPythonSettings({ pythonPath: pythonPathSaved, allowNetwork });
+    } catch (e) {
+      console.error('[settings] failed to save network setting:', e);
+      // Revert the optimistic toggle so the UI reflects what's on disk.
+      allowNetwork = !allowNetwork;
     }
   }
 
@@ -182,6 +198,27 @@
     pipeline. After changing the interpreter, click
     <em>Save &amp; Restart Kernel</em> so the next cell runs
     against the new env.
+  </p>
+</div>
+
+<div class="field toggle-field">
+  <label class="toggle-row">
+    <input
+      type="checkbox"
+      bind:checked={allowNetwork}
+      onchange={() => { void saveNetworkSetting(); }}
+    />
+    <span>Allow network access for Python cells</span>
+  </label>
+  <p class="hint">
+    Off by default. The kernel blocks outbound connections
+    (<code>requests</code>, <code>urllib</code>,
+    <code>pandas.read_csv(url)</code>, raw sockets) to everything but
+    <code>localhost</code>, so a cell can't quietly send your data
+    elsewhere — the scariest thing an unreviewed cell could do. Turn this
+    on only if you trust the code you run to reach the network. Takes
+    effect when the kernel next starts; use
+    <em>Save &amp; Restart Kernel</em> above to apply now.
   </p>
 </div>
 
@@ -328,6 +365,23 @@
     gap: 6px;
     align-items: center;
     margin: 8px 0;
+  }
+
+  /* Network toggle (#1413). */
+  .toggle-field {
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border);
+  }
+  .toggle-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+  }
+  .toggle-row input[type="checkbox"] {
+    margin: 0;
+    accent-color: var(--accent);
   }
 
   /* Trusted-thoughtbases list (#1413). */

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -404,8 +404,8 @@ export interface ComputeApi {
    * Electron's userData dir, NOT in the project — the override is
    * machine-scoped (different projects on the same machine share it).
    */
-  getPythonSettings(): Promise<{ pythonPath: string }>;
-  setPythonSettings(settings: { pythonPath: string }): Promise<void>;
+  getPythonSettings(): Promise<{ pythonPath: string; allowNetwork: boolean }>;
+  setPythonSettings(settings: { pythonPath: string; allowNetwork: boolean }): Promise<void>;
   /**
    * Probe a candidate interpreter — verify it runs + capture the
    * version string. Empty / omitted `candidate` probes the active

--- a/src/renderer/lib/stores/settings.svelte.ts
+++ b/src/renderer/lib/stores/settings.svelte.ts
@@ -48,7 +48,7 @@ export function getSettingsStore() {
     setSkillsMenuConfig: (config: MenuConfig) => api.skills.setMenuConfig(config),
 
     // ── Compute (Python) ──────────────────────────────────────────────────
-    setPythonSettings: (settings: { pythonPath: string }) =>
+    setPythonSettings: (settings: { pythonPath: string; allowNetwork: boolean }) =>
       api.compute.setPythonSettings(settings),
     restartPythonKernel: () => api.compute.restartPythonKernel(),
     /** Revoke a thoughtbase's compute trust (#1413) — its cells prompt

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -296,8 +296,8 @@ export interface ChannelMap {
   'compute:interruptPython': () =>
     | { ok: true }
     | { ok: false; reason: 'no-kernel' | 'unsupported-platform' | 'signal-failed' };
-  'compute:getPythonSettings': () => { pythonPath: string };
-  'compute:setPythonSettings': (settings: { pythonPath: string }) => void;
+  'compute:getPythonSettings': () => { pythonPath: string; allowNetwork: boolean };
+  'compute:setPythonSettings': (settings: { pythonPath: string; allowNetwork: boolean }) => void;
   'compute:probePython': (candidate?: string) => { ok: boolean; path: string; version?: string; error?: string };
   'compute:browsePython': () => string | null;
   'compute:consentStatus': (language: string, code: string) => 'cell' | 'blanket' | 'none';

--- a/tests/main/compute/network-guard.test.ts
+++ b/tests/main/compute/network-guard.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Kernel network guard (#1413).
+ *
+ * The compute kernel installs a socket guard at bootstrap that blocks outbound
+ * connections to non-local addresses unless MINERVA_ALLOW_NETWORK == '1'. These
+ * tests import `minerva_kernel` (which runs the guard at module load, but NOT
+ * `main()`, since `__name__` isn't `__main__`) in a real python3 and assert the
+ * guard's behavior directly — no actual network is touched because the guard
+ * raises *before* the underlying connect runs.
+ *
+ * Skips when python3 isn't on PATH so CI without Python doesn't fail.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+const PY = process.env.MINERVA_PYTHON ?? 'python3';
+const RESOURCES = path.join(process.cwd(), 'resources', 'python');
+
+function pythonAvailable(): boolean {
+  try {
+    execFileSync(PY, ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Run a Python snippet with `minerva_kernel` importable; return trimmed stdout. */
+function runPy(snippet: string, env: Record<string, string> = {}): string {
+  return execFileSync(PY, ['-c', snippet], {
+    env: { ...process.env, PYTHONPATH: RESOURCES, ...env },
+    encoding: 'utf-8',
+  }).trim();
+}
+
+const skipIfNoPython = pythonAvailable() ? describe : describe.skip;
+
+skipIfNoPython('kernel network guard (#1413)', () => {
+  it('installs the guard by default (connect is wrapped)', () => {
+    const out = runPy('import minerva_kernel, socket; print(socket.socket.connect.__name__)');
+    expect(out).toBe('guarded_connect');
+  });
+
+  it('blocks a non-local connection with a clear error — before any real connect', () => {
+    // 203.0.113.0 is TEST-NET-3 (RFC 5737): guaranteed non-routable. The guard
+    // raises immediately, so this never actually reaches the network.
+    const out = runPy(
+      'import minerva_kernel, socket\n' +
+      'try:\n' +
+      "    socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(('203.0.113.0', 80))\n" +
+      "    print('NO-RAISE')\n" +
+      'except OSError as e:\n' +
+      "    print('disabled' if 'Network access is disabled' in str(e) else 'OTHER: ' + str(e))",
+    );
+    expect(out).toBe('disabled');
+  });
+
+  it('lets loopback through the guard (reaches the real connect)', () => {
+    // 127.0.0.1 on an almost-certainly-closed port: the guard permits it, so the
+    // real connect runs and is refused — proving the guard did NOT block it.
+    const out = runPy(
+      'import minerva_kernel, socket\n' +
+      's = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n' +
+      's.settimeout(1)\n' +
+      'try:\n' +
+      "    s.connect(('127.0.0.1', 1))\n" +
+      "    print('CONNECTED')\n" +
+      'except OSError as e:\n' +
+      "    print('blocked' if 'Network access is disabled' in str(e) else 'passed-guard')",
+    );
+    expect(out).toBe('passed-guard');
+  });
+
+  it('does NOT install the guard when MINERVA_ALLOW_NETWORK=1', () => {
+    const out = runPy(
+      'import minerva_kernel, socket; print(socket.socket.connect.__name__)',
+      { MINERVA_ALLOW_NETWORK: '1' },
+    );
+    expect(out).toBe('connect');
+  });
+});

--- a/tests/main/compute/python-settings.test.ts
+++ b/tests/main/compute/python-settings.test.ts
@@ -65,13 +65,45 @@ describe('getPythonSettings (#374)', () => {
     const s = await getPythonSettings();
     expect(s.pythonPath).toBe('');
   });
+
+  it('defaults allowNetwork to false when absent (#1413)', async () => {
+    const s = await getPythonSettings();
+    expect(s.allowNetwork).toBe(false);
+  });
+
+  it('reads allowNetwork: true when set (#1413)', async () => {
+    await fs.writeFile(
+      path.join(tempDir, 'python-settings.json'),
+      JSON.stringify({ pythonPath: '', allowNetwork: true }),
+      'utf-8',
+    );
+    const s = await getPythonSettings();
+    expect(s.allowNetwork).toBe(true);
+  });
+
+  it('fails closed — only a literal true enables network (#1413)', async () => {
+    await fs.writeFile(
+      path.join(tempDir, 'python-settings.json'),
+      JSON.stringify({ pythonPath: '', allowNetwork: 'yes' }),
+      'utf-8',
+    );
+    const s = await getPythonSettings();
+    expect(s.allowNetwork).toBe(false);
+  });
 });
 
 describe('setPythonSettings (#374)', () => {
   it('persists round-trip', async () => {
-    await setPythonSettings({ pythonPath: '/usr/local/bin/python3.12' });
+    await setPythonSettings({ pythonPath: '/usr/local/bin/python3.12', allowNetwork: false });
     const reread = await getPythonSettings();
     expect(reread.pythonPath).toBe('/usr/local/bin/python3.12');
+  });
+
+  it('round-trips allowNetwork (#1413)', async () => {
+    await setPythonSettings({ pythonPath: '', allowNetwork: true });
+    expect((await getPythonSettings()).allowNetwork).toBe(true);
+    await setPythonSettings({ pythonPath: '', allowNetwork: false });
+    expect((await getPythonSettings()).allowNetwork).toBe(false);
   });
 });
 
@@ -83,7 +115,7 @@ describe('resolvePythonInterpreter (#374) — discovery order', () => {
   });
 
   it('Settings override wins over env var and PATH default', async () => {
-    await setPythonSettings({ pythonPath: '/explicit/override/python' });
+    await setPythonSettings({ pythonPath: '/explicit/override/python', allowNetwork: false });
     process.env.MINERVA_PYTHON = '/env/python';
     const r = await resolvePythonInterpreter();
     expect(r).toBe('/explicit/override/python');
@@ -102,7 +134,7 @@ describe('resolvePythonInterpreter (#374) — discovery order', () => {
   });
 
   it('whitespace-only override does not satisfy the override branch', async () => {
-    await setPythonSettings({ pythonPath: '   ' });
+    await setPythonSettings({ pythonPath: '   ', allowNetwork: false });
     delete process.env.MINERVA_PYTHON;
     const r = await resolvePythonInterpreter();
     expect(r).toBe('python3');

--- a/tests/renderer/components/ComputeSettings.test.ts
+++ b/tests/renderer/components/ComputeSettings.test.ts
@@ -7,18 +7,20 @@
  * probe status line, Browse, Save (with dirty-state gating), and Clear override.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
 
 const {
   getPythonSettingsMock, probePythonMock, browsePythonMock,
-  setPythonSettingsMock, restartKernelMock,
+  setPythonSettingsMock, restartKernelMock, listConsentMock, revokeConsentMock,
 } = vi.hoisted(() => ({
   getPythonSettingsMock: vi.fn(),
   probePythonMock: vi.fn(),
   browsePythonMock: vi.fn(),
   setPythonSettingsMock: vi.fn(),
   restartKernelMock: vi.fn(),
+  listConsentMock: vi.fn(),
+  revokeConsentMock: vi.fn(),
 }));
 
 vi.mock('../../../src/renderer/lib/ipc/client', () => ({
@@ -29,21 +31,30 @@ vi.mock('../../../src/renderer/lib/ipc/client', () => ({
       browsePython: browsePythonMock,
       setPythonSettings: setPythonSettingsMock,
       restartPythonKernel: restartKernelMock,
+      listConsent: listConsentMock,
+      revokeConsent: revokeConsentMock,
     },
   },
 }));
 
 import ComputeSettings from '../../../src/renderer/lib/components/ComputeSettings.svelte';
 
+beforeEach(() => {
+  // Panels load these on mount; default to inert values so each test only sets
+  // what it asserts on.
+  listConsentMock.mockResolvedValue([]);
+  setPythonSettingsMock.mockResolvedValue(undefined);
+});
+
 afterEach(() => {
   cleanup();
-  [getPythonSettingsMock, probePythonMock, browsePythonMock, setPythonSettingsMock, restartKernelMock]
-    .forEach((m) => m.mockReset());
+  [getPythonSettingsMock, probePythonMock, browsePythonMock, setPythonSettingsMock,
+    restartKernelMock, listConsentMock, revokeConsentMock].forEach((m) => m.mockReset());
 });
 
 describe('ComputeSettings (#672)', () => {
   it('loads the saved path on mount and probes, showing the version', async () => {
-    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/usr/bin/python3' });
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/usr/bin/python3', allowNetwork: false });
     probePythonMock.mockResolvedValue({ ok: true, path: '/usr/bin/python3', version: 'Python 3.12.1' });
     const { findByText, getByDisplayValue } = render(ComputeSettings, {});
 
@@ -54,7 +65,7 @@ describe('ComputeSettings (#672)', () => {
   });
 
   it('shows the error state when the probe fails', async () => {
-    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/bad/python' });
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/bad/python', allowNetwork: false });
     probePythonMock.mockResolvedValue({ ok: false, path: '/bad/python', error: 'not executable' });
     const { findByText } = render(ComputeSettings, {});
     expect(await findByText(/Couldn't run interpreter/)).toBeTruthy();
@@ -62,7 +73,7 @@ describe('ComputeSettings (#672)', () => {
   });
 
   it('Browse sets the picked path and re-probes', async () => {
-    getPythonSettingsMock.mockResolvedValue({ pythonPath: '' });
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '', allowNetwork: false });
     probePythonMock.mockResolvedValue({ ok: true, path: 'x', version: 'Python 3.12' });
     browsePythonMock.mockResolvedValue('/opt/py/bin/python');
     const { findByText, getByText, getByDisplayValue } = render(ComputeSettings, {});
@@ -74,7 +85,7 @@ describe('ComputeSettings (#672)', () => {
   });
 
   it('Save is gated on dirty state and persists via api.compute.setPythonSettings', async () => {
-    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/usr/bin/python3' });
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/usr/bin/python3', allowNetwork: false });
     probePythonMock.mockResolvedValue({ ok: true, path: '/usr/bin/python3', version: 'Python 3.12' });
     setPythonSettingsMock.mockResolvedValue(undefined);
     const { findByText, getByText, getByDisplayValue } = render(ComputeSettings, {});
@@ -87,17 +98,42 @@ describe('ComputeSettings (#672)', () => {
     expect(getByText('Save').closest('button')!.disabled).toBe(false);
 
     await fireEvent.click(getByText('Save'));
-    expect(setPythonSettingsMock).toHaveBeenCalledWith({ pythonPath: '/new/python' });
+    expect(setPythonSettingsMock).toHaveBeenCalledWith({ pythonPath: '/new/python', allowNetwork: false });
   });
 
   it('Clear override blanks the path and saves', async () => {
-    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/usr/bin/python3' });
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/usr/bin/python3', allowNetwork: false });
     probePythonMock.mockResolvedValue({ ok: true, path: '/usr/bin/python3', version: 'Python 3.12' });
     setPythonSettingsMock.mockResolvedValue(undefined);
     const { findByText, getByText } = render(ComputeSettings, {});
     await findByText('Python 3.12');
 
     await fireEvent.click(getByText('Clear override'));
-    await waitFor(() => expect(setPythonSettingsMock).toHaveBeenCalledWith({ pythonPath: '' }));
+    await waitFor(() => expect(setPythonSettingsMock).toHaveBeenCalledWith({ pythonPath: '', allowNetwork: false }));
+  });
+
+  it('network toggle reflects the saved setting and persists on change (#1413)', async () => {
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '/usr/bin/python3', allowNetwork: false });
+    probePythonMock.mockResolvedValue({ ok: true, path: '/usr/bin/python3', version: 'Python 3.12' });
+    const { findByText, getByLabelText } = render(ComputeSettings, {});
+    await findByText('Python 3.12');
+
+    const toggle = getByLabelText('Allow network access for Python cells') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+
+    await fireEvent.click(toggle);
+    // Persists with the saved interpreter path + the new network choice.
+    await waitFor(() =>
+      expect(setPythonSettingsMock).toHaveBeenCalledWith({ pythonPath: '/usr/bin/python3', allowNetwork: true }),
+    );
+  });
+
+  it('network toggle loads as checked when network is allowed (#1413)', async () => {
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '', allowNetwork: true });
+    probePythonMock.mockResolvedValue({ ok: true, path: 'python3', version: 'Python 3.12' });
+    const { findByText, getByLabelText } = render(ComputeSettings, {});
+    await findByText('Python 3.12');
+
+    expect((getByLabelText('Allow network access for Python cells') as HTMLInputElement).checked).toBe(true);
   });
 });


### PR DESCRIPTION
Second item of #1413: **network egress off by default** for the Python kernel.

> ⚠️ **Stacked on #1416** (`feat/compute-trust-management-1413`). Review/merge that first — GitHub will auto-retarget this PR to `main` once it lands. The diff here is just the single network commit.

## What

The scariest thing an unreviewed — or LLM-authored — compute cell can do is quietly **exfiltrate your data**. This closes that path by default: the kernel installs a socket guard at bootstrap that refuses outbound connections to anything but `localhost`. `requests`, `urllib`, `http.client`, raw sockets, `pandas.read_csv('https://…')` all funnel through `socket.connect`, so a "phone home" fails unless the user opts in via **Settings → Compute → "Allow network access for Python cells"** (off by default).

Loopback and AF_UNIX stay open, so the kernel's own RPC channel to the main process and any localhost dev services keep working.

## Scope / threat model

This is **defense-in-depth, not a hard sandbox** — a determined cell can still shell out (`subprocess`) or re-enter libc (`ctypes`); real capability containment is the OS sandbox (#1329). But it shuts the *common* exfiltration path with a cheap, cross-platform mechanism, and it's the Python analogue of the DuckDB `httpfs` block already shipped in `sources/tables.ts`. The socket guard also doesn't stop DNS-based exfil (`getaddrinfo` isn't hooked) — low-bandwidth, out of scope here.

## Changes

- **`minerva_kernel.py`**: `install_network_guard()` wraps `socket.connect`/`connect_ex` to reject non-local addresses; gated on `MINERVA_ALLOW_NETWORK`. Runs at module load, before any cell.
- **`python-kernel.ts`**: passes `MINERVA_ALLOW_NETWORK` at spawn from the setting — read at spawn, so it applies on the next kernel start/restart (hint says so).
- **`python-settings.ts`**: `allowNetwork` (per-machine, default false, **fails closed** on a non-bool value); threaded through the `getPythonSettings`/`setPythonSettings` IPC contract.
- **ComputeSettings**: a checkbox toggle with an explanatory hint.
- **tests**: `network-guard.test.ts` drives a real `python3` to prove the guard **blocks non-local** (raises before any real connect, using TEST-NET-3 `203.0.113.0`), **permits loopback** (reaches the real connect → refused), and **no-ops under the env flag**; `python-settings` + `ComputeSettings` cover the round-trip + toggle.

Full suite: 4424 passing; lint clean.

## #1413 remaining after this

- Execution audit log
- Static red-flag scan (attention-raiser, not a boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)