### PR TITLE
Models: add Opus 5.0 to the picker and make it the default

### DIFF
--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -6,14 +6,14 @@ import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { isEffort, type Effort } from '../../shared/tools/effort';
 import { encryptSecret, decryptSecret, isEncrypted, secretEncryptionAvailable } from '../secret-storage';
 
-const DEFAULT_MODEL = 'claude-sonnet-5';
+const DEFAULT_MODEL = 'claude-opus-5';
 
 const DEPRECATED_MODELS = new Set<string>([
   'claude-sonnet-4-20250514',
 ]);
-// Note: claude-sonnet-4-6 is intentionally NOT deprecated — it's still active
-// and remains in the picker, so a user who explicitly selected it keeps it. Only
-// the default for fresh installs / unset configs moves to Sonnet 5.
+// Note: neither claude-sonnet-4-6 nor claude-opus-4-8 is deprecated — both are
+// still active and remain in the picker, so a user who explicitly selected one
+// keeps it. Only the default for fresh installs / unset configs moves to Opus 5.
 
 function resolveModel(stored: unknown): string {
   if (typeof stored !== 'string' || !stored) return DEFAULT_MODEL;

--- a/src/main/skills/stock/antithesize.md
+++ b/src/main/skills/stock/antithesize.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Generation
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, generate the antithesis."
 longDescription: >-

--- a/src/main/skills/stock/create-learning-journey.md
+++ b/src/main/skills/stock/create-learning-journey.md
@@ -10,7 +10,7 @@ context: [fullNote]
 # derivation that would otherwise mark it note-required).
 requiresNote: false
 slashCommand: /learning-journey
-model: claude-opus-4-8
+model: claude-opus-5
 web: true
 firstMessage: "{{#if note}}Build me a learning journey.{{/if}}"
 longDescription: >-

--- a/src/main/skills/stock/decompose.md
+++ b/src/main/skills/stock/decompose.md
@@ -6,7 +6,7 @@ menu: Research
 group: Decomposition
 outputMode: openConversation
 context: [fullNote]
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 tools: [ask_user]
 firstMessage: "{{#if note.path}}Decompose `{{note.path}}` into linked smaller notes.{{else}}Decompose this note into linked smaller notes.{{/if}}"

--- a/src/main/skills/stock/doublecrux.md
+++ b/src/main/skills/stock/doublecrux.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Disagreement
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, find the double crux."
 longDescription: >-

--- a/src/main/skills/stock/extract-key-claims.md
+++ b/src/main/skills/stock/extract-key-claims.md
@@ -7,7 +7,7 @@ group: Mining
 scope: source
 outputMode: openConversation
 context: [sourceMetadata, sourceBody]
-model: claude-opus-4-8
+model: claude-opus-5
 firstMessage: |-
   {{#if source}}{{#if source.body}}Extract the key claims from "{{source.title}}" — each with a verbatim supporting quote and a confidence — for my review.{{else}}This source has no extracted body text to mine yet — ingest or add its body.md first.{{/if}}{{else}}Open a source first, then run Extract Key Claims from its Tools menu.{{/if}}
 longDescription: >-

--- a/src/main/skills/stock/find-correlations.md
+++ b/src/main/skills/stock/find-correlations.md
@@ -5,7 +5,7 @@ description: Surface the strongest correlations across the thoughtbase's tabular
 menu: Analysis
 group: Data
 outputMode: openConversation
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 slashCommand: /find-correlations
 firstMessage: "Find the strongest correlations in this thoughtbase's tabular data, and show me a note to review."

--- a/src/main/skills/stock/find-outliers.md
+++ b/src/main/skills/stock/find-outliers.md
@@ -5,7 +5,7 @@ description: Flag the anomalous values in the thoughtbase's tabular data, as a r
 menu: Analysis
 group: Data
 outputMode: openConversation
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 slashCommand: /find-outliers
 firstMessage: "Find the outliers in this thoughtbase's tabular data, and show me a note to review."

--- a/src/main/skills/stock/find-tensions.md
+++ b/src/main/skills/stock/find-tensions.md
@@ -7,7 +7,7 @@ group: Disagreement
 outputMode: openConversation
 context: [fullNote]
 slashCommand: /tensions
-model: claude-opus-4-8
+model: claude-opus-5
 parameters:
   - id: otherNote
     label: Compare against

--- a/src/main/skills/stock/generate-visualizations.md
+++ b/src/main/skills/stock/generate-visualizations.md
@@ -5,7 +5,7 @@ description: Propose the right charts for the thoughtbase's tabular data, as a r
 menu: Analysis
 group: Data
 outputMode: openConversation
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 slashCommand: /visualize
 firstMessage: "Look at this thoughtbase's tabular data and propose a few good charts for me to review."

--- a/src/main/skills/stock/hamming.md
+++ b/src/main/skills/stock/hamming.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Planning
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, apply the Hamming question."
 longDescription: >-

--- a/src/main/skills/stock/organize-by-topic.md
+++ b/src/main/skills/stock/organize-by-topic.md
@@ -5,7 +5,7 @@ description: Propose moving loose notes into topic folders, reviewed as one plan
 menu: Analysis
 group: Organization
 outputMode: openConversation
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 firstMessage: "Survey this thoughtbase and propose a tidier organization — group related notes into topic folders. Show me the plan to review."
 longDescription: >-

--- a/src/main/skills/stock/synthesize.md
+++ b/src/main/skills/stock/synthesize.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Generation
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, synthesize."
 longDescription: >-

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -106,7 +106,7 @@
   /** Resolve the model a conversation actually runs on (override → global
    *  default → built-in fallback), for gating the effort picker. */
   function effectiveModel(model: string | undefined): string {
-    return model ?? defaultModel ?? 'claude-sonnet-5';
+    return model ?? defaultModel ?? 'claude-opus-5';
   }
 
   async function handleModelChange(tabId: string, e: Event) {

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -290,7 +290,7 @@
   let clipper = $state<import('../../../shared/clipper-pairing').ClipperState | null>(null);
   let clipperRevealed = $state(false);
   let clipperCopied = $state(false);
-  let model = $state('claude-sonnet-5');
+  let model = $state('claude-opus-5');
   let effort = $state<import('../../../shared/tools/effort').Effort | undefined>(undefined);
   let apiKeyInput = $state('');
   let apiKeyStatus = $state<'unknown' | 'set' | 'unset'>('unknown');

--- a/src/shared/tools/effort.ts
+++ b/src/shared/tools/effort.ts
@@ -10,7 +10,7 @@
  *   |------------------|-------------------------------------|
  *   | Haiku 4.5        | none (sending effort 400s)          |
  *   | Sonnet 4.6 / 5   | low / medium / high / max           |
- *   | Opus 4.8         | low / medium / high / xhigh / max   |
+ *   | Opus 4.8 / 5     | low / medium / high / xhigh / max   |
  *   | Fable 5          | low / medium / high / xhigh / max   |
  *
  * The UI label "Extra" maps to `xhigh`, which is Opus/Fable-tier only (Sonnet
@@ -41,6 +41,7 @@ export const DEFAULT_EFFORT: Effort = 'medium';
  * yields `[]` — we send no effort rather than risk a 400.
  */
 const SUPPORT: Record<string, Effort[]> = {
+  'claude-opus-5': ['low', 'medium', 'high', 'xhigh', 'max'],
   'claude-fable-5': ['low', 'medium', 'high', 'xhigh', 'max'],
   'claude-opus-4-8': ['low', 'medium', 'high', 'xhigh', 'max'],
   'claude-sonnet-5': ['low', 'medium', 'high', 'max'],

--- a/src/shared/tools/models.ts
+++ b/src/shared/tools/models.ts
@@ -13,11 +13,14 @@ export interface ModelOption {
 }
 
 export const MODEL_OPTIONS: ModelOption[] = [
-  // Fable 5, Opus 4.8, and Sonnet 5 all ship with a 1M-token context window by
-  // default — there is no separate "1M context" model ID at the Anthropic API,
-  // so we don't list duplicate entries for it. Ordered most→least capable.
-  // Sonnet 4.6 is kept (still active) so users who selected it aren't reset to
-  // the default; Sonnet 5 is its successor tier.
+  // Opus 5, Fable 5, Opus 4.8, and Sonnet 5 all ship with a 1M-token context
+  // window by default — there is no separate "1M context" model ID at the
+  // Anthropic API, so we don't list duplicate entries for it. Ordered
+  // most→least capable. Opus 5 is the current flagship and the default (see
+  // DEFAULT_MODEL in main/llm/settings.ts). Opus 4.8 is kept (still active) so
+  // a user who explicitly selected it isn't reset to the default. Sonnet 4.6 is
+  // likewise kept; Sonnet 5 is its successor tier.
+  { value: 'claude-opus-5', label: 'Claude Opus 5' },
   { value: 'claude-fable-5', label: 'Claude Fable 5' },
   { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
   { value: 'claude-sonnet-5', label: 'Claude Sonnet 5' },
@@ -45,6 +48,9 @@ export interface ModelPrice {
  * cost degrades to a token count with no dollar figure rather than a guess.
  */
 export const MODEL_PRICING: Record<string, ModelPrice> = {
+  // Opus 5 at the standard Opus tier ($5/$25), matching every prior Opus 4.x
+  // release (confirmed at GA — no flagship premium).
+  'claude-opus-5': { input: 5, output: 25 },
   'claude-fable-5': { input: 10, output: 50 },
   'claude-opus-4-8': { input: 5, output: 25 },
   // Sonnet 5 standard rate. It has introductory pricing of $2/$10 through

--- a/tests/shared/tools/learning-tools.test.ts
+++ b/tests/shared/tools/learning-tools.test.ts
@@ -61,7 +61,7 @@ describe('Learning skills (migrated from #180–#186 tools)', () => {
   });
 
   it('create-learning-journey is Opus-preferred (richer planning)', () => {
-    expect(defs.get('learning.create-learning-journey')!.preferredModel).toBe('claude-opus-4-8');
+    expect(defs.get('learning.create-learning-journey')!.preferredModel).toBe('claude-opus-5');
   });
 
   it('deep-dive is marked requiresSelection', () => {


### PR DESCRIPTION
Opus 5.0 GA — the last model-picker + routing update before ship.

## Picker & gating (`src/shared/tools/`)
- **`models.ts`** — `claude-opus-5` ("Claude Opus 5") added to `MODEL_OPTIONS` at the top (new flagship, and the default), and to `MODEL_PRICING` at the standard Opus tier (**$5/$25 per MTok**, confirmed — no flagship premium).
- **`effort.ts`** — `claude-opus-5` added to `SUPPORT` with the full Opus set (`low`→`max`, including `xhigh`); doc table updated. The three picker UIs render from these dynamically, so no component edits were required.

## Routing
- **`main/llm/settings.ts`** — `DEFAULT_MODEL` moved `claude-sonnet-5` → `claude-opus-5` (new global default for fresh installs / unset configs). **Opus 4.8 and Sonnet 4.6 stay listed and un-deprecated**, so a user who explicitly picked either keeps it.
- Two hardcoded default fallbacks (`ConversationsPanel.svelte`, `SettingsDialog.svelte`) bumped to match.
- **12 flagship-Opus stock skills** re-routed `claude-opus-4-8` → `claude-opus-5` (synthesize, decompose, hamming, doublecrux, the find-* analysis skills, etc.). The **35 skills deliberately on Sonnet 5 are unchanged**.

## Tests
- Updated the one assertion pinning `create-learning-journey` to the old Opus id.
- `pnpm lint` clean; affected suites (`settings`, `effort`, `conversation-cost`, `skills-compile`, `learning-tools`, `skills-registry`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)