### PR TITLE
docs: add "Connecting to Minerva" section (CLI + MCP)

### DIFF
--- a/website/docs/connecting-cli.html
+++ b/website/docs/connecting-cli.html
@@ -83,10 +83,11 @@
     <p class="lede">The Minerva CLI gives headless, scriptable access to a thoughtbase from your shell — the same core the app runs on, so it works with the app closed. Every result is printed as <b>JSON</b> on standard output, so it pipes straight into <code>jq</code> or feeds an agent directly.</p>
 
     <h2 id="build">Building and running</h2>
-    <p>The CLI is built from the Minerva source tree into a standalone Node bundle:</p>
-    <pre><code>pnpm cli:build                       # → .vite/build/cli.js
-node .vite/build/cli.js &lt;command&gt; [args] [--project &lt;path&gt;]</code></pre>
-    <p><code>pnpm cli</code> builds and runs in one step. Point any command at a thoughtbase with <code>--project &lt;path&gt;</code> — it defaults to the current directory.</p>
+    <p>Build the CLI once from the Minerva source tree and put it on your PATH as the <code>minerva</code> command:</p>
+    <pre><code>pnpm cli:build        # builds .vite/build/cli.js and marks it executable
+pnpm link --global    # exposes it globally as `minerva`</code></pre>
+    <p>From then on, <code>minerva</code> works anywhere. Point any command at a thoughtbase with <code>--project &lt;path&gt;</code> — it defaults to the current directory.</p>
+    <pre><code>minerva &lt;command&gt; [args] [--project &lt;path&gt;]</code></pre>
 
     <h2 id="commands">Commands</h2>
     <div class="deflist">
@@ -123,16 +124,16 @@ node .vite/build/cli.js &lt;command&gt; [args] [--project &lt;path&gt;]</code></
     <h2 id="grounded">Grounded JSON output</h2>
     <p>Every result is grounded and printed as JSON, so it composes with the rest of your tools — query bindings carry node identifiers, search hits carry the note path, and <code>read</code> echoes the path back.</p>
     <pre><code># What do I already know about photosynthesis?
-node .vite/build/cli.js search photosynthesis --project ~/vault | jq '.hits[].relativePath'
+minerva search photosynthesis --project ~/vault | jq '.hits[].relativePath'
 
 # Every note with a title, alphabetized.
-node .vite/build/cli.js query \
+minerva query \
   'SELECT ?title WHERE { ?n a minerva:Note ; dc:title ?title } ORDER BY ?title' \
   --project ~/vault</code></pre>
 
     <h2 id="proposing">Proposing a note</h2>
     <p>External tools never write your thoughtbase directly. <code>propose-note</code> files a note as a <b>pending proposal</b> through Minerva's approval engine — the same gate the built-in AI uses — stamped with who proposed it. Nothing lands until you review and approve it in Minerva's Proposals panel (see <a href="conversations.html">Conversations</a>).</p>
-    <pre><code>cat draft.md | node .vite/build/cli.js propose-note notes/idea.md --by cli --project ~/vault</code></pre>
+    <pre><code>cat draft.md | minerva propose-note notes/idea.md --by cli --project ~/vault</code></pre>
     <p>The body comes from stdin, so it composes with anything upstream. <code>--by &lt;id&gt;</code> records who proposed it (default <code>cli</code>), and that attribution survives a reindex — a note proposed while the app was closed still shows up, and stays attributed, once you reopen it.</p>
 
     <div class="box">

--- a/website/docs/connecting-cli.html
+++ b/website/docs/connecting-cli.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — CLI use</title>
+<meta name="description" content="Use the Minerva command-line interface: build and run it, query the knowledge graph with SPARQL and SQL, search and read notes, gather context, and file gated proposals — all as JSON." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="settings.html">Settings</a>
+
+    <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="data.html">Data</a>
+    <a href="ingest.html">Ingest</a>
+    <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
+    <a href="connecting-cli.html" class="sub active">CLI use</a>
+    <a href="connecting-mcp.html" class="sub">MCP use</a>
+    <a href="maintenance.html">Maintenance</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="connecting.html">Connecting to Minerva</a><span class="sep">/</span>CLI use</p>
+
+    <h1>CLI use</h1>
+    <p class="lede">The Minerva CLI gives headless, scriptable access to a thoughtbase from your shell — the same core the app runs on, so it works with the app closed. Every result is printed as <b>JSON</b> on standard output, so it pipes straight into <code>jq</code> or feeds an agent directly.</p>
+
+    <h2 id="build">Building and running</h2>
+    <p>The CLI is built from the Minerva source tree into a standalone Node bundle:</p>
+    <pre><code>pnpm cli:build                       # → .vite/build/cli.js
+node .vite/build/cli.js &lt;command&gt; [args] [--project &lt;path&gt;]</code></pre>
+    <p><code>pnpm cli</code> builds and runs in one step. Point any command at a thoughtbase with <code>--project &lt;path&gt;</code> — it defaults to the current directory.</p>
+
+    <h2 id="commands">Commands</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>query &lt;sparql&gt;</code></div>
+        <div class="v">Run a <b>SPARQL</b> query over the knowledge graph. The standard prefixes are injected for you, so you can write <code>minerva:</code>, <code>dc:</code>, and the rest without declaring them.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>sql &lt;sql&gt;</code></div>
+        <div class="v">Run <b>DuckDB SQL</b> over your CSV <a href="data.html">tables</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>search &lt;text&gt;</code></div>
+        <div class="v">Full-text search over notes (<code>--limit &lt;n&gt;</code>, default 20).</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>semantic &lt;text&gt;</code></div>
+        <div class="v">Meaning-based search over notes. It covers only what the app has already embedded — against a thoughtbase never opened in the app, it returns no hits.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>read &lt;path&gt;</code></div>
+        <div class="v">A note's raw markdown, by its path within the thoughtbase.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>context &lt;topic&gt;</code></div>
+        <div class="v">A task-relevant slice: the notes matching a topic plus each one's link neighborhood (backlinks and outgoing links) and content, returned as one bundle for an agent to seed itself with.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>propose-note &lt;path&gt;</code></div>
+        <div class="v">File a new note as a pending proposal, with the body read from <b>stdin</b>. Gated — see below.</div>
+      </div>
+    </div>
+
+    <h2 id="grounded">Grounded JSON output</h2>
+    <p>Every result is grounded and printed as JSON, so it composes with the rest of your tools — query bindings carry node identifiers, search hits carry the note path, and <code>read</code> echoes the path back.</p>
+    <pre><code># What do I already know about photosynthesis?
+node .vite/build/cli.js search photosynthesis --project ~/vault | jq '.hits[].relativePath'
+
+# Every note with a title, alphabetized.
+node .vite/build/cli.js query \
+  'SELECT ?title WHERE { ?n a minerva:Note ; dc:title ?title } ORDER BY ?title' \
+  --project ~/vault</code></pre>
+
+    <h2 id="proposing">Proposing a note</h2>
+    <p>External tools never write your thoughtbase directly. <code>propose-note</code> files a note as a <b>pending proposal</b> through Minerva's approval engine — the same gate the built-in AI uses — stamped with who proposed it. Nothing lands until you review and approve it in Minerva's Proposals panel (see <a href="conversations.html">Conversations</a>).</p>
+    <pre><code>cat draft.md | node .vite/build/cli.js propose-note notes/idea.md --by cli --project ~/vault</code></pre>
+    <p>The body comes from stdin, so it composes with anything upstream. <code>--by &lt;id&gt;</code> records who proposed it (default <code>cli</code>), and that attribution survives a reindex — a note proposed while the app was closed still shows up, and stays attributed, once you reopen it.</p>
+
+    <div class="box">
+      <span class="label">One writer at a time</span>
+      <p>A proposal is written into the thoughtbase's graph file. If Minerva has the same thoughtbase open, both processes write it, so file proposals when the app isn't actively editing — and expect the app to surface them after its next refresh.</p>
+    </div>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="connecting-mcp.html">
+        <span class="em">🔌</span>
+        <h3>MCP use</h3>
+        <p>The same commands as tools for an AI agent.</p>
+      </a>
+      <a class="doc-card" href="data.html">
+        <span class="em">🔎</span>
+        <h3>Working with data</h3>
+        <p>The SPARQL and SQL you'll run, from the app's side.</p>
+      </a>
+      <a class="doc-card" href="conversations.html">
+        <span class="em">💬</span>
+        <h3>Conversations</h3>
+        <p>Where proposals surface for you to approve.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="connecting.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Connecting to Minerva</span>
+      </a>
+      <a class="next" href="connecting-mcp.html">
+        <span class="dir">Next</span>
+        <span class="ttl">MCP use →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/connecting-mcp.html
+++ b/website/docs/connecting-mcp.html
@@ -83,17 +83,26 @@
     <p class="lede">The <b>Model Context Protocol (MCP)</b> is a standard way to give an AI agent tools. Minerva's MCP server exposes the same reads and proposals as the <a href="connecting-cli.html">CLI</a> — as tools any MCP client can call — so an agent like Claude Desktop, a coding agent, or an editor can ground itself in your thoughtbase and hand work back through the approval gate.</p>
 
     <h2 id="start">Starting the server</h2>
-    <p>The server runs over standard input/output as a subprocess — you don't start it by hand so much as tell a client how to launch it. On its own:</p>
-    <pre><code>node .vite/build/cli.js mcp --project /path/to/thoughtbase</code></pre>
+    <p>The MCP server is the <code>mcp</code> subcommand of the same CLI — <a href="connecting-cli.html#build">build and link it once</a> and you have the <code>minerva</code> command. The server runs over standard input/output as a subprocess — you don't start it by hand so much as tell a client how to launch it. On its own:</p>
+    <pre><code>minerva mcp --project /path/to/thoughtbase</code></pre>
     <p>It speaks newline-delimited JSON-RPC 2.0 and stays running until its input closes. Each modality initializes once and stays warm across tool calls.</p>
 
     <h2 id="connect">Connecting a client</h2>
-    <p>Most MCP clients take a small JSON entry naming a command to launch. Point it at the built CLI with the <code>mcp</code> subcommand and your thoughtbase path — the client runs it as a subprocess:</p>
+    <p>Most MCP clients take a small JSON entry naming a command to launch. Point it at <code>minerva</code> with the <code>mcp</code> subcommand and your thoughtbase path — the client runs it as a subprocess:</p>
+    <pre><code>{
+  "mcpServers": {
+    "minerva": {
+      "command": "minerva",
+      "args": ["mcp", "--project", "/path/to/thoughtbase"]
+    }
+  }
+}</code></pre>
+    <p>Some clients launch from a bare environment without your shell's PATH, so <code>minerva</code> may not resolve. If so, give the absolute path to the built file instead:</p>
     <pre><code>{
   "mcpServers": {
     "minerva": {
       "command": "node",
-      "args": ["/path/to/minerva/.vite/build/cli.js", "mcp", "--project", "/path/to/thoughtbase"]
+      "args": ["/absolute/path/to/minerva/.vite/build/cli.js", "mcp", "--project", "/path/to/thoughtbase"]
     }
   }
 }</code></pre>

--- a/website/docs/connecting-mcp.html
+++ b/website/docs/connecting-mcp.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Minerva — Docs — Command Palette</title>
-<meta name="description" content="The command palette (⌘K / Ctrl+K): a keyboard launcher for running any command in Minerva without reaching for the menus." />
+<title>Minerva — Docs — MCP use</title>
+<meta name="description" content="Connect an AI agent to a Minerva thoughtbase over the Model Context Protocol: start the stdio MCP server, point a client at it, and use the read and propose tools — grounded and gated." />
 <link rel="stylesheet" href="../minerva.css" />
 <link rel="stylesheet" href="docs.css" />
 </head>
@@ -54,12 +54,6 @@
     <h4>Using Minerva</h4>
     <a href="notes.html">Notes</a>
     <a href="navigation.html">Navigation</a>
-    <a href="navigation-command-palette.html" class="sub active">Command palette</a>
-    <a href="navigation-quick-switch.html" class="sub">Quick switch</a>
-    <a href="navigation-wiki-links.html" class="sub">Wiki-links</a>
-    <a href="navigation-search.html" class="sub">Search</a>
-    <a href="navigation-breadcrumbs.html" class="sub">Breadcrumbs</a>
-    <a href="navigation-back-forward.html" class="sub">Back / forward</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html">Editor</a>
 
@@ -76,55 +70,97 @@
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
     <a href="connecting.html">Connecting to Minerva</a>
+    <a href="connecting-cli.html" class="sub">CLI use</a>
+    <a href="connecting-mcp.html" class="sub active">MCP use</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="navigation.html">Navigation</a><span class="sep">/</span>Command palette</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="connecting.html">Connecting to Minerva</a><span class="sep">/</span>MCP use</p>
 
-    <h1>Command palette</h1>
-    <p class="lede">The command palette is a keyboard launcher for everything Minerva can do. Press <kbd>⌘</kbd><kbd>K</kbd> (or <kbd>Ctrl</kbd><kbd>K</kbd> on Windows and Linux) from anywhere, type a few letters, and press <kbd>↵</kbd> to run the highlighted command — no hunting through menus. It finds <b>commands and actions</b>; to jump to a note, source, or saved query by name, use <a href="navigation-quick-switch.html">Quick switch</a> instead.</p>
+    <h1>MCP use</h1>
+    <p class="lede">The <b>Model Context Protocol (MCP)</b> is a standard way to give an AI agent tools. Minerva's MCP server exposes the same reads and proposals as the <a href="connecting-cli.html">CLI</a> — as tools any MCP client can call — so an agent like Claude Desktop, a coding agent, or an editor can ground itself in your thoughtbase and hand work back through the approval gate.</p>
 
-    <p>The palette floats over your note without dimming or covering it, so you can still see what you're about to act on as you type.</p>
+    <h2 id="start">Starting the server</h2>
+    <p>The server runs over standard input/output as a subprocess — you don't start it by hand so much as tell a client how to launch it. On its own:</p>
+    <pre><code>node .vite/build/cli.js mcp --project /path/to/thoughtbase</code></pre>
+    <p>It speaks newline-delimited JSON-RPC 2.0 and stays running until its input closes. Each modality initializes once and stays warm across tool calls.</p>
 
-    <h2 id="empty">Browsing everything</h2>
-    <p>Open the palette with nothing typed and it lists every command Minerva offers — creating notes, editing, viewing, navigating, refactoring, research, queries, and app-wide actions. Commands you've run recently appear at the top, most recent first; everything else follows in alphabetical order.</p>
+    <h2 id="connect">Connecting a client</h2>
+    <p>Most MCP clients take a small JSON entry naming a command to launch. Point it at the built CLI with the <code>mcp</code> subcommand and your thoughtbase path — the client runs it as a subprocess:</p>
+    <pre><code>{
+  "mcpServers": {
+    "minerva": {
+      "command": "node",
+      "args": ["/path/to/minerva/.vite/build/cli.js", "mcp", "--project", "/path/to/thoughtbase"]
+    }
+  }
+}</code></pre>
 
-    <h2 id="filtering">Finding a command</h2>
-    <p>As you type, the list narrows and re-sorts to put the best matches first. You don't have to type a command's exact name — a few letters from anywhere in it usually gets you there, and initials work too (type <b>nn</b> to find "New Note"). Commands you've used recently are nudged toward the top, so the things you reach for most stay close at hand.</p>
-
-    <figure class="shot-img">
-      <img src="img/navigation-command-palette.png" alt="The palette open over a note with &quot;link&quot; typed in, and a ranked list of matching commands below — each row showing the command name, a small label for its category, and its keyboard shortcut on the right where it has one. The top result is highlighted." loading="lazy" />
-      <figcaption>Screenshot — the command palette with a typed query</figcaption>
-    </figure>
-
-    <p>If nothing matches what you typed, the palette simply tells you so.</p>
-
-    <h2 id="keyboard">Getting around by keyboard</h2>
+    <h2 id="tools">Tools</h2>
+    <p>The server exposes seven tools — the reads return grounded JSON, and the one write is gated:</p>
     <div class="deflist">
       <div class="row">
-        <div class="k"><kbd>↑</kbd> <kbd>↓</kbd></div>
-        <div class="v">Move the highlight up or down through the results. Hovering a row with the mouse selects it too.</div>
+        <div class="k"><code>query_graph</code></div>
+        <div class="v">SPARQL over the knowledge graph.</div>
       </div>
       <div class="row">
-        <div class="k"><kbd>↵</kbd></div>
-        <div class="v">Run the highlighted command. The palette closes right away and focus returns to your note.</div>
+        <div class="k"><code>sql_query</code></div>
+        <div class="v">DuckDB SQL over your CSV <a href="data.html">tables</a>.</div>
       </div>
       <div class="row">
-        <div class="k"><kbd>esc</kbd></div>
-        <div class="v">Close the palette without running anything.</div>
+        <div class="k"><code>search_notes</code></div>
+        <div class="v">Full-text search over notes.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>semantic_search</code></div>
+        <div class="v">Meaning-based search over notes the app has embedded.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>read_note</code></div>
+        <div class="v">A note's raw markdown, by path.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>gather_context</code></div>
+        <div class="v">A topic slice — matching notes plus their link neighborhood — for the agent to seed itself.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>propose_note</code></div>
+        <div class="v">File a new note as a pending proposal (gated).</div>
       </div>
     </div>
 
-    <div class="pager">
-      <a class="prev" href="navigation.html">
-        <span class="dir">Previous</span>
-        <span class="ttl">← Navigation</span>
+    <div class="box">
+      <span class="label">Grounded and gated</span>
+      <p>Reads come back grounded, so the agent can cite the exact notes it drew on. The only write is <code>propose_note</code>, which files a <b>pending proposal</b> stamped <code>mcp:&lt;client-name&gt;</code> — taken from the client's own name at connect time — and nothing lands until you approve it in the Proposals panel. In Minerva, proposals from an MCP client are labelled distinctly from the built-in AI, so the graph stays an audit log of who contributed what. See <a href="conversations.html">Conversations</a>.</p>
+    </div>
+
+    <h2 id="freshness">A note on freshness</h2>
+    <p>The server reads your thoughtbase once at startup and serves results as of that moment. If you edit notes in the app while it's running, restart the server to pick up the changes. And as with the CLI, file proposals when the app isn't actively editing the same thoughtbase, so the two aren't writing the graph at once.</p>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="connecting-cli.html">
+        <span class="em">⌥</span>
+        <h3>CLI use</h3>
+        <p>The same operations from your shell, as JSON.</p>
       </a>
-      <a class="next" href="navigation-quick-switch.html">
+      <a class="doc-card" href="conversations.html">
+        <span class="em">💬</span>
+        <h3>Conversations</h3>
+        <p>Review and approve what an agent proposes.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="connecting-cli.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← CLI use</span>
+      </a>
+      <a class="next" href="maintenance.html">
         <span class="dir">Next</span>
-        <span class="ttl">Quick switch →</span>
+        <span class="ttl">Maintenance →</span>
       </a>
     </div>
   </main>

--- a/website/docs/connecting.html
+++ b/website/docs/connecting.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Minerva — Docs — Command Palette</title>
-<meta name="description" content="The command palette (⌘K / Ctrl+K): a keyboard launcher for running any command in Minerva without reaching for the menus." />
+<title>Minerva — Docs — Connecting to Minerva</title>
+<meta name="description" content="Reach into a thoughtbase from outside the app: a command-line interface and an MCP server let scripts and AI agents query your notes and propose new ones — grounded reads, gated writes." />
 <link rel="stylesheet" href="../minerva.css" />
 <link rel="stylesheet" href="docs.css" />
 </head>
@@ -54,12 +54,6 @@
     <h4>Using Minerva</h4>
     <a href="notes.html">Notes</a>
     <a href="navigation.html">Navigation</a>
-    <a href="navigation-command-palette.html" class="sub active">Command palette</a>
-    <a href="navigation-quick-switch.html" class="sub">Quick switch</a>
-    <a href="navigation-wiki-links.html" class="sub">Wiki-links</a>
-    <a href="navigation-search.html" class="sub">Search</a>
-    <a href="navigation-breadcrumbs.html" class="sub">Breadcrumbs</a>
-    <a href="navigation-back-forward.html" class="sub">Back / forward</a>
     <a href="viewing-options.html">Viewing options</a>
     <a href="editor.html">Editor</a>
 
@@ -75,56 +69,83 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
-    <a href="connecting.html">Connecting to Minerva</a>
+    <a href="connecting.html" class="active">Connecting to Minerva</a>
+    <a href="connecting-cli.html" class="sub">CLI use</a>
+    <a href="connecting-mcp.html" class="sub">MCP use</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="navigation.html">Navigation</a><span class="sep">/</span>Command palette</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Connecting to Minerva</p>
 
-    <h1>Command palette</h1>
-    <p class="lede">The command palette is a keyboard launcher for everything Minerva can do. Press <kbd>⌘</kbd><kbd>K</kbd> (or <kbd>Ctrl</kbd><kbd>K</kbd> on Windows and Linux) from anywhere, type a few letters, and press <kbd>↵</kbd> to run the highlighted command — no hunting through menus. It finds <b>commands and actions</b>; to jump to a note, source, or saved query by name, use <a href="navigation-quick-switch.html">Quick switch</a> instead.</p>
+    <h1>Connecting to Minerva</h1>
+    <p class="lede">A <a href="thoughtbase.html">thoughtbase</a> is plain files and a <a href="data.html">knowledge graph</a>, so you don't have to be sitting in the app to use it. Minerva ships a command-line interface and a <b>Model Context Protocol (MCP)</b> server that let scripts and AI agents query your notes and propose new ones from outside — even while the app is closed. They reuse the same core the app does, so what they see is exactly what Minerva sees.</p>
 
-    <p>The palette floats over your note without dimming or covering it, so you can still see what you're about to act on as you type.</p>
-
-    <h2 id="empty">Browsing everything</h2>
-    <p>Open the palette with nothing typed and it lists every command Minerva offers — creating notes, editing, viewing, navigating, refactoring, research, queries, and app-wide actions. Commands you've run recently appear at the top, most recent first; everything else follows in alphabetical order.</p>
-
-    <h2 id="filtering">Finding a command</h2>
-    <p>As you type, the list narrows and re-sorts to put the best matches first. You don't have to type a command's exact name — a few letters from anywhere in it usually gets you there, and initials work too (type <b>nn</b> to find "New Note"). Commands you've used recently are nudged toward the top, so the things you reach for most stay close at hand.</p>
-
-    <figure class="shot-img">
-      <img src="img/navigation-command-palette.png" alt="The palette open over a note with &quot;link&quot; typed in, and a ranked list of matching commands below — each row showing the command name, a small label for its category, and its keyboard shortcut on the right where it has one. The top result is highlighted." loading="lazy" />
-      <figcaption>Screenshot — the command palette with a typed query</figcaption>
-    </figure>
-
-    <p>If nothing matches what you typed, the palette simply tells you so.</p>
-
-    <h2 id="keyboard">Getting around by keyboard</h2>
+    <h2 id="two-ways">Two ways in</h2>
     <div class="deflist">
       <div class="row">
-        <div class="k"><kbd>↑</kbd> <kbd>↓</kbd></div>
-        <div class="v">Move the highlight up or down through the results. Hovering a row with the mouse selects it too.</div>
+        <div class="k"><a href="connecting-cli.html">CLI use</a></div>
+        <div class="v">Headless, scriptable access from your shell — query the graph, search notes, and file proposals, with grounded JSON output you can pipe straight into other tools.</div>
       </div>
       <div class="row">
-        <div class="k"><kbd>↵</kbd></div>
-        <div class="v">Run the highlighted command. The palette closes right away and focus returns to your note.</div>
-      </div>
-      <div class="row">
-        <div class="k"><kbd>esc</kbd></div>
-        <div class="v">Close the palette without running anything.</div>
+        <div class="k"><a href="connecting-mcp.html">MCP use</a></div>
+        <div class="v">The same reads and proposals exposed as tools to any MCP client — Claude Desktop, a coding agent, an editor — so an AI agent can ground itself in your thoughtbase and hand work back.</div>
       </div>
     </div>
 
-    <div class="pager">
-      <a class="prev" href="navigation.html">
-        <span class="dir">Previous</span>
-        <span class="ttl">← Navigation</span>
+    <h2 id="what">What you can do</h2>
+    <p>Both surfaces expose the same core operations over an open thoughtbase:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Query</div>
+        <div class="v">Run <b>SPARQL</b> over the knowledge graph or <b>SQL</b> over your CSV tables — the same queries you'd write in the app's <a href="data.html">Query</a> panel.</div>
+      </div>
+      <div class="row">
+        <div class="k">Search</div>
+        <div class="v">Full-text or meaning-based (semantic) search across your notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Read</div>
+        <div class="v">Fetch a note's raw markdown by path.</div>
+      </div>
+      <div class="row">
+        <div class="k">Gather context</div>
+        <div class="v">Pull a task-relevant slice for a topic — the matching notes <em>plus</em> their link neighborhood — so an agent can seed itself before it starts work.</div>
+      </div>
+      <div class="row">
+        <div class="k">Propose a note</div>
+        <div class="v">File a new note as a <b>pending proposal</b> — never a direct write.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Grounded reads, gated writes</span>
+      <p>Reads come back <b>grounded</b>: query results carry node identifiers, search hits carry the note's path — so an agent can cite exactly what it drew on. Writes are never direct. A proposal goes through the <em>same</em> approval gate as the built-in AI, stamped with who proposed it, and nothing touches your notes until you approve it in the Proposals panel. See <a href="conversations.html">Conversations</a> for that review flow.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="connecting-cli.html">
+        <span class="em">⌥</span>
+        <h3>CLI use</h3>
+        <p>Query, search, and propose from your shell, with JSON output.</p>
       </a>
-      <a class="next" href="navigation-quick-switch.html">
+      <a class="doc-card" href="connecting-mcp.html">
+        <span class="em">🔌</span>
+        <h3>MCP use</h3>
+        <p>Expose the thoughtbase to an AI agent as MCP tools.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="export-scopes-privacy.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Scopes &amp; privacy</span>
+      </a>
+      <a class="next" href="connecting-cli.html">
         <span class="dir">Next</span>
-        <span class="ttl">Quick switch →</span>
+        <span class="ttl">CLI use →</span>
       </a>
     </div>
   </main>

--- a/website/docs/conversations-chatting.html
+++ b/website/docs/conversations-chatting.html
@@ -72,6 +72,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/conversations-drafts.html
+++ b/website/docs/conversations-drafts.html
@@ -72,6 +72,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/conversations-propose-review-approve.html
+++ b/website/docs/conversations-propose-review-approve.html
@@ -72,6 +72,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/conversations.html
+++ b/website/docs/conversations.html
@@ -72,6 +72,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/data-operations.html
+++ b/website/docs/data-operations.html
@@ -73,6 +73,7 @@
     <a href="query-result-blocks.html" class="sub">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/data.html
+++ b/website/docs/data.html
@@ -73,6 +73,7 @@
     <a href="query-result-blocks.html" class="sub">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/editor-keyboard-shortcuts.html
+++ b/website/docs/editor-keyboard-shortcuts.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/editor-link-autocomplete.html
+++ b/website/docs/editor-link-autocomplete.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/editor-markdown-formatting.html
+++ b/website/docs/editor-markdown-formatting.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/editor-operations.html
+++ b/website/docs/editor-operations.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/editor-voice-dictation.html
+++ b/website/docs/editor-voice-dictation.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/editor-writing-surface.html
+++ b/website/docs/editor-writing-surface.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/editor.html
+++ b/website/docs/editor.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/export-bibliography.html
+++ b/website/docs/export-bibliography.html
@@ -74,6 +74,7 @@
     <a href="export-bibliography.html" class="sub active">Bibliography &amp; citations</a>
     <a href="export-flashcards.html" class="sub">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub">Scopes &amp; privacy</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/export-documents.html
+++ b/website/docs/export-documents.html
@@ -74,6 +74,7 @@
     <a href="export-bibliography.html" class="sub">Bibliography &amp; citations</a>
     <a href="export-flashcards.html" class="sub">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub">Scopes &amp; privacy</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/export-flashcards.html
+++ b/website/docs/export-flashcards.html
@@ -74,6 +74,7 @@
     <a href="export-bibliography.html" class="sub">Bibliography &amp; citations</a>
     <a href="export-flashcards.html" class="sub active">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub">Scopes &amp; privacy</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/export-publishing.html
+++ b/website/docs/export-publishing.html
@@ -74,6 +74,7 @@
     <a href="export-bibliography.html" class="sub">Bibliography &amp; citations</a>
     <a href="export-flashcards.html" class="sub">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub">Scopes &amp; privacy</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/export-scopes-privacy.html
+++ b/website/docs/export-scopes-privacy.html
@@ -74,6 +74,7 @@
     <a href="export-bibliography.html" class="sub">Bibliography &amp; citations</a>
     <a href="export-flashcards.html" class="sub">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub active">Scopes &amp; privacy</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 
@@ -126,9 +127,9 @@
         <span class="dir">Previous</span>
         <span class="ttl">← Flashcards</span>
       </a>
-      <a class="next" href="maintenance.html">
+      <a class="next" href="connecting.html">
         <span class="dir">Next</span>
-        <span class="ttl">Maintenance →</span>
+        <span class="ttl">Connecting to Minerva →</span>
       </a>
     </div>
   </main>

--- a/website/docs/export.html
+++ b/website/docs/export.html
@@ -74,6 +74,7 @@
     <a href="export-bibliography.html" class="sub">Bibliography &amp; citations</a>
     <a href="export-flashcards.html" class="sub">Flashcards</a>
     <a href="export-scopes-privacy.html" class="sub">Scopes &amp; privacy</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -69,6 +69,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/ingest-adding-sources.html
+++ b/website/docs/ingest-adding-sources.html
@@ -73,6 +73,7 @@
     <a href="ingest-clipper.html" class="sub">Browser clipper</a>
     <a href="ingest-citing-duplicates.html" class="sub">Citing &amp; duplicates</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/ingest-citing-duplicates.html
+++ b/website/docs/ingest-citing-duplicates.html
@@ -73,6 +73,7 @@
     <a href="ingest-clipper.html" class="sub">Browser clipper</a>
     <a href="ingest-citing-duplicates.html" class="sub active">Citing &amp; duplicates</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/ingest-clipper.html
+++ b/website/docs/ingest-clipper.html
@@ -73,6 +73,7 @@
     <a href="ingest-clipper.html" class="sub active">Browser clipper</a>
     <a href="ingest-citing-duplicates.html" class="sub">Citing &amp; duplicates</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/ingest-pdf.html
+++ b/website/docs/ingest-pdf.html
@@ -73,6 +73,7 @@
     <a href="ingest-clipper.html" class="sub">Browser clipper</a>
     <a href="ingest-citing-duplicates.html" class="sub">Citing &amp; duplicates</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/ingest.html
+++ b/website/docs/ingest.html
@@ -73,6 +73,7 @@
     <a href="ingest-clipper.html" class="sub">Browser clipper</a>
     <a href="ingest-citing-duplicates.html" class="sub">Citing &amp; duplicates</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/left-sidebar-bookmarks.html
+++ b/website/docs/left-sidebar-bookmarks.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/left-sidebar-notes-tree.html
+++ b/website/docs/left-sidebar-notes-tree.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/left-sidebar-sources.html
+++ b/website/docs/left-sidebar-sources.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/left-sidebar-tables.html
+++ b/website/docs/left-sidebar-tables.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/left-sidebar-tags.html
+++ b/website/docs/left-sidebar-tags.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/left-sidebar.html
+++ b/website/docs/left-sidebar.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/maintenance.html
+++ b/website/docs/maintenance.html
@@ -69,6 +69,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html" class="active">Maintenance</a>
   </aside>
 
@@ -110,9 +111,9 @@
     </div>
 
     <div class="pager">
-      <a class="prev" href="export-scopes-privacy.html">
+      <a class="prev" href="connecting-mcp.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Scopes &amp; privacy</span>
+        <span class="ttl">← MCP use</span>
       </a>
       <span></span>
     </div>

--- a/website/docs/navigation-back-forward.html
+++ b/website/docs/navigation-back-forward.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/navigation-breadcrumbs.html
+++ b/website/docs/navigation-breadcrumbs.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/navigation-quick-switch.html
+++ b/website/docs/navigation-quick-switch.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/navigation-search.html
+++ b/website/docs/navigation-search.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/navigation-wiki-links.html
+++ b/website/docs/navigation-wiki-links.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/navigation.html
+++ b/website/docs/navigation.html
@@ -75,6 +75,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-callouts.html
+++ b/website/docs/notes-callouts.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-charts.html
+++ b/website/docs/notes-charts.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-code.html
+++ b/website/docs/notes-code.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-diagrams.html
+++ b/website/docs/notes-diagrams.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-flashcards.html
+++ b/website/docs/notes-flashcards.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-footnotes.html
+++ b/website/docs/notes-footnotes.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-frontmatter.html
+++ b/website/docs/notes-frontmatter.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-highlights.html
+++ b/website/docs/notes-highlights.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-images.html
+++ b/website/docs/notes-images.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-links.html
+++ b/website/docs/notes-links.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-math.html
+++ b/website/docs/notes-math.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-media.html
+++ b/website/docs/notes-media.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-query.html
+++ b/website/docs/notes-query.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-rdf.html
+++ b/website/docs/notes-rdf.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-search.html
+++ b/website/docs/notes-search.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-tables.html
+++ b/website/docs/notes-tables.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes-tasks.html
+++ b/website/docs/notes-tasks.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/notes.html
+++ b/website/docs/notes.html
@@ -86,6 +86,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/query-menu-panel.html
+++ b/website/docs/query-menu-panel.html
@@ -73,6 +73,7 @@
     <a href="query-result-blocks.html" class="sub">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/query-result-blocks.html
+++ b/website/docs/query-result-blocks.html
@@ -73,6 +73,7 @@
     <a href="query-result-blocks.html" class="sub active">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/query-runnable-cells.html
+++ b/website/docs/query-runnable-cells.html
@@ -73,6 +73,7 @@
     <a href="query-result-blocks.html" class="sub">Result blocks</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/refactoring-ai-assisted.html
+++ b/website/docs/refactoring-ai-assisted.html
@@ -73,6 +73,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/refactoring-manual.html
+++ b/website/docs/refactoring-manual.html
@@ -73,6 +73,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/refactoring-operations.html
+++ b/website/docs/refactoring-operations.html
@@ -73,6 +73,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/refactoring-safe-delete.html
+++ b/website/docs/refactoring-safe-delete.html
@@ -73,6 +73,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/refactoring.html
+++ b/website/docs/refactoring.html
@@ -73,6 +73,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-backlinks.html
+++ b/website/docs/right-sidebar-backlinks.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-bookmarks.html
+++ b/website/docs/right-sidebar-bookmarks.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-citations.html
+++ b/website/docs/right-sidebar-citations.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-footnotes.html
+++ b/website/docs/right-sidebar-footnotes.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-heading-graph.html
+++ b/website/docs/right-sidebar-heading-graph.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-outgoing-links.html
+++ b/website/docs/right-sidebar-outgoing-links.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-outline.html
+++ b/website/docs/right-sidebar-outline.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-properties.html
+++ b/website/docs/right-sidebar-properties.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-proposals.html
+++ b/website/docs/right-sidebar-proposals.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-related.html
+++ b/website/docs/right-sidebar-related.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-tables.html
+++ b/website/docs/right-sidebar-tables.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar-tags.html
+++ b/website/docs/right-sidebar-tags.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/right-sidebar.html
+++ b/website/docs/right-sidebar.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-ai.html
+++ b/website/docs/settings-ai.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-appearance.html
+++ b/website/docs/settings-appearance.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-behaviors.html
+++ b/website/docs/settings-behaviors.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-bibliography.html
+++ b/website/docs/settings-bibliography.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-clipper.html
+++ b/website/docs/settings-clipper.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-compute.html
+++ b/website/docs/settings-compute.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-editor.html
+++ b/website/docs/settings-editor.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-formatter.html
+++ b/website/docs/settings-formatter.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-notes.html
+++ b/website/docs/settings-notes.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-skills.html
+++ b/website/docs/settings-skills.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-sources.html
+++ b/website/docs/settings-sources.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings-web.html
+++ b/website/docs/settings-web.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/settings.html
+++ b/website/docs/settings.html
@@ -81,6 +81,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/thinking-tools-managing-authoring.html
+++ b/website/docs/thinking-tools-managing-authoring.html
@@ -73,6 +73,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/thinking-tools-running-a-skill.html
+++ b/website/docs/thinking-tools-running-a-skill.html
@@ -73,6 +73,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/thinking-tools-three-menus.html
+++ b/website/docs/thinking-tools-three-menus.html
@@ -73,6 +73,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/thinking-tools-what-they-are.html
+++ b/website/docs/thinking-tools-what-they-are.html
@@ -73,6 +73,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/thinking-tools.html
+++ b/website/docs/thinking-tools.html
@@ -73,6 +73,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/thoughtbase-operations.html
+++ b/website/docs/thoughtbase-operations.html
@@ -70,6 +70,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/thoughtbase.html
+++ b/website/docs/thoughtbase.html
@@ -70,6 +70,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/viewing-options-font-size-zoom.html
+++ b/website/docs/viewing-options-font-size-zoom.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/viewing-options-operations.html
+++ b/website/docs/viewing-options-operations.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/viewing-options-split-panes-windows.html
+++ b/website/docs/viewing-options-split-panes-windows.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/viewing-options-themes.html
+++ b/website/docs/viewing-options-themes.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/viewing-options-view-modes.html
+++ b/website/docs/viewing-options-view-modes.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 

--- a/website/docs/viewing-options.html
+++ b/website/docs/viewing-options.html
@@ -74,6 +74,7 @@
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
     <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
     <a href="maintenance.html">Maintenance</a>
   </aside>
 


### PR DESCRIPTION
Adds a **Connecting to Minerva** section to the user docs — headless/programmatic access to a thoughtbase — placed in *Data & workflows*, just before Maintenance, as a hub with two sub-pages.

## New pages
- **`connecting.html` — "Connecting to Minerva"** (hub): why you'd reach into a thoughtbase from outside the app, the two ways in (CLI / MCP), the shared operations (query, search, read, gather context, propose), and the trust model — **grounded reads, gated writes**.
- **`connecting-cli.html` — "CLI use"**: build & link the `minerva` command (`pnpm cli:build && pnpm link --global`), the command table (`query`, `sql`, `search`, `semantic`, `read`, `context`, `propose-note`), grounded JSON output with `jq`, and the gated `propose-note` flow.
- **`connecting-mcp.html` — "MCP use"**: starting the stdio server (`minerva mcp`), the `mcpServers` client config (with an absolute-path fallback for PATH-less clients), the seven tools, `mcp:<client-name>` proposal stamping, and the startup-snapshot freshness caveat.

Content is drawn from `docs/cli.md` and verified accurate. The CLI is invoked as **`minerva`** — the `bin` alias in `package.json` (`minerva` → `.vite/build/cli.js`), exposed on PATH via `pnpm link --global` after `pnpm cli:build`.

## Wiring
- Nav + prev/next pagers regenerated from the model across all pages; reading order is `Export → Connecting to Minerva → CLI use → MCP use → Maintenance`.
- All internal links verified; one nav + one pager per page; no orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)