### PR TITLE
Compute: sandbox the Python kernel — network containment, fail-closed (#1329 P1)

### DIFF
--- a/src/main/compute/python-kernel.ts
+++ b/src/main/compute/python-kernel.ts
@@ -23,6 +23,7 @@ import { randomUUID } from 'node:crypto';
 import type { CellOutput, CellResult, KernelMimeBundle } from '../../shared/compute/types';
 import { startRpcServer, type RpcServer } from './rpc-server';
 import { resolvePythonInterpreter, getPythonSettings } from './python-settings';
+import { planKernelLaunch } from './sandbox';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 
@@ -103,9 +104,14 @@ async function spawnKernel(rootPath: string): Promise<KernelState> {
   // takes effect on the next kernel start / restart, not mid-session.
   const { allowNetwork } = await getPythonSettings();
   const script = kernelScriptPath();
+  // OS sandbox (#1329 P1): wrap the interpreter in sandbox-exec on macOS. This
+  // is computed BEFORE the RPC server starts and can throw (fail-closed if the
+  // sandbox is unavailable) — doing it first means there's no RPC socket to
+  // clean up on that path.
+  const launch = planKernelLaunch(py, script, { allowNetwork });
   // RPC server up first so the kernel can connect on first import.
   const rpc = await startRpcServer(rootPath);
-  const proc = spawn(py, [script], {
+  const proc = spawn(launch.command, launch.args, {
     stdio: ['pipe', 'pipe', 'pipe'],
     env: {
       ...process.env,
@@ -375,7 +381,13 @@ export async function runPython(
 ): Promise<CellResult> {
   let state = kernels.get(rootPath);
   if (!state || state.proc.killed || state.proc.exitCode !== null) {
-    state = await spawnKernel(rootPath);
+    try {
+      state = await spawnKernel(rootPath);
+    } catch (err) {
+      // Fail-closed (#1329): sandbox unavailable → refuse to run rather than
+      // fall back to an unsandboxed interpreter. Surfaced as a normal cell error.
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
     kernels.set(rootPath, state);
   }
   try {

--- a/src/main/compute/sandbox.ts
+++ b/src/main/compute/sandbox.ts
@@ -1,0 +1,91 @@
+/**
+ * macOS OS-sandbox for the Python compute kernel — Phase 1 (#1329, #1421).
+ *
+ * Wraps the kernel spawn in `sandbox-exec` with a Seatbelt profile so the
+ * interpreter runs under an OS-enforced boundary, not just the in-process
+ * guards. Phase 1 contains **network egress**: it denies IP outbound/inbound
+ * (re-allowing loopback) while leaving the filesystem open — filesystem
+ * containment is Phase 2 (#1422).
+ *
+ * Two properties make this a real boundary rather than an advisory one:
+ *   - Seatbelt policies are **inherited by child processes**, so a `subprocess`
+ *     spawned from a cell also can't reach the network. Denying IP egress alone
+ *     therefore closes the shell-out escape — no `(deny process-exec*)` needed
+ *     (which would break pyenv/venv shim interpreters that re-exec the real
+ *     binary, and we run fail-closed so a broken interpreter = no compute).
+ *   - The deny filters are **IP-only**, so unix-domain sockets are untouched and
+ *     the kernel's RPC channel to main (`MINERVA_IPC_SOCKET`) keeps working with
+ *     no special carve-out.
+ *
+ * Fail-closed (decided): on macOS, if `sandbox-exec` is unavailable the kernel
+ * refuses to run rather than falling back to unsandboxed. On non-darwin
+ * (dev/CI only — we ship macOS) the interpreter runs directly; a shipping macOS
+ * build always sandboxes-or-refuses.
+ */
+import fs from 'node:fs';
+
+export const SANDBOX_EXEC = '/usr/bin/sandbox-exec';
+
+export const SANDBOX_UNAVAILABLE_ERROR =
+  'Compute is unavailable: the macOS sandbox (sandbox-exec) could not be found, ' +
+  'and Minerva will not run compute without it.';
+
+/**
+ * Seatbelt (SBPL) profile for the kernel. `(allow default)` keeps Python startup
+ * working (dyld, frameworks, site-packages, mach services); we subtract only IP
+ * network egress. When `allowNetwork` is set (the per-machine Settings toggle),
+ * the profile imposes no network restriction — the setting stays the single
+ * source of truth for network posture.
+ */
+export function buildKernelSandboxProfile(opts: { allowNetwork: boolean }): string {
+  if (opts.allowNetwork) {
+    return '(version 1)\n(allow default)\n';
+  }
+  return [
+    '(version 1)',
+    '(allow default)',
+    '; Block IP network egress (#1329 P1). Inherited by any child process, so a',
+    '; subprocess cannot reach the network either. Loopback stays allowed (not an',
+    '; exfiltration risk), and unix-domain sockets are untouched by the IP filters',
+    "; so the kernel's RPC channel to main keeps working.",
+    '(deny network-outbound (remote ip "*:*"))',
+    '(deny network-inbound (local ip "*:*"))',
+    '(allow network-outbound (remote ip "localhost:*"))',
+    '',
+  ].join('\n');
+}
+
+/** True when the macOS Seatbelt wrapper can be applied on this machine. */
+export function isMacSandboxAvailable(): boolean {
+  return process.platform === 'darwin' && fs.existsSync(SANDBOX_EXEC);
+}
+
+export interface KernelLaunch {
+  command: string;
+  args: string[];
+}
+
+/**
+ * Decide how to launch the kernel process. On macOS the interpreter is wrapped
+ * in `sandbox-exec -p <profile> <py> <script>` (fail-closed — throws
+ * `SANDBOX_UNAVAILABLE_ERROR` if the sandbox binary is missing). On non-darwin
+ * the interpreter runs directly (dev/CI only).
+ *
+ * `platform` / `sandboxAvailable` are injectable so the decision is unit-testable
+ * off a real macOS; production passes neither and they resolve from the host.
+ */
+export function planKernelLaunch(
+  pythonBin: string,
+  scriptPath: string,
+  opts: { allowNetwork: boolean; platform?: NodeJS.Platform; sandboxAvailable?: boolean },
+): KernelLaunch {
+  const platform = opts.platform ?? process.platform;
+  if (platform !== 'darwin') {
+    // Not the ship target — no macOS sandbox to apply.
+    return { command: pythonBin, args: [scriptPath] };
+  }
+  const available = opts.sandboxAvailable ?? isMacSandboxAvailable();
+  if (!available) throw new Error(SANDBOX_UNAVAILABLE_ERROR);
+  const profile = buildKernelSandboxProfile({ allowNetwork: opts.allowNetwork });
+  return { command: SANDBOX_EXEC, args: ['-p', profile, pythonBin, scriptPath] };
+}

--- a/tests/main/compute/sandbox-integration.test.ts
+++ b/tests/main/compute/sandbox-integration.test.ts
@@ -1,0 +1,75 @@
+/**
+ * macOS Seatbelt profile — real OS enforcement (#1329 P1).
+ *
+ * Runs the actual `sandbox-exec` with the kernel profile against a real python3
+ * and asserts the boundary holds. Skips off macOS or when python3 is absent, so
+ * non-darwin CI doesn't fail. No real network is contacted: the deny path raises
+ * *before* the connection, and the loopback/child probes hit closed ports.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { buildKernelSandboxProfile, SANDBOX_EXEC } from '../../../src/main/compute/sandbox';
+
+const PY = process.env.MINERVA_PYTHON ?? 'python3';
+
+function canRun(): boolean {
+  if (process.platform !== 'darwin') return false;
+  try {
+    execFileSync(SANDBOX_EXEC, ['-p', '(version 1)(allow default)', PY, '--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Run `python -c snippet` under the given profile; return {code, out}. */
+function runSandboxed(profile: string, snippet: string): { code: number; out: string } {
+  try {
+    const out = execFileSync(SANDBOX_EXEC, ['-p', profile, PY, '-c', snippet], { encoding: 'utf-8' });
+    return { code: 0, out: out.trim() };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return { code: err.status ?? 1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+const skip = canRun() ? describe : describe.skip;
+
+skip('kernel Seatbelt profile — OS enforcement (#1329 P1)', () => {
+  const netOff = buildKernelSandboxProfile({ allowNetwork: false });
+
+  it('a benign cell still runs (profile does not break Python startup)', () => {
+    expect(runSandboxed(netOff, 'print(6*7)').out).toBe('42');
+  });
+
+  it('blocks outbound IP egress at the OS level', () => {
+    // 1.1.1.1 — the guard raises PermissionError before any packet leaves.
+    const r = runSandboxed(netOff, "import socket; socket.create_connection(('1.1.1.1', 80), 2)");
+    expect(r.code).not.toBe(0);
+    expect(r.out).toMatch(/not permitted|PermissionError/);
+  });
+
+  it('the deny is INHERITED by child processes (closes the subprocess escape)', () => {
+    const r = runSandboxed(
+      netOff,
+      'import subprocess, sys; '
+      + "p = subprocess.run([sys.executable, '-c', \"import socket; socket.create_connection(('1.1.1.1',80),2)\"], capture_output=True, text=True); "
+      + "print('BLOCKED' if p.returncode != 0 else 'REACHED')",
+    );
+    expect(r.out).toContain('BLOCKED');
+  });
+
+  it('permits loopback (reaches the OS — connection refused, not sandbox-denied)', () => {
+    const r = runSandboxed(netOff, "import socket; socket.create_connection(('127.0.0.1', 1), 2)");
+    expect(r.out).toMatch(/ConnectionRefused|refused/);
+    expect(r.out).not.toMatch(/not permitted|PermissionError/);
+  });
+
+  it('imposes no network restriction when allowNetwork is on', () => {
+    // Can't hit the real network in a test, but a loopback connect must not be
+    // sandbox-denied under the permissive profile.
+    const netOn = buildKernelSandboxProfile({ allowNetwork: true });
+    const r = runSandboxed(netOn, "import socket; socket.create_connection(('127.0.0.1', 1), 2)");
+    expect(r.out).not.toMatch(/not permitted|PermissionError/);
+  });
+});

--- a/tests/main/compute/sandbox.test.ts
+++ b/tests/main/compute/sandbox.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Kernel sandbox launch planning (#1329 P1) — pure logic, runs on any platform.
+ *
+ * The Seatbelt profile's actual OS enforcement is covered by
+ * sandbox-integration.test.ts (macOS-only); here we pin the profile text and
+ * the platform/fail-closed launch decision, which are host-independent because
+ * platform + availability are injected.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildKernelSandboxProfile,
+  planKernelLaunch,
+  SANDBOX_EXEC,
+  SANDBOX_UNAVAILABLE_ERROR,
+} from '../../../src/main/compute/sandbox';
+
+describe('buildKernelSandboxProfile (#1329 P1)', () => {
+  it('denies IP egress and re-allows loopback when network is off', () => {
+    const p = buildKernelSandboxProfile({ allowNetwork: false });
+    expect(p).toContain('(allow default)');
+    expect(p).toContain('(deny network-outbound (remote ip "*:*"))');
+    expect(p).toContain('(deny network-inbound (local ip "*:*"))');
+    expect(p).toContain('(allow network-outbound (remote ip "localhost:*"))');
+  });
+
+  it('imposes no network restriction when network is allowed', () => {
+    const p = buildKernelSandboxProfile({ allowNetwork: true });
+    expect(p).toContain('(allow default)');
+    expect(p).not.toContain('deny network');
+  });
+});
+
+describe('planKernelLaunch (#1329 P1)', () => {
+  it('wraps the interpreter in sandbox-exec on macOS', () => {
+    const launch = planKernelLaunch('/usr/bin/python3', '/k/kernel.py', {
+      allowNetwork: false,
+      platform: 'darwin',
+      sandboxAvailable: true,
+    });
+    expect(launch.command).toBe(SANDBOX_EXEC);
+    // sandbox-exec -p <profile> <py> <script>
+    expect(launch.args[0]).toBe('-p');
+    expect(launch.args[1]).toContain('(deny network-outbound');
+    expect(launch.args.slice(2)).toEqual(['/usr/bin/python3', '/k/kernel.py']);
+  });
+
+  it('passes allowNetwork through to the profile it wraps', () => {
+    const launch = planKernelLaunch('/py', '/k.py', {
+      allowNetwork: true,
+      platform: 'darwin',
+      sandboxAvailable: true,
+    });
+    expect(launch.args[1]).not.toContain('deny network');
+  });
+
+  it('fails closed on macOS when sandbox-exec is unavailable', () => {
+    expect(() =>
+      planKernelLaunch('/py', '/k.py', { allowNetwork: false, platform: 'darwin', sandboxAvailable: false }),
+    ).toThrow(SANDBOX_UNAVAILABLE_ERROR);
+  });
+
+  it('runs the interpreter directly on non-darwin (dev/CI — we ship macOS)', () => {
+    const launch = planKernelLaunch('/usr/bin/python3', '/k/kernel.py', {
+      allowNetwork: false,
+      platform: 'linux',
+      sandboxAvailable: false,
+    });
+    expect(launch).toEqual({ command: '/usr/bin/python3', args: ['/k/kernel.py'] });
+  });
+});


### PR DESCRIPTION
Closes #1421 (Phase 1 of the OS sandbox, #1329). Design: `docs/architecture/compute-sandbox.md` (#1424). **macOS-only**, matching the ship target.

## What

Wraps the Python kernel spawn in `sandbox-exec` with a Seatbelt profile, so the interpreter runs under an **OS-enforced** boundary rather than only the in-process guards. Phase 1 contains **network egress**; filesystem stays open (that's P2, #1422).

This turns the network-off default (#1418) from a bypassable in-kernel guard into a real kernel boundary.

## Why it's a real boundary, not advisory

- **Seatbelt policies are inherited by child processes** — empirically verified: a `subprocess` spawned from a sandboxed cell also can't reach the network. So denying IP egress alone **closes the shell-out escape**; no `(deny process-exec*)` is needed (and it's deliberately omitted — it would break pyenv/venv shim interpreters that re-exec the real binary, fatal under fail-closed).
- The deny filters are **IP-only**, so unix-domain sockets are untouched and the kernel's RPC channel to main keeps working with **no special carve-out**.
- **Verified end-to-end**: the existing real-kernel integration tests (`import minerva` over the RPC socket) pass through the wrapper.

## Fail-closed (decided)

On macOS, if `sandbox-exec` is unavailable the cell returns a clear *"compute is unavailable"* error rather than running unsandboxed. On non-darwin (dev/CI — we ship macOS) the interpreter runs directly.

## Changes

- **`sandbox.ts`** — `buildKernelSandboxProfile` / `planKernelLaunch` (platform + availability injected for testing off a real Mac).
- **`python-kernel.ts`** — `spawnKernel` plans the launch *before* starting the RPC server (so a fail-closed throw needs no socket cleanup); `runPython` surfaces the throw as a `CellResult` error. `allowNetwork` (#1418) drives both the profile and the in-kernel guard.

## Tests

- `sandbox.test.ts` (any platform) — profile text + platform/fail-closed launch planning.
- `sandbox-integration.test.ts` (**macOS-only**, skips off darwin / without python3) — real `sandbox-exec` proves: benign cell runs, **IP egress denied**, **deny inherited by a child process**, loopback permitted (reaches OS), `allowNetwork` imposes no restriction.

Full suite: 4456 passing; lint clean.

## Next

- P2 (#1422) — filesystem containment (write to project/tmp only; read-deny a fixed sensitive list).
- P3 (#1423, deferred) — allow-list hardening / XPC helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)