### PR TITLE
docs: Learning / Research / Analysis operations pages under Thinking tools

### DIFF
--- a/website/docs/thinking-tools-analysis.html
+++ b/website/docs/thinking-tools-analysis.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Minerva — Docs — Analysis Operations</title>
+<meta name="description" content="The skills in Minerva's Analysis menu: generation, disagreement, diagnostics, semantics, pattern-finding, motivation, planning, data analysis, and organization — 27 skills for working a claim or argument over." />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+    <h4>Introduction</h4>
+    <a href="index.html">Overview</a>
+    <a href="thoughtbase.html">What is a thoughtbase?</a>
+    <a href="../getting-started.html">Getting started</a>
+
+    <h4>Using Minerva</h4>
+    <a href="notes.html">Notes</a>
+    <a href="navigation.html">Navigation</a>
+    <a href="viewing-options.html">Viewing options</a>
+    <a href="editor.html">Editor</a>
+
+    <h4>The workspace</h4>
+    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
+    <a href="conversations.html">Conversations</a>
+    <a href="settings.html">Settings</a>
+
+    <h4>Data &amp; workflows</h4>
+    <a href="refactoring.html">Refactoring</a>
+    <a href="thinking-tools.html">Thinking tools</a>
+    <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
+    <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
+    <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
+    <a href="thinking-tools-learning.html" class="sub">Learning Operations</a>
+    <a href="thinking-tools-research.html" class="sub">Research Operations</a>
+    <a href="thinking-tools-analysis.html" class="sub active">Analysis Operations</a>
+    <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
+    <a href="data.html">Data</a>
+    <a href="ingest.html">Ingest</a>
+    <a href="export.html">Export</a>
+    <a href="connecting.html">Connecting to Minerva</a>
+    <a href="maintenance.html">Maintenance</a>
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="thinking-tools.html">Thinking tools</a><span class="sep">/</span>Analysis Operations</p>
+
+    <h1>Analysis Operations</h1>
+    <p class="lede">The <b>Analysis</b> menu is the largest — skills for working over a claim, argument, or plan you already have: generating opposition and synthesis, exposing assumptions, mapping a decision's dimensions, finding patterns, stress-testing plans, and analyzing your data. Its skills fall into <a href="thinking-tools-three-menus.html#grouping">themed groups</a>, and every one hands back a <a href="thinking-tools-running-a-skill.html">suggestion you review</a>.</p>
+
+    <h2 id="generation">Generation</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Antithesize</div><div class="v">Generate a standalone opposition — a complete rival worldview.</div></div>
+      <div class="row"><div class="k">Synthesize</div><div class="v">Compress thesis + antithesis into a unified frame.</div></div>
+      <div class="row"><div class="k">Metaphorize</div><div class="v">High-coverage source→target domain mapping.</div></div>
+      <div class="row"><div class="k">Fill Out Note</div><div class="v">Expand a sparse or dictated note into a fuller draft, reviewed as a diff.</div></div>
+    </div>
+
+    <h2 id="disagreement">Disagreement</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Steelman</div><div class="v">Construct the strongest version of an opposing argument.</div></div>
+      <div class="row"><div class="k">Double Crux</div><div class="v">Find the shared crux that would resolve a disagreement.</div></div>
+      <div class="row"><div class="k">Find Tensions</div><div class="v">Surface where this note and another conflict.</div></div>
+    </div>
+
+    <h2 id="diagnostic">Diagnostic</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Excavate</div><div class="v">Surface hidden assumptions underlying arguments.</div></div>
+      <div class="row"><div class="k">Rhetoricize</div><div class="v">Map the rhetorical "spin-space" — where could the argument pivot?</div></div>
+    </div>
+
+    <h2 id="semantic">Semantic</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Dimensionalize</div><div class="v">Reduce a decision to 3–7 measurable dimensions.</div></div>
+      <div class="row"><div class="k">Handlize</div><div class="v">Extract operational "handles" — short phrases you can grab and use.</div></div>
+      <div class="row"><div class="k">Taboo</div><div class="v">Semantic decomposition by banning a contested term.</div></div>
+    </div>
+
+    <h2 id="pattern">Pattern</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Inductify</div><div class="v">Cross-example pattern extraction — what underlies these cases?</div></div>
+      <div class="row"><div class="k">Rhyme</div><div class="v">Fast structural-similarity recognition — what does this echo?</div></div>
+      <div class="row"><div class="k">Negspace</div><div class="v">Detect what is conspicuously absent.</div></div>
+      <div class="row"><div class="k">Noticing</div><div class="v">Surface the felt sense the prose isn't saying out loud.</div></div>
+    </div>
+
+    <h2 id="motivation">Motivation</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Goal Factor</div><div class="v">Decompose a goal into the underlying needs it serves.</div></div>
+      <div class="row"><div class="k">Aversion Factor</div><div class="v">Decompose a stated objection into the underlying aversions.</div></div>
+      <div class="row"><div class="k">Inner Loop</div><div class="v">Sim the plan from the inside — what would actually happen?</div></div>
+    </div>
+
+    <h2 id="planning">Planning</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Hamming Question</div><div class="v">Surface the most-important problem you are not working on.</div></div>
+      <div class="row"><div class="k">Murphyjitsu</div><div class="v">Pre-mortem failure analysis for plans and decisions.</div></div>
+      <div class="row"><div class="k">Reference Class</div><div class="v">Forecast via base rates from the right outside view.</div></div>
+    </div>
+
+    <h2 id="data">Data</h2>
+    <p>These three work over the <a href="data.html">tabular data</a> in your thoughtbase and return a reviewable note:</p>
+    <div class="deflist">
+      <div class="row"><div class="k">Find Correlations</div><div class="v">Surface the strongest correlations across the thoughtbase's tabular data.</div></div>
+      <div class="row"><div class="k">Find Outliers</div><div class="v">Flag the anomalous values in the thoughtbase's tabular data.</div></div>
+      <div class="row"><div class="k">Generate Visualizations</div><div class="v">Propose the right <a href="notes-charts.html">charts</a> for the thoughtbase's tabular data.</div></div>
+    </div>
+
+    <h2 id="organization">Organization</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Reorganize by Topic</div><div class="v">Propose moving loose notes into topic folders, reviewed as one plan.</div></div>
+      <div class="row"><div class="k">Tidy Filenames</div><div class="v">Propose <a href="refactoring.html">renaming</a> notes toward a consistent filename convention.</div></div>
+    </div>
+
+    <div class="box">
+      <span class="label">These are the stock skills</span>
+      <p>This is what ships in the Analysis menu. Turn skills on and off, move them between menus, reorder them, or write your own — see <a href="thinking-tools-managing-authoring.html">Managing &amp; authoring</a>.</p>
+    </div>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="thinking-tools-learning.html">
+        <span class="em">🎓</span>
+        <h3>Learning Operations</h3>
+        <p>The Learning menu — understand what's in front of you.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-research.html">
+        <span class="em">🔬</span>
+        <h3>Research Operations</h3>
+        <p>The Research menu — gather, verify, and decompose.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-managing-authoring.html">
+        <span class="em">🛠️</span>
+        <h3>Managing &amp; authoring</h3>
+        <p>Turn skills on/off, move them, or write your own.</p>
+      </a>
+    </div>
+
+    <div class="pager">
+      <a class="prev" href="thinking-tools-research.html">
+        <span class="dir">Previous</span>
+        <span class="ttl">← Research Operations</span>
+      </a>
+      <a class="next" href="thinking-tools-managing-authoring.html">
+        <span class="dir">Next</span>
+        <span class="ttl">Managing &amp; authoring →</span>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/thinking-tools-learning.html
+++ b/website/docs/thinking-tools-learning.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Minerva — Docs — Thinking Tools</title>
-<meta name="description" content="The Learning, Research, and Analysis skills: what they are, running one, the three menus, and making them your own." />
+<title>Minerva — Docs — Learning Operations</title>
+<meta name="description" content="The skills in Minerva's Learning menu: explain, summarize, give examples and counterexamples, find prerequisites, build a learning journey and glossary, quiz yourself, and draft flashcards." />
 <link rel="stylesheet" href="../minerva.css" />
 <link rel="stylesheet" href="docs.css" />
 </head>
@@ -65,11 +65,11 @@
 
     <h4>Data &amp; workflows</h4>
     <a href="refactoring.html">Refactoring</a>
-    <a href="thinking-tools.html" class="active">Thinking tools</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
-    <a href="thinking-tools-learning.html" class="sub">Learning Operations</a>
+    <a href="thinking-tools-learning.html" class="sub active">Learning Operations</a>
     <a href="thinking-tools-research.html" class="sub">Research Operations</a>
     <a href="thinking-tools-analysis.html" class="sub">Analysis Operations</a>
     <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
@@ -82,87 +82,91 @@
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Thinking tools</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="thinking-tools.html">Thinking tools</a><span class="sep">/</span>Learning Operations</p>
 
-    <h1>Thinking tools</h1>
-    <p class="lede">The Learning, Research, and Analysis menus are ready-made thinking moves you run over the note you're looking at — steelman an argument, pull out its claims, quiz yourself on it, check a fact. Each one is a <b>skill</b>, and the set is yours to turn on and off, rearrange, or add to.</p>
+    <h1>Learning Operations</h1>
+    <p class="lede">The <b>Learning</b> menu holds skills for understanding something already in front of you — re-explaining it at your level, drawing out examples and prerequisites, building study material, and testing yourself. Each runs over the current note (or a selection) and hands back a suggestion you <a href="thinking-tools-running-a-skill.html">review</a> before anything is kept.</p>
 
-    <h2 id="glance">At a glance</h2>
+    <h2 id="skills">The skills</h2>
     <div class="deflist">
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="thinking-tools-what-they-are.html"><b>What thinking tools are</b></a> — the skills that come with Minerva, and ones you can add.</div>
+        <div class="k">Explain Like I’m…</div>
+        <div class="v">Re-explain a topic at a chosen audience level.</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="thinking-tools-running-a-skill.html"><b>Running a skill</b></a> — pick one from a menu; it works and hands back a suggestion to review.</div>
+        <div class="k">Summarize</div>
+        <div class="v">Open a conversation that summarizes the active note.</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="thinking-tools-three-menus.html"><b>The three menus</b></a> — Learning, Research, Analysis, and how skills group within each.</div>
+        <div class="k">Give Examples</div>
+        <div class="v">Generate concrete examples illustrating the note.</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v">The full catalogs — <a href="thinking-tools-learning.html"><b>Learning</b></a>, <a href="thinking-tools-research.html"><b>Research</b></a>, and <a href="thinking-tools-analysis.html"><b>Analysis</b> Operations</a> — every stock skill in each menu, with what it does.</div>
+        <div class="k">Find Counterexamples</div>
+        <div class="v">Where does this note’s argument break down?</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="thinking-tools-managing-authoring.html"><b>Making them your own</b></a> — turn skills on and off, move and reorder them, or write your own.</div>
+        <div class="k">Find Prerequisites</div>
+        <div class="v">List concepts to understand before tackling this note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Create Learning Journey</div>
+        <div class="v">Design an ordered learning path ending at mastery.</div>
+      </div>
+      <div class="row">
+        <div class="k">Generate Glossary</div>
+        <div class="v">Build a structured, graph-typed glossary for a note or topic.</div>
+      </div>
+      <div class="row">
+        <div class="k">Add Term to Glossary</div>
+        <div class="v">Add one term to the existing glossary, matching its conventions.</div>
+      </div>
+      <div class="row">
+        <div class="k">Deep Dive on Term</div>
+        <div class="v">Expand a selected term into a fuller explanation.</div>
+      </div>
+      <div class="row">
+        <div class="k">Quiz Me</div>
+        <div class="v">Test your understanding of the note with graded questions.</div>
+      </div>
+      <div class="row">
+        <div class="k">Propose Flashcards</div>
+        <div class="v">Draft atomic <a href="notes-flashcards.html">spaced-repetition cards</a> from the note, for your review.</div>
       </div>
     </div>
 
     <div class="box">
-      <span class="label">You stay in control</span>
-      <p>A skill's result is a suggestion, never a silent change. Anything a skill wants to add or edit comes back for you to approve or reject first — see <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a>.</p>
+      <span class="label">These are the stock skills</span>
+      <p>This is what ships in the Learning menu. You can turn skills on and off, move them between menus, reorder them, or write your own — see <a href="thinking-tools-managing-authoring.html">Managing &amp; authoring</a>.</p>
     </div>
 
-    <h2 id="learn-more">In depth</h2>
+    <h2 id="related">Related</h2>
     <div class="doc-cards">
-      <a class="doc-card" href="thinking-tools-what-they-are.html">
-        <span class="em">📄</span>
-        <h3>What thinking tools are</h3>
-        <p>The skills that come with Minerva, and ones you add, sitting side by side.</p>
-      </a>
-      <a class="doc-card" href="thinking-tools-running-a-skill.html">
-        <span class="em">▶️</span>
-        <h3>Running a skill</h3>
-        <p>Pick one from a menu; it works and hands back a suggestion to review.</p>
-      </a>
-      <a class="doc-card" href="thinking-tools-three-menus.html">
-        <span class="em">🗂️</span>
-        <h3>The three menus</h3>
-        <p>Learning, Research, Analysis — and how skills group within each.</p>
-      </a>
-      <a class="doc-card" href="thinking-tools-learning.html">
-        <span class="em">🎓</span>
-        <h3>Learning Operations</h3>
-        <p>Every skill in the Learning menu — understand what's in front of you.</p>
-      </a>
       <a class="doc-card" href="thinking-tools-research.html">
         <span class="em">🔬</span>
         <h3>Research Operations</h3>
-        <p>Every skill in the Research menu — gather, verify, and decompose.</p>
+        <p>The Research menu — gather, verify, and decompose.</p>
       </a>
       <a class="doc-card" href="thinking-tools-analysis.html">
         <span class="em">🧩</span>
         <h3>Analysis Operations</h3>
-        <p>Every skill in the Analysis menu — work a claim or argument over.</p>
+        <p>The Analysis menu — work a claim or argument over.</p>
       </a>
-      <a class="doc-card" href="thinking-tools-managing-authoring.html">
-        <span class="em">🛠️</span>
-        <h3>Making them your own</h3>
-        <p>Turn skills on and off, move and reorder them — and how to write your own.</p>
+      <a class="doc-card" href="thinking-tools-three-menus.html">
+        <span class="em">🧠</span>
+        <h3>The three menus</h3>
+        <p>How Learning, Research, and Analysis divide the work.</p>
       </a>
     </div>
 
     <div class="pager">
-      <a class="prev" href="refactoring-ai-assisted.html">
+      <a class="prev" href="thinking-tools-three-menus.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← AI-assisted refactors</span>
+        <span class="ttl">← The three menus</span>
       </a>
-      <a class="next" href="thinking-tools-what-they-are.html">
+      <a class="next" href="thinking-tools-research.html">
         <span class="dir">Next</span>
-        <span class="ttl">What thinking tools are →</span>
+        <span class="ttl">Research Operations →</span>
       </a>
     </div>
   </main>

--- a/website/docs/thinking-tools-managing-authoring.html
+++ b/website/docs/thinking-tools-managing-authoring.html
@@ -69,6 +69,9 @@
     <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
+    <a href="thinking-tools-learning.html" class="sub">Learning Operations</a>
+    <a href="thinking-tools-research.html" class="sub">Research Operations</a>
+    <a href="thinking-tools-analysis.html" class="sub">Analysis Operations</a>
     <a href="thinking-tools-managing-authoring.html" class="sub active">Managing &amp; authoring</a>
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
@@ -111,9 +114,9 @@
     <p>Beyond rearranging the skills that come built in, you can write your own to capture a way of thinking you return to often. Authoring is a more advanced topic with its own dedicated guide — start there when you're ready.</p>
 
     <div class="pager">
-      <a class="prev" href="thinking-tools-three-menus.html">
+      <a class="prev" href="thinking-tools-analysis.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← The three menus</span>
+        <span class="ttl">← Analysis Operations</span>
       </a>
       <a class="next" href="data.html">
         <span class="dir">Next</span>

--- a/website/docs/thinking-tools-research.html
+++ b/website/docs/thinking-tools-research.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Minerva — Docs — Thinking Tools</title>
-<meta name="description" content="The Learning, Research, and Analysis skills: what they are, running one, the three menus, and making them your own." />
+<title>Minerva — Docs — Research Operations</title>
+<meta name="description" content="The skills in Minerva's Research menu: find sources, mine and verify claims, weigh arguments, decompose notes into claims and linked notes, and draft summaries." />
 <link rel="stylesheet" href="../minerva.css" />
 <link rel="stylesheet" href="docs.css" />
 </head>
@@ -65,12 +65,12 @@
 
     <h4>Data &amp; workflows</h4>
     <a href="refactoring.html">Refactoring</a>
-    <a href="thinking-tools.html" class="active">Thinking tools</a>
+    <a href="thinking-tools.html">Thinking tools</a>
     <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
     <a href="thinking-tools-learning.html" class="sub">Learning Operations</a>
-    <a href="thinking-tools-research.html" class="sub">Research Operations</a>
+    <a href="thinking-tools-research.html" class="sub active">Research Operations</a>
     <a href="thinking-tools-analysis.html" class="sub">Analysis Operations</a>
     <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
     <a href="data.html">Data</a>
@@ -82,87 +82,119 @@
 
   <!-- ===== Content ===== -->
   <main class="docs-content">
-    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span>Thinking tools</p>
+    <p class="crumbs"><a href="index.html">Docs</a><span class="sep">/</span><a href="thinking-tools.html">Thinking tools</a><span class="sep">/</span>Research Operations</p>
 
-    <h1>Thinking tools</h1>
-    <p class="lede">The Learning, Research, and Analysis menus are ready-made thinking moves you run over the note you're looking at — steelman an argument, pull out its claims, quiz yourself on it, check a fact. Each one is a <b>skill</b>, and the set is yours to turn on and off, rearrange, or add to.</p>
+    <h1>Research Operations</h1>
+    <p class="lede">The <b>Research</b> menu holds skills that go out and gather new material and hold it to account — finding sources, mining and verifying claims, weighing the arguments for and against, and breaking a note down into its parts. Its skills are organized into <a href="thinking-tools-three-menus.html#grouping">themed groups</a>; several reach the web, and every one hands back a <a href="thinking-tools-running-a-skill.html">suggestion you review</a>.</p>
 
-    <h2 id="glance">At a glance</h2>
+    <h2 id="discovery">Discovery</h2>
     <div class="deflist">
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="thinking-tools-what-they-are.html"><b>What thinking tools are</b></a> — the skills that come with Minerva, and ones you can add.</div>
+        <div class="k">Find Sources</div>
+        <div class="v">Assemble a candidate reading list for a topic — you pick what to <a href="ingest.html">ingest</a>.</div>
+      </div>
+    </div>
+
+    <h2 id="mining">Mining</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Extract Key Claims</div>
+        <div class="v">Mine the central claims a source makes, each with a supporting excerpt.</div>
+      </div>
+    </div>
+
+    <h2 id="verification">Verification</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Check Facts</div>
+        <div class="v">Web-verify a claim — corroborated, contested, or unverifiable.</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="thinking-tools-running-a-skill.html"><b>Running a skill</b></a> — pick one from a menu; it works and hands back a suggestion to review.</div>
+        <div class="k">Date / Scope Check</div>
+        <div class="v">Is this still true now, and was it ever true as stated?</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="thinking-tools-three-menus.html"><b>The three menus</b></a> — Learning, Research, Analysis, and how skills group within each.</div>
+        <div class="k">Find Primary Sources</div>
+        <div class="v">Trace a claim past the citation chain to the actual primary source.</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v">The full catalogs — <a href="thinking-tools-learning.html"><b>Learning</b></a>, <a href="thinking-tools-research.html"><b>Research</b></a>, and <a href="thinking-tools-analysis.html"><b>Analysis</b> Operations</a> — every stock skill in each menu, with what it does.</div>
+        <div class="k">Translate the Magnitude</div>
+        <div class="v">Re-ground a quantitative claim against its base rate and baseline.</div>
+      </div>
+    </div>
+
+    <h2 id="argumentation">Argumentation</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Find Supporting Arguments</div>
+        <div class="v">Surface the strongest cases in favour of a specific claim.</div>
       </div>
       <div class="row">
-        <div class="k">—</div>
-        <div class="v"><a href="thinking-tools-managing-authoring.html"><b>Making them your own</b></a> — turn skills on and off, move and reorder them, or write your own.</div>
+        <div class="k">Find Opposing Arguments</div>
+        <div class="v">Surface the strongest cases against a specific claim.</div>
+      </div>
+      <div class="row">
+        <div class="k">Find Load-Bearing Claim</div>
+        <div class="v">Identify the single claim whose falsity would collapse the argument.</div>
+      </div>
+    </div>
+
+    <h2 id="decomposition">Decomposition</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Decompose into Claims</div>
+        <div class="v">Pull every distinct assertion out as its own typed claim.</div>
+      </div>
+      <div class="row">
+        <div class="k">Decompose into Linked Notes</div>
+        <div class="v">Split the note into a parent index + 2–7 focused children.</div>
+      </div>
+      <div class="row">
+        <div class="k">Crystallize as Components</div>
+        <div class="v">Extract thought components and file as a crystallization note.</div>
+      </div>
+    </div>
+
+    <h2 id="summarize">Summarize</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Propose Summary</div>
+        <div class="v">Draft an abstract + TL;DR for this source, for your review.</div>
       </div>
     </div>
 
     <div class="box">
-      <span class="label">You stay in control</span>
-      <p>A skill's result is a suggestion, never a silent change. Anything a skill wants to add or edit comes back for you to approve or reject first — see <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a>.</p>
+      <span class="label">These are the stock skills</span>
+      <p>This is what ships in the Research menu. Turn skills on and off, move them between menus, reorder them, or write your own — see <a href="thinking-tools-managing-authoring.html">Managing &amp; authoring</a>.</p>
     </div>
 
-    <h2 id="learn-more">In depth</h2>
+    <h2 id="related">Related</h2>
     <div class="doc-cards">
-      <a class="doc-card" href="thinking-tools-what-they-are.html">
-        <span class="em">📄</span>
-        <h3>What thinking tools are</h3>
-        <p>The skills that come with Minerva, and ones you add, sitting side by side.</p>
-      </a>
-      <a class="doc-card" href="thinking-tools-running-a-skill.html">
-        <span class="em">▶️</span>
-        <h3>Running a skill</h3>
-        <p>Pick one from a menu; it works and hands back a suggestion to review.</p>
-      </a>
-      <a class="doc-card" href="thinking-tools-three-menus.html">
-        <span class="em">🗂️</span>
-        <h3>The three menus</h3>
-        <p>Learning, Research, Analysis — and how skills group within each.</p>
-      </a>
       <a class="doc-card" href="thinking-tools-learning.html">
         <span class="em">🎓</span>
         <h3>Learning Operations</h3>
-        <p>Every skill in the Learning menu — understand what's in front of you.</p>
-      </a>
-      <a class="doc-card" href="thinking-tools-research.html">
-        <span class="em">🔬</span>
-        <h3>Research Operations</h3>
-        <p>Every skill in the Research menu — gather, verify, and decompose.</p>
+        <p>The Learning menu — understand what's in front of you.</p>
       </a>
       <a class="doc-card" href="thinking-tools-analysis.html">
         <span class="em">🧩</span>
         <h3>Analysis Operations</h3>
-        <p>Every skill in the Analysis menu — work a claim or argument over.</p>
+        <p>The Analysis menu — work a claim or argument over.</p>
       </a>
-      <a class="doc-card" href="thinking-tools-managing-authoring.html">
-        <span class="em">🛠️</span>
-        <h3>Making them your own</h3>
-        <p>Turn skills on and off, move and reorder them — and how to write your own.</p>
+      <a class="doc-card" href="ingest.html">
+        <span class="em">📥</span>
+        <h3>Ingest</h3>
+        <p>Bring the sources you find into the thoughtbase.</p>
       </a>
     </div>
 
     <div class="pager">
-      <a class="prev" href="refactoring-ai-assisted.html">
+      <a class="prev" href="thinking-tools-learning.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← AI-assisted refactors</span>
+        <span class="ttl">← Learning Operations</span>
       </a>
-      <a class="next" href="thinking-tools-what-they-are.html">
+      <a class="next" href="thinking-tools-analysis.html">
         <span class="dir">Next</span>
-        <span class="ttl">What thinking tools are →</span>
+        <span class="ttl">Analysis Operations →</span>
       </a>
     </div>
   </main>

--- a/website/docs/thinking-tools-running-a-skill.html
+++ b/website/docs/thinking-tools-running-a-skill.html
@@ -69,6 +69,9 @@
     <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub active">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
+    <a href="thinking-tools-learning.html" class="sub">Learning Operations</a>
+    <a href="thinking-tools-research.html" class="sub">Research Operations</a>
+    <a href="thinking-tools-analysis.html" class="sub">Analysis Operations</a>
     <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>

--- a/website/docs/thinking-tools-three-menus.html
+++ b/website/docs/thinking-tools-three-menus.html
@@ -69,6 +69,9 @@
     <a href="thinking-tools-what-they-are.html" class="sub">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub active">The three menus</a>
+    <a href="thinking-tools-learning.html" class="sub">Learning Operations</a>
+    <a href="thinking-tools-research.html" class="sub">Research Operations</a>
+    <a href="thinking-tools-analysis.html" class="sub">Analysis Operations</a>
     <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>
@@ -90,20 +93,20 @@
     <div class="deflist">
       <div class="row">
         <div class="k">Learning</div>
-        <div class="v">Tools that work on something you already have open — explain it, expand it, or quiz you on it. <b>Deep Dive on Term</b> expands a word or phrase you've selected into a fuller explanation at the depth you choose, using the surrounding note for context. <b>Explain Like I'm…</b> and <b>Quiz Me</b> are the same shape: nothing new comes in from outside, the tool just changes how you engage with what's already there.</div>
+        <div class="v">Tools that work on something you already have open — explain it, expand it, or quiz you on it. <b>Deep Dive on Term</b> expands a word or phrase you've selected into a fuller explanation at the depth you choose, using the surrounding note for context. <b>Explain Like I'm…</b> and <b>Quiz Me</b> are the same shape: nothing new comes in from outside, the tool just changes how you engage with what's already there. See <a href="thinking-tools-learning.html">Learning Operations</a> for the full menu.</div>
       </div>
       <div class="row">
         <div class="k">Research</div>
-        <div class="v">Tools that go get something — from the web, from your existing notes, or from a source you're reading — and hand it back as a draft for you to keep. <b>Find Sources</b> builds a candidate reading list; you decide which ones are worth actually adding. <b>Extract Key Claims</b> pulls the main claims out of a source, each linked back to the passage it came from. <b>Check Facts</b> tests a specific claim against outside evidence.</div>
+        <div class="v">Tools that go get something — from the web, from your existing notes, or from a source you're reading — and hand it back as a draft for you to keep. <b>Find Sources</b> builds a candidate reading list; you decide which ones are worth actually adding. <b>Extract Key Claims</b> pulls the main claims out of a source, each linked back to the passage it came from. <b>Check Facts</b> tests a specific claim against outside evidence. See <a href="thinking-tools-research.html">Research Operations</a> for the full menu.</div>
       </div>
       <div class="row">
         <div class="k">Analysis</div>
-        <div class="v">Tools that operate on a claim, argument, or note you already have — drawing out its structure, its tensions, or a stronger version of it. <b>Steelman</b> builds the strongest possible version of an opposing argument. <b>Find Tensions</b> compares two notes for where they disagree. <b>Doublecrux</b> and <b>Murphyjitsu</b> belong to the same family. This is by far the largest menu, which is why it's the one that benefits most from grouping.</div>
+        <div class="v">Tools that operate on a claim, argument, or note you already have — drawing out its structure, its tensions, or a stronger version of it. <b>Steelman</b> builds the strongest possible version of an opposing argument. <b>Find Tensions</b> compares two notes for where they disagree. <b>Doublecrux</b> and <b>Murphyjitsu</b> belong to the same family. This is by far the largest menu, which is why it's the one that benefits most from grouping. See <a href="thinking-tools-analysis.html">Analysis Operations</a> for the full menu.</div>
       </div>
     </div>
 
     <h2 id="grouping">Themed groups within a menu</h2>
-    <p>When a menu holds a lot of tools, related ones are gathered into themed submenus — labels like <b>Disagreement</b>, <b>Verification</b>, or <b>Discovery</b> — so you're not scrolling one long list. For example, Steelman and Doublecrux sit together under Disagreement, while Check Facts and Find Primary Sources sit under Verification. Tools that don't belong to a theme simply stay in the menu alongside the submenus. Today the Analysis menu is the one large enough to use groups; Learning and Research stay as flat lists.</p>
+    <p>When a menu holds a lot of tools, related ones are gathered into themed submenus — labels like <b>Disagreement</b>, <b>Verification</b>, or <b>Discovery</b> — so you're not scrolling one long list. For example, Steelman and Doublecrux sit together under Disagreement, while Check Facts and Find Primary Sources sit under Verification. Tools that don't belong to a theme simply stay in the menu alongside the submenus. Today the Research and Analysis menus use groups — Analysis, the largest, most heavily; the Learning menu stays a flat list.</p>
 
     <figure class="shot-img">
       <img src="img/thinking-tools-three-menus.png" alt="The Analysis menu is open, showing themed submenus like Disagreement and Verification alongside any standalone tools, with the Disagreement submenu expanded to reveal Steelman, Find Tensions, and Doublecrux." loading="lazy" />
@@ -115,9 +118,9 @@
         <span class="dir">Previous</span>
         <span class="ttl">← Running a skill</span>
       </a>
-      <a class="next" href="thinking-tools-managing-authoring.html">
+      <a class="next" href="thinking-tools-learning.html">
         <span class="dir">Next</span>
-        <span class="ttl">Managing &amp; authoring →</span>
+        <span class="ttl">Learning Operations →</span>
       </a>
     </div>
   </main>

--- a/website/docs/thinking-tools-what-they-are.html
+++ b/website/docs/thinking-tools-what-they-are.html
@@ -69,6 +69,9 @@
     <a href="thinking-tools-what-they-are.html" class="sub active">What thinking tools are</a>
     <a href="thinking-tools-running-a-skill.html" class="sub">Running a skill</a>
     <a href="thinking-tools-three-menus.html" class="sub">The three menus</a>
+    <a href="thinking-tools-learning.html" class="sub">Learning Operations</a>
+    <a href="thinking-tools-research.html" class="sub">Research Operations</a>
+    <a href="thinking-tools-analysis.html" class="sub">Analysis Operations</a>
     <a href="thinking-tools-managing-authoring.html" class="sub">Managing &amp; authoring</a>
     <a href="data.html">Data</a>
     <a href="ingest.html">Ingest</a>


### PR DESCRIPTION
Finishes the "operations" pages: per-menu skill catalogs for the three Thinking tools menus, placed after **The three menus** in the family.

## New pages
- **`thinking-tools-learning.html` — Learning Operations** (11 skills, flat list): explain, summarize, examples/counterexamples, prerequisites, learning journey, glossary, quiz, flashcards.
- **`thinking-tools-research.html` — Research Operations** (13 skills, grouped): Discovery · Mining · Verification · Argumentation · Decomposition · Summarize.
- **`thinking-tools-analysis.html` — Analysis Operations** (27 skills, nine groups): Generation · Disagreement · Diagnostic · Semantic · Pattern · Motivation · Planning · Data · Organization.

Skill names and descriptions are taken directly from the stock skill frontmatter (`src/main/skills/stock/*.md`), so the catalogs match what actually ships.

> Note on naming: the third menu is **Analysis** in the app (`registry.ts`) — "Planning" is a *group inside* it (Hamming Question, Murphyjitsu, Reference Class), so the page is "Analysis Operations."

## Wiring & fixes
- Surfaced in the hub's "At a glance" + "In depth" cards, and linked from each row of **The three menus**.
- Fixed a stale sentence in `three-menus.html`: the Research menu is grouped too (its skills carry `group:`), not just Analysis.
- Nav + prev/next pagers regenerated from the model; reading order `The three menus → Learning → Research → Analysis → Managing & authoring`. All internal links verified; one nav + one pager per page; no orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)