### PR TITLE
docs: nav-tree reorg + View / Editor / Refactoring operations pages

### DIFF
--- a/website/docs/conversations-chatting.html
+++ b/website/docs/conversations-chatting.html
@@ -64,16 +64,15 @@
     <a href="conversations-chatting.html" class="sub active">Chatting with the AI</a>
     <a href="conversations-drafts.html" class="sub">Drafts</a>
     <a href="conversations-propose-review-approve.html" class="sub">The propose → review → approve loop</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/conversations-drafts.html
+++ b/website/docs/conversations-drafts.html
@@ -64,16 +64,15 @@
     <a href="conversations-chatting.html" class="sub">Chatting with the AI</a>
     <a href="conversations-drafts.html" class="sub active">Drafts</a>
     <a href="conversations-propose-review-approve.html" class="sub">The propose → review → approve loop</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/conversations-propose-review-approve.html
+++ b/website/docs/conversations-propose-review-approve.html
@@ -64,16 +64,15 @@
     <a href="conversations-chatting.html" class="sub">Chatting with the AI</a>
     <a href="conversations-drafts.html" class="sub">Drafts</a>
     <a href="conversations-propose-review-approve.html" class="sub active">The propose → review → approve loop</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -121,9 +120,9 @@
         <span class="dir">Previous</span>
         <span class="ttl">← Drafts</span>
       </a>
-      <a class="next" href="thinking-tools.html">
+      <a class="next" href="settings.html">
         <span class="dir">Next</span>
-        <span class="ttl">Thinking tools →</span>
+        <span class="ttl">Settings →</span>
       </a>
     </div>
   </main>

--- a/website/docs/conversations.html
+++ b/website/docs/conversations.html
@@ -64,16 +64,15 @@
     <a href="conversations-chatting.html" class="sub">Chatting with the AI</a>
     <a href="conversations-drafts.html" class="sub">Drafts</a>
     <a href="conversations-propose-review-approve.html" class="sub">The propose → review → approve loop</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/data-operations.html
+++ b/website/docs/data-operations.html
@@ -61,17 +61,19 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
     <a href="data-operations.html" class="sub active">Data operations</a>
-    <a href="query.html">Query</a>
+    <a href="query-menu-panel.html" class="sub">Query menu &amp; panel</a>
+    <a href="query-runnable-cells.html" class="sub">Runnable cells</a>
+    <a href="query-result-blocks.html" class="sub">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -85,7 +87,7 @@
     <div class="deflist">
       <div class="row">
         <div class="k">New Query</div>
-        <div class="v"><b>Query → New Query</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>Q</kbd>) opens a fresh query in the Query panel, where you write <b>SPARQL</b> (for the knowledge graph) or <b>SQL</b> (for tables) and run it to see the results. See <a href="query.html">Query</a> for how the panel and cells work.</div>
+        <div class="v"><b>Query → New Query</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>Q</kbd>) opens a fresh query in the Query panel, where you write <b>SPARQL</b> (for the knowledge graph) or <b>SQL</b> (for tables) and run it to see the results. See <a href="query-menu-panel.html">Query menu &amp; panel</a> for how the panel and cells work.</div>
       </div>
       <div class="row">
         <div class="k">Stock Queries</div>
@@ -107,9 +109,9 @@
 
     <h2 id="related">Related</h2>
     <div class="doc-cards">
-      <a class="doc-card" href="query.html">
+      <a class="doc-card" href="query-menu-panel.html">
         <span class="em">🔎</span>
-        <h3>Query</h3>
+        <h3>Query panel &amp; cells</h3>
         <p>The Query panel, runnable cells, and how result blocks work.</p>
       </a>
       <a class="doc-card" href="notes-tables.html">
@@ -129,9 +131,9 @@
         <span class="dir">Previous</span>
         <span class="ttl">← Working with data</span>
       </a>
-      <a class="next" href="query.html">
+      <a class="next" href="query-menu-panel.html">
         <span class="dir">Next</span>
-        <span class="ttl">Query →</span>
+        <span class="ttl">Query menu &amp; panel →</span>
       </a>
     </div>
   </main>

--- a/website/docs/data.html
+++ b/website/docs/data.html
@@ -61,17 +61,19 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html" class="active">Data</a>
     <a href="data-operations.html" class="sub">Data operations</a>
-    <a href="query.html">Query</a>
+    <a href="query-menu-panel.html" class="sub">Query menu &amp; panel</a>
+    <a href="query-runnable-cells.html" class="sub">Runnable cells</a>
+    <a href="query-result-blocks.html" class="sub">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -122,15 +124,20 @@
     <h2 id="do-with-it">What you can do with it</h2>
     <p>Once your work is data, you can query it, compute over it, and visualize it — each has its own page:</p>
     <div class="doc-cards">
-      <a class="doc-card" href="query.html">
+      <a class="doc-card" href="query-menu-panel.html">
         <span class="em">🔎</span>
-        <h3>Query panel</h3>
-        <p>Ask questions in SPARQL or SQL from a dedicated panel, and see the answers as a table.</p>
+        <h3>Query menu &amp; panel</h3>
+        <p>A dedicated place to write a question, run it, and reuse it — with ready-made and saved queries.</p>
       </a>
-      <a class="doc-card" href="notes-query.html">
+      <a class="doc-card" href="query-runnable-cells.html">
+        <span class="em">▶️</span>
+        <h3>Runnable cells</h3>
+        <p>A question you write and run right inside a note, with the answer appearing just below it.</p>
+      </a>
+      <a class="doc-card" href="query-result-blocks.html">
         <span class="em">📊</span>
-        <h3>Query cells</h3>
-        <p>Embed a live answer straight into a note — it re-runs as your data changes.</p>
+        <h3>Result blocks</h3>
+        <p>Drop a question's answer into a note as a live list, table, or chart that stays up to date.</p>
       </a>
       <a class="doc-card" href="notes-tables.html">
         <span class="em">📋</span>
@@ -154,6 +161,11 @@
       </a>
     </div>
 
+    <div class="box">
+      <span class="label">Asking questions yourself vs. asking the assistant</span>
+      <p>When you chat with the assistant, it can look things up in your knowledge base for you — see <a href="conversations.html">Conversations</a>. This section is about doing that yourself, whether from the Query panel or right inside a note.</p>
+    </div>
+
     <h2 id="where">Where your data lives</h2>
     <p>Both forms are generated from your files and stored inside the thoughtbase's hidden <code>.minerva</code> folder — the knowledge graph as a Turtle file, the tables in a local database. You never edit these directly: they're rebuilt from your notes as you work, so your markdown files always remain the source of truth. If something ever looks out of date, <a href="maintenance.html">Maintenance</a> can rebuild them on demand.</p>
 
@@ -161,9 +173,9 @@
     <p>The <b>Query</b> menu gathers the commands for asking questions and taking the graph out — running a new query, stock and saved queries, and exporting the knowledge graph. See <a href="data-operations.html">Data operations</a> for each one.</p>
 
     <div class="pager">
-      <a class="prev" href="settings-skills.html">
+      <a class="prev" href="thinking-tools-managing-authoring.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Settings: Skills</span>
+        <span class="ttl">← Managing &amp; authoring</span>
       </a>
       <a class="next" href="data-operations.html">
         <span class="dir">Next</span>

--- a/website/docs/editor-keyboard-shortcuts.html
+++ b/website/docs/editor-keyboard-shortcuts.html
@@ -56,6 +56,7 @@
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html">Editor</a>
+    <a href="editor-operations.html" class="sub">Editor operations</a>
     <a href="editor-writing-surface.html" class="sub">The writing surface</a>
     <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
     <a href="editor-keyboard-shortcuts.html" class="sub active">Keyboard shortcuts</a>
@@ -66,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/editor-link-autocomplete.html
+++ b/website/docs/editor-link-autocomplete.html
@@ -56,6 +56,7 @@
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html">Editor</a>
+    <a href="editor-operations.html" class="sub">Editor operations</a>
     <a href="editor-writing-surface.html" class="sub">The writing surface</a>
     <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
     <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
@@ -66,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/editor-markdown-formatting.html
+++ b/website/docs/editor-markdown-formatting.html
@@ -56,6 +56,7 @@
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html">Editor</a>
+    <a href="editor-operations.html" class="sub">Editor operations</a>
     <a href="editor-writing-surface.html" class="sub">The writing surface</a>
     <a href="editor-markdown-formatting.html" class="sub active">Markdown formatting</a>
     <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
@@ -66,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/editor-operations.html
+++ b/website/docs/editor-operations.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Minerva — Docs — Query</title>
-<meta name="description" content="Ask questions of your knowledge base and your tables of data: the Query panel, runnable query cells in a note, and result blocks." />
+<title>Minerva — Docs — Editor operations</title>
+<meta name="description" content="The Edit menu commands in Minerva: undo and redo, find and replace within a note and across notes, insert a template, and sort lines." />
 <link rel="stylesheet" href="../minerva.css" />
 <link rel="stylesheet" href="docs.css" />
 </head>
@@ -56,81 +56,107 @@
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html">Editor</a>
+    <a href="editor-operations.html" class="sub active">Editor operations</a>
+    <a href="editor-writing-surface.html" class="sub">The writing surface</a>
+    <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
+    <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
+    <a href="editor-link-autocomplete.html" class="sub">Link autocomplete</a>
+    <a href="editor-voice-dictation.html" class="sub">Voice dictation</a>
 
     <h4>The workspace</h4>
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html" class="active">Query</a>
-    <a href="query-menu-panel.html" class="sub">Query menu &amp; panel</a>
-    <a href="query-runnable-cells.html" class="sub">Runnable cells</a>
-    <a href="query-result-blocks.html" class="sub">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Query</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="editor.html">Editor</a><span class="sep">/</span>Editor operations</p>
 
-    <h1>Query</h1>
-    <p class="lede">Your notes aren't just something to read — you can ask questions of them. As you write, Minerva keeps track of the connections, tags, and details across everything you've written, so you can pull up answers like "every note tagged unresolved" or "all the figures in this table." You can ask from a dedicated Query panel, or right inside a note.</p>
+    <h1>Editor operations</h1>
+    <p class="lede">The <b>Edit</b> menu holds the text commands that act on the note you're writing — the familiar undo and copy/paste, plus finding and replacing, inserting a template, and tidying lines. Most also carry a keyboard shortcut.</p>
 
-    <h2 id="glance">At a glance</h2>
+    <h2 id="basics">The basics</h2>
     <div class="deflist">
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="query-menu-panel.html"><b>Query panel</b></a> — a dedicated place to write a question, run it, and reuse it: start a new one, pick from ready-made examples, or save your own.</div>
+        <div class="k">Undo · Redo · Cut · Copy · Paste · Select All</div>
+        <div class="v">The standard editing commands at the top of the <b>Edit</b> menu, with their usual shortcuts (<kbd>⌘</kbd><kbd>Z</kbd>, <kbd>⌘</kbd><kbd>C</kbd>, <kbd>⌘</kbd><kbd>V</kbd>, and so on). Undo history is per note.</div>
+      </div>
+    </div>
+
+    <h2 id="find-replace">Find and replace</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Find</div>
+        <div class="v"><b>Edit → Find</b> (<kbd>⌘</kbd><kbd>F</kbd>) searches within the current note and steps through the matches.</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="query-runnable-cells.html"><b>Runnable cells</b></a> — a question you write and run right inside a note, with the answer appearing just below it.</div>
+        <div class="k">Find and Replace</div>
+        <div class="v"><b>Edit → Find and Replace</b> (<kbd>⌘</kbd><kbd>H</kbd>) does the same, with a field to replace matches in the current note.</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="query-result-blocks.html"><b>Result blocks</b></a> — dropping a question's answer into a note as a live list, table, or chart that stays up to date.</div>
+        <div class="k">Find in Notes…</div>
+        <div class="v"><b>Edit → Find in Notes…</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd>) searches across <em>every</em> note in the thoughtbase, not just the open one. See <a href="navigation-search.html">Search</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Replace in Notes…</div>
+        <div class="v"><b>Edit → Replace in Notes…</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>H</kbd>) replaces text across every note — a careful, base-wide find-and-replace.</div>
+      </div>
+    </div>
+
+    <h2 id="insert-transform">Inserting and transforming</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Insert Template…</div>
+        <div class="v"><b>Edit → Insert Template…</b> drops a saved template into the note at the cursor — a quick way to reuse boilerplate or a standard structure.</div>
+      </div>
+      <div class="row">
+        <div class="k">Sort Lines</div>
+        <div class="v"><b>Edit → Sort Lines</b> sorts the selected lines into alphabetical order — handy for lists and tables of contents.</div>
       </div>
     </div>
 
     <div class="box">
-      <span class="label">Asking questions yourself vs. asking the assistant</span>
-      <p>When you chat with the assistant, it can look things up in your knowledge base for you — see <a href="conversations.html">Conversations</a>. This section is about doing that yourself, whether from the Query panel or right inside a note.</p>
+      <span class="label">Windows / Linux</span>
+      <p>Every shortcut above uses <kbd>Ctrl</kbd> in place of <kbd>⌘</kbd>.</p>
     </div>
 
-    <h2 id="learn-more">In depth</h2>
+    <h2 id="related">Related</h2>
     <div class="doc-cards">
-      <a class="doc-card" href="query-menu-panel.html">
-        <span class="em">🗂️</span>
-        <h3>Query panel</h3>
-        <p>Start a new question, pick a ready-made example, or save your own.</p>
+      <a class="doc-card" href="editor-keyboard-shortcuts.html">
+        <span class="em">⌨️</span>
+        <h3>Keyboard shortcuts</h3>
+        <p>Every shortcut the editor answers to, in one place.</p>
       </a>
-      <a class="doc-card" href="query-runnable-cells.html">
-        <span class="em">▶️</span>
-        <h3>Runnable cells</h3>
-        <p>Write a question and run it in place, right inside a note.</p>
+      <a class="doc-card" href="editor-writing-surface.html">
+        <span class="em">✍️</span>
+        <h3>The writing surface</h3>
+        <p>How your text formats itself as you type.</p>
       </a>
-      <a class="doc-card" href="query-result-blocks.html">
-        <span class="em">📊</span>
-        <h3>Result blocks</h3>
-        <p>Drop an answer into a note as a live list, table, or chart.</p>
+      <a class="doc-card" href="editor-voice-dictation.html">
+        <span class="em">🎙️</span>
+        <h3>Voice dictation</h3>
+        <p>Speak, and your words appear in the note.</p>
       </a>
     </div>
 
     <div class="pager">
-      <a class="prev" href="data-operations.html">
+      <a class="prev" href="editor.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Data operations</span>
+        <span class="ttl">← Editor</span>
       </a>
-      <a class="next" href="query-menu-panel.html">
+      <a class="next" href="editor-writing-surface.html">
         <span class="dir">Next</span>
-        <span class="ttl">Query menu &amp; panel →</span>
+        <span class="ttl">The writing surface →</span>
       </a>
     </div>
   </main>

--- a/website/docs/editor-voice-dictation.html
+++ b/website/docs/editor-voice-dictation.html
@@ -56,6 +56,7 @@
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html">Editor</a>
+    <a href="editor-operations.html" class="sub">Editor operations</a>
     <a href="editor-writing-surface.html" class="sub">The writing surface</a>
     <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
     <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
@@ -66,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/editor-writing-surface.html
+++ b/website/docs/editor-writing-surface.html
@@ -56,6 +56,7 @@
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html">Editor</a>
+    <a href="editor-operations.html" class="sub">Editor operations</a>
     <a href="editor-writing-surface.html" class="sub active">The writing surface</a>
     <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
     <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
@@ -66,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -128,9 +128,9 @@
     </div>
 
     <div class="pager">
-      <a class="prev" href="editor.html">
+      <a class="prev" href="editor-operations.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Editor</span>
+        <span class="ttl">← Editor operations</span>
       </a>
       <a class="next" href="editor-markdown-formatting.html">
         <span class="dir">Next</span>

--- a/website/docs/editor.html
+++ b/website/docs/editor.html
@@ -56,6 +56,7 @@
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html" class="active">Editor</a>
+    <a href="editor-operations.html" class="sub">Editor operations</a>
     <a href="editor-writing-surface.html" class="sub">The writing surface</a>
     <a href="editor-markdown-formatting.html" class="sub">Markdown formatting</a>
     <a href="editor-keyboard-shortcuts.html" class="sub">Keyboard shortcuts</a>
@@ -66,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -87,6 +87,10 @@
 
     <h2 id="glance">At a glance</h2>
     <div class="deflist">
+      <div class="row">
+        <div class="k">Edit menu</div>
+        <div class="v"><a href="editor-operations.html"><b>Editor operations</b></a> — the Edit menu at a glance: find &amp; replace, insert a template, and sort lines.</div>
+      </div>
       <div class="row">
         <div class="k">—</div>
         <div class="v"><a href="editor-writing-surface.html"><b>The writing surface</b></a> — how your text formats itself as you type.</div>
@@ -116,6 +120,11 @@
 
     <h2 id="learn-more">In depth</h2>
     <div class="doc-cards">
+      <a class="doc-card" href="editor-operations.html">
+        <span class="em">🧰</span>
+        <h3>Editor operations</h3>
+        <p>The Edit menu commands, grouped and explained.</p>
+      </a>
       <a class="doc-card" href="editor-writing-surface.html">
         <span class="em">🖋️</span>
         <h3>The writing surface</h3>
@@ -148,9 +157,9 @@
         <span class="dir">Previous</span>
         <span class="ttl">← Split panes &amp; windows</span>
       </a>
-      <a class="next" href="editor-writing-surface.html">
+      <a class="next" href="editor-operations.html">
         <span class="dir">Next</span>
-        <span class="ttl">The writing surface →</span>
+        <span class="ttl">Editor operations →</span>
       </a>
     </div>
   </main>

--- a/website/docs/export-bibliography.html
+++ b/website/docs/export-bibliography.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="export-documents.html" class="sub">Document exports</a>
@@ -75,7 +75,6 @@
     <a href="export-flashcards.html" class="sub">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub">Scopes &amp; privacy</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/export-documents.html
+++ b/website/docs/export-documents.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="export-documents.html" class="sub active">Document exports</a>
@@ -75,7 +75,6 @@
     <a href="export-flashcards.html" class="sub">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub">Scopes &amp; privacy</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/export-flashcards.html
+++ b/website/docs/export-flashcards.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="export-documents.html" class="sub">Document exports</a>
@@ -75,7 +75,6 @@
     <a href="export-flashcards.html" class="sub active">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub">Scopes &amp; privacy</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/export-publishing.html
+++ b/website/docs/export-publishing.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="export-documents.html" class="sub">Document exports</a>
@@ -75,7 +75,6 @@
     <a href="export-flashcards.html" class="sub">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub">Scopes &amp; privacy</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/export-scopes-privacy.html
+++ b/website/docs/export-scopes-privacy.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="export-documents.html" class="sub">Document exports</a>
@@ -75,7 +75,6 @@
     <a href="export-flashcards.html" class="sub">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub active">Scopes &amp; privacy</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/export.html
+++ b/website/docs/export.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html" class="active">Export</a>
     <a href="export-documents.html" class="sub">Document exports</a>
@@ -75,7 +75,6 @@
     <a href="export-flashcards.html" class="sub">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub">Scopes &amp; privacy</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -61,16 +61,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/ingest-adding-sources.html
+++ b/website/docs/ingest-adding-sources.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="ingest-adding-sources.html" class="sub active">Adding sources</a>
     <a href="ingest-pdf.html" class="sub">PDF ingest</a>
@@ -74,7 +74,6 @@
     <a href="ingest-citing-duplicates.html" class="sub">Citing &amp; duplicates</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/ingest-citing-duplicates.html
+++ b/website/docs/ingest-citing-duplicates.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="ingest-adding-sources.html" class="sub">Adding sources</a>
     <a href="ingest-pdf.html" class="sub">PDF ingest</a>
@@ -74,7 +74,6 @@
     <a href="ingest-citing-duplicates.html" class="sub active">Citing &amp; duplicates</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/ingest-clipper.html
+++ b/website/docs/ingest-clipper.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="ingest-adding-sources.html" class="sub">Adding sources</a>
     <a href="ingest-pdf.html" class="sub">PDF ingest</a>
@@ -74,7 +74,6 @@
     <a href="ingest-citing-duplicates.html" class="sub">Citing &amp; duplicates</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/ingest-pdf.html
+++ b/website/docs/ingest-pdf.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="ingest-adding-sources.html" class="sub">Adding sources</a>
     <a href="ingest-pdf.html" class="sub active">PDF ingest</a>
@@ -74,7 +74,6 @@
     <a href="ingest-citing-duplicates.html" class="sub">Citing &amp; duplicates</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/ingest.html
+++ b/website/docs/ingest.html
@@ -61,12 +61,12 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html" class="active">Ingest</a>
     <a href="ingest-adding-sources.html" class="sub">Adding sources</a>
     <a href="ingest-pdf.html" class="sub">PDF ingest</a>
@@ -74,7 +74,6 @@
     <a href="ingest-citing-duplicates.html" class="sub">Citing &amp; duplicates</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/left-sidebar-bookmarks.html
+++ b/website/docs/left-sidebar-bookmarks.html
@@ -66,16 +66,15 @@
     <a href="left-sidebar-bookmarks.html" class="sub active">Bookmarks</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/left-sidebar-notes-tree.html
+++ b/website/docs/left-sidebar-notes-tree.html
@@ -66,16 +66,15 @@
     <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/left-sidebar-sources.html
+++ b/website/docs/left-sidebar-sources.html
@@ -66,16 +66,15 @@
     <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/left-sidebar-tables.html
+++ b/website/docs/left-sidebar-tables.html
@@ -66,16 +66,15 @@
     <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/left-sidebar-tags.html
+++ b/website/docs/left-sidebar-tags.html
@@ -66,16 +66,15 @@
     <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/left-sidebar.html
+++ b/website/docs/left-sidebar.html
@@ -66,16 +66,15 @@
     <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -139,9 +138,9 @@
     </div>
 
     <div class="pager">
-      <a class="prev" href="editor.html">
+      <a class="prev" href="editor-voice-dictation.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Editor</span>
+        <span class="ttl">← Voice dictation</span>
       </a>
       <a class="next" href="left-sidebar-notes-tree.html">
         <span class="dir">Next</span>

--- a/website/docs/maintenance.html
+++ b/website/docs/maintenance.html
@@ -61,16 +61,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html" class="active">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -98,10 +97,6 @@
         <div class="k">Restart Calculations<br><span class="v" style="opacity:.7">File menu</span></div>
         <div class="v">Clears everything your calculation cells have worked out and starts them fresh. Reach for this when results look confused or you want a clean slate. See <a href="editor.html">Editor</a> for how calculation cells work.</div>
       </div>
-      <div class="row">
-        <div class="k">Export Knowledge Graph…<br><span class="v" style="opacity:.7">Export menu</span></div>
-        <div class="v">Saves a complete copy of everything Minerva knows about your notes and their connections to a file you can keep. See <a href="export.html">Export</a> for the other ways to get your work out.</div>
-      </div>
     </div>
 
     <figure class="shot-img">
@@ -119,10 +114,7 @@
         <span class="dir">Previous</span>
         <span class="ttl">← Scopes &amp; privacy</span>
       </a>
-      <a class="next" href="refactoring.html">
-        <span class="dir">Next</span>
-        <span class="ttl">Refactoring →</span>
-      </a>
+      <span></span>
     </div>
   </main>
 </div>

--- a/website/docs/navigation-back-forward.html
+++ b/website/docs/navigation-back-forward.html
@@ -67,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/navigation-breadcrumbs.html
+++ b/website/docs/navigation-breadcrumbs.html
@@ -67,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/navigation-command-palette.html
+++ b/website/docs/navigation-command-palette.html
@@ -67,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/navigation-quick-switch.html
+++ b/website/docs/navigation-quick-switch.html
@@ -67,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/navigation-search.html
+++ b/website/docs/navigation-search.html
@@ -67,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/navigation-wiki-links.html
+++ b/website/docs/navigation-wiki-links.html
@@ -67,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/navigation.html
+++ b/website/docs/navigation.html
@@ -67,16 +67,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-callouts.html
+++ b/website/docs/notes-callouts.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-charts.html
+++ b/website/docs/notes-charts.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-code.html
+++ b/website/docs/notes-code.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-diagrams.html
+++ b/website/docs/notes-diagrams.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-flashcards.html
+++ b/website/docs/notes-flashcards.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-footnotes.html
+++ b/website/docs/notes-footnotes.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-frontmatter.html
+++ b/website/docs/notes-frontmatter.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-highlights.html
+++ b/website/docs/notes-highlights.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-images.html
+++ b/website/docs/notes-images.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-links.html
+++ b/website/docs/notes-links.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-math.html
+++ b/website/docs/notes-math.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-media.html
+++ b/website/docs/notes-media.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-query.html
+++ b/website/docs/notes-query.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -176,7 +175,7 @@ title: Mentioned in
 
     <div class="box">
       <span class="label">These cells only read</span>
-      <p>A query cell never changes your note or your knowledge base — it just shows what it finds. It refreshes on its own as your notes change, so an embedded list or table always reflects where things stand right now. To run a query once and keep its answer as fixed text, or to explore in a dedicated space, see <a href="notes-code.html">Code &amp; compute cells</a> and the <a href="query.html">Query</a> section.</p>
+      <p>A query cell never changes your note or your knowledge base — it just shows what it finds. It refreshes on its own as your notes change, so an embedded list or table always reflects where things stand right now. To run a query once and keep its answer as fixed text, or to explore in a dedicated space, see <a href="notes-code.html">Code &amp; compute cells</a> and <a href="data.html">Working with data</a>.</p>
     </div>
 
     <div class="pager">

--- a/website/docs/notes-rdf.html
+++ b/website/docs/notes-rdf.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-search.html
+++ b/website/docs/notes-search.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-tables.html
+++ b/website/docs/notes-tables.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes-tasks.html
+++ b/website/docs/notes-tasks.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/notes.html
+++ b/website/docs/notes.html
@@ -78,16 +78,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/query-menu-panel.html
+++ b/website/docs/query-menu-panel.html
@@ -61,24 +61,24 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
+    <a href="data-operations.html" class="sub">Data operations</a>
     <a href="query-menu-panel.html" class="sub active">Query menu &amp; panel</a>
     <a href="query-runnable-cells.html" class="sub">Runnable cells</a>
     <a href="query-result-blocks.html" class="sub">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="query.html">Query</a><span class="sep">/</span>Query menu &amp; panel</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="data.html">Working with data</a><span class="sep">/</span>Query menu &amp; panel</p>
 
     <h1>Query menu &amp; panel</h1>
     <p class="lede">A dedicated tab for asking questions of your knowledge base — the links between your notes, or the data in your tables — and getting back a results table you can sort, save, or drop into a note.</p>
@@ -155,9 +155,9 @@
     </div>
 
     <div class="pager">
-      <a class="prev" href="query.html">
+      <a class="prev" href="data-operations.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Query</span>
+        <span class="ttl">← Data operations</span>
       </a>
       <a class="next" href="query-runnable-cells.html">
         <span class="dir">Next</span>

--- a/website/docs/query-result-blocks.html
+++ b/website/docs/query-result-blocks.html
@@ -61,24 +61,24 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
+    <a href="data-operations.html" class="sub">Data operations</a>
     <a href="query-menu-panel.html" class="sub">Query menu &amp; panel</a>
     <a href="query-runnable-cells.html" class="sub">Runnable cells</a>
     <a href="query-result-blocks.html" class="sub active">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="query.html">Query</a><span class="sep">/</span>Result blocks</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="data.html">Working with data</a><span class="sep">/</span>Result blocks</p>
 
     <h1>Result blocks</h1>
     <p class="lede">A result block puts a query's answer right inside a note and keeps it up to date — as a list, a table, or a chart that refreshes on its own whenever you open the note. You don't have to paste in fresh numbers by hand. The easiest way to create one is the Query panel's "Copy as…" menu (see <a href="query-menu-panel.html">Query menu &amp; panel</a>), which builds the block for you, but you can also write one yourself.</p>

--- a/website/docs/query-runnable-cells.html
+++ b/website/docs/query-runnable-cells.html
@@ -61,24 +61,24 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
+    <a href="data-operations.html" class="sub">Data operations</a>
     <a href="query-menu-panel.html" class="sub">Query menu &amp; panel</a>
     <a href="query-runnable-cells.html" class="sub active">Runnable cells</a>
     <a href="query-result-blocks.html" class="sub">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="query.html">Query</a><span class="sep">/</span>Runnable cells</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="data.html">Working with data</a><span class="sep">/</span>Runnable cells</p>
 
     <h1>Runnable cells</h1>
     <p class="lede">A query written inside a note isn't just an example to read — it's live. Run it right where it sits, and the answer appears just below. It's a natural way to keep a question and its answer together in your notes.</p>

--- a/website/docs/refactoring-ai-assisted.html
+++ b/website/docs/refactoring-ai-assisted.html
@@ -61,19 +61,19 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
-    <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
-    <a href="ingest.html">Ingest</a>
-    <a href="export.html">Export</a>
-    <a href="maintenance.html">Maintenance</a>
     <a href="refactoring.html">Refactoring</a>
+    <a href="refactoring-operations.html" class="sub">Refactoring operations</a>
     <a href="refactoring-manual.html" class="sub">Manual rename, move &amp; delete</a>
     <a href="refactoring-safe-delete.html" class="sub">Safe delete &amp; dangling links</a>
     <a href="refactoring-ai-assisted.html" class="sub active">AI-assisted refactors</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="data.html">Data</a>
+    <a href="ingest.html">Ingest</a>
+    <a href="export.html">Export</a>
+    <a href="maintenance.html">Maintenance</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -108,7 +108,10 @@
         <span class="dir">Previous</span>
         <span class="ttl">← Safe delete &amp; dangling links</span>
       </a>
-      <span></span>
+      <a class="next" href="thinking-tools.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Thinking tools →</span>
+      </a>
     </div>
   </main>
 </div>

--- a/website/docs/refactoring-manual.html
+++ b/website/docs/refactoring-manual.html
@@ -61,19 +61,19 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
-    <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
-    <a href="ingest.html">Ingest</a>
-    <a href="export.html">Export</a>
-    <a href="maintenance.html">Maintenance</a>
     <a href="refactoring.html">Refactoring</a>
+    <a href="refactoring-operations.html" class="sub">Refactoring operations</a>
     <a href="refactoring-manual.html" class="sub active">Manual rename, move &amp; delete</a>
     <a href="refactoring-safe-delete.html" class="sub">Safe delete &amp; dangling links</a>
     <a href="refactoring-ai-assisted.html" class="sub">AI-assisted refactors</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="data.html">Data</a>
+    <a href="ingest.html">Ingest</a>
+    <a href="export.html">Export</a>
+    <a href="maintenance.html">Maintenance</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -129,9 +129,9 @@
     </div>
 
     <div class="pager">
-      <a class="prev" href="refactoring.html">
+      <a class="prev" href="refactoring-operations.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Refactoring</span>
+        <span class="ttl">← Refactoring operations</span>
       </a>
       <a class="next" href="refactoring-safe-delete.html">
         <span class="dir">Next</span>

--- a/website/docs/refactoring-operations.html
+++ b/website/docs/refactoring-operations.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Minerva — Docs — Refactoring</title>
-<meta name="description" content="Renaming, moving, and deleting notes — by hand and via the AI — and what happens to links when you do." />
+<title>Minerva — Docs — Refactoring operations</title>
+<meta name="description" content="The Refactor menu commands in Minerva: rename, move, and copy a note; split and extract; AI-assisted auto-tag, auto-link, and decompose; format and insert a bibliography." />
 <link rel="stylesheet" href="../minerva.css" />
 <link rel="stylesheet" href="docs.css" />
 </head>
@@ -64,8 +64,8 @@
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
-    <a href="refactoring.html" class="active">Refactoring</a>
-    <a href="refactoring-operations.html" class="sub">Refactoring operations</a>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="refactoring-operations.html" class="sub active">Refactoring operations</a>
     <a href="refactoring-manual.html" class="sub">Manual rename, move &amp; delete</a>
     <a href="refactoring-safe-delete.html" class="sub">Safe delete &amp; dangling links</a>
     <a href="refactoring-ai-assisted.html" class="sub">AI-assisted refactors</a>
@@ -78,68 +78,103 @@
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Refactoring</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="refactoring.html">Refactoring</a><span class="sep">/</span>Refactoring operations</p>
 
-    <h1>Refactoring</h1>
-    <p class="lede">Rename, move, and delete notes — either by hand or by asking the assistant to do it for you. Whichever way you go, the links between your notes stay coherent, because Minerva keeps them up to date for you.</p>
+    <h1>Refactoring operations</h1>
+    <p class="lede">The <b>Refactor</b> menu gathers every structural change you can make to the current note in one place — renaming and moving, splitting a note apart, AI-assisted reorganization, and formatting. Through all of them, Minerva keeps the links between your notes coherent, so a change never leaves a broken reference behind. Each command works on the note you're editing.</p>
 
-    <h2 id="glance">At a glance</h2>
+    <h2 id="rename-move">Renaming and moving</h2>
     <div class="deflist">
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="refactoring-operations.html"><b>Refactoring operations</b></a> — the Refactor menu at a glance: every rename, split, AI-assisted, and formatting command.</div>
+        <div class="k">Rename…</div>
+        <div class="v"><b>Refactor → Rename…</b> gives the note a new name and updates every <a href="notes-links.html">link</a> that pointed at the old one, so nothing breaks. See <a href="refactoring-manual.html">Manual rename, move &amp; delete</a>.</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="refactoring-manual.html"><b>Manual rename, move &amp; delete</b></a> — right-click, drag, and what updates for you.</div>
+        <div class="k">Move…</div>
+        <div class="v"><b>Refactor → Move…</b> moves the note to a different folder; its links follow it. (You can also drag it in the sidebar.)</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="refactoring-safe-delete.html"><b>Safe delete &amp; dangling links</b></a> — a heads-up before you delete a note others link to.</div>
-      </div>
-      <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="refactoring-ai-assisted.html"><b>AI-assisted refactors</b></a> — ask the assistant to rename, move, reorganize, or delete, and review before anything changes.</div>
+        <div class="k">Copy…</div>
+        <div class="v"><b>Refactor → Copy…</b> makes a duplicate of the note at a location you choose.</div>
       </div>
     </div>
 
-    <div class="box">
-      <span class="label">Deleting is a normal operation</span>
-      <p>Renaming, moving, and deleting are everyday actions, not scary ones. Minerva asks for a simple confirmation and then gets out of your way.</p>
+    <h2 id="splitting">Splitting a note</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Extract Selection to New Note</div>
+        <div class="v"><b>Refactor → Extract Selection to New Note</b> pulls the selected text out into a brand-new note and leaves a link to it in its place. Select some text first.</div>
+      </div>
+      <div class="row">
+        <div class="k">Split Note Here</div>
+        <div class="v"><b>Refactor → Split Note Here</b> divides the note in two at the cursor, keeping the text above and moving the text below into a new, linked note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Split by Heading…</div>
+        <div class="v"><b>Refactor → Split by Heading…</b> breaks one long note into several — one per heading — linked together.</div>
+      </div>
     </div>
 
-    <h2 id="learn-more">In depth</h2>
+    <h2 id="ai-assisted">AI-assisted</h2>
+    <p>These ask the assistant to do the work and hand you the result as a <a href="conversations.html">proposal</a> to review — nothing changes until you approve it. See <a href="refactoring-ai-assisted.html">AI-assisted refactors</a>.</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Auto-tag</div>
+        <div class="v"><b>Refactor → Auto-tag</b> suggests <a href="notes-frontmatter.html">tags</a> for the note based on what it's about.</div>
+      </div>
+      <div class="row">
+        <div class="k">Auto-link outbound…</div>
+        <div class="v"><b>Refactor → Auto-link outbound…</b> proposes links <em>from</em> this note to other relevant notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Auto-link inbound…</div>
+        <div class="v"><b>Refactor → Auto-link inbound…</b> proposes links <em>to</em> this note from other relevant notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Decompose Note…</div>
+        <div class="v"><b>Refactor → Decompose Note…</b> proposes breaking a long note into smaller, linked notes.</div>
+      </div>
+    </div>
+
+    <h2 id="format-biblio">Formatting and bibliography</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Format</div>
+        <div class="v"><b>Refactor → Format</b> tidies the note's Markdown into a consistent style (or every note selected in the sidebar). See <a href="settings-formatter.html">Formatter settings</a> for what it does.</div>
+      </div>
+      <div class="row">
+        <div class="k">Insert/Update Bibliography</div>
+        <div class="v"><b>Refactor → Insert/Update Bibliography</b> renders a References section listing every <a href="ingest.html">source</a> the note cites, in your configured citation style. See <a href="export-bibliography.html">Bibliography &amp; citations</a>.</div>
+      </div>
+    </div>
+
+    <h2 id="related">Related</h2>
     <div class="doc-cards">
-      <a class="doc-card" href="refactoring-operations.html">
-        <span class="em">🧰</span>
-        <h3>Refactoring operations</h3>
-        <p>The Refactor menu commands, grouped and explained.</p>
-      </a>
       <a class="doc-card" href="refactoring-manual.html">
         <span class="em">✏️</span>
         <h3>Manual rename, move &amp; delete</h3>
-        <p>Right-click, drag, and what automatically updates when you do.</p>
-      </a>
-      <a class="doc-card" href="refactoring-safe-delete.html">
-        <span class="em">🔗</span>
-        <h3>Safe delete &amp; dangling links</h3>
-        <p>What Minerva checks before you delete a note others link to.</p>
+        <p>Right-click and drag in the sidebar, and what updates for you.</p>
       </a>
       <a class="doc-card" href="refactoring-ai-assisted.html">
         <span class="em">🤖</span>
         <h3>AI-assisted refactors</h3>
         <p>Ask the assistant — review the plan before anything changes.</p>
       </a>
+      <a class="doc-card" href="refactoring-safe-delete.html">
+        <span class="em">🔗</span>
+        <h3>Safe delete &amp; dangling links</h3>
+        <p>What Minerva checks before you delete a note others link to.</p>
+      </a>
     </div>
 
     <div class="pager">
-      <a class="prev" href="settings-skills.html">
+      <a class="prev" href="refactoring.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Skills</span>
+        <span class="ttl">← Refactoring</span>
       </a>
-      <a class="next" href="refactoring-operations.html">
+      <a class="next" href="refactoring-manual.html">
         <span class="dir">Next</span>
-        <span class="ttl">Refactoring operations →</span>
+        <span class="ttl">Manual rename, move &amp; delete →</span>
       </a>
     </div>
   </main>

--- a/website/docs/refactoring-safe-delete.html
+++ b/website/docs/refactoring-safe-delete.html
@@ -61,19 +61,19 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
-    <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
-    <a href="ingest.html">Ingest</a>
-    <a href="export.html">Export</a>
-    <a href="maintenance.html">Maintenance</a>
     <a href="refactoring.html">Refactoring</a>
+    <a href="refactoring-operations.html" class="sub">Refactoring operations</a>
     <a href="refactoring-manual.html" class="sub">Manual rename, move &amp; delete</a>
     <a href="refactoring-safe-delete.html" class="sub active">Safe delete &amp; dangling links</a>
     <a href="refactoring-ai-assisted.html" class="sub">AI-assisted refactors</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="data.html">Data</a>
+    <a href="ingest.html">Ingest</a>
+    <a href="export.html">Export</a>
+    <a href="maintenance.html">Maintenance</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-backlinks.html
+++ b/website/docs/right-sidebar-backlinks.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-bookmarks.html
+++ b/website/docs/right-sidebar-bookmarks.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub active">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-citations.html
+++ b/website/docs/right-sidebar-citations.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-footnotes.html
+++ b/website/docs/right-sidebar-footnotes.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-heading-graph.html
+++ b/website/docs/right-sidebar-heading-graph.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub active">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-outgoing-links.html
+++ b/website/docs/right-sidebar-outgoing-links.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-outline.html
+++ b/website/docs/right-sidebar-outline.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-properties.html
+++ b/website/docs/right-sidebar-properties.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-proposals.html
+++ b/website/docs/right-sidebar-proposals.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-related.html
+++ b/website/docs/right-sidebar-related.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-tables.html
+++ b/website/docs/right-sidebar-tables.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar-tags.html
+++ b/website/docs/right-sidebar-tags.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/right-sidebar.html
+++ b/website/docs/right-sidebar.html
@@ -73,16 +73,15 @@
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-ai.html
+++ b/website/docs/settings-ai.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-appearance.html
+++ b/website/docs/settings-appearance.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub active">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-behaviors.html
+++ b/website/docs/settings-behaviors.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-bibliography.html
+++ b/website/docs/settings-bibliography.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-clipper.html
+++ b/website/docs/settings-clipper.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-compute.html
+++ b/website/docs/settings-compute.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-editor.html
+++ b/website/docs/settings-editor.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub active">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-formatter.html
+++ b/website/docs/settings-formatter.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-notes.html
+++ b/website/docs/settings-notes.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-skills.html
+++ b/website/docs/settings-skills.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub active">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -111,9 +110,9 @@
         <span class="dir">Previous</span>
         <span class="ttl">← AI</span>
       </a>
-      <a class="next" href="data.html">
+      <a class="next" href="refactoring.html">
         <span class="dir">Next</span>
-        <span class="ttl">Working with data →</span>
+        <span class="ttl">Refactoring →</span>
       </a>
     </div>
   </main>

--- a/website/docs/settings-sources.html
+++ b/website/docs/settings-sources.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings-web.html
+++ b/website/docs/settings-web.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/settings.html
+++ b/website/docs/settings.html
@@ -61,7 +61,6 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html" class="active">Settings</a>
     <a href="settings-editor.html" class="sub">Editor</a>
     <a href="settings-appearance.html" class="sub">Appearance</a>
@@ -77,12 +76,12 @@
     <a href="settings-skills.html" class="sub">Skills</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -209,9 +208,9 @@
     </div>
 
     <div class="pager">
-      <a class="prev" href="thinking-tools-managing-authoring.html">
+      <a class="prev" href="conversations-propose-review-approve.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Managing &amp; authoring</span>
+        <span class="ttl">← The propose → review → approve loop</span>
       </a>
       <a class="next" href="settings-editor.html">
         <span class="dir">Next</span>

--- a/website/docs/thinking-tools-managing-authoring.html
+++ b/website/docs/thinking-tools-managing-authoring.html
@@ -61,20 +61,19 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
+    <a href="settings.html">Settings</a>
+
+    <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
     <a href="thinking-tools.html">Thinking tools</a>
     <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
     <a href="thinking-tools-managing-authoring.html" class="sub active">Managing &amp; authoring</a>
-    <a href="settings.html">Settings</a>
-
-    <h4>Data &amp; workflows</h4>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -115,9 +114,9 @@
         <span class="dir">Previous</span>
         <span class="ttl">← The three menus</span>
       </a>
-      <a class="next" href="settings.html">
+      <a class="next" href="data.html">
         <span class="dir">Next</span>
-        <span class="ttl">Settings →</span>
+        <span class="ttl">Working with data →</span>
       </a>
     </div>
   </main>

--- a/website/docs/thinking-tools-running-a-skill.html
+++ b/website/docs/thinking-tools-running-a-skill.html
@@ -61,20 +61,19 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
+    <a href="settings.html">Settings</a>
+
+    <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
     <a href="thinking-tools.html">Thinking tools</a>
     <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub active">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
     <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
-    <a href="settings.html">Settings</a>
-
-    <h4>Data &amp; workflows</h4>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/thinking-tools-three-menus.html
+++ b/website/docs/thinking-tools-three-menus.html
@@ -61,20 +61,19 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
+    <a href="settings.html">Settings</a>
+
+    <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
     <a href="thinking-tools.html">Thinking tools</a>
     <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub active">The three menus</a>
     <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
-    <a href="settings.html">Settings</a>
-
-    <h4>Data &amp; workflows</h4>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/thinking-tools-what-they-are.html
+++ b/website/docs/thinking-tools-what-they-are.html
@@ -61,20 +61,19 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
+    <a href="settings.html">Settings</a>
+
+    <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
     <a href="thinking-tools.html">Thinking tools</a>
     <a href="thinking-tools-what-they-are.html" class="sub active">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
     <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
-    <a href="settings.html">Settings</a>
-
-    <h4>Data &amp; workflows</h4>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/thinking-tools.html
+++ b/website/docs/thinking-tools.html
@@ -61,20 +61,19 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
+    <a href="settings.html">Settings</a>
+
+    <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
     <a href="thinking-tools.html" class="active">Thinking tools</a>
     <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
     <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
-    <a href="settings.html">Settings</a>
-
-    <h4>Data &amp; workflows</h4>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -134,9 +133,9 @@
     </div>
 
     <div class="pager">
-      <a class="prev" href="conversations-propose-review-approve.html">
+      <a class="prev" href="refactoring-ai-assisted.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← The propose → review → approve loop</span>
+        <span class="ttl">← AI-assisted refactors</span>
       </a>
       <a class="next" href="thinking-tools-what-they-are.html">
         <span class="dir">Next</span>

--- a/website/docs/thoughtbase-operations.html
+++ b/website/docs/thoughtbase-operations.html
@@ -62,15 +62,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
-    <a href="query.html">Query</a>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -139,7 +139,7 @@
       <a class="doc-card" href="export.html">
         <span class="em">📤</span>
         <h3>Export &amp; publish</h3>
-        <p>Publish a thoughtbase to the web or export its knowledge graph.</p>
+        <p>Publish a thoughtbase to the web, or export notes as documents and citations.</p>
       </a>
       <a class="doc-card" href="maintenance.html">
         <span class="em">🛠️</span>

--- a/website/docs/thoughtbase.html
+++ b/website/docs/thoughtbase.html
@@ -62,15 +62,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
-    <a href="query.html">Query</a>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -80,7 +80,7 @@
     <h1>What is a thoughtbase?</h1>
     <p class="lede">A <b>thoughtbase</b> is where your thinking on a subject lives and grows. Instead of scattered documents and lost chat threads, you gather what you're working through as <a href="notes.html">notes</a> — and notes link to each other, so ideas connect the way they do in your head. Some you write yourself; some you draft side by side with the AI. Over time a thoughtbase becomes a living map of what you know, not a folder of dead files.</p>
 
-    <p>Each thoughtbase is self-contained: one folder of plain files, with its own <a href="query.html">knowledge graph</a> built automatically from what's inside. You can keep several — one per subject — and open whichever you're working in. Everything is stored locally, in plain text, and stays yours.</p>
+    <p>Each thoughtbase is self-contained: one folder of plain files, with its own <a href="data.html">knowledge graph</a> built automatically from what's inside. You can keep several — one per subject — and open whichever you're working in. Everything is stored locally, in plain text, and stays yours.</p>
 
     <h2 id="what-for">What you might build one of</h2>
     <p>A thoughtbase suits any subject you return to and want to build up over time rather than finish and forget. A few shapes it commonly takes:</p>
@@ -145,7 +145,7 @@
         <h3>Data &amp; tables</h3>
         <p>CSV files as typed tables, and tables inside notes — queryable data that charts and cells read.</p>
       </a>
-      <a class="doc-card" href="query.html">
+      <a class="doc-card" href="data.html">
         <span class="em">🕸️</span>
         <h3>The knowledge graph</h3>
         <p>A precise map of titles, tags, links, and facts, built automatically on every save — queryable with SPARQL and SQL.</p>

--- a/website/docs/viewing-options-font-size-zoom.html
+++ b/website/docs/viewing-options-font-size-zoom.html
@@ -55,6 +55,7 @@
     <a href="notes.html">Notes</a>
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
+    <a href="viewing-options-operations.html" class="sub">View operations</a>
     <a href="viewing-options-view-modes.html" class="sub">View modes</a>
     <a href="viewing-options-themes.html" class="sub">Themes</a>
     <a href="viewing-options-font-size-zoom.html" class="sub active">Font size &amp; zoom</a>
@@ -65,16 +66,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/viewing-options-operations.html
+++ b/website/docs/viewing-options-operations.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Minerva — Docs — Viewing Options</title>
-<meta name="description" content="How you view a note in Minerva: the three view modes, appearance themes, font size and zoom, and splitting panes or opening new windows." />
+<title>Minerva — Docs — View operations</title>
+<meta name="description" content="The View menu commands in Minerva: toggle the sidebars and conversations, cycle preview mode, split the editor, switch theme, and adjust zoom and editor font size." />
 <link rel="stylesheet" href="../minerva.css" />
 <link rel="stylesheet" href="docs.css" />
 </head>
@@ -54,8 +54,8 @@
     <h4>Using Minerva</h4>
     <a href="notes.html">Notes</a>
     <a href="navigation.html">Navigation</a>
-    <a href="viewing-options.html" class="active">Viewing options</a>
-    <a href="viewing-options-operations.html" class="sub">View operations</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="viewing-options-operations.html" class="sub active">View operations</a>
     <a href="viewing-options-view-modes.html" class="sub">View modes</a>
     <a href="viewing-options-themes.html" class="sub">Themes</a>
     <a href="viewing-options-font-size-zoom.html" class="sub">Font size &amp; zoom</a>
@@ -79,77 +79,104 @@
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Viewing options</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="viewing-options.html">Viewing options</a><span class="sep">/</span>View operations</p>
 
-    <h1>Viewing options</h1>
-    <p class="lede">How a note looks on screen is separate from what's in it. Four independent controls shape that: how a pane displays a note, which color theme the app wears, how large the text is, and how many notes you can see side by side. None of these change your notes — they just change how you're looking at them.</p>
+    <h1>View operations</h1>
+    <p class="lede">The <b>View</b> menu controls what's on screen — which panels are showing, how a note is displayed, the split layout, the theme, and text size. Almost every command has a keyboard shortcut, so you rarely need the menu itself once they're in your fingers.</p>
 
-    <h2 id="glance">At a glance</h2>
+    <h2 id="panels">Showing and hiding panels</h2>
     <div class="deflist">
       <div class="row">
-        <div class="k">View menu</div>
-        <div class="v"><a href="viewing-options-operations.html"><b>View operations</b></a> — the View menu at a glance: panels, splits, theme, zoom, and font size.</div>
+        <div class="k">Toggle Left Sidebar</div>
+        <div class="v"><b>View → Toggle Left Sidebar</b> (<kbd>⌘</kbd><kbd>B</kbd>) shows or hides the <a href="left-sidebar.html">left rail</a> — the Notes tree, Sources, Tags, and more.</div>
       </div>
       <div class="row">
-        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd></div>
-        <div class="v"><a href="viewing-options-view-modes.html"><b>View modes</b></a> — cycle a pane through Source, Preview, and side-by-side.</div>
+        <div class="k">Toggle Right Sidebar</div>
+        <div class="v"><b>View → Toggle Right Sidebar</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>B</kbd>) shows or hides the <a href="right-sidebar.html">right rail</a> — backlinks, outline, properties, and the rest.</div>
       </div>
       <div class="row">
-        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd></div>
-        <div class="v"><a href="viewing-options-themes.html"><b>Themes</b></a> — cycle Dark, Light, High Contrast, and System.</div>
+        <div class="k">Toggle Conversations</div>
+        <div class="v"><b>View → Toggle Conversations</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>K</kbd>) shows or hides the <a href="conversations.html">Conversations</a> panel.</div>
       </div>
       <div class="row">
-        <div class="k">several</div>
-        <div class="v"><a href="viewing-options-font-size-zoom.html"><b>Font size &amp; zoom</b></a> — resize editor text and the whole window independently — they compound.</div>
-      </div>
-      <div class="row">
-        <div class="k"><kbd>⌘</kbd><kbd>\</kbd> / <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd></div>
-        <div class="v"><a href="viewing-options-split-panes-windows.html"><b>Split panes &amp; windows</b></a> — split the current window, or open a new one entirely.</div>
+        <div class="k">Cycle Preview Mode</div>
+        <div class="v"><b>View → Cycle Preview Mode</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd>) steps the current pane through Source, Preview, and side-by-side. See <a href="viewing-options-view-modes.html">View modes</a>.</div>
       </div>
     </div>
+
+    <h2 id="splits">Splitting the editor</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Split Editor Right / Down</div>
+        <div class="v"><b>View → Split Editor Right</b> (<kbd>⌘</kbd><kbd>\</kbd>) and <b>Split Editor Down</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>\</kbd>) divide the window into panes so you can see two notes at once. See <a href="viewing-options-split-panes-windows.html">Split panes &amp; windows</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Focus Next / Previous Group</div>
+        <div class="v"><b>View → Focus Next Group</b> (<kbd>⌘</kbd><kbd>⌥</kbd><kbd>→</kbd>) and <b>Focus Previous Group</b> (<kbd>⌘</kbd><kbd>⌥</kbd><kbd>←</kbd>) move the cursor between panes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Close Group</div>
+        <div class="v"><b>View → Close Group</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>W</kbd>) closes the focused pane.</div>
+      </div>
+    </div>
+
+    <h2 id="theme">Theme</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Theme</div>
+        <div class="v"><b>View → Theme</b> picks a look directly — Dark, Light, High Contrast, or System.</div>
+      </div>
+      <div class="row">
+        <div class="k">Cycle Theme</div>
+        <div class="v"><b>View → Cycle Theme</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd>) steps through them without opening the menu. See <a href="viewing-options-themes.html">Themes</a>.</div>
+      </div>
+    </div>
+
+    <h2 id="zoom">Zoom and font size</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Actual Size · Zoom In · Zoom Out</div>
+        <div class="v"><b>View → Zoom In / Zoom Out</b> scales the whole window; <b>Actual Size</b> resets it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Editor Font Size</div>
+        <div class="v"><b>View → Increase / Decrease Editor Font Size</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>=</kbd> / <kbd>⌘</kbd><kbd>⇧</kbd><kbd>-</kbd>) resizes the editor text only, and <b>Reset Editor Font Size</b> restores it. Zoom and font size are independent and compound — see <a href="viewing-options-font-size-zoom.html">Font size &amp; zoom</a>.</div>
+      </div>
+    </div>
+    <p>The View menu also offers full-screen and developer tools at the bottom.</p>
 
     <div class="box">
       <span class="label">Windows / Linux</span>
       <p>Every shortcut above uses <kbd>Ctrl</kbd> in place of <kbd>⌘</kbd>.</p>
     </div>
 
-    <h2 id="learn-more">In depth</h2>
+    <h2 id="related">Related</h2>
     <div class="doc-cards">
-      <a class="doc-card" href="viewing-options-operations.html">
-        <span class="em">🖥️</span>
-        <h3>View operations</h3>
-        <p>The View menu commands, grouped and explained.</p>
-      </a>
       <a class="doc-card" href="viewing-options-view-modes.html">
         <span class="em">🔄</span>
         <h3>View modes</h3>
-        <p>Source, Preview, or both side by side — a per-pane setting.</p>
-      </a>
-      <a class="doc-card" href="viewing-options-themes.html">
-        <span class="em">🎨</span>
-        <h3>Themes</h3>
-        <p>Dark, Light, High Contrast, or follow the OS — switches instantly.</p>
-      </a>
-      <a class="doc-card" href="viewing-options-font-size-zoom.html">
-        <span class="em">🔠</span>
-        <h3>Font size &amp; zoom</h3>
-        <p>Two separate controls for bigger text, and they compound.</p>
+        <p>Source, Preview, and side-by-side, per pane.</p>
       </a>
       <a class="doc-card" href="viewing-options-split-panes-windows.html">
         <span class="em">🪟</span>
         <h3>Split panes &amp; windows</h3>
-        <p>See two notes at once — split the window, or open a new one.</p>
+        <p>Two notes at once — in one window or several.</p>
+      </a>
+      <a class="doc-card" href="viewing-options-themes.html">
+        <span class="em">🎨</span>
+        <h3>Themes</h3>
+        <p>Dark, Light, High Contrast, and System.</p>
       </a>
     </div>
 
     <div class="pager">
-      <a class="prev" href="navigation-back-forward.html">
+      <a class="prev" href="viewing-options.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Back / forward</span>
+        <span class="ttl">← Viewing options</span>
       </a>
-      <a class="next" href="viewing-options-operations.html">
+      <a class="next" href="viewing-options-view-modes.html">
         <span class="dir">Next</span>
-        <span class="ttl">View operations →</span>
+        <span class="ttl">View modes →</span>
       </a>
     </div>
   </main>

--- a/website/docs/viewing-options-split-panes-windows.html
+++ b/website/docs/viewing-options-split-panes-windows.html
@@ -55,6 +55,7 @@
     <a href="notes.html">Notes</a>
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
+    <a href="viewing-options-operations.html" class="sub">View operations</a>
     <a href="viewing-options-view-modes.html" class="sub">View modes</a>
     <a href="viewing-options-themes.html" class="sub">Themes</a>
     <a href="viewing-options-font-size-zoom.html" class="sub">Font size &amp; zoom</a>
@@ -65,16 +66,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/viewing-options-themes.html
+++ b/website/docs/viewing-options-themes.html
@@ -55,6 +55,7 @@
     <a href="notes.html">Notes</a>
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
+    <a href="viewing-options-operations.html" class="sub">View operations</a>
     <a href="viewing-options-view-modes.html" class="sub">View modes</a>
     <a href="viewing-options-themes.html" class="sub active">Themes</a>
     <a href="viewing-options-font-size-zoom.html" class="sub">Font size &amp; zoom</a>
@@ -65,16 +66,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->

--- a/website/docs/viewing-options-view-modes.html
+++ b/website/docs/viewing-options-view-modes.html
@@ -55,6 +55,7 @@
     <a href="notes.html">Notes</a>
     <a href="navigation.html">Navigation</a>
     <a href="viewing-options.html">Viewing options</a>
+    <a href="viewing-options-operations.html" class="sub">View operations</a>
     <a href="viewing-options-view-modes.html" class="sub active">View modes</a>
     <a href="viewing-options-themes.html" class="sub">Themes</a>
     <a href="viewing-options-font-size-zoom.html" class="sub">Font size &amp; zoom</a>
@@ -65,16 +66,15 @@
     <a href="left-sidebar.html">Left sidebar</a>
     <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
-    <a href="thinking-tools.html">Thinking tools</a>
     <a href="settings.html">Settings</a>
 
     <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="data.html">Data</a>
-    <a href="query.html">Query</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="maintenance.html">Maintenance</a>
-    <a href="refactoring.html">Refactoring</a>
   </aside>
 
   <!-- ===== Content ===== -->
@@ -124,9 +124,9 @@
     </div>
 
     <div class="pager">
-      <a class="prev" href="viewing-options.html">
+      <a class="prev" href="viewing-options-operations.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Viewing options</span>
+        <span class="ttl">← View operations</span>
       </a>
       <a class="next" href="viewing-options-themes.html">
         <span class="dir">Next</span>


### PR DESCRIPTION
Consolidates all the docs work that built on #1433 into one clean change off `main` (no stacking, no conflicts). **Supersedes #1434**, which couldn't merge cleanly after #1433's squash-merge.

## Nav tree
- **Query merged under Data** — `query.html` landing page dropped (its intro folded into `data.html`); *Query menu & panel*, *Runnable cells*, *Result blocks* are now Data sub-pages, crumbs repointed.
- **Refactoring** moved to the top of *Data & workflows* (before Data).
- **Thinking tools** moved out of *The workspace* to after Refactoring.

## New "operations" pages
Menu references, parallel to the existing Thoughtbase / Data operations pages — each verified against `src/main/menu.ts` and added as the first sub of its hub:
- **`refactoring-operations.html`** — the Refactor menu (rename/move/copy, extract/split, auto-tag/auto-link/decompose, format, bibliography).
- **`viewing-options-operations.html`** — the View menu (toggle sidebars & conversations, cycle preview, split editor, theme, zoom, font size).
- **`editor-operations.html`** — the Edit menu (undo/redo, find & replace in a note and across notes, insert template, sort lines).

## Mechanics
`docs-nav` and prev/next pagers regenerated on every page from one model (unchanged families' sub-lists extracted from their own hubs; existing pager titles preserved). All internal links verified; one nav + one pager per page; no orphans.

104 files (3 new pages, `query.html` removed, the rest nav/pager regen from the reorg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)