### PR TITLE
feat(cli): bundle the minerva CLI into the packaged app + install-in-PATH

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -129,6 +129,14 @@ self-contained demo machine.
 - `vite.main.config.ts` / `vite.preload.config.ts` /
   `vite.renderer.config.mts` — per-process bundle configs that the
   VitePlugin invokes during package.
+- `vite.cli.config.ts` — self-contained build of the headless `minerva`
+  CLI (#1437). `forge.config.ts`'s `afterPrune` (`copyCliBundle`) builds it
+  and stages `.vite/build/cli.js` into the app beside `main.js`, so it
+  resolves the same shipped `node_modules`. At runtime it's launched via the
+  app's own Electron binary under `ELECTRON_RUN_AS_NODE` — no separate `node`
+  ships. Users expose it on PATH with **Help → Install 'minerva' Command in
+  PATH…** (`src/main/cli-install.ts`), which writes a shim to
+  `~/.local/bin/minerva`. macOS/Linux; Windows is a follow-up.
 - `resources/python/` — bundled Python kernel + `minerva` helper
   library. Staged into `Minerva.app/Contents/Resources/python/` by the
   `extraResource` config.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -78,6 +78,29 @@ function copyExternalDeps(buildPath: string): void {
   }
 }
 
+// Stage the headless CLI (#1437) into the packaged app next to `main.js`, so it
+// resolves the same shipped `node_modules` (the native roots `copyExternalDeps`
+// stages) — `cli.js` is self-contained JS otherwise (vite.cli.config.ts). At
+// runtime it's launched via the app's own Electron binary under
+// ELECTRON_RUN_AS_NODE (the "Install minerva Command" action writes the shim),
+// so no separate `node` ships.
+//
+// We build cli.js HERE rather than in a `generateAssets` hook: that runs before
+// the Vite plugin, which then empties `.vite/build` and deletes it. By afterPrune
+// the plugin's builds are done, and `vite.cli.config`'s `emptyOutDir:false` keeps
+// `main.js` intact. The build runs against the repo's node_modules (unaffected by
+// the app prune), and afterPrune is before signing, so the addition is signed.
+function copyCliBundle(buildPath: string): void {
+  execFileSync('pnpm', ['cli:build'], { stdio: 'inherit' });
+  const src = path.join(process.cwd(), '.vite', 'build', 'cli.js');
+  if (!fs.existsSync(src)) {
+    throw new Error('[forge] cli:build did not produce .vite/build/cli.js');
+  }
+  const destDir = path.join(buildPath, '.vite', 'build');
+  fs.mkdirSync(destDir, { recursive: true });
+  fs.copyFileSync(src, path.join(destDir, 'cli.js'));
+}
+
 // macOS code signing + notarization (#661/#662). Signing runs only on macOS;
 // notarization additionally requires the App Store Connect API-key env vars, so a
 // plain local `pnpm build` (no creds) still signs but skips notarization instead
@@ -138,6 +161,7 @@ const config: ForgeConfig = {
       (buildPath, _electronVersion, _platform, _arch, done) => {
         try {
           copyExternalDeps(buildPath);
+          copyCliBundle(buildPath);
           done();
         } catch (err) {
           done(err instanceof Error ? err : new Error(String(err)));

--- a/src/cli/electron-stub.ts
+++ b/src/cli/electron-stub.ts
@@ -1,0 +1,27 @@
+/**
+ * `electron` stub for the headless CLI build (#1437).
+ *
+ * The read core imports `electron` transitively (notebase/fs, notebase/watcher,
+ * llm/settings) but never calls it on the CLI's code path. In a dev checkout the
+ * CLI externalizes `electron`, so `require('electron')` resolves to the npm
+ * `electron` package whose module is the binary-path *string* — meaning every
+ * `import { app, dialog, … } from 'electron'` is already `undefined` there, and
+ * nothing on the CLI path touches them. The packaged app ships no npm `electron`
+ * package, so that runtime require can't resolve. Aliasing `electron` to this
+ * stub (see vite.cli.config.ts) bundles the same all-`undefined` shape in,
+ * removing the require while preserving the exact dev behavior.
+ *
+ * These are the value names imported from `electron` anywhere in src/main; type
+ * imports are erased at build time and need no export.
+ */
+export const app = undefined;
+export const BrowserWindow = undefined;
+export const Menu = undefined;
+export const shell = undefined;
+export const dialog = undefined;
+export const session = undefined;
+export const ipcMain = undefined;
+export const safeStorage = undefined;
+export const autoUpdater = undefined;
+export const Notification = undefined;
+export default {};

--- a/src/main/cli-install.ts
+++ b/src/main/cli-install.ts
@@ -1,0 +1,92 @@
+/**
+ * "Install `minerva` Command in PATH" (#1437, epic #1145 — Substrate).
+ *
+ * The packaged app bundles the headless CLI at `<app>/.vite/build/cli.js`
+ * (forge.config `copyCliBundle`). This writes a small launcher to
+ * `~/.local/bin/minerva` that runs the app's own Electron binary as Node
+ * (`ELECTRON_RUN_AS_NODE`) against that bundle — so `minerva query …` /
+ * `minerva mcp …` work with no separate Node and no dev checkout.
+ *
+ * `~/.local/bin` is user-writable (no admin prompt); if it isn't on PATH we say
+ * so, and always surface the absolute path for MCP clients (e.g. Claude
+ * Desktop) that launch from a bare environment. macOS/Linux (sh); Windows is a
+ * follow-up.
+ */
+import { app, dialog, shell } from 'electron';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export interface MinervaCliPaths {
+  electronBinary: string;
+  cliJs: string;
+  binDir: string;
+  shimPath: string;
+}
+
+export function minervaCliPaths(): MinervaCliPaths {
+  const binDir = path.join(os.homedir(), '.local', 'bin');
+  return {
+    electronBinary: process.execPath,
+    cliJs: path.join(app.getAppPath(), '.vite', 'build', 'cli.js'),
+    binDir,
+    shimPath: path.join(binDir, 'minerva'),
+  };
+}
+
+/** Single-quote a path for /bin/sh, escaping embedded single quotes. */
+function shQuote(p: string): string {
+  return `'${p.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Write `~/.local/bin/minerva` and report where it went (with a PATH hint). */
+export async function installMinervaCommand(): Promise<void> {
+  const { electronBinary, cliJs, binDir, shimPath } = minervaCliPaths();
+
+  if (!fs.existsSync(cliJs)) {
+    await dialog.showMessageBox({
+      type: 'error',
+      message: 'Minerva CLI not found in this build',
+      detail: `Expected the bundled CLI at:\n  ${cliJs}\n\nThe “minerva” command is only available in a packaged build of Minerva.`,
+    });
+    return;
+  }
+
+  const shim =
+    '#!/bin/sh\n' +
+    '# Minerva CLI launcher — installed by Minerva.app (#1437). Re-run\n' +
+    '# “Install ‘minerva’ Command in PATH…” from the Help menu if you\n' +
+    '# move or reinstall the app.\n' +
+    `exec env ELECTRON_RUN_AS_NODE=1 ${shQuote(electronBinary)} ${shQuote(cliJs)} "$@"\n`;
+
+  try {
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(shimPath, shim, { mode: 0o755 });
+    fs.chmodSync(shimPath, 0o755); // ensure exec bit even if the file pre-existed
+  } catch (err) {
+    await dialog.showMessageBox({
+      type: 'error',
+      message: 'Could not install the minerva command',
+      detail: `Writing ${shimPath} failed:\n${err instanceof Error ? err.message : String(err)}`,
+    });
+    return;
+  }
+
+  const onPath = (process.env.PATH ?? '').split(path.delimiter).includes(binDir);
+  const detail =
+    `Installed the “minerva” command at:\n  ${shimPath}\n\n` +
+    (onPath
+      ? 'It’s on your PATH — open a new terminal and run:\n  minerva --help'
+      : `Add ${binDir} to your PATH to run it as “minerva”. In ~/.zshrc (or ~/.bashrc):\n  export PATH="$HOME/.local/bin:$PATH"\n\nThen open a new terminal and run “minerva --help”.`) +
+    `\n\nFor MCP clients that don’t use your shell PATH (e.g. Claude Desktop), point them at the full path:\n  ${shimPath}`;
+
+  const { response } = await dialog.showMessageBox({
+    type: 'info',
+    message: 'minerva command installed',
+    detail,
+    buttons: ['OK', 'Reveal in Finder'],
+    defaultId: 0,
+    cancelId: 0,
+  });
+  if (response === 1) shell.showItemInFolder(shimPath);
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -10,6 +10,7 @@ import { projectContext } from './project-context-types';
 import * as search from './search/index';
 import * as tables from './sources/tables';
 import { STOCK_QUERIES } from '../shared/stock-queries';
+import { installMinervaCommand } from './cli-install';
 import { listSavedQueries } from './saved-queries';
 import { restartKernel as restartPythonKernel, interruptKernel as interruptPythonKernel } from './compute/python-kernel';
 import * as publish from './publish';
@@ -875,6 +876,17 @@ function buildHelpMenu(isMac: boolean): Electron.MenuItemConstructorOptions {
         label: 'Report an Issue…',
         click: () => { void shell.openExternal(ISSUES_URL); },
       },
+      // Expose the headless `minerva` CLI on PATH (#1437). macOS/Linux only —
+      // the launcher is an sh shim; Windows is a follow-up.
+      ...(isMac
+        ? [
+            { type: 'separator' as const },
+            {
+              label: 'Install ‘minerva’ Command in PATH…',
+              click: () => { void installMinervaCommand(); },
+            },
+          ]
+        : []),
       // macOS keeps About in the app menu; Windows/Linux have no app menu,
       // so About lives at the foot of Help (the platform convention).
       ...(isMac

--- a/vite.cli.config.ts
+++ b/vite.cli.config.ts
@@ -1,20 +1,27 @@
 import { defineConfig } from 'vite';
 import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Standalone Node build of the headless CLI (#1149, epic #1145 — Substrate).
  *
- * `ssr: true` externalizes node builtins + everything in node_modules and
- * bundles only our own `src/**`, so the emitted `cli.js` is small and resolves
- * heavy/native deps (rdflib, comunica, DuckDB, onnxruntime) from node_modules at
- * runtime — the same way the app does. The explicit `external` list additionally
- * pins the native packages that must never be bundled (mirrors
- * vite.main.config) and adds `electron`: the read core imports it transitively
- * (notebase/fs's picker, llm/settings), but the CLI never calls those, so in
- * plain Node `require('electron')` harmlessly yields the binary-path string.
+ * `build.ssr` targets Node (builtins external, CJS out); `ssr.noExternal: true`
+ * then *bundles* the JS dep tree (rdflib, comunica, n3, …) INTO `cli.js`,
+ * exactly like `main.js` does — so the emitted bundle is self-contained and
+ * needs only the handful of native/wasm roots at runtime. That's what lets the
+ * CLI ship inside the packaged app (#1437): the app bundles those same JS deps
+ * into `main.js` and never stages them as node_modules, so a CLI that
+ * externalized them would fail to resolve them in the `.app`. The `external`
+ * list pins the packages that must NOT be bundled — the native/wasm roots that
+ * load `.node`/`.wasm` from disk (mirrors vite.main.config, and forge.config's
+ * `EXTERNAL_DEP_ROOTS` ships their closure) — plus `electron`: the read core
+ * imports it transitively (notebase/fs's picker, llm/settings) but never calls
+ * it, so under `ELECTRON_RUN_AS_NODE` (or plain Node) `require('electron')`
+ * harmlessly yields the binary-path string.
  *
  * Build:  vite build --config vite.cli.config.ts   (→ .vite/build/cli.js)
  * Run:    node .vite/build/cli.js query "SELECT ..." --project /path/to/vault
+ *         (packaged: ELECTRON_RUN_AS_NODE=1 Minerva.app/…/cli.js …)
  */
 function gitCommit(): string {
   try {
@@ -30,6 +37,17 @@ export default defineConfig({
     __APP_COMMIT__: JSON.stringify(gitCommit()),
     __BUILD_DATE__: JSON.stringify(new Date().toISOString().slice(0, 10)),
   },
+  // Bundle the JS dep tree into cli.js (leaving only `external` out), so the
+  // packaged CLI needs no node_modules beyond the shipped native roots (#1437).
+  ssr: { noExternal: true },
+  resolve: {
+    // `electron` is never called on the CLI path; alias it to an all-undefined
+    // stub so the bundle carries no runtime `require('electron')` (which the
+    // packaged app can't resolve — it ships no npm electron package). #1437
+    alias: {
+      electron: fileURLToPath(new URL('./src/cli/electron-stub.ts', import.meta.url)),
+    },
+  },
   build: {
     ssr: true,
     outDir: '.vite/build',
@@ -38,7 +56,6 @@ export default defineConfig({
       input: 'src/cli/main.ts',
       output: { entryFileNames: 'cli.js', format: 'cjs' },
       external: [
-        'electron',
         'canvas',
         /^@duckdb\/node-bindings/,
         'vega',

--- a/website/docs/connecting-cli.html
+++ b/website/docs/connecting-cli.html
@@ -82,11 +82,12 @@
     <h1>CLI use</h1>
     <p class="lede">The Minerva CLI gives headless, scriptable access to a thoughtbase from your shell — the same core the app runs on, so it works with the app closed. Every result is printed as <b>JSON</b> on standard output, so it pipes straight into <code>jq</code> or feeds an agent directly.</p>
 
-    <h2 id="build">Building and running</h2>
-    <p>Build the CLI once from the Minerva source tree and put it on your PATH as the <code>minerva</code> command:</p>
-    <pre><code>pnpm cli:build        # builds .vite/build/cli.js and marks it executable
+    <h2 id="build">Getting the command</h2>
+    <p>If you installed Minerva from the download, choose <b>Help → Install ‘minerva’ Command in PATH…</b> in the app. That writes a <code>minerva</code> launcher to <code>~/.local/bin</code> — the app runs its own bundled Node, so there's nothing else to install. If <code>~/.local/bin</code> isn't on your <code>PATH</code>, the dialog shows how to add it, and gives the full path to use for MCP clients.</p>
+    <p>Working from the source tree instead? Build and link it:</p>
+    <pre><code>pnpm cli:build        # builds .vite/build/cli.js
 pnpm link --global    # exposes it globally as `minerva`</code></pre>
-    <p>From then on, <code>minerva</code> works anywhere. Point any command at a thoughtbase with <code>--project &lt;path&gt;</code> — it defaults to the current directory.</p>
+    <p>Either way, <code>minerva</code> then works anywhere. Point any command at a thoughtbase with <code>--project &lt;path&gt;</code> — it defaults to the current directory.</p>
     <pre><code>minerva &lt;command&gt; [args] [--project &lt;path&gt;]</code></pre>
 
     <h2 id="commands">Commands</h2>

--- a/website/docs/connecting-mcp.html
+++ b/website/docs/connecting-mcp.html
@@ -83,7 +83,7 @@
     <p class="lede">The <b>Model Context Protocol (MCP)</b> is a standard way to give an AI agent tools. Minerva's MCP server exposes the same reads and proposals as the <a href="connecting-cli.html">CLI</a> — as tools any MCP client can call — so an agent like Claude Desktop, a coding agent, or an editor can ground itself in your thoughtbase and hand work back through the approval gate.</p>
 
     <h2 id="start">Starting the server</h2>
-    <p>The MCP server is the <code>mcp</code> subcommand of the same CLI — <a href="connecting-cli.html#build">build and link it once</a> and you have the <code>minerva</code> command. The server runs over standard input/output as a subprocess — you don't start it by hand so much as tell a client how to launch it. On its own:</p>
+    <p>The MCP server is the <code>mcp</code> subcommand of the same CLI — <a href="connecting-cli.html#build">install it once</a> (Help → Install ‘minerva’ Command, or build from source) and you have the <code>minerva</code> command. The server runs over standard input/output as a subprocess — you don't start it by hand so much as tell a client how to launch it. On its own:</p>
     <pre><code>minerva mcp --project /path/to/thoughtbase</code></pre>
     <p>It speaks newline-delimited JSON-RPC 2.0 and stays running until its input closes. Each modality initializes once and stays warm across tool calls.</p>
 


### PR DESCRIPTION
Makes the headless `minerva` CLI / MCP server usable from an **installed build**, not just a dev checkout. Closes #1437.

## The real crux (deeper than the issue's "Node runtime")
The packaged app ships only the **native-root closure** (`copyExternalDeps`: duckdb, onnxruntime, vega, sql.js, …) because `main.js` *bundles* its JS deps. The old `cli.js` used `ssr: true`, externalizing **all** of `node_modules` (rdflib, comunica, n3) — so a packaged `cli.js` couldn't resolve them. Two fixes:

1. **Self-contained CLI build** (`vite.cli.config.ts`): `ssr.noExternal` bundles the JS dep tree into `cli.js` (like `main.js`), leaving only the same native/wasm roots external. `electron` is aliased to an all-`undefined` **stub** (`src/cli/electron-stub.ts`) — the read core imports it transitively but never calls it, so this drops the runtime `require('electron')` the packaged app can't resolve, matching dev behavior exactly.
2. **Node runtime** = the app's own Electron under `ELECTRON_RUN_AS_NODE` (the VS Code pattern) — no separate `node` ships.

## What's in the PR
- **`forge.config.ts`** — `afterPrune` builds `cli.js` and stages it at `<app>/.vite/build/cli.js` (beside `main.js`, so it resolves the shipped `node_modules`). Built in `afterPrune` because the Vite plugin empties `.vite/build` after `generateAssets`; `afterPrune` is also *before* signing, so the addition is notarized cleanly.
- **`src/main/cli-install.ts` + `menu.ts`** — **Help → Install 'minerva' Command in PATH…** (macOS) writes `~/.local/bin/minerva`, a shim that runs the app's Electron-as-node against the bundled CLI. Reports the path, a PATH hint if `~/.local/bin` isn't on PATH, and the absolute path for MCP clients (Claude Desktop) that launch from a bare environment.
- **Docs** — `connecting-cli`/`connecting-mcp` lead with the installed command; `docs/packaging.md` documents the flow.

## Validation
Ran a full `pnpm package` and exercised the **freshly bundled** CLI (no `NODE_PATH` tricks — real resolution from the app's `node_modules`):
- `query` (SPARQL) → real results
- `search` (full-text) → hits
- `mcp` → server responds to `tools/list` with all seven tools
- the exact `~/.local/bin/minerva` shim runs it

`pnpm lint` clean; `tests/cli/` green (42). Corpus staleness snapshot unaffected (section ids unchanged).

## Scope
macOS-first (matches the DMG). Windows/Linux PATH exposure tracked in **#1440**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)