### PR TITLE
docs: add "What is a thoughtbase?" intro + thoughtbase operations pages

### DIFF
--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -6,14 +6,14 @@ import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { isEffort, type Effort } from '../../shared/tools/effort';
 import { encryptSecret, decryptSecret, isEncrypted, secretEncryptionAvailable } from '../secret-storage';
 
-const DEFAULT_MODEL = 'claude-sonnet-5';
+const DEFAULT_MODEL = 'claude-opus-5';
 
 const DEPRECATED_MODELS = new Set<string>([
   'claude-sonnet-4-20250514',
 ]);
-// Note: claude-sonnet-4-6 is intentionally NOT deprecated — it's still active
-// and remains in the picker, so a user who explicitly selected it keeps it. Only
-// the default for fresh installs / unset configs moves to Sonnet 5.
+// Note: neither claude-sonnet-4-6 nor claude-opus-4-8 is deprecated — both are
+// still active and remain in the picker, so a user who explicitly selected one
+// keeps it. Only the default for fresh installs / unset configs moves to Opus 5.
 
 function resolveModel(stored: unknown): string {
   if (typeof stored !== 'string' || !stored) return DEFAULT_MODEL;

--- a/src/main/skills/stock/antithesize.md
+++ b/src/main/skills/stock/antithesize.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Generation
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, generate the antithesis."
 longDescription: >-

--- a/src/main/skills/stock/create-learning-journey.md
+++ b/src/main/skills/stock/create-learning-journey.md
@@ -10,7 +10,7 @@ context: [fullNote]
 # derivation that would otherwise mark it note-required).
 requiresNote: false
 slashCommand: /learning-journey
-model: claude-opus-4-8
+model: claude-opus-5
 web: true
 firstMessage: "{{#if note}}Build me a learning journey.{{/if}}"
 longDescription: >-

--- a/src/main/skills/stock/decompose.md
+++ b/src/main/skills/stock/decompose.md
@@ -6,7 +6,7 @@ menu: Research
 group: Decomposition
 outputMode: openConversation
 context: [fullNote]
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 tools: [ask_user]
 firstMessage: "{{#if note.path}}Decompose `{{note.path}}` into linked smaller notes.{{else}}Decompose this note into linked smaller notes.{{/if}}"

--- a/src/main/skills/stock/doublecrux.md
+++ b/src/main/skills/stock/doublecrux.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Disagreement
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, find the double crux."
 longDescription: >-

--- a/src/main/skills/stock/extract-key-claims.md
+++ b/src/main/skills/stock/extract-key-claims.md
@@ -7,7 +7,7 @@ group: Mining
 scope: source
 outputMode: openConversation
 context: [sourceMetadata, sourceBody]
-model: claude-opus-4-8
+model: claude-opus-5
 firstMessage: |-
   {{#if source}}{{#if source.body}}Extract the key claims from "{{source.title}}" — each with a verbatim supporting quote and a confidence — for my review.{{else}}This source has no extracted body text to mine yet — ingest or add its body.md first.{{/if}}{{else}}Open a source first, then run Extract Key Claims from its Tools menu.{{/if}}
 longDescription: >-

--- a/src/main/skills/stock/find-correlations.md
+++ b/src/main/skills/stock/find-correlations.md
@@ -5,7 +5,7 @@ description: Surface the strongest correlations across the thoughtbase's tabular
 menu: Analysis
 group: Data
 outputMode: openConversation
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 slashCommand: /find-correlations
 firstMessage: "Find the strongest correlations in this thoughtbase's tabular data, and show me a note to review."

--- a/src/main/skills/stock/find-outliers.md
+++ b/src/main/skills/stock/find-outliers.md
@@ -5,7 +5,7 @@ description: Flag the anomalous values in the thoughtbase's tabular data, as a r
 menu: Analysis
 group: Data
 outputMode: openConversation
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 slashCommand: /find-outliers
 firstMessage: "Find the outliers in this thoughtbase's tabular data, and show me a note to review."

--- a/src/main/skills/stock/find-tensions.md
+++ b/src/main/skills/stock/find-tensions.md
@@ -7,7 +7,7 @@ group: Disagreement
 outputMode: openConversation
 context: [fullNote]
 slashCommand: /tensions
-model: claude-opus-4-8
+model: claude-opus-5
 parameters:
   - id: otherNote
     label: Compare against

--- a/src/main/skills/stock/generate-visualizations.md
+++ b/src/main/skills/stock/generate-visualizations.md
@@ -5,7 +5,7 @@ description: Propose the right charts for the thoughtbase's tabular data, as a r
 menu: Analysis
 group: Data
 outputMode: openConversation
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 slashCommand: /visualize
 firstMessage: "Look at this thoughtbase's tabular data and propose a few good charts for me to review."

--- a/src/main/skills/stock/hamming.md
+++ b/src/main/skills/stock/hamming.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Planning
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, apply the Hamming question."
 longDescription: >-

--- a/src/main/skills/stock/organize-by-topic.md
+++ b/src/main/skills/stock/organize-by-topic.md
@@ -5,7 +5,7 @@ description: Propose moving loose notes into topic folders, reviewed as one plan
 menu: Analysis
 group: Organization
 outputMode: openConversation
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 firstMessage: "Survey this thoughtbase and propose a tidier organization — group related notes into topic folders. Show me the plan to review."
 longDescription: >-

--- a/src/main/skills/stock/synthesize.md
+++ b/src/main/skills/stock/synthesize.md
@@ -6,7 +6,7 @@ menu: Analysis
 group: Generation
 outputMode: openConversation
 context: [selectedText, fullNote]
-model: claude-opus-4-8
+model: claude-opus-5
 web: false
 firstMessage: "For {{#if selection}}this selection{{else}}this note{{/if}}, synthesize."
 longDescription: >-

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -106,7 +106,7 @@
   /** Resolve the model a conversation actually runs on (override → global
    *  default → built-in fallback), for gating the effort picker. */
   function effectiveModel(model: string | undefined): string {
-    return model ?? defaultModel ?? 'claude-sonnet-5';
+    return model ?? defaultModel ?? 'claude-opus-5';
   }
 
   async function handleModelChange(tabId: string, e: Event) {

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -290,7 +290,7 @@
   let clipper = $state<import('../../../shared/clipper-pairing').ClipperState | null>(null);
   let clipperRevealed = $state(false);
   let clipperCopied = $state(false);
-  let model = $state('claude-sonnet-5');
+  let model = $state('claude-opus-5');
   let effort = $state<import('../../../shared/tools/effort').Effort | undefined>(undefined);
   let apiKeyInput = $state('');
   let apiKeyStatus = $state<'unknown' | 'set' | 'unset'>('unknown');

--- a/src/shared/tools/effort.ts
+++ b/src/shared/tools/effort.ts
@@ -10,7 +10,7 @@
  *   |------------------|-------------------------------------|
  *   | Haiku 4.5        | none (sending effort 400s)          |
  *   | Sonnet 4.6 / 5   | low / medium / high / max           |
- *   | Opus 4.8         | low / medium / high / xhigh / max   |
+ *   | Opus 4.8 / 5     | low / medium / high / xhigh / max   |
  *   | Fable 5          | low / medium / high / xhigh / max   |
  *
  * The UI label "Extra" maps to `xhigh`, which is Opus/Fable-tier only (Sonnet
@@ -41,6 +41,7 @@ export const DEFAULT_EFFORT: Effort = 'medium';
  * yields `[]` — we send no effort rather than risk a 400.
  */
 const SUPPORT: Record<string, Effort[]> = {
+  'claude-opus-5': ['low', 'medium', 'high', 'xhigh', 'max'],
   'claude-fable-5': ['low', 'medium', 'high', 'xhigh', 'max'],
   'claude-opus-4-8': ['low', 'medium', 'high', 'xhigh', 'max'],
   'claude-sonnet-5': ['low', 'medium', 'high', 'max'],

--- a/src/shared/tools/models.ts
+++ b/src/shared/tools/models.ts
@@ -13,11 +13,14 @@ export interface ModelOption {
 }
 
 export const MODEL_OPTIONS: ModelOption[] = [
-  // Fable 5, Opus 4.8, and Sonnet 5 all ship with a 1M-token context window by
-  // default — there is no separate "1M context" model ID at the Anthropic API,
-  // so we don't list duplicate entries for it. Ordered most→least capable.
-  // Sonnet 4.6 is kept (still active) so users who selected it aren't reset to
-  // the default; Sonnet 5 is its successor tier.
+  // Opus 5, Fable 5, Opus 4.8, and Sonnet 5 all ship with a 1M-token context
+  // window by default — there is no separate "1M context" model ID at the
+  // Anthropic API, so we don't list duplicate entries for it. Ordered
+  // most→least capable. Opus 5 is the current flagship and the default (see
+  // DEFAULT_MODEL in main/llm/settings.ts). Opus 4.8 is kept (still active) so
+  // a user who explicitly selected it isn't reset to the default. Sonnet 4.6 is
+  // likewise kept; Sonnet 5 is its successor tier.
+  { value: 'claude-opus-5', label: 'Claude Opus 5' },
   { value: 'claude-fable-5', label: 'Claude Fable 5' },
   { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
   { value: 'claude-sonnet-5', label: 'Claude Sonnet 5' },
@@ -45,6 +48,9 @@ export interface ModelPrice {
  * cost degrades to a token count with no dollar figure rather than a guess.
  */
 export const MODEL_PRICING: Record<string, ModelPrice> = {
+  // Opus 5 at the standard Opus tier ($5/$25), matching every prior Opus 4.x
+  // release (confirmed at GA — no flagship premium).
+  'claude-opus-5': { input: 5, output: 25 },
   'claude-fable-5': { input: 10, output: 50 },
   'claude-opus-4-8': { input: 5, output: 25 },
   // Sonnet 5 standard rate. It has introductory pricing of $2/$10 through

--- a/tests/shared/tools/learning-tools.test.ts
+++ b/tests/shared/tools/learning-tools.test.ts
@@ -61,7 +61,7 @@ describe('Learning skills (migrated from #180–#186 tools)', () => {
   });
 
   it('create-learning-journey is Opus-preferred (richer planning)', () => {
-    expect(defs.get('learning.create-learning-journey')!.preferredModel).toBe('claude-opus-4-8');
+    expect(defs.get('learning.create-learning-journey')!.preferredModel).toBe('claude-opus-5');
   });
 
   it('deep-dive is marked requiresSelection', () => {

--- a/website/docs/conversations-chatting.html
+++ b/website/docs/conversations-chatting.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/conversations-drafts.html
+++ b/website/docs/conversations-drafts.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/conversations-propose-review-approve.html
+++ b/website/docs/conversations-propose-review-approve.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/conversations.html
+++ b/website/docs/conversations.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/editor-keyboard-shortcuts.html
+++ b/website/docs/editor-keyboard-shortcuts.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/editor-link-autocomplete.html
+++ b/website/docs/editor-link-autocomplete.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/editor-markdown-formatting.html
+++ b/website/docs/editor-markdown-formatting.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/editor-voice-dictation.html
+++ b/website/docs/editor-voice-dictation.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/editor.html
+++ b/website/docs/editor.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/export-bibliography.html
+++ b/website/docs/export-bibliography.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/export-documents.html
+++ b/website/docs/export-documents.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/export-flashcards.html
+++ b/website/docs/export-flashcards.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/export-publishing.html
+++ b/website/docs/export-publishing.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/export-scopes-privacy.html
+++ b/website/docs/export-scopes-privacy.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/export.html
+++ b/website/docs/export.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html" class="active">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>
@@ -78,6 +79,11 @@
 
     <h2 id="sections">Browse by section</h2>
     <div class="doc-cards">
+      <a class="doc-card" href="thoughtbase.html">
+        <span class="em">📚</span>
+        <h3>What is a thoughtbase?</h3>
+        <p>The big picture — what a thoughtbase is, what people build one for, everything it holds, and how to create, open, and switch between them.</p>
+      </a>
       <a class="doc-card" href="notes.html">
         <span class="em">🧵</span>
         <h3>Notes</h3>
@@ -127,9 +133,9 @@
 
     <div class="pager">
       <span></span>
-      <a class="next" href="notes.html">
+      <a class="next" href="thoughtbase.html">
         <span class="dir">Next</span>
-        <span class="ttl">Notes →</span>
+        <span class="ttl">What is a thoughtbase? →</span>
       </a>
     </div>
   </main>

--- a/website/docs/ingest-adding-sources.html
+++ b/website/docs/ingest-adding-sources.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/ingest-citing-duplicates.html
+++ b/website/docs/ingest-citing-duplicates.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/ingest-clipper.html
+++ b/website/docs/ingest-clipper.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/ingest-pdf.html
+++ b/website/docs/ingest-pdf.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/ingest.html
+++ b/website/docs/ingest.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/left-sidebar-bookmarks.html
+++ b/website/docs/left-sidebar-bookmarks.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/left-sidebar-notes-tree.html
+++ b/website/docs/left-sidebar-notes-tree.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/left-sidebar-sources.html
+++ b/website/docs/left-sidebar-sources.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/left-sidebar-tables.html
+++ b/website/docs/left-sidebar-tables.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/left-sidebar-tags.html
+++ b/website/docs/left-sidebar-tags.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/left-sidebar.html
+++ b/website/docs/left-sidebar.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/maintenance.html
+++ b/website/docs/maintenance.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>
@@ -95,10 +96,6 @@
       <div class="row">
         <div class="k">Restart Calculations<br><span class="v" style="opacity:.7">File menu</span></div>
         <div class="v">Clears everything your calculation cells have worked out and starts them fresh. Reach for this when results look confused or you want a clean slate. See <a href="editor.html">Editor</a> for how calculation cells work.</div>
-      </div>
-      <div class="row">
-        <div class="k">Clear Recent Thoughtbases<br><span class="v" style="opacity:.7">File menu</span></div>
-        <div class="v">Empties the list of recently opened thoughtbases you see when Minerva starts. It only tidies that list — none of your notes are touched.</div>
       </div>
       <div class="row">
         <div class="k">Export Knowledge Graph…<br><span class="v" style="opacity:.7">Export menu</span></div>

--- a/website/docs/navigation-back-forward.html
+++ b/website/docs/navigation-back-forward.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/navigation-breadcrumbs.html
+++ b/website/docs/navigation-breadcrumbs.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/navigation-command-palette.html
+++ b/website/docs/navigation-command-palette.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/navigation-quick-switch.html
+++ b/website/docs/navigation-quick-switch.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/navigation-search.html
+++ b/website/docs/navigation-search.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/navigation-wiki-links.html
+++ b/website/docs/navigation-wiki-links.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/navigation.html
+++ b/website/docs/navigation.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-callouts.html
+++ b/website/docs/notes-callouts.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-charts.html
+++ b/website/docs/notes-charts.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-code.html
+++ b/website/docs/notes-code.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-diagrams.html
+++ b/website/docs/notes-diagrams.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-flashcards.html
+++ b/website/docs/notes-flashcards.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-footnotes.html
+++ b/website/docs/notes-footnotes.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-frontmatter.html
+++ b/website/docs/notes-frontmatter.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-highlights.html
+++ b/website/docs/notes-highlights.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-images.html
+++ b/website/docs/notes-images.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-links.html
+++ b/website/docs/notes-links.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-math.html
+++ b/website/docs/notes-math.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-media.html
+++ b/website/docs/notes-media.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-query.html
+++ b/website/docs/notes-query.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-rdf.html
+++ b/website/docs/notes-rdf.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-search.html
+++ b/website/docs/notes-search.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-tables.html
+++ b/website/docs/notes-tables.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes-tasks.html
+++ b/website/docs/notes-tasks.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/notes.html
+++ b/website/docs/notes.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/query-menu-panel.html
+++ b/website/docs/query-menu-panel.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/query-result-blocks.html
+++ b/website/docs/query-result-blocks.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/query-runnable-cells.html
+++ b/website/docs/query-runnable-cells.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/query.html
+++ b/website/docs/query.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/refactoring-ai-assisted.html
+++ b/website/docs/refactoring-ai-assisted.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/refactoring-manual.html
+++ b/website/docs/refactoring-manual.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/refactoring-safe-delete.html
+++ b/website/docs/refactoring-safe-delete.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/refactoring.html
+++ b/website/docs/refactoring.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-backlinks.html
+++ b/website/docs/right-sidebar-backlinks.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-bookmarks.html
+++ b/website/docs/right-sidebar-bookmarks.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-citations.html
+++ b/website/docs/right-sidebar-citations.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-footnotes.html
+++ b/website/docs/right-sidebar-footnotes.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-heading-graph.html
+++ b/website/docs/right-sidebar-heading-graph.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-outgoing-links.html
+++ b/website/docs/right-sidebar-outgoing-links.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-outline.html
+++ b/website/docs/right-sidebar-outline.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-properties.html
+++ b/website/docs/right-sidebar-properties.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-proposals.html
+++ b/website/docs/right-sidebar-proposals.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-related.html
+++ b/website/docs/right-sidebar-related.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-tables.html
+++ b/website/docs/right-sidebar-tables.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar-tags.html
+++ b/website/docs/right-sidebar-tags.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/right-sidebar.html
+++ b/website/docs/right-sidebar.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-ai.html
+++ b/website/docs/settings-ai.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-appearance.html
+++ b/website/docs/settings-appearance.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-behaviors.html
+++ b/website/docs/settings-behaviors.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-bibliography.html
+++ b/website/docs/settings-bibliography.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-clipper.html
+++ b/website/docs/settings-clipper.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-compute.html
+++ b/website/docs/settings-compute.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-editor.html
+++ b/website/docs/settings-editor.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-formatter.html
+++ b/website/docs/settings-formatter.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-notes.html
+++ b/website/docs/settings-notes.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-skills.html
+++ b/website/docs/settings-skills.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-sources.html
+++ b/website/docs/settings-sources.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings-web.html
+++ b/website/docs/settings-web.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/settings.html
+++ b/website/docs/settings.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/thinking-tools-managing-authoring.html
+++ b/website/docs/thinking-tools-managing-authoring.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/thinking-tools-running-a-skill.html
+++ b/website/docs/thinking-tools-running-a-skill.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/thinking-tools-three-menus.html
+++ b/website/docs/thinking-tools-three-menus.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/thinking-tools-what-they-are.html
+++ b/website/docs/thinking-tools-what-they-are.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/thinking-tools.html
+++ b/website/docs/thinking-tools.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/thoughtbase-operations.html
+++ b/website/docs/thoughtbase-operations.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Minerva — Docs — The Writing Surface</title>
-<meta name="description" content="How the editor styles your writing as you type — headers, emphasis, and links come to life in place, without ever hiding what you actually typed." />
+<title>Minerva — Docs — Thoughtbase operations</title>
+<meta name="description" content="The File-menu commands for handling thoughtbases in Minerva: create a new thoughtbase, open one, switch between recents, close, and edit the thoughtbase guide." />
 <link rel="stylesheet" href="../minerva.css" />
 <link rel="stylesheet" href="docs.css" />
 </head>
@@ -49,6 +49,7 @@
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
     <a href="thoughtbase.html">What is a thoughtbase?</a>
+    <a href="thoughtbase-operations.html" class="sub active">Thoughtbase operations</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>
@@ -56,11 +57,6 @@
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html">Editor</a>
-    <a href="editor-writing-surface.html" class="sub active">The writing surface</a>
-    <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
-    <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
-    <a href="editor-link-autocomplete.html" class="sub">Link autocomplete</a>
-    <a href="editor-voice-dictation.html" class="sub">Voice dictation</a>
 
     <h4>The workspace</h4>
     <a href="left-sidebar.html">Left sidebar</a>
@@ -79,61 +75,87 @@
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="editor.html">Editor</a><span class="sep">/</span>The writing surface</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="thoughtbase.html">What is a thoughtbase?</a><span class="sep">/</span>Thoughtbase operations</p>
 
-    <h1>The writing surface</h1>
-    <p class="lede">The editor styles your writing as you type. Headings, emphasis, links, and more come to life right where you wrote them — you never have to switch to a preview to see how your note is shaping up. This page is about the editing pane itself. For how it sits alongside Preview and Side by side, see <a href="viewing-options-view-modes.html">View modes</a>.</p>
+    <h1>Thoughtbase operations</h1>
+    <p class="lede">A <a href="thoughtbase.html">thoughtbase</a> is a folder on your disk, and the commands for handling one live at the top of the <b>File</b> menu — grouped there first because the natural first move is "open my thoughtbase" before doing anything in it. Each window holds one open thoughtbase at a time.</p>
 
-    <h2 id="live-rendering">Your writing, styled as you type</h2>
-    <p>As soon as the editor recognizes a piece of markup, it styles it in place. A heading turns bold and colored the moment you start the line with <code>#</code>. Bold and italic text takes on real weight and slant as soon as you close it. Links become clickable, and highlights get a tinted background — all while you keep typing.</p>
-
-    <p>The one thing the editor never does is hide what you typed. The <code>#</code>, <code>**</code>, <code>==</code>, and <code>[[ ]]</code> markers stay right where you put them, styled along with the text rather than vanishing when your cursor moves away. You always see exactly what's in your note, just dressed up — so nothing is ever a surprise when you look at it again later.</p>
-
+    <h2 id="creating">Creating and opening</h2>
     <div class="deflist">
       <div class="row">
-        <div class="k">Headings</div>
-        <div class="v">Turn bold and colored as soon as the line starts with <code>#</code>. The <code>#</code> markers stay visible.</div>
+        <div class="k">New Thoughtbase…</div>
+        <div class="v"><b>File → New Thoughtbase…</b> Choose a location and name; Minerva creates the folder and sets up an empty thoughtbase, ready for your first note.</div>
       </div>
       <div class="row">
-        <div class="k">Bold, italic, strikethrough</div>
-        <div class="v"><code>**bold**</code>, <code>_italic_</code>, and <code>~~struck~~</code> take on real weight, slant, or a line-through the moment you close them — the markers stay on screen, just styled along with the text.</div>
-      </div>
-      <div class="row">
-        <div class="k">Highlights</div>
-        <div class="v"><code>==text==</code> picks up a tinted background as you type it.</div>
-      </div>
-      <div class="row">
-        <div class="k">Links</div>
-        <div class="v">Wiki links and web addresses become soft, clickable chips. You can still move your cursor through the link text to edit it, and hovering one briefly shows a preview of where it leads.</div>
-      </div>
-      <div class="row">
-        <div class="k">Footnotes</div>
-        <div class="v">A footnote marker becomes clickable, jumping between the reference and its note at the bottom; hovering shows the footnote's text.</div>
-      </div>
-      <div class="row">
-        <div class="k">Runnable cells</div>
-        <div class="v">A run marker appears next to any cell you can run, and its results are written back into the note just below it — no separate panel to check. See <a href="notes-code.html">Code &amp; queries</a>.</div>
+        <div class="k">Open Thoughtbase…</div>
+        <div class="v"><b>File → Open Thoughtbase…</b> (<kbd>⌘</kbd><kbd>O</kbd>). Pick an existing thoughtbase folder to open it in the current window. Opening any folder of markdown notes works — Minerva builds the graph for it the first time.</div>
       </div>
     </div>
 
-    <figure class="shot-img">
-      <img src="img/editor-writing-surface.png" alt="A note in the editor: a heading in bold color with its &quot;#&quot; still showing, bold text with its &quot;**&quot; markers intact, and a wiki link shown as a rounded chip — the cursor resting inside the bold text to show that your markup stays on screen while you edit." loading="lazy" />
-      <figcaption>Writing styled as you type</figcaption>
-    </figure>
+    <h2 id="switching">Switching between thoughtbases</h2>
+    <p>Keep a thoughtbase per subject and move between them however suits you:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Recent Thoughtbases</div>
+        <div class="v"><b>File → Recent Thoughtbases</b> lists the ones you've opened lately — pick one to jump straight back in.</div>
+      </div>
+      <div class="row">
+        <div class="k">Clear Recent Thoughtbases</div>
+        <div class="v"><b>File → Recent Thoughtbases → Clear Recent Thoughtbases</b> empties that list. It only tidies the list of recently opened thoughtbases — none of your notes are touched.</div>
+      </div>
+      <div class="row">
+        <div class="k">New Window</div>
+        <div class="v"><b>File → New Window</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd>) opens a second window. Because each window holds one thoughtbase, this is how you keep two open side by side — open one thoughtbase in each.</div>
+      </div>
+    </div>
 
-    <div class="box">
-      <span class="label">Themes come along</span>
-      <p>The editor takes on whatever <a href="viewing-options-themes.html">theme</a> you choose. Switch themes and your writing re-colors instantly, right along with the rest of the app.</p>
+    <h2 id="closing">Closing</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Close Thoughtbase</div>
+        <div class="v"><b>File → Close Thoughtbase</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>W</kbd>) closes the current thoughtbase and returns the window to an empty state, ready to open another. Your files are saved as you go, so nothing is lost.</div>
+      </div>
+    </div>
+
+    <h2 id="guide">The thoughtbase guide</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Edit Thoughtbase Guide…</div>
+        <div class="v"><b>File → Edit Thoughtbase Guide…</b> opens <code>thoughtbase.md</code>, a plain-English guide to this thoughtbase — its structure, intent, and conventions — that Minerva shows the assistant at the start of every conversation. It's created from a template the first time you open it. Keeping it up to date is the simplest way to make the AI's help fit how <em>this</em> thoughtbase is organized.</div>
+      </div>
+    </div>
+
+    <h2 id="rename-delete">Renaming, moving, or deleting a thoughtbase</h2>
+    <p>Because a thoughtbase is an ordinary folder, there's no separate command to rename or delete one — you do it in Finder or your file manager, like any folder. Rename or move the folder, then open it again from its new location; delete the folder to remove the thoughtbase. (Renaming, moving, and deleting individual <a href="notes.html#lifecycle">notes</a> <em>is</em> handled inside Minerva, from the sidebar.)</p>
+
+    <h2 id="related">Related</h2>
+    <p>Once a thoughtbase is open, these cover what you do next:</p>
+    <div class="doc-cards">
+      <a class="doc-card" href="ingest.html">
+        <span class="em">📥</span>
+        <h3>Ingest</h3>
+        <p>Bring web pages, PDFs, and references in as sources.</p>
+      </a>
+      <a class="doc-card" href="export.html">
+        <span class="em">📤</span>
+        <h3>Export &amp; publish</h3>
+        <p>Publish a thoughtbase to the web or export its knowledge graph.</p>
+      </a>
+      <a class="doc-card" href="maintenance.html">
+        <span class="em">🛠️</span>
+        <h3>Maintenance</h3>
+        <p>Rebuild indexes and keep the graph and search in sync.</p>
+      </a>
     </div>
 
     <div class="pager">
-      <a class="prev" href="editor.html">
+      <a class="prev" href="thoughtbase.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Editor</span>
+        <span class="ttl">← What is a thoughtbase?</span>
       </a>
-      <a class="next" href="editor-markdown-formatting.html">
+      <a class="next" href="../getting-started.html">
         <span class="dir">Next</span>
-        <span class="ttl">Markdown formatting →</span>
+        <span class="ttl">Getting started →</span>
       </a>
     </div>
   </main>

--- a/website/docs/thoughtbase.html
+++ b/website/docs/thoughtbase.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — What is a thoughtbase?</title>
+<meta name="description" content="What a thoughtbase is in Minerva, the kinds of work people build one for, and a map of everything a thoughtbase holds — notes, links, sources, data, the knowledge graph, and AI conversations." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="thoughtbase.html" class="active">What is a thoughtbase?</a>
+    <a href="thoughtbase-operations.html" class="sub">Thoughtbase operations</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="settings.html">Settings</a>
+
+    <h4>Data &amp; workflows</h4>
+    <a href="query.html">Query</a>
+    <a href="ingest.html">Ingest</a>
+    <a href="export.html">Export</a>
+    <a href="maintenance.html">Maintenance</a>
+    <a href="refactoring.html">Refactoring</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>What is a thoughtbase?</p>
+
+    <h1>What is a thoughtbase?</h1>
+    <p class="lede">A <b>thoughtbase</b> is where your thinking on a subject lives and grows. Instead of scattered documents and lost chat threads, you gather what you're working through as <a href="notes.html">notes</a> — and notes link to each other, so ideas connect the way they do in your head. Some you write yourself; some you draft side by side with the AI. Over time a thoughtbase becomes a living map of what you know, not a folder of dead files.</p>
+
+    <p>Each thoughtbase is self-contained: one folder of plain files, with its own <a href="query.html">knowledge graph</a> built automatically from what's inside. You can keep several — one per subject — and open whichever you're working in. Everything is stored locally, in plain text, and stays yours.</p>
+
+    <h2 id="what-for">What you might build one of</h2>
+    <p>A thoughtbase suits any subject you return to and want to build up over time rather than finish and forget. A few shapes it commonly takes:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">A research project</div>
+        <div class="v">A literature review, a thesis, or an ongoing investigation — papers and web pages brought in as <a href="ingest.html">sources</a>, key claims extracted, and your own synthesis linking them together.</div>
+      </div>
+      <div class="row">
+        <div class="k">A writing project</div>
+        <div class="v">A book, a report, or a long essay — the manuscript alongside the background notes, characters, arguments, and references that feed it.</div>
+      </div>
+      <div class="row">
+        <div class="k">A subject you're learning</div>
+        <div class="v">A course or a field you're getting to grips with — explanations in your own words, <a href="notes-flashcards.html">flashcards</a>, and worked examples that build on each other.</div>
+      </div>
+      <div class="row">
+        <div class="k">A decision or investigation</div>
+        <div class="v">Options, evidence, and arguments laid out and connected — support, rebut, and depends-on <a href="notes-links.html">links</a> making the structure of the reasoning visible.</div>
+      </div>
+      <div class="row">
+        <div class="k">A domain you're mapping</div>
+        <div class="v">A product area, a system's architecture, a body of law, a company's history — a reference map of what's true and how the parts relate.</div>
+      </div>
+      <div class="row">
+        <div class="k">A data analysis</div>
+        <div class="v">A question you're answering with data — <a href="notes-tables.html">CSV tables</a> you query with SQL, notes that <a href="notes-code.html">compute</a>, and <a href="notes-charts.html">charts</a> that render live against the numbers.</div>
+      </div>
+      <div class="row">
+        <div class="k">A personal knowledge base</div>
+        <div class="v">A durable place for what you know and keep coming back to — a "second brain" you can actually query, not just search.</div>
+      </div>
+    </div>
+
+    <h2 id="contents">What's inside a thoughtbase</h2>
+    <p>A thoughtbase collects several kinds of thing. Most of it is notes; the rest is the connective tissue and structure that turns a pile of notes into something you can query and build on.</p>
+
+    <div class="doc-cards">
+      <a class="doc-card" href="notes.html">
+        <span class="em">🧵</span>
+        <h3>Notes</h3>
+        <p>The main content — prose, tables, images, math, diagrams, and more. One note per idea, page, or piece.</p>
+      </a>
+      <a class="doc-card" href="notes-links.html">
+        <span class="em">🔗</span>
+        <h3>Links</h3>
+        <p>Connections between notes — plain wiki-links plus typed links like supports, rebuts, and depends-on.</p>
+      </a>
+      <a class="doc-card" href="ingest.html">
+        <span class="em">📥</span>
+        <h3>Sources</h3>
+        <p>Outside material brought in — web pages, PDFs, and references you cite and mine for claims.</p>
+      </a>
+      <a class="doc-card" href="notes-frontmatter.html">
+        <span class="em">🏷️</span>
+        <h3>Properties &amp; tags</h3>
+        <p>Structured details on a note — tags, status, and other metadata that the graph reads.</p>
+      </a>
+      <a class="doc-card" href="notes-tables.html">
+        <span class="em">📋</span>
+        <h3>Data &amp; tables</h3>
+        <p>CSV files as typed tables, and tables inside notes — queryable data that charts and cells read.</p>
+      </a>
+      <a class="doc-card" href="query.html">
+        <span class="em">🕸️</span>
+        <h3>The knowledge graph</h3>
+        <p>A precise map of titles, tags, links, and facts, built automatically on every save — queryable with SPARQL and SQL.</p>
+      </a>
+      <a class="doc-card" href="conversations.html">
+        <span class="em">💬</span>
+        <h3>Conversations &amp; proposals</h3>
+        <p>Your threads with the AI, and the changes it proposes — filed as notes and claims only after you approve them.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools.html">
+        <span class="em">🧠</span>
+        <h3>Thinking-tool output</h3>
+        <p>Results of the Learning, Research, and Analysis skills — each returned as a note you review and keep or discard.</p>
+      </a>
+    </div>
+
+    <h2 id="where">Where a thoughtbase lives</h2>
+    <p>A thoughtbase is just a folder on your disk. Your notes are ordinary markdown files inside it, organized into subfolders however you like — readable and portable, with or without Minerva. Alongside them, a hidden <code>.minerva</code> folder holds the knowledge graph and other generated data, rebuilt from your files as you work.</p>
+    <p>Because it's local-first and plain-text, a thoughtbase is yours: back it up, sync it, or put it under version control like any other folder. Nothing lives in a proprietary database you can't get out of. When you're ready to share, you can <a href="export.html">publish or export</a> a thoughtbase without giving up the original.</p>
+
+    <h2 id="managing">Creating and managing thoughtbases</h2>
+    <p>You create, open, switch between, and close thoughtbases from the <b>File</b> menu. See <a href="thoughtbase-operations.html">Thoughtbase operations</a> for each command and its keyboard shortcut.</p>
+
+    <div class="pager">
+      <a class="prev" href="index.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Overview</span>
+      </a>
+      <a class="next" href="thoughtbase-operations.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Thoughtbase operations →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/viewing-options-font-size-zoom.html
+++ b/website/docs/viewing-options-font-size-zoom.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/viewing-options-split-panes-windows.html
+++ b/website/docs/viewing-options-split-panes-windows.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/viewing-options-themes.html
+++ b/website/docs/viewing-options-themes.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/viewing-options-view-modes.html
+++ b/website/docs/viewing-options-view-modes.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>

--- a/website/docs/viewing-options.html
+++ b/website/docs/viewing-options.html
@@ -48,6 +48,7 @@
   <aside class="docs-nav">
     <h4>Introduction</h4>
     <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
     <a href="../getting-started.html">Getting started</a>
 
     <h4>Using Minerva</h4>


### PR DESCRIPTION
Another pass at the user-facing docs (`website/docs/`): an introductory section on the core concept, and a reference page for the thoughtbase-management commands.

## New pages
- **`thoughtbase.html` — "What is a thoughtbase?"** (Introduction hub)
  - What a thoughtbase is (living map of your thinking on a subject; notes that link; you + AI; self-contained, local-first).
  - **What you might build one of** — research project, writing project, a subject you're learning, a decision/investigation, a domain you're mapping, a data analysis, a personal knowledge base.
  - **What's inside** — an 8-card map (Notes, Links, Sources, Properties/tags, Data/tables, the knowledge graph, Conversations/proposals, thinking-tool output), each linking to its detail page.
  - **Where it lives** — plain markdown folder + hidden `.minerva` graph; portable and yours.
- **`thoughtbase-operations.html` — "Thoughtbase operations"** (sub-page)
  - Every File-menu lifecycle command, labels + accelerators verified against `src/main/menu.ts`: **New Thoughtbase…**, **Open Thoughtbase…** (⌘O), **Recent Thoughtbases**, **Clear Recent Thoughtbases**, **New Window** (⌘⇧N), **Close Thoughtbase** (⌘⇧W), **Edit Thoughtbase Guide…**, plus renaming/deleting via the folder.

## Wiring
- Both pages added to the **Introduction** nav group across all docs pages; the sub-link shows only within the thoughtbase family (collapse-by-family convention).
- Reading order + pagers: **Overview → What is a thoughtbase? → Thoughtbase operations → Getting started**; `index.html` gets a browse card and a repointed **Next**.
- Moved the **Clear Recent Thoughtbases** entry out of `maintenance.html` into the operations page.

## Notes
- 100 files: 2 new pages + 98 per-page nav edits (the nav block is copy-pasted per page by design).
- All internal link targets verified to exist; the help-search corpus is gitignored and rebuilds on `predev`/`prebuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)