### PR TITLE
Docs: document the CLI way to publish a release

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -88,9 +88,28 @@ Watch it under **Actions**; a green run leaves a draft under **Releases**.
 
 ### 5. Publish
 
-Hit **Publish release**. This is the moment auto-update turns on for this
+Flip the draft public. This is the moment auto-update turns on for this
 version: within the next poll interval, already-installed apps see it and
 offer to update.
+
+From the CLI (works even when the web UI doesn't show a **Publish release**
+button — a common quirk):
+
+```bash
+gh release edit vX.Y.Z --draft=false --latest
+```
+
+`--draft=false` publishes it; `--latest` marks it the repo's latest release so
+the update feed and Releases page point at it. Before flipping, confirm the
+draft is sound (step 4) — publishing is forward-only (see below):
+
+```bash
+gh release view vX.Y.Z --json isDraft,tagName,assets \
+  --jq '{isDraft, tagName, assets: [.assets[].name]}'   # expect a .dmg and the .zip
+```
+
+Or, in the web UI when the button is present: open the draft under **Releases**
+and hit **Publish release**.
 
 ---
 


### PR DESCRIPTION
## What

Step 5 of `docs/releasing.md` said "Hit **Publish release**", but the GitHub web UI sometimes doesn't render that button on a draft. Document the CLI path as the primary way to publish:

```bash
gh release edit vX.Y.Z --draft=false --latest
```

Plus a pre-flight asset check so you confirm the load-bearing `.zip` (and a `.dmg`) are attached before flipping the draft public:

```bash
gh release view vX.Y.Z --json isDraft,tagName,assets \
  --jq '{isDraft, tagName, assets: [.assets[].name]}'
```

The web-UI **Publish release** button stays documented as the alternative when it's present.

## Why

Hit this cutting v0.3.0 — no button appeared, and the CLI was the way through. This keeps the checklist accurate for the next release.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)