### PR TITLE
Compute: filesystem containment in the kernel sandbox (#1329 P2)

### DIFF
--- a/src/main/compute/python-kernel.ts
+++ b/src/main/compute/python-kernel.ts
@@ -22,8 +22,9 @@ import { app } from 'electron';
 import { randomUUID } from 'node:crypto';
 import type { CellOutput, CellResult, KernelMimeBundle } from '../../shared/compute/types';
 import { startRpcServer, type RpcServer } from './rpc-server';
+import os from 'node:os';
 import { resolvePythonInterpreter, getPythonSettings } from './python-settings';
-import { planKernelLaunch } from './sandbox';
+import { planKernelLaunch, resolveRealPath } from './sandbox';
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 
@@ -104,11 +105,16 @@ async function spawnKernel(rootPath: string): Promise<KernelState> {
   // takes effect on the next kernel start / restart, not mid-session.
   const { allowNetwork } = await getPythonSettings();
   const script = kernelScriptPath();
-  // OS sandbox (#1329 P1): wrap the interpreter in sandbox-exec on macOS. This
-  // is computed BEFORE the RPC server starts and can throw (fail-closed if the
+  // OS sandbox (#1329): wrap the interpreter in sandbox-exec on macOS. This is
+  // computed BEFORE the RPC server starts and can throw (fail-closed if the
   // sandbox is unavailable) — doing it first means there's no RPC socket to
-  // clean up on that path.
-  const launch = planKernelLaunch(py, script, { allowNetwork });
+  // clean up on that path. Paths are resolved (realpath) because Seatbelt
+  // matches on the canonical path (/var → /private/var, etc.).
+  const launch = planKernelLaunch(py, script, {
+    allowNetwork,
+    projectRoot: resolveRealPath(rootPath),
+    homeDir: resolveRealPath(os.homedir()),
+  });
   // RPC server up first so the kernel can connect on first import.
   const rpc = await startRpcServer(rootPath);
   const proc = spawn(launch.command, launch.args, {
@@ -143,6 +149,12 @@ async function spawnKernel(rootPath: string): Promise<KernelState> {
       // backend is pure overhead. Reading MPLBACKEND on import is
       // matplotlib's documented config seam — no user code change.
       MPLBACKEND: 'Agg',
+      // Point matplotlib's font/config cache at a writable temp dir (#1329 P2).
+      // Its default (~/.matplotlib or ~/.cache) is outside the sandbox's
+      // write-allowed regions, so without this the first import fails to build
+      // its font cache. os.tmpdir() resolves under /private/var/folders, which
+      // the profile permits.
+      MPLCONFIGDIR: path.join(os.tmpdir(), 'minerva-matplotlib'),
     },
   });
 

--- a/src/main/compute/sandbox.ts
+++ b/src/main/compute/sandbox.ts
@@ -31,28 +31,99 @@ export const SANDBOX_UNAVAILABLE_ERROR =
   'and Minerva will not run compute without it.';
 
 /**
- * Seatbelt (SBPL) profile for the kernel. `(allow default)` keeps Python startup
- * working (dyld, frameworks, site-packages, mach services); we subtract only IP
- * network egress. When `allowNetwork` is set (the per-machine Settings toggle),
- * the profile imposes no network restriction — the setting stays the single
- * source of truth for network posture.
+ * Filesystem regions the kernel may WRITE to (#1329 P2), beyond the project
+ * root. All macOS-canonical (resolved) paths — Seatbelt matches on the real
+ * path, and `/tmp`→`/private/tmp`, `/var`→`/private/var` are symlinks. Covers
+ * per-user temp (`/private/var/folders/**`), `/tmp`, and `/dev` (for
+ * `/dev/null` and friends).
  */
-export function buildKernelSandboxProfile(opts: { allowNetwork: boolean }): string {
-  if (opts.allowNetwork) {
-    return '(version 1)\n(allow default)\n';
+const TMP_WRITE_SUBPATHS = ['/private/var/folders', '/private/tmp', '/dev'];
+
+/**
+ * Home-relative paths whose READS are denied (#1329 P2) — the fixed
+ * "well-known secrets" denylist. Blocks the read half of the "exfiltrate a
+ * secret" chain even if network were later enabled. Extend here in code, not
+ * via config (a deliberate decision — see docs/architecture/compute-sandbox.md).
+ */
+const HOME_READ_DENYLIST = [
+  '.ssh',
+  '.aws',
+  '.gnupg',
+  '.config',
+  '.docker',
+  '.netrc',
+  '.kube',
+  'Library/Keychains',
+  'Library/Application Support/Google/Chrome',
+  'Library/Application Support/Firefox',
+  'Library/Application Support/BraveSoftware',
+  'Library/Application Support/Microsoft Edge',
+  'Library/Safari',
+  'Library/Cookies',
+];
+
+/** Escape a path for an SBPL double-quoted string literal. */
+function sbQuote(p: string): string {
+  return p.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/** Resolve symlinks so a path matches Seatbelt's real-path checks; falls back
+ *  to the input if it can't be resolved (e.g. doesn't exist yet). */
+export function resolveRealPath(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return p;
   }
-  return [
-    '(version 1)',
-    '(allow default)',
-    '; Block IP network egress (#1329 P1). Inherited by any child process, so a',
-    '; subprocess cannot reach the network either. Loopback stays allowed (not an',
-    '; exfiltration risk), and unix-domain sockets are untouched by the IP filters',
-    "; so the kernel's RPC channel to main keeps working.",
-    '(deny network-outbound (remote ip "*:*"))',
-    '(deny network-inbound (local ip "*:*"))',
-    '(allow network-outbound (remote ip "localhost:*"))',
-    '',
-  ].join('\n');
+}
+
+/**
+ * Seatbelt (SBPL) profile for the kernel. `(allow default)` keeps Python startup
+ * working (dyld, frameworks, site-packages, mach services); we subtract:
+ *
+ *   - **network** (P1) — IP egress denied unless `allowNetwork`, loopback + unix
+ *     sockets left intact.
+ *   - **file writes** (P2) — denied outside the project root + temp + `/dev`, so
+ *     a cell can't overwrite `~/.bashrc`, plant a launch agent, etc.
+ *   - **sensitive reads** (P2) — a fixed denylist of secret locations.
+ *
+ * All rules are inherited by child processes. `projectRoot` / `homeDir` must be
+ * already-resolved (real) paths — see `resolveRealPath`.
+ */
+export function buildKernelSandboxProfile(opts: {
+  allowNetwork: boolean;
+  projectRoot: string;
+  homeDir: string;
+}): string {
+  const lines = ['(version 1)', '(allow default)'];
+
+  if (!opts.allowNetwork) {
+    lines.push(
+      '; Block IP network egress (#1329 P1). Inherited by any child process, so a',
+      '; subprocess cannot reach the network either. Loopback stays allowed (not an',
+      '; exfiltration risk), and unix-domain sockets are untouched by the IP filters',
+      "; so the kernel's RPC channel to main keeps working.",
+      '(deny network-outbound (remote ip "*:*"))',
+      '(deny network-inbound (local ip "*:*"))',
+      '(allow network-outbound (remote ip "localhost:*"))',
+    );
+  }
+
+  lines.push(
+    '; Deny file writes outside the project + temp (#1329 P2). Inherited by',
+    '; children, so a subprocess can\'t escape the write boundary either.',
+    '(deny file-write*)',
+    `(allow file-write* (subpath "${sbQuote(opts.projectRoot)}"))`,
+    ...TMP_WRITE_SUBPATHS.map((p) => `(allow file-write* (subpath "${p}"))`),
+  );
+
+  lines.push('; Deny reads of well-known secret locations (#1329 P2).');
+  for (const rel of HOME_READ_DENYLIST) {
+    lines.push(`(deny file-read* (subpath "${sbQuote(`${opts.homeDir}/${rel}`)}"))`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
 }
 
 /** True when the macOS Seatbelt wrapper can be applied on this machine. */
@@ -77,7 +148,13 @@ export interface KernelLaunch {
 export function planKernelLaunch(
   pythonBin: string,
   scriptPath: string,
-  opts: { allowNetwork: boolean; platform?: NodeJS.Platform; sandboxAvailable?: boolean },
+  opts: {
+    allowNetwork: boolean;
+    projectRoot: string;
+    homeDir: string;
+    platform?: NodeJS.Platform;
+    sandboxAvailable?: boolean;
+  },
 ): KernelLaunch {
   const platform = opts.platform ?? process.platform;
   if (platform !== 'darwin') {
@@ -86,6 +163,10 @@ export function planKernelLaunch(
   }
   const available = opts.sandboxAvailable ?? isMacSandboxAvailable();
   if (!available) throw new Error(SANDBOX_UNAVAILABLE_ERROR);
-  const profile = buildKernelSandboxProfile({ allowNetwork: opts.allowNetwork });
+  const profile = buildKernelSandboxProfile({
+    allowNetwork: opts.allowNetwork,
+    projectRoot: opts.projectRoot,
+    homeDir: opts.homeDir,
+  });
   return { command: SANDBOX_EXEC, args: ['-p', profile, pythonBin, scriptPath] };
 }

--- a/tests/main/compute/python-kernel.test.ts
+++ b/tests/main/compute/python-kernel.test.ts
@@ -316,6 +316,10 @@ pd.DataFrame({'i': list(range(1500))})
     expect(r.output.totalRows).toBe(1500);
   });
 
+  // Generous timeout: the first matplotlib import builds a font cache (~10s).
+  // Under the sandbox (#1329 P2) the cache lives in a temp MPLCONFIGDIR (~/.
+  // matplotlib is write-denied), so on a cold machine that build isn't already
+  // warm. MPLCONFIGDIR is stable, so only the first matplotlib test pays it.
   skipIfNoMatplotlib('matplotlib Figure as last expression → image/png output', async () => {
     const r = await runPython(ROOT, 'fig.md', `
 import matplotlib
@@ -331,7 +335,7 @@ fig
     // base64-encoded PNGs always start with the magic-bytes signature
     // `iVBORw0KGgo` (decoding to 89 50 4E 47 0D 0A 1A 0A).
     expect(r.output.data.startsWith('iVBORw0KGgo')).toBe(true);
-  });
+  }, 60_000);
 
   skipIfNoMatplotlib('Axes object also resolves to its parent Figure', async () => {
     const r = await runPython(ROOT, 'axes.md', `
@@ -345,7 +349,7 @@ ax  # bare Axes — should still render as a PNG via fig
     expect(r.ok).toBe(true);
     if (!r.ok || r.output.type !== 'image') return;
     expect(r.output.mime).toBe('image/png');
-  });
+  }, 60_000);
 
   skipIfNoPil('PIL.Image as last expression → image/png output', async () => {
     const r = await runPython(ROOT, 'pil.md', `

--- a/tests/main/compute/sandbox-integration.test.ts
+++ b/tests/main/compute/sandbox-integration.test.ts
@@ -6,11 +6,15 @@
  * non-darwin CI doesn't fail. No real network is contacted: the deny path raises
  * *before* the connection, and the loopback/child probes hit closed ports.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { buildKernelSandboxProfile, SANDBOX_EXEC } from '../../../src/main/compute/sandbox';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { buildKernelSandboxProfile, SANDBOX_EXEC, resolveRealPath } from '../../../src/main/compute/sandbox';
 
 const PY = process.env.MINERVA_PYTHON ?? 'python3';
+const HOME = resolveRealPath(os.homedir());
 
 function canRun(): boolean {
   if (process.platform !== 'darwin') return false;
@@ -35,8 +39,17 @@ function runSandboxed(profile: string, snippet: string): { code: number; out: st
 
 const skip = canRun() ? describe : describe.skip;
 
-skip('kernel Seatbelt profile — OS enforcement (#1329 P1)', () => {
-  const netOff = buildKernelSandboxProfile({ allowNetwork: false });
+skip('kernel Seatbelt profile — OS enforcement (#1329 P1/P2)', () => {
+  let projectRoot: string;
+  let netOff: string;
+
+  beforeAll(() => {
+    projectRoot = resolveRealPath(fs.mkdtempSync(path.join(os.tmpdir(), 'mv-sandbox-')));
+    netOff = buildKernelSandboxProfile({ allowNetwork: false, projectRoot, homeDir: HOME });
+  });
+  afterAll(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
 
   it('a benign cell still runs (profile does not break Python startup)', () => {
     expect(runSandboxed(netOff, 'print(6*7)').out).toBe('42');
@@ -68,8 +81,55 @@ skip('kernel Seatbelt profile — OS enforcement (#1329 P1)', () => {
   it('imposes no network restriction when allowNetwork is on', () => {
     // Can't hit the real network in a test, but a loopback connect must not be
     // sandbox-denied under the permissive profile.
-    const netOn = buildKernelSandboxProfile({ allowNetwork: true });
+    const netOn = buildKernelSandboxProfile({ allowNetwork: true, projectRoot, homeDir: HOME });
     const r = runSandboxed(netOn, "import socket; socket.create_connection(('127.0.0.1', 1), 2)");
     expect(r.out).not.toMatch(/not permitted|PermissionError/);
+  });
+
+  // ── Filesystem containment (P2) ──────────────────────────────────────────
+
+  it('permits writes inside the project root', () => {
+    const r = runSandboxed(netOff, `open(${JSON.stringify(path.join(projectRoot, 'out.txt'))}, 'w').write('ok'); print('WROTE')`);
+    expect(r.out).toContain('WROTE');
+  });
+
+  it('denies writes outside the project (e.g. into $HOME)', () => {
+    const target = path.join(HOME, 'mv_sandbox_evil.txt');
+    const r = runSandboxed(netOff, `open(${JSON.stringify(target)}, 'w').write('x')`);
+    expect(r.code).not.toBe(0);
+    expect(r.out).toMatch(/not permitted|PermissionError/);
+    expect(fs.existsSync(target)).toBe(false); // nothing was written
+  });
+
+  it('denies reads of a sensitive location (~/.ssh)', () => {
+    // Plant a file under ~/.ssh, confirm the sandbox blocks reading it, clean up.
+    const sshDir = path.join(os.homedir(), '.ssh');
+    const planted = path.join(sshDir, 'mv_sandbox_probe');
+    fs.mkdirSync(sshDir, { recursive: true });
+    fs.writeFileSync(planted, 'SECRET');
+    try {
+      const r = runSandboxed(netOff, `print(open(${JSON.stringify(planted)}).read())`);
+      expect(r.code).not.toBe(0);
+      expect(r.out).toMatch(/not permitted|PermissionError/);
+      expect(r.out).not.toContain('SECRET');
+    } finally {
+      fs.rmSync(planted, { force: true });
+    }
+  });
+
+  it('the write boundary is inherited by child processes', () => {
+    const target = path.join(HOME, 'mv_sandbox_child_evil.txt');
+    // The parent builds the child's -c code with %r so the path is safely quoted
+    // as a Python literal, avoiding nested-quote fragility.
+    const snippet = [
+      'import subprocess, sys',
+      `target = ${JSON.stringify(target)}`,
+      "code = \"open(%r, 'w').write('x')\" % target",
+      'p = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)',
+      "print('BLOCKED' if p.returncode != 0 else 'WROTE')",
+    ].join('\n');
+    const r = runSandboxed(netOff, snippet);
+    expect(r.out).toContain('BLOCKED');
+    expect(fs.existsSync(target)).toBe(false);
   });
 });

--- a/tests/main/compute/sandbox.test.ts
+++ b/tests/main/compute/sandbox.test.ts
@@ -14,9 +14,11 @@ import {
   SANDBOX_UNAVAILABLE_ERROR,
 } from '../../../src/main/compute/sandbox';
 
-describe('buildKernelSandboxProfile (#1329 P1)', () => {
+const PATHS = { projectRoot: '/private/tb', homeDir: '/Users/me' };
+
+describe('buildKernelSandboxProfile (#1329 P1/P2)', () => {
   it('denies IP egress and re-allows loopback when network is off', () => {
-    const p = buildKernelSandboxProfile({ allowNetwork: false });
+    const p = buildKernelSandboxProfile({ allowNetwork: false, ...PATHS });
     expect(p).toContain('(allow default)');
     expect(p).toContain('(deny network-outbound (remote ip "*:*"))');
     expect(p).toContain('(deny network-inbound (local ip "*:*"))');
@@ -24,38 +26,59 @@ describe('buildKernelSandboxProfile (#1329 P1)', () => {
   });
 
   it('imposes no network restriction when network is allowed', () => {
-    const p = buildKernelSandboxProfile({ allowNetwork: true });
+    const p = buildKernelSandboxProfile({ allowNetwork: true, ...PATHS });
     expect(p).toContain('(allow default)');
     expect(p).not.toContain('deny network');
+  });
+
+  it('denies file writes except the project root + temp (#1329 P2)', () => {
+    const p = buildKernelSandboxProfile({ allowNetwork: false, ...PATHS });
+    expect(p).toContain('(deny file-write*)');
+    expect(p).toContain('(allow file-write* (subpath "/private/tb"))');
+    expect(p).toContain('(allow file-write* (subpath "/private/var/folders"))');
+    expect(p).toContain('(allow file-write* (subpath "/private/tmp"))');
+  });
+
+  it('denies reads of the sensitive home-relative denylist (#1329 P2)', () => {
+    const p = buildKernelSandboxProfile({ allowNetwork: false, ...PATHS });
+    expect(p).toContain('(deny file-read* (subpath "/Users/me/.ssh"))');
+    expect(p).toContain('(deny file-read* (subpath "/Users/me/.aws"))');
+    expect(p).toContain('(deny file-read* (subpath "/Users/me/Library/Keychains"))');
+  });
+
+  it('write/read containment applies even when network is allowed', () => {
+    const p = buildKernelSandboxProfile({ allowNetwork: true, ...PATHS });
+    expect(p).toContain('(deny file-write*)');
+    expect(p).toContain('(deny file-read* (subpath "/Users/me/.ssh"))');
+  });
+
+  it('escapes quotes/backslashes in interpolated paths', () => {
+    const p = buildKernelSandboxProfile({ allowNetwork: false, projectRoot: '/tb/a"b\\c', homeDir: '/Users/me' });
+    expect(p).toContain('(allow file-write* (subpath "/tb/a\\"b\\\\c"))');
   });
 });
 
 describe('planKernelLaunch (#1329 P1)', () => {
+  const macOpts = { platform: 'darwin' as const, sandboxAvailable: true, ...PATHS };
+
   it('wraps the interpreter in sandbox-exec on macOS', () => {
-    const launch = planKernelLaunch('/usr/bin/python3', '/k/kernel.py', {
-      allowNetwork: false,
-      platform: 'darwin',
-      sandboxAvailable: true,
-    });
+    const launch = planKernelLaunch('/usr/bin/python3', '/k/kernel.py', { allowNetwork: false, ...macOpts });
     expect(launch.command).toBe(SANDBOX_EXEC);
     // sandbox-exec -p <profile> <py> <script>
     expect(launch.args[0]).toBe('-p');
     expect(launch.args[1]).toContain('(deny network-outbound');
+    expect(launch.args[1]).toContain('(deny file-write*)');
     expect(launch.args.slice(2)).toEqual(['/usr/bin/python3', '/k/kernel.py']);
   });
 
   it('passes allowNetwork through to the profile it wraps', () => {
-    const launch = planKernelLaunch('/py', '/k.py', {
-      allowNetwork: true,
-      platform: 'darwin',
-      sandboxAvailable: true,
-    });
+    const launch = planKernelLaunch('/py', '/k.py', { allowNetwork: true, ...macOpts });
     expect(launch.args[1]).not.toContain('deny network');
   });
 
   it('fails closed on macOS when sandbox-exec is unavailable', () => {
     expect(() =>
-      planKernelLaunch('/py', '/k.py', { allowNetwork: false, platform: 'darwin', sandboxAvailable: false }),
+      planKernelLaunch('/py', '/k.py', { allowNetwork: false, platform: 'darwin', sandboxAvailable: false, ...PATHS }),
     ).toThrow(SANDBOX_UNAVAILABLE_ERROR);
   });
 
@@ -64,6 +87,7 @@ describe('planKernelLaunch (#1329 P1)', () => {
       allowNetwork: false,
       platform: 'linux',
       sandboxAvailable: false,
+      ...PATHS,
     });
     expect(launch).toEqual({ command: '/usr/bin/python3', args: ['/k/kernel.py'] });
   });


### PR DESCRIPTION
Closes #1422 (Phase 2 of the OS sandbox, #1329). Extends P1's network-only Seatbelt profile with **filesystem containment**, per the settled decisions (project+tmp writes; fixed read denylist).

## What

- **`(deny file-write*)`** except the **project root**, temp (`/private/var/folders`, `/private/tmp`), and `/dev` → a cell can't overwrite `~/.bashrc`, plant a launch agent, etc. Writes into the thoughtbase (`df.to_csv`, `savefig`) still work.
- **`(deny file-read*)`** of a **fixed sensitive denylist** — `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config`, `~/.docker`, `~/.netrc`, `~/.kube`, login keychains, and the major browser profiles (Chrome/Firefox/Brave/Edge/Safari) → blocks the read half of the "read a secret → exfiltrate" chain even if network were later enabled.

Both are **inherited by child processes** (verified), so a `subprocess` can't escape the write boundary either.

## Implementation notes (the subtle bits)

- **Paths are `realpath`'d** before entering the profile. Seatbelt matches the *canonical* path, and `/tmp`→`/private/tmp`, `/var`→`/private/var` are symlinks — an unresolved project path silently matches nothing and *every* write gets denied. (Found this empirically before writing code.)
- Interpolated paths are **escaped** for the SBPL string literal.
- **matplotlib**: its default cache (`~/.matplotlib`) is now write-denied, so the kernel points `MPLCONFIGDIR` at a temp dir. The first plot on a cold machine rebuilds the font cache (~10s, one-time — this cost was previously hidden by a warm `~/.matplotlib`). The two matplotlib kernel tests get a 60s timeout to cover it.

## Tests

- `sandbox.test.ts` — write/read rules present, path escaping.
- `sandbox-integration.test.ts` (**macOS-only**) — real `sandbox-exec` proves: project writes allowed, `$HOME` write denied (and nothing written), `~/.ssh` read denied, and the write boundary is **inherited by a child process**.
- Existing real-kernel + matplotlib tests pass under the tightened profile.

Full suite: 4464 passing; lint clean.

## Sandbox status after this

- ✅ P1 (#1421) — network containment, fail-closed
- ✅ P2 (this) — filesystem containment
- ⏸️ P3 (#1423, deferred) — allow-list read hardening / `mach-lookup` minimization / XPC helper

With P1+P2, the "trust this thoughtbase = full-user RCE" finding (#1329) is substantially mitigated: an untrusted cell can't reach the network, spawn a process that reaches the network, write outside the project, or read your secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)