### PR TITLE
Compute: execution audit log (#1413)

### DIFF
--- a/src/main/compute/audit.ts
+++ b/src/main/compute/audit.ts
@@ -1,0 +1,126 @@
+/**
+ * Compute execution audit log (#1413).
+ *
+ * Records what code ran, when, from where, and with what outcome — a local
+ * forensic trail for the "an LLM wrote subtly broken code into a proposal that
+ * got run" threat (#1329). Stored per-machine under
+ * `userData/compute-audit.jsonl` (never in the thoughtbase, so a shared/cloned
+ * project can't tamper with or omit its own history), one JSON object per line.
+ *
+ * This is a *record*, not a gate: it never blocks or alters execution, and a
+ * write failure is swallowed so auditing can never break a cell run. The
+ * consent gate (#1412) and network guard (#1413) are the boundaries; this is
+ * the paper trail behind them.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import { cellHash } from './consent';
+import type { CellResult } from '../../shared/compute/types';
+
+/** Where a cell run originated — an editor ▶ (human-authored/reviewed) vs a
+ *  conversation propose_compute Run (LLM-authored). The latter is the
+ *  higher-risk path this audit trail most cares about. */
+export type ComputeProvenance = 'editor' | 'conversation';
+
+export interface AuditEntry {
+  /** ISO-8601 timestamp of when the run finished. */
+  at: string;
+  /** Thoughtbase root the cell ran against. */
+  project: string;
+  language: string;
+  provenance: ComputeProvenance;
+  /** Note the cell lives in, when known (editor runs). */
+  notePath?: string;
+  /** Content hash of the code — same key the consent store uses, so an audit
+   *  entry can be tied back to the consent decision that let it run. */
+  codeHash: string;
+  /** First slice of the code, for human scanning without opening every hash. */
+  codePreview: string;
+  /** Whether the run succeeded. */
+  ok: boolean;
+  /** Truncated error text when `ok` is false. */
+  error?: string;
+}
+
+const PREVIEW_CHARS = 280;
+/** Trim the log once it grows past this; keeps it a bounded tail, not a leak. */
+const MAX_BYTES = 1_000_000;
+const KEEP_LINES = 1000;
+
+export function auditLogPath(): string {
+  return path.join(app.getPath('userData'), 'compute-audit.jsonl');
+}
+
+/**
+ * Append one execution to the audit log. Never throws — auditing is a
+ * side-record that must not affect the run it describes; a write failure is
+ * logged to the main console and dropped.
+ */
+export function recordExecution(input: {
+  project: string;
+  language: string;
+  code: string;
+  notePath?: string;
+  provenance: ComputeProvenance;
+  result: CellResult;
+}): void {
+  try {
+    const { project, language, code, notePath, provenance, result } = input;
+    const preview = code.length > PREVIEW_CHARS ? code.slice(0, PREVIEW_CHARS) + '…' : code;
+    const entry: AuditEntry = {
+      at: new Date().toISOString(),
+      project,
+      language,
+      provenance,
+      ...(notePath !== undefined ? { notePath } : {}),
+      codeHash: cellHash(language, code),
+      codePreview: preview,
+      ok: result.ok,
+      ...(result.ok ? {} : { error: String(result.error).slice(0, 500) }),
+    };
+    const p = auditLogPath();
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.appendFileSync(p, JSON.stringify(entry) + '\n', 'utf-8');
+    trimIfOversized(p);
+  } catch (err) {
+    console.warn('[compute-audit] failed to record execution:', err);
+  }
+}
+
+/** Read the audit log newest-first. Returns [] when the log is missing or
+ *  unreadable; skips any corrupt line rather than throwing. */
+export function readAuditLog(limit?: number): AuditEntry[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(auditLogPath(), 'utf-8');
+  } catch {
+    return [];
+  }
+  const entries: AuditEntry[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      entries.push(JSON.parse(line) as AuditEntry);
+    } catch {
+      // Skip a torn/partial line (e.g. a crash mid-append) rather than fail.
+    }
+  }
+  entries.reverse(); // newest first
+  return typeof limit === 'number' ? entries.slice(0, limit) : entries;
+}
+
+/** Keep the log bounded: once it exceeds MAX_BYTES, rewrite it with only the
+ *  most recent KEEP_LINES entries. Cheap stat-gated check on each append. */
+function trimIfOversized(p: string): void {
+  let size: number;
+  try {
+    size = fs.statSync(p).size;
+  } catch {
+    return;
+  }
+  if (size <= MAX_BYTES) return;
+  const lines = fs.readFileSync(p, 'utf-8').split('\n').filter((l) => l.trim());
+  const kept = lines.slice(-KEEP_LINES);
+  fs.writeFileSync(p, kept.join('\n') + '\n', 'utf-8');
+}

--- a/src/main/ipc/register-compute.ts
+++ b/src/main/ipc/register-compute.ts
@@ -1,8 +1,11 @@
-import { dialog } from 'electron';
+import { dialog, shell } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
 import { Channels } from '../../shared/channels';
 import { handle } from './typed-ipc';
 import { runCell as runComputeCell, registeredLanguages as computeLanguages } from '../compute/registry';
 import { computeConsentGuard, consentStatus, grantConsent, listConsent, revokeConsent } from '../compute/consent';
+import { recordExecution, auditLogPath } from '../compute/audit';
 import { restartKernel as restartPythonKernel, interruptKernel as interruptPythonKernel } from '../compute/python-kernel';
 import {
   getPythonSettings,
@@ -29,7 +32,9 @@ export function registerCompute(): void {
     // hasn't consented to, even if a caller reached the IPC without prompting.
     const guard = computeConsentGuard(rootPath, language, code);
     if (guard) return guard;
-    return await runComputeCell(language, code, { rootPath, ...(notePath !== undefined ? { notePath } : {}) });
+    const result = await runComputeCell(language, code, { rootPath, ...(notePath !== undefined ? { notePath } : {}) });
+    recordExecution({ project: rootPath, language, code, provenance: 'editor', result, ...(notePath !== undefined ? { notePath } : {}) });
+    return result;
   }));
 
   handle(Channels.COMPUTE_LANGUAGES, () => computeLanguages());
@@ -77,6 +82,20 @@ export function registerCompute(): void {
 
   handle(Channels.COMPUTE_REVOKE_CONSENT, (_e, rootPath: string) => {
     revokeConsent(rootPath);
+  });
+
+  // Execution audit log (#1413): reveal the per-machine JSONL trail in the OS
+  // file manager. Ensure it exists first so reveal never fails on a machine
+  // that hasn't run a cell yet.
+  handle(Channels.COMPUTE_REVEAL_AUDIT_LOG, () => {
+    const p = auditLogPath();
+    try {
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      if (!fs.existsSync(p)) fs.writeFileSync(p, '', 'utf-8');
+    } catch (err) {
+      console.warn('[compute-audit] could not ensure audit log before reveal:', err);
+    }
+    shell.showItemInFolder(p);
   });
 
   handle(Channels.COMPUTE_BROWSE_PYTHON, async (e) => {

--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -11,6 +11,7 @@ import { ttlString } from '../sources/source-meta-write';
 import { fileSourceProperties } from '../llm/source-properties';
 import { runCell as runComputeCell } from '../compute/registry';
 import { computeConsentGuard } from '../compute/consent';
+import { recordExecution } from '../compute/audit';
 import { buildExcerptTtl } from '../sources/create-excerpt';
 import { slugify } from '../../shared/slug';
 import { applyPropertyUpdates } from '../llm/set-properties';
@@ -808,6 +809,9 @@ export function registerConversation(): void {
       const guard = computeConsentGuard(rootPath, draft.language, codeToRun);
       if (guard) return { result: guard };
       const result = await runComputeCell(draft.language, codeToRun, { rootPath });
+      // Audit trail (#1413): a conversation-run cell is LLM-authored — the
+      // highest-risk provenance, so it's exactly what the log exists to capture.
+      recordExecution({ project: rootPath, language: draft.language, code: codeToRun, provenance: 'conversation', result });
       // Append the result to the conversation log as a user-role
       // message so the LLM's next turn sees it as context. Format
       // for legibility — the model parses these like any other

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -189,6 +189,7 @@ contextBridge.exposeInMainWorld('api', {
       invoke(Channels.COMPUTE_GRANT_CONSENT, language, code, scope),
     listConsent: () => invoke(Channels.COMPUTE_LIST_CONSENT),
     revokeConsent: (rootPath: string) => invoke(Channels.COMPUTE_REVOKE_CONSENT, rootPath),
+    revealAuditLog: () => invoke(Channels.COMPUTE_REVEAL_AUDIT_LOG),
   },
   publish: {
     listExporters: () => invoke(Channels.PUBLISH_LIST_EXPORTERS),

--- a/src/renderer/lib/components/ComputeSettings.svelte
+++ b/src/renderer/lib/components/ComputeSettings.svelte
@@ -258,6 +258,19 @@
   {/if}
 </div>
 
+<div class="field audit-field">
+  <label id="audit-heading">Execution audit log</label>
+  <p class="hint">
+    Every compute cell that runs is recorded to a local log — when it ran,
+    which thoughtbase and note, whether it came from the editor or a
+    conversation (AI-authored), and its outcome. Stored on this machine
+    only, so it can't be tampered with by a shared thoughtbase.
+  </p>
+  <button class="action-btn" onclick={() => { void api.compute.revealAuditLog(); }}>
+    Reveal audit log
+  </button>
+</div>
+
 <style>
   /* Shared form vocabulary, scoped to this panel (the app's per-dialog
      convention — each component carries its own .field / .hint / button CSS). */
@@ -384,8 +397,9 @@
     accent-color: var(--accent);
   }
 
-  /* Trusted-thoughtbases list (#1413). */
-  .trust-field {
+  /* Trusted-thoughtbases list + audit section (#1413). */
+  .trust-field,
+  .audit-field {
     margin-top: 20px;
     padding-top: 16px;
     border-top: 1px solid var(--border);

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -433,6 +433,9 @@ export interface ComputeApi {
    * its cells prompt eyes-on-code again. */
   listConsent(): Promise<ComputeConsentSummary[]>;
   revokeConsent(rootPath: string): Promise<void>;
+  /** Reveal the per-machine compute execution audit log (#1413) in the OS file
+   *  manager — a stateless OS side-effect, so components may call it directly. */
+  revealAuditLog(): Promise<void>;
 }
 
 export interface ShellApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -551,6 +551,9 @@ export const Channels = {
   /** Revoke all compute consent (blanket + remembered cells) for a thoughtbase
    *  so its cells prompt eyes-on-code again (#1413). */
   COMPUTE_REVOKE_CONSENT: 'compute:revokeConsent',
+  /** Reveal the per-machine compute execution audit log in the OS file manager
+   *  (#1413). Creates an empty log first if none exists yet. */
+  COMPUTE_REVEAL_AUDIT_LOG: 'compute:revealAuditLog',
   /** List every fence language that has a registered executor. Drives the editor's gutter. */
   COMPUTE_LANGUAGES: 'compute:languages',
   /** Save a cell's output as a first-class note with provenance (#244). */

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -304,6 +304,7 @@ export interface ChannelMap {
   'compute:grantConsent': (language: string, code: string, scope: 'cell' | 'project') => void;
   'compute:listConsent': () => ComputeConsentSummary[];
   'compute:revokeConsent': (rootPath: string) => void;
+  'compute:revealAuditLog': () => void;
   'compute:saveCellOutput': (input: {
     sourcePath: string;
     cellLanguage: string;

--- a/tests/main/compute/audit.test.ts
+++ b/tests/main/compute/audit.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Compute execution audit log (#1413).
+ *
+ * Records live per-machine under `app.getPath('userData')` (stubbed to a temp
+ * dir, same trick as consent.test / python-settings.test), one JSON line each.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { CellResult } from '../../../src/shared/compute/types';
+
+let userDataDir: string;
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name !== 'userData') throw new Error(`unexpected getPath(${name})`);
+      return userDataDir;
+    },
+  },
+}));
+
+import { recordExecution, readAuditLog, auditLogPath } from '../../../src/main/compute/audit';
+import { cellHash } from '../../../src/main/compute/consent';
+
+const OK: CellResult = { ok: true, output: { type: 'text', value: 'hi' } };
+const ERR: CellResult = { ok: false, error: 'boom' };
+
+beforeEach(() => {
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-audit-'));
+});
+afterEach(() => {
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+});
+
+describe('compute execution audit log (#1413)', () => {
+  it('records an execution with provenance, hash, outcome, and note path', () => {
+    recordExecution({
+      project: '/tb', language: 'python', code: 'print(1)', notePath: 'n.md',
+      provenance: 'editor', result: OK,
+    });
+    const [entry] = readAuditLog();
+    expect(entry.project).toBe('/tb');
+    expect(entry.language).toBe('python');
+    expect(entry.provenance).toBe('editor');
+    expect(entry.notePath).toBe('n.md');
+    expect(entry.ok).toBe(true);
+    expect(entry.codeHash).toBe(cellHash('python', 'print(1)'));
+    expect(entry.codePreview).toBe('print(1)');
+    expect(entry.at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('records a conversation (AI-authored) run and a failure with its error', () => {
+    recordExecution({ project: '/tb', language: 'sql', code: 'select 1', provenance: 'conversation', result: ERR });
+    const [entry] = readAuditLog();
+    expect(entry.provenance).toBe('conversation');
+    expect(entry.ok).toBe(false);
+    expect(entry.error).toBe('boom');
+    expect(entry.notePath).toBeUndefined();
+  });
+
+  it('returns entries newest-first', () => {
+    recordExecution({ project: '/tb', language: 'python', code: 'a', provenance: 'editor', result: OK });
+    recordExecution({ project: '/tb', language: 'python', code: 'b', provenance: 'editor', result: OK });
+    recordExecution({ project: '/tb', language: 'python', code: 'c', provenance: 'editor', result: OK });
+    expect(readAuditLog().map((e) => e.codePreview)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('respects the limit argument', () => {
+    for (const c of ['a', 'b', 'c', 'd']) {
+      recordExecution({ project: '/tb', language: 'python', code: c, provenance: 'editor', result: OK });
+    }
+    expect(readAuditLog(2).map((e) => e.codePreview)).toEqual(['d', 'c']);
+  });
+
+  it('truncates a long code preview with an ellipsis', () => {
+    const long = 'x'.repeat(500);
+    recordExecution({ project: '/tb', language: 'python', code: long, provenance: 'editor', result: OK });
+    const [entry] = readAuditLog();
+    expect(entry.codePreview.length).toBe(281); // 280 + '…'
+    expect(entry.codePreview.endsWith('…')).toBe(true);
+    // The hash still covers the FULL code, not the preview.
+    expect(entry.codeHash).toBe(cellHash('python', long));
+  });
+
+  it('reading a missing log returns []', () => {
+    expect(readAuditLog()).toEqual([]);
+  });
+
+  it('skips a torn/corrupt line rather than throwing', () => {
+    recordExecution({ project: '/tb', language: 'python', code: 'ok', provenance: 'editor', result: OK });
+    fs.appendFileSync(auditLogPath(), '{ this is not json\n', 'utf-8');
+    const entries = readAuditLog();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].codePreview).toBe('ok');
+  });
+
+  it('never throws from recordExecution even if the result error is non-string', () => {
+    expect(() =>
+      recordExecution({
+        project: '/tb', language: 'python', code: 'x', provenance: 'editor',
+        result: { ok: false, error: undefined as unknown as string },
+      }),
+    ).not.toThrow();
+    expect(readAuditLog()[0].ok).toBe(false);
+  });
+
+  it('keeps the on-disk log bounded once it grows past the cap', () => {
+    // Enough small entries to blow well past the 1 MB cap, forcing at least one
+    // trim. The invariant is the *on-disk size* stays bounded (the trim runs
+    // synchronously after each append), and the newest entry always survives.
+    for (let i = 0; i < 8000; i++) {
+      recordExecution({ project: '/tb', language: 'python', code: `cell ${i}`, provenance: 'editor', result: OK });
+    }
+    expect(fs.statSync(auditLogPath()).size).toBeLessThanOrEqual(1_000_000);
+    const entries = readAuditLog();
+    expect(entries.length).toBeLessThan(8000); // proves a trim happened
+    expect(entries[0].codePreview).toBe('cell 7999'); // newest survived
+  });
+});

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -34,6 +34,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "compute:listConsent",
   "compute:probePython",
   "compute:restartPythonKernel",
+  "compute:revealAuditLog",
   "compute:revokeConsent",
   "compute:runCell",
   "compute:saveCellOutput",

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -48,6 +48,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "listConsent",
     "probePython",
     "restartPythonKernel",
+    "revealAuditLog",
     "revokeConsent",
     "runCell",
     "saveCellOutput",

--- a/tests/renderer/components/ComputeSettings.test.ts
+++ b/tests/renderer/components/ComputeSettings.test.ts
@@ -12,7 +12,7 @@ import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
 
 const {
   getPythonSettingsMock, probePythonMock, browsePythonMock,
-  setPythonSettingsMock, restartKernelMock, listConsentMock, revokeConsentMock,
+  setPythonSettingsMock, restartKernelMock, listConsentMock, revokeConsentMock, revealAuditLogMock,
 } = vi.hoisted(() => ({
   getPythonSettingsMock: vi.fn(),
   probePythonMock: vi.fn(),
@@ -21,6 +21,7 @@ const {
   restartKernelMock: vi.fn(),
   listConsentMock: vi.fn(),
   revokeConsentMock: vi.fn(),
+  revealAuditLogMock: vi.fn(),
 }));
 
 vi.mock('../../../src/renderer/lib/ipc/client', () => ({
@@ -33,6 +34,7 @@ vi.mock('../../../src/renderer/lib/ipc/client', () => ({
       restartPythonKernel: restartKernelMock,
       listConsent: listConsentMock,
       revokeConsent: revokeConsentMock,
+      revealAuditLog: revealAuditLogMock,
     },
   },
 }));
@@ -49,7 +51,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   [getPythonSettingsMock, probePythonMock, browsePythonMock, setPythonSettingsMock,
-    restartKernelMock, listConsentMock, revokeConsentMock].forEach((m) => m.mockReset());
+    restartKernelMock, listConsentMock, revokeConsentMock, revealAuditLogMock].forEach((m) => m.mockReset());
 });
 
 describe('ComputeSettings (#672)', () => {
@@ -135,5 +137,16 @@ describe('ComputeSettings (#672)', () => {
     await findByText('Python 3.12');
 
     expect((getByLabelText('Allow network access for Python cells') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('Reveal audit log calls api.compute.revealAuditLog (#1413)', async () => {
+    getPythonSettingsMock.mockResolvedValue({ pythonPath: '', allowNetwork: false });
+    probePythonMock.mockResolvedValue({ ok: true, path: 'python3', version: 'Python 3.12' });
+    revealAuditLogMock.mockResolvedValue(undefined);
+    const { findByText, getByText } = render(ComputeSettings, {});
+    await findByText('Python 3.12');
+
+    await fireEvent.click(getByText('Reveal audit log'));
+    expect(revealAuditLogMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Fourth item of #1413: **execution audit log**.

## What

Records every compute cell that runs to a per-machine JSONL log under `userData/compute-audit.jsonl` — one line per execution capturing: timestamp, thoughtbase, note path, **provenance** (`editor` vs `conversation`/AI-authored), code hash + preview, and outcome (ok / truncated error).

It's the paper trail behind the consent gate (#1412) and network guard (#1413): the threat model is *an LLM writing subtly broken code into a proposal that gets run*, and now there's a durable record of exactly what ran, from where, and whether it succeeded.

## Design

- **`audit.ts`**: `recordExecution()` **never throws** (auditing must not break the run it describes — a write failure is logged and dropped); `readAuditLog()` is newest-first and skips torn/partial lines; the log is **size-bounded** (trims to a recent tail once it passes 1 MB).
- **Per-machine**, so a shared/cloned thoughtbase can't tamper with or omit its own history. The `codeHash` is the same key the consent store uses, so an audit entry ties back to the consent decision that let it run.
- Hooked at **both** execution chokepoints — `COMPUTE_RUN_CELL` (editor, `provenance: 'editor'`) and `CONVERSATION_RUN_COMPUTE_DRAFT` (conversation, `provenance: 'conversation'`) — after the run so the outcome is captured.
- **`COMPUTE_REVEAL_AUDIT_LOG`** reveals the log in the OS file manager (a stateless OS side-effect → component-callable, like `api.shell.*`); **Settings → Compute** gains an "Execution audit log" section with a **Reveal** button. (An in-app viewer would be scope creep; reveal-in-Finder is the pragmatic MVP.)

## Tests

- `audit.test.ts`: provenance, hash-matches-consent-key, outcome, note-path present/absent, newest-first, `limit`, preview truncation (hash still covers full code), corrupt-line skip, never-throws on a bad result, and the size-bound trim.
- `ComputeSettings` reveal-button test.

Full suite: 4434 passing; lint clean.

## #1413 after this

Only **static red-flag scan** remains (subprocess / socket / `os.system` / `eval` → a warning badge — explicitly an attention-raiser, not a boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)