### PR TITLE
feat(query): Tab fills the ghosted example query when the editor is empty

### DIFF
--- a/src/renderer/lib/components/QueryPanel.svelte
+++ b/src/renderer/lib/components/QueryPanel.svelte
@@ -145,6 +145,21 @@
       : 'SELECT ?note ?title WHERE {\n  ?note a minerva:Note ;\n        dc:title ?title .\n}';
   }
 
+  /** On an empty editor, Tab drops the ghosted example query in as real,
+   *  editable text (cursor at end) so it can actually be used — otherwise
+   *  the placeholder just vanishes on the first keystroke. Returns false
+   *  when the doc is non-empty so Tab falls through to accept-completion /
+   *  indent as usual. */
+  function fillPlaceholderIfEmpty(v: EditorView): boolean {
+    if (v.state.doc.length !== 0) return false;
+    const text = placeholderFor(tab.language);
+    v.dispatch({
+      changes: { from: 0, insert: text },
+      selection: { anchor: text.length },
+    });
+    return true;
+  }
+
   function completionFor(lang: QueryLanguage): Extension {
     // `defaultKeymap: false` drops the built-in completion keybindings so our
     // own Enter (accept + eat tail, #206) owns that key — the default Enter
@@ -206,6 +221,7 @@
           { key: 'Mod-Enter', run: () => { if (!isEmpty) onExecute(); return true; } },
           { key: 'Mod-s', run: () => { if (!isEmpty) onSave(); return true; } },
           { key: 'Shift-Alt-f', run: () => { if (isEmpty) return true; return reformat(); } },
+          { key: 'Tab', run: fillPlaceholderIfEmpty },
           { key: 'Tab', run: acceptCompletion },
           // Enter accepts the active completion and eats the half-typed word
           // tail (#206); returns false with no popup open so Enter is a


### PR DESCRIPTION
## What

The New Query editor shows a ghosted example query (SPARQL or SQL) as a CodeMirror placeholder, but there was no way to actually *use* it — the placeholder vanishes on the first keystroke.

Now, when the query editor is empty, pressing **Tab** drops that example in as real, editable text with the cursor at the end. You can run it as-is or tweak it. When the editor already has content, Tab behaves exactly as before (accept-completion, then indent).

## How

- New `fillPlaceholderIfEmpty(view)` handler reuses the existing `placeholderFor(lang)` string, so the inserted text always matches the ghost the user just saw (and switches with the SPARQL/SQL language toggle).
- Bound as a `Tab` entry in the `Prec.highest` keymap *before* `acceptCompletion`. It returns `false` on a non-empty doc, so Tab falls through to the existing accept-completion / `indentWithTab` chain untouched. On an empty doc there's no active completion to accept, so nothing is stolen.
- The insertion dispatches a normal change, so the existing `updateListener` fires `onQueryChange` and the tab state picks up the query as usual.

## Testing

- `pnpm lint` clean.
- Verified by reasoning through the keymap precedence; did not drive the Electron GUI. Manual check: open **Query → New Query**, press Tab on the empty editor → example fills in; switch language → Tab fills the matching example; type something first → Tab still indents / accepts completions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)