### PR TITLE
Compute: keep DuckDB integer columns numeric across the JS→pandas boundary

### DIFF
--- a/src/main/compute/duck-values.ts
+++ b/src/main/compute/duck-values.ts
@@ -1,0 +1,27 @@
+/**
+ * Coercions for DuckDB values crossing the JS → cell/Python boundary.
+ *
+ * The node-duckdb client hands 64-bit integer columns (INTEGER, BIGINT, …)
+ * back as JS `BigInt`, which `JSON.stringify` refuses outright. Both the RPC
+ * path that feeds `minerva.sql()` and the ```sql fence table path have to turn
+ * those into something JSON-safe.
+ */
+
+const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE_BIGINT = BigInt(Number.MIN_SAFE_INTEGER);
+
+/**
+ * Turn a DuckDB `BigInt` into a JSON-safe scalar, keeping it *numeric*
+ * whenever it fits exactly in a JS double. Only values outside the
+ * safe-integer range fall back to a decimal string, where `Number()` would
+ * silently drop precision.
+ *
+ * Preserving in-range integers as real numbers is what lets `minerva.sql(...)`
+ * hand pandas an `int64` column instead of a string one. Stringifying every
+ * integer was a latent type-loss that pandas ≤2 papered over by coercing
+ * numeric-looking object columns; pandas 3.0's strict `str` dtype does not —
+ * it rejects `.mean()`/`.sum()`/`groupby` aggregation on the column outright.
+ */
+export function coerceDuckBigInt(v: bigint): number | string {
+  return v >= MIN_SAFE_BIGINT && v <= MAX_SAFE_BIGINT ? Number(v) : v.toString();
+}

--- a/src/main/compute/executors/sql.ts
+++ b/src/main/compute/executors/sql.ts
@@ -8,6 +8,7 @@
 
 import { runQuery } from '../../sources/tables';
 import { projectContext } from '../../project-context-types';
+import { coerceDuckBigInt } from '../duck-values';
 import type { ExecutorFn } from '../registry';
 
 /**
@@ -15,8 +16,9 @@ import type { ExecutorFn } from '../registry';
  * a `type:"table"` cell output with rows normalised into the cell-output
  * primitive set (`string | number | boolean | null`) so the preview
  * renderer can draw them without running a JSON type check per cell.
- * BigInts stringify (DuckDB returns INTEGER columns as BigInt); Dates
- * become ISO strings; everything else passes through as-is.
+ * DuckDB returns INTEGER columns as BigInt; in-range values stay numeric
+ * (only out-of-range ones stringify — see coerceDuckBigInt); Dates become
+ * ISO strings; everything else passes through as-is.
  */
 export const executeSql: ExecutorFn = async (code, ctx) => {
   const response = await runQuery(projectContext(ctx.rootPath), code);
@@ -33,7 +35,7 @@ export const executeSql: ExecutorFn = async (code, ctx) => {
 
 function normalizeCell(v: unknown): string | number | boolean | null {
   if (v == null) return null;
-  if (typeof v === 'bigint') return v.toString();
+  if (typeof v === 'bigint') return coerceDuckBigInt(v);
   if (v instanceof Date) return v.toISOString();
   if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return v;
   // Arrays / structs / maps — DuckDB nested types don't have a canonical

--- a/src/main/compute/rpc-server.ts
+++ b/src/main/compute/rpc-server.ts
@@ -32,6 +32,7 @@ import * as search from '../search/index';
 import * as notebaseFs from '../notebase/fs';
 import { parseMarkdown } from '../graph/parser';
 import { projectContext } from '../project-context-types';
+import { coerceDuckBigInt } from './duck-values';
 
 interface RpcRequest {
   id: number;
@@ -162,13 +163,16 @@ const methods: Record<string, RpcMethod> = {
 };
 
 /** DuckDB returns BigInt for INTEGER columns; JSON.stringify can't
- *  handle them, so coerce to string here. Mirrors what the SQL
- *  executor does for the cell-output path. */
+ *  handle them, so coerce here. In-range integers stay numeric (so
+ *  `minerva.sql()` hands pandas an int64 column, not a string one —
+ *  see coerceDuckBigInt); only out-of-range values fall back to a
+ *  decimal string. Mirrors what the SQL executor does for the
+ *  cell-output path. */
 function serializeForJson(rows: Record<string, unknown>[]): Record<string, unknown>[] {
   return rows.map((row) => {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(row)) {
-      if (typeof v === 'bigint') out[k] = v.toString();
+      if (typeof v === 'bigint') out[k] = coerceDuckBigInt(v);
       else if (v instanceof Date) out[k] = v.toISOString();
       else out[k] = v;
     }

--- a/src/main/llm/tools/query-sql.ts
+++ b/src/main/llm/tools/query-sql.ts
@@ -1,5 +1,6 @@
 import { projectContext } from '../../project-context-types';
 import * as tables from '../../sources/tables';
+import { coerceDuckBigInt } from '../../compute/duck-values';
 import type { NotebaseTool, ToolContext } from './types';
 
 const SQL_READONLY_FIRST_WORDS = new Set([
@@ -11,18 +12,13 @@ const QUERY_SQL_ROW_CAP = 200;
  * JSON.stringify replacer that survives DuckDB's integer columns. The node-api
  * returns BIGINT/HUGEINT (and COUNT(*), which SUMMARIZE is full of) as JS
  * `bigint`, which plain JSON.stringify refuses to serialize ("Do not know how to
- * serialize a BigInt"). Render a bigint as a real number when it fits in a
- * double without precision loss, else as a string so a 19-digit id isn't
- * silently rounded. (Date columns are already handled — Date.toJSON emits ISO
- * before the replacer sees them.)
+ * serialize a BigInt"). `coerceDuckBigInt` renders it as a real number when it
+ * fits in a double without precision loss, else as a string so a 19-digit id
+ * isn't silently rounded. (Date columns are already handled — Date.toJSON emits
+ * ISO before the replacer sees them.)
  */
 function bigintSafeReplacer(_key: string, value: unknown): unknown {
-  if (typeof value === 'bigint') {
-    return value >= BigInt(Number.MIN_SAFE_INTEGER) && value <= BigInt(Number.MAX_SAFE_INTEGER)
-      ? Number(value)
-      : value.toString();
-  }
-  return value;
+  return typeof value === 'bigint' ? coerceDuckBigInt(value) : value;
 }
 
 /** query_sql (#781): immediate read-only SQL over the project's DuckDB. */

--- a/tests/main/compute/duck-values.test.ts
+++ b/tests/main/compute/duck-values.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { coerceDuckBigInt } from '../../../src/main/compute/duck-values';
+
+describe('coerceDuckBigInt', () => {
+  it('keeps small positive integers as numbers', () => {
+    const out = coerceDuckBigInt(42n);
+    expect(out).toBe(42);
+    expect(typeof out).toBe('number');
+  });
+
+  it('keeps negative integers as numbers', () => {
+    expect(coerceDuckBigInt(-7n)).toBe(-7);
+  });
+
+  it('keeps zero as a number', () => {
+    expect(coerceDuckBigInt(0n)).toBe(0);
+  });
+
+  it('keeps MAX_SAFE_INTEGER numeric (boundary is inclusive)', () => {
+    const out = coerceDuckBigInt(BigInt(Number.MAX_SAFE_INTEGER));
+    expect(out).toBe(Number.MAX_SAFE_INTEGER);
+    expect(typeof out).toBe('number');
+  });
+
+  it('keeps MIN_SAFE_INTEGER numeric (boundary is inclusive)', () => {
+    const out = coerceDuckBigInt(BigInt(Number.MIN_SAFE_INTEGER));
+    expect(out).toBe(Number.MIN_SAFE_INTEGER);
+    expect(typeof out).toBe('number');
+  });
+
+  it('falls back to a decimal string one past the safe-integer ceiling', () => {
+    const v = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
+    const out = coerceDuckBigInt(v);
+    expect(out).toBe('9007199254740992');
+    expect(typeof out).toBe('string');
+  });
+
+  it('falls back to a decimal string one past the safe-integer floor', () => {
+    const v = BigInt(Number.MIN_SAFE_INTEGER) - 1n;
+    expect(coerceDuckBigInt(v)).toBe('-9007199254740992');
+  });
+
+  it('preserves full precision of a 64-bit max value as a string', () => {
+    expect(coerceDuckBigInt(9223372036854775807n)).toBe('9223372036854775807');
+  });
+});

--- a/tests/main/compute/sql-executor.test.ts
+++ b/tests/main/compute/sql-executor.test.ts
@@ -38,13 +38,30 @@ describe('executeSql (#240)', () => {
     expect(result.ok).toBe(true);
     if (!result.ok || result.output.type !== 'table') return;
     expect(result.output.columns).toEqual(['name', 'count']);
-    // DuckDB returns INTEGER as BigInt; normalizeCell stringifies bigints so
-    // the preview can render them without JSON reviver hoops.
+    // DuckDB returns INTEGER as BigInt; normalizeCell keeps in-range integers
+    // numeric so the column reads as numbers (and `minerva.sql()` hands pandas
+    // an int64 column) rather than text.
     expect(result.output.rows).toEqual([
-      ['alpha', '1'],
-      ['beta', '2'],
-      ['gamma', '3'],
+      ['alpha', 1],
+      ['beta', 2],
+      ['gamma', 3],
     ]);
+  });
+
+  it('keeps large BigInts as decimal strings to avoid precision loss', async () => {
+    // 2^63 - 1 exceeds Number.MAX_SAFE_INTEGER, so it must survive as a string
+    // rather than a lossy Number.
+    const result = await executeSql('SELECT 9223372036854775807::BIGINT AS big', CTX);
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.output.type !== 'table') return;
+    expect(result.output.rows).toEqual([['9223372036854775807']]);
+  });
+
+  it('keeps in-range BigInts numeric', async () => {
+    const result = await executeSql('SELECT 42::BIGINT AS n', CTX);
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.output.type !== 'table') return;
+    expect(result.output.rows).toEqual([[42]]);
   });
 
   it('surfaces SQL syntax errors as ok:false rather than throwing', async () => {


### PR DESCRIPTION
## The bug

On a compute cell:

```python
import minerva
df = minerva.sql("SELECT * FROM mandolin_models")
df.groupby('body_shape')['scale_length_mm'].agg(['min', 'mean', 'max'])
```

now fails with:

```
TypeError: dtype 'str' does not support operation 'mean'
```

`scale_length_mm` is an integer column, but it reaches pandas as **text**, so `.mean()` can't average it.

## Root cause

DuckDB's node client returns 64-bit integer columns as JS `BigInt`, which `JSON.stringify` refuses. Two of the three serialization paths coerced *every* BigInt to a string with `.toString()` and never restored the numeric type:

- `serializeForJson` in `rpc-server.ts` — feeds `minerva.sql()` → `pd.DataFrame(rows)`
- `normalizeCell` in `executors/sql.ts` — the ` ```sql ` fence table output

This was a latent type-loss that **pandas ≤2 papered over** by leniently coercing numeric-looking `object` columns during aggregation. **pandas 3.0** (this venv is on 3.0.2 / Python 3.14) infers a strict pyarrow-backed `str` dtype for string columns (PDEP-14), and that dtype rejects arithmetic outright — turning a long-standing bug into a hard error. Float/DOUBLE columns were never affected because they arrive as JS numbers, not BigInt.

The third path — the `query_sql` LLM tool — already got this right via `bigintSafeReplacer`, which keeps in-range integers numeric and only stringifies values past the safe-integer range.

## The fix

Extract that safe-integer-aware coercion into a shared `coerceDuckBigInt` (`src/main/compute/duck-values.ts`) and use it in all three paths:

- In `Number.MIN_SAFE_INTEGER … MAX_SAFE_INTEGER` (inclusive) → real `number`
- Outside that range → decimal string, so a 19-digit id isn't silently rounded

`minerva.sql()` hands pandas an `int64` column again and aggregation works. Confirmed against the actual venv (pandas 3.0.2): numeric rows → `int64` → `groupby().mean()` succeeds.

## Tests

- New `duck-values.test.ts` — boundary coverage for the helper (inclusive safe-int edges, one-past on both sides, 64-bit max precision).
- Updated `sql-executor.test.ts` — integer columns now assert numbers, plus a large-BIGINT-stays-string case.
- Full `tests/main/compute/` + `sql-tools.test.ts` green (173 tests); `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)