### PR TITLE
Sidebar: open a collapsed folder by clicking anywhere on its row

### DIFF
--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -203,13 +203,22 @@
           data-relative-path={file.relativePath}
           style:padding-left="{depth * 16 + 8}px"
           onclick={(e) => {
-            // Clicking the disclosure arrow expands/collapses; clicking anywhere
-            // else on the row just selects the folder (#1034 follow-up).
+            // Clicking the disclosure arrow expands/collapses either way — and
+            // it stays the *only* way to collapse an open folder (#1034).
             if ((e.target as HTMLElement).closest('[data-chevron]')) {
               onToggleDir(file.relativePath);
               return;
             }
+            // A plain click anywhere on a *collapsed* folder row opens it, on
+            // top of selecting it — a folder shouldn't be harder to open than a
+            // file is. Modified clicks (shift range / ⌘ toggle) keep pure
+            // selection semantics and never expand; an already-open folder is
+            // only closed via the chevron, so its row click just selects.
+            const plain = !e.shiftKey && !e.metaKey && !e.ctrlKey;
             onItemClick(file.relativePath, true, { shift: e.shiftKey, meta: e.metaKey || e.ctrlKey });
+            if (plain && !expanded[file.relativePath]) {
+              onToggleDir(file.relativePath);
+            }
           }}
           oncontextmenu={(e) => handleContextMenu(e, file.relativePath, file.relativePath, true)}
           draggable={true}

--- a/tests/renderer/components/FileTree.test.ts
+++ b/tests/renderer/components/FileTree.test.ts
@@ -147,6 +147,65 @@ describe('FileTree (#1002)', () => {
     expect(onToggleDir).toHaveBeenCalledWith('notes');
   });
 
+  it('plain-clicking a collapsed folder row opens it and selects it', async () => {
+    const onToggleDir = vi.fn();
+    const onItemClick = vi.fn();
+    const { container } = render(
+      FileTree,
+      props({ expanded: {}, onToggleDir, onItemClick }),
+    );
+    // Click the row body (not the chevron) of the collapsed `notes` folder.
+    await fireEvent.click(row(container, 'notes')!);
+    // Selects…
+    expect(onItemClick).toHaveBeenCalledWith('notes', true, { shift: false, meta: false });
+    // …and opens.
+    expect(onToggleDir).toHaveBeenCalledWith('notes');
+  });
+
+  it('plain-clicking an already-open folder row selects but does NOT collapse it', async () => {
+    const onToggleDir = vi.fn();
+    const onItemClick = vi.fn();
+    const { container } = render(
+      FileTree,
+      props({ expanded: { notes: true }, onToggleDir, onItemClick }),
+    );
+    await fireEvent.click(row(container, 'notes')!);
+    expect(onItemClick).toHaveBeenCalledWith('notes', true, { shift: false, meta: false });
+    // Closing stays chevron-only — a row click must not toggle it shut.
+    expect(onToggleDir).not.toHaveBeenCalled();
+  });
+
+  it('shift/⌘-clicking a collapsed folder row selects but does NOT open it', async () => {
+    const onToggleDir = vi.fn();
+    const onItemClick = vi.fn();
+    const { container } = render(
+      FileTree,
+      props({ expanded: {}, onToggleDir, onItemClick }),
+    );
+    await fireEvent.click(row(container, 'notes')!, { shiftKey: true });
+    expect(onItemClick).toHaveBeenCalledWith('notes', true, { shift: true, meta: false });
+    expect(onToggleDir).not.toHaveBeenCalled();
+
+    onItemClick.mockClear();
+    await fireEvent.click(row(container, 'notes')!, { metaKey: true });
+    expect(onItemClick).toHaveBeenCalledWith('notes', true, { shift: false, meta: true });
+    expect(onToggleDir).not.toHaveBeenCalled();
+  });
+
+  it('clicking the chevron on a collapsed folder toggles without double-firing', async () => {
+    const onToggleDir = vi.fn();
+    const onItemClick = vi.fn();
+    const { getByLabelText } = render(
+      FileTree,
+      props({ expanded: {}, onToggleDir, onItemClick }),
+    );
+    // The chevron branch returns early: it toggles once and never selects.
+    await fireEvent.click(getByLabelText('Expand folder'));
+    expect(onToggleDir).toHaveBeenCalledTimes(1);
+    expect(onToggleDir).toHaveBeenCalledWith('notes');
+    expect(onItemClick).not.toHaveBeenCalled();
+  });
+
   it('clicking a file row fires onItemClick with its path and modifier flags', async () => {
     const onItemClick = vi.fn();
     const { container } = render(


### PR DESCRIPTION
## What & why

A collapsed folder in the note tree could only be expanded by clicking the little disclosure chevron (#1034 made row clicks selection-only). Opening a folder shouldn't be harder than opening a file — so a **plain click anywhere on a collapsed folder row** now expands it, on top of selecting it.

The behavior is deliberately asymmetric, exactly as requested:

| Interaction | Result |
|-------------|--------|
| Plain click, **collapsed** folder row | Selects **and opens** |
| Plain click, **open** folder row | Selects only — **does not close** |
| Click the chevron | Toggles both ways (unchanged) — the only way to collapse |
| Shift / ⌘ / Ctrl click | Pure selection/range semantics — **never** opens |

Closing stays chevron-only and modifier clicks are untouched, so nothing about multi-select or range-select changes.

## Implementation

One handler in `FileTree.svelte`: the chevron branch still returns early; otherwise we always fire `onItemClick` (selection), then additionally toggle open **only** when the click is unmodified and the folder is currently collapsed.

## Tests

Four new cases in `FileTree.test.ts` covering each row of the table above (collapsed-plain opens+selects, open-plain selects-only, shift/⌘ select-only, chevron toggles once without double-firing). Full FileTree suite green (12 tests); `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)