### PR TITLE
fix(website): make docs-page chrome consistent with the root site (nav + footer links)

### DIFF
--- a/website/about.html
+++ b/website/about.html
@@ -48,6 +48,7 @@
     <div class="links">
       <a href="features.html" class="hide-sm">Features</a>
       <a href="getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="docs/index.html" class="hide-sm">Docs</a>
       <a href="about.html" class="active hide-sm">About</a>
       <a href="privacy.html" class="hide-sm">Privacy</a>
       <a href="getting-started.html" class="navcta">Download</a>

--- a/website/about.html
+++ b/website/about.html
@@ -126,7 +126,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/connecting-cli.html
+++ b/website/docs/connecting-cli.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/connecting-cli.html
+++ b/website/docs/connecting-cli.html
@@ -184,7 +184,7 @@ minerva query \
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/connecting-cli.html
+++ b/website/docs/connecting-cli.html
@@ -183,7 +183,7 @@ minerva query \
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/connecting-mcp.html
+++ b/website/docs/connecting-mcp.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/connecting-mcp.html
+++ b/website/docs/connecting-mcp.html
@@ -185,7 +185,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/connecting-mcp.html
+++ b/website/docs/connecting-mcp.html
@@ -184,7 +184,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/connecting.html
+++ b/website/docs/connecting.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/connecting.html
+++ b/website/docs/connecting.html
@@ -161,7 +161,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/connecting.html
+++ b/website/docs/connecting.html
@@ -160,7 +160,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/conversations-chatting.html
+++ b/website/docs/conversations-chatting.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/conversations-chatting.html
+++ b/website/docs/conversations-chatting.html
@@ -177,7 +177,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/conversations-chatting.html
+++ b/website/docs/conversations-chatting.html
@@ -178,7 +178,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/conversations-drafts.html
+++ b/website/docs/conversations-drafts.html
@@ -134,7 +134,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/conversations-drafts.html
+++ b/website/docs/conversations-drafts.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/conversations-drafts.html
+++ b/website/docs/conversations-drafts.html
@@ -135,7 +135,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/conversations-propose-review-approve.html
+++ b/website/docs/conversations-propose-review-approve.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/conversations-propose-review-approve.html
+++ b/website/docs/conversations-propose-review-approve.html
@@ -140,7 +140,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/conversations-propose-review-approve.html
+++ b/website/docs/conversations-propose-review-approve.html
@@ -139,7 +139,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/conversations-slash-commands.html
+++ b/website/docs/conversations-slash-commands.html
@@ -182,7 +182,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/conversations-slash-commands.html
+++ b/website/docs/conversations-slash-commands.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/conversations-slash-commands.html
+++ b/website/docs/conversations-slash-commands.html
@@ -183,7 +183,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/conversations.html
+++ b/website/docs/conversations.html
@@ -155,7 +155,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/conversations.html
+++ b/website/docs/conversations.html
@@ -156,7 +156,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/conversations.html
+++ b/website/docs/conversations.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/data-operations.html
+++ b/website/docs/data-operations.html
@@ -150,7 +150,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/data-operations.html
+++ b/website/docs/data-operations.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/data-operations.html
+++ b/website/docs/data-operations.html
@@ -149,7 +149,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/data.html
+++ b/website/docs/data.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/data.html
+++ b/website/docs/data.html
@@ -196,7 +196,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/data.html
+++ b/website/docs/data.html
@@ -195,7 +195,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/editor-keyboard-shortcuts.html
+++ b/website/docs/editor-keyboard-shortcuts.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/editor-keyboard-shortcuts.html
+++ b/website/docs/editor-keyboard-shortcuts.html
@@ -259,7 +259,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/editor-keyboard-shortcuts.html
+++ b/website/docs/editor-keyboard-shortcuts.html
@@ -258,7 +258,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/editor-link-autocomplete.html
+++ b/website/docs/editor-link-autocomplete.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/editor-link-autocomplete.html
+++ b/website/docs/editor-link-autocomplete.html
@@ -137,7 +137,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/editor-link-autocomplete.html
+++ b/website/docs/editor-link-autocomplete.html
@@ -138,7 +138,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/editor-markdown-formatting.html
+++ b/website/docs/editor-markdown-formatting.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/editor-markdown-formatting.html
+++ b/website/docs/editor-markdown-formatting.html
@@ -201,7 +201,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/editor-markdown-formatting.html
+++ b/website/docs/editor-markdown-formatting.html
@@ -200,7 +200,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/editor-operations.html
+++ b/website/docs/editor-operations.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/editor-operations.html
+++ b/website/docs/editor-operations.html
@@ -172,7 +172,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/editor-operations.html
+++ b/website/docs/editor-operations.html
@@ -173,7 +173,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/editor-voice-dictation.html
+++ b/website/docs/editor-voice-dictation.html
@@ -141,7 +141,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/editor-voice-dictation.html
+++ b/website/docs/editor-voice-dictation.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/editor-voice-dictation.html
+++ b/website/docs/editor-voice-dictation.html
@@ -142,7 +142,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/editor-writing-surface.html
+++ b/website/docs/editor-writing-surface.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/editor-writing-surface.html
+++ b/website/docs/editor-writing-surface.html
@@ -151,7 +151,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/editor-writing-surface.html
+++ b/website/docs/editor-writing-surface.html
@@ -150,7 +150,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/editor.html
+++ b/website/docs/editor.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/editor.html
+++ b/website/docs/editor.html
@@ -176,7 +176,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/editor.html
+++ b/website/docs/editor.html
@@ -175,7 +175,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/export-bibliography.html
+++ b/website/docs/export-bibliography.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/export-bibliography.html
+++ b/website/docs/export-bibliography.html
@@ -135,7 +135,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/export-bibliography.html
+++ b/website/docs/export-bibliography.html
@@ -136,7 +136,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/export-documents.html
+++ b/website/docs/export-documents.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/export-documents.html
+++ b/website/docs/export-documents.html
@@ -158,7 +158,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/export-documents.html
+++ b/website/docs/export-documents.html
@@ -157,7 +157,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/export-flashcards.html
+++ b/website/docs/export-flashcards.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/export-flashcards.html
+++ b/website/docs/export-flashcards.html
@@ -127,7 +127,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/export-flashcards.html
+++ b/website/docs/export-flashcards.html
@@ -128,7 +128,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/export-publishing.html
+++ b/website/docs/export-publishing.html
@@ -140,7 +140,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/export-publishing.html
+++ b/website/docs/export-publishing.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/export-publishing.html
+++ b/website/docs/export-publishing.html
@@ -141,7 +141,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/export-scopes-privacy.html
+++ b/website/docs/export-scopes-privacy.html
@@ -144,7 +144,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/export-scopes-privacy.html
+++ b/website/docs/export-scopes-privacy.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/export-scopes-privacy.html
+++ b/website/docs/export-scopes-privacy.html
@@ -145,7 +145,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/export.html
+++ b/website/docs/export.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/export.html
+++ b/website/docs/export.html
@@ -161,7 +161,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/export.html
+++ b/website/docs/export.html
@@ -160,7 +160,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -156,7 +156,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -157,7 +157,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/ingest-adding-sources.html
+++ b/website/docs/ingest-adding-sources.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/ingest-adding-sources.html
+++ b/website/docs/ingest-adding-sources.html
@@ -158,7 +158,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/ingest-adding-sources.html
+++ b/website/docs/ingest-adding-sources.html
@@ -157,7 +157,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/ingest-citing-duplicates.html
+++ b/website/docs/ingest-citing-duplicates.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/ingest-citing-duplicates.html
+++ b/website/docs/ingest-citing-duplicates.html
@@ -134,7 +134,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/ingest-citing-duplicates.html
+++ b/website/docs/ingest-citing-duplicates.html
@@ -133,7 +133,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/ingest-clipper.html
+++ b/website/docs/ingest-clipper.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/ingest-clipper.html
+++ b/website/docs/ingest-clipper.html
@@ -143,7 +143,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/ingest-clipper.html
+++ b/website/docs/ingest-clipper.html
@@ -142,7 +142,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/ingest-pdf.html
+++ b/website/docs/ingest-pdf.html
@@ -134,7 +134,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/ingest-pdf.html
+++ b/website/docs/ingest-pdf.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/ingest-pdf.html
+++ b/website/docs/ingest-pdf.html
@@ -135,7 +135,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/ingest.html
+++ b/website/docs/ingest.html
@@ -155,7 +155,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/ingest.html
+++ b/website/docs/ingest.html
@@ -156,7 +156,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/ingest.html
+++ b/website/docs/ingest.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/left-sidebar-bookmarks.html
+++ b/website/docs/left-sidebar-bookmarks.html
@@ -146,7 +146,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/left-sidebar-bookmarks.html
+++ b/website/docs/left-sidebar-bookmarks.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/left-sidebar-bookmarks.html
+++ b/website/docs/left-sidebar-bookmarks.html
@@ -145,7 +145,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/left-sidebar-notes-tree.html
+++ b/website/docs/left-sidebar-notes-tree.html
@@ -193,7 +193,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/left-sidebar-notes-tree.html
+++ b/website/docs/left-sidebar-notes-tree.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/left-sidebar-notes-tree.html
+++ b/website/docs/left-sidebar-notes-tree.html
@@ -194,7 +194,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/left-sidebar-sources.html
+++ b/website/docs/left-sidebar-sources.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/left-sidebar-sources.html
+++ b/website/docs/left-sidebar-sources.html
@@ -203,7 +203,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/left-sidebar-sources.html
+++ b/website/docs/left-sidebar-sources.html
@@ -204,7 +204,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/left-sidebar-tables.html
+++ b/website/docs/left-sidebar-tables.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/left-sidebar-tables.html
+++ b/website/docs/left-sidebar-tables.html
@@ -176,7 +176,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/left-sidebar-tables.html
+++ b/website/docs/left-sidebar-tables.html
@@ -175,7 +175,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/left-sidebar-tags.html
+++ b/website/docs/left-sidebar-tags.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/left-sidebar-tags.html
+++ b/website/docs/left-sidebar-tags.html
@@ -163,7 +163,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/left-sidebar-tags.html
+++ b/website/docs/left-sidebar-tags.html
@@ -164,7 +164,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/left-sidebar.html
+++ b/website/docs/left-sidebar.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/left-sidebar.html
+++ b/website/docs/left-sidebar.html
@@ -161,7 +161,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/left-sidebar.html
+++ b/website/docs/left-sidebar.html
@@ -160,7 +160,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/maintenance.html
+++ b/website/docs/maintenance.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/maintenance.html
+++ b/website/docs/maintenance.html
@@ -130,7 +130,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/maintenance.html
+++ b/website/docs/maintenance.html
@@ -129,7 +129,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/navigation-back-forward.html
+++ b/website/docs/navigation-back-forward.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/navigation-back-forward.html
+++ b/website/docs/navigation-back-forward.html
@@ -165,7 +165,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/navigation-back-forward.html
+++ b/website/docs/navigation-back-forward.html
@@ -164,7 +164,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/navigation-breadcrumbs.html
+++ b/website/docs/navigation-breadcrumbs.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/navigation-breadcrumbs.html
+++ b/website/docs/navigation-breadcrumbs.html
@@ -137,7 +137,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/navigation-breadcrumbs.html
+++ b/website/docs/navigation-breadcrumbs.html
@@ -138,7 +138,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/navigation-command-palette.html
+++ b/website/docs/navigation-command-palette.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/navigation-command-palette.html
+++ b/website/docs/navigation-command-palette.html
@@ -140,7 +140,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/navigation-command-palette.html
+++ b/website/docs/navigation-command-palette.html
@@ -139,7 +139,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/navigation-quick-switch.html
+++ b/website/docs/navigation-quick-switch.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/navigation-quick-switch.html
+++ b/website/docs/navigation-quick-switch.html
@@ -196,7 +196,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/navigation-quick-switch.html
+++ b/website/docs/navigation-quick-switch.html
@@ -195,7 +195,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/navigation-search.html
+++ b/website/docs/navigation-search.html
@@ -186,7 +186,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/navigation-search.html
+++ b/website/docs/navigation-search.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/navigation-search.html
+++ b/website/docs/navigation-search.html
@@ -185,7 +185,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/navigation-wiki-links.html
+++ b/website/docs/navigation-wiki-links.html
@@ -134,7 +134,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/navigation-wiki-links.html
+++ b/website/docs/navigation-wiki-links.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/navigation-wiki-links.html
+++ b/website/docs/navigation-wiki-links.html
@@ -135,7 +135,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/navigation.html
+++ b/website/docs/navigation.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/navigation.html
+++ b/website/docs/navigation.html
@@ -176,7 +176,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/navigation.html
+++ b/website/docs/navigation.html
@@ -175,7 +175,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-callouts.html
+++ b/website/docs/notes-callouts.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-callouts.html
+++ b/website/docs/notes-callouts.html
@@ -193,7 +193,7 @@ No leading &gt; required — this still becomes a callout.</code></pre>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-callouts.html
+++ b/website/docs/notes-callouts.html
@@ -192,7 +192,7 @@ No leading &gt; required — this still becomes a callout.</code></pre>
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-charts.html
+++ b/website/docs/notes-charts.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-charts.html
+++ b/website/docs/notes-charts.html
@@ -175,7 +175,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-charts.html
+++ b/website/docs/notes-charts.html
@@ -174,7 +174,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-code.html
+++ b/website/docs/notes-code.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-code.html
+++ b/website/docs/notes-code.html
@@ -169,7 +169,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-code.html
+++ b/website/docs/notes-code.html
@@ -170,7 +170,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-diagrams.html
+++ b/website/docs/notes-diagrams.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-diagrams.html
+++ b/website/docs/notes-diagrams.html
@@ -166,7 +166,7 @@ sequenceDiagram
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-diagrams.html
+++ b/website/docs/notes-diagrams.html
@@ -167,7 +167,7 @@ sequenceDiagram
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-flashcards.html
+++ b/website/docs/notes-flashcards.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-flashcards.html
+++ b/website/docs/notes-flashcards.html
@@ -147,7 +147,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-flashcards.html
+++ b/website/docs/notes-flashcards.html
@@ -146,7 +146,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-footnotes.html
+++ b/website/docs/notes-footnotes.html
@@ -177,7 +177,7 @@ effect size.[^size]
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-footnotes.html
+++ b/website/docs/notes-footnotes.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-footnotes.html
+++ b/website/docs/notes-footnotes.html
@@ -176,7 +176,7 @@ effect size.[^size]
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-frontmatter.html
+++ b/website/docs/notes-frontmatter.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-frontmatter.html
+++ b/website/docs/notes-frontmatter.html
@@ -179,7 +179,7 @@ The body of the note starts here.</code></pre>
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-frontmatter.html
+++ b/website/docs/notes-frontmatter.html
@@ -180,7 +180,7 @@ The body of the note starts here.</code></pre>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-highlights.html
+++ b/website/docs/notes-highlights.html
@@ -151,7 +151,7 @@ Flagged for review: ==orange:re-check this once the rebuild finishes==.</code></
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-highlights.html
+++ b/website/docs/notes-highlights.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-highlights.html
+++ b/website/docs/notes-highlights.html
@@ -152,7 +152,7 @@ Flagged for review: ==orange:re-check this once the rebuild finishes==.</code></
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-images.html
+++ b/website/docs/notes-images.html
@@ -186,7 +186,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-images.html
+++ b/website/docs/notes-images.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-images.html
+++ b/website/docs/notes-images.html
@@ -187,7 +187,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-links.html
+++ b/website/docs/notes-links.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-links.html
+++ b/website/docs/notes-links.html
@@ -226,7 +226,7 @@ See [[depends-on::auth-redesign|the redesign proposal]] before touching this.</c
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-links.html
+++ b/website/docs/notes-links.html
@@ -225,7 +225,7 @@ See [[depends-on::auth-redesign|the redesign proposal]] before touching this.</c
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-math.html
+++ b/website/docs/notes-math.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-math.html
+++ b/website/docs/notes-math.html
@@ -152,7 +152,7 @@ $$</code></pre>
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-math.html
+++ b/website/docs/notes-math.html
@@ -153,7 +153,7 @@ $$</code></pre>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-media.html
+++ b/website/docs/notes-media.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-media.html
+++ b/website/docs/notes-media.html
@@ -145,7 +145,7 @@ Feynman on how rubber bands work
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-media.html
+++ b/website/docs/notes-media.html
@@ -144,7 +144,7 @@ Feynman on how rubber bands work
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-query.html
+++ b/website/docs/notes-query.html
@@ -202,7 +202,7 @@ title: Mentioned in
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-query.html
+++ b/website/docs/notes-query.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-query.html
+++ b/website/docs/notes-query.html
@@ -201,7 +201,7 @@ title: Mentioned in
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-rdf.html
+++ b/website/docs/notes-rdf.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-rdf.html
+++ b/website/docs/notes-rdf.html
@@ -141,7 +141,7 @@ this: a thought:Term ;
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-rdf.html
+++ b/website/docs/notes-rdf.html
@@ -140,7 +140,7 @@ this: a thought:Term ;
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-search.html
+++ b/website/docs/notes-search.html
@@ -165,7 +165,7 @@ working memory
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-search.html
+++ b/website/docs/notes-search.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-search.html
+++ b/website/docs/notes-search.html
@@ -166,7 +166,7 @@ working memory
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-tables.html
+++ b/website/docs/notes-tables.html
@@ -167,7 +167,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-tables.html
+++ b/website/docs/notes-tables.html
@@ -166,7 +166,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes-tables.html
+++ b/website/docs/notes-tables.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-tasks.html
+++ b/website/docs/notes-tasks.html
@@ -155,7 +155,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes-tasks.html
+++ b/website/docs/notes-tasks.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes-tasks.html
+++ b/website/docs/notes-tasks.html
@@ -154,7 +154,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/notes.html
+++ b/website/docs/notes.html
@@ -238,7 +238,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/notes.html
+++ b/website/docs/notes.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/notes.html
+++ b/website/docs/notes.html
@@ -237,7 +237,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/query-menu-panel.html
+++ b/website/docs/query-menu-panel.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/query-menu-panel.html
+++ b/website/docs/query-menu-panel.html
@@ -177,7 +177,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/query-menu-panel.html
+++ b/website/docs/query-menu-panel.html
@@ -178,7 +178,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/query-result-blocks.html
+++ b/website/docs/query-result-blocks.html
@@ -131,7 +131,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/query-result-blocks.html
+++ b/website/docs/query-result-blocks.html
@@ -132,7 +132,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/query-result-blocks.html
+++ b/website/docs/query-result-blocks.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/query-runnable-cells.html
+++ b/website/docs/query-runnable-cells.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/query-runnable-cells.html
+++ b/website/docs/query-runnable-cells.html
@@ -121,7 +121,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/query-runnable-cells.html
+++ b/website/docs/query-runnable-cells.html
@@ -120,7 +120,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/refactoring-ai-assisted.html
+++ b/website/docs/refactoring-ai-assisted.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/refactoring-ai-assisted.html
+++ b/website/docs/refactoring-ai-assisted.html
@@ -126,7 +126,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/refactoring-ai-assisted.html
+++ b/website/docs/refactoring-ai-assisted.html
@@ -127,7 +127,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/refactoring-manual.html
+++ b/website/docs/refactoring-manual.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/refactoring-manual.html
+++ b/website/docs/refactoring-manual.html
@@ -151,7 +151,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/refactoring-manual.html
+++ b/website/docs/refactoring-manual.html
@@ -152,7 +152,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/refactoring-operations.html
+++ b/website/docs/refactoring-operations.html
@@ -190,7 +190,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/refactoring-operations.html
+++ b/website/docs/refactoring-operations.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/refactoring-operations.html
+++ b/website/docs/refactoring-operations.html
@@ -191,7 +191,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/refactoring-safe-delete.html
+++ b/website/docs/refactoring-safe-delete.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/refactoring-safe-delete.html
+++ b/website/docs/refactoring-safe-delete.html
@@ -126,7 +126,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/refactoring-safe-delete.html
+++ b/website/docs/refactoring-safe-delete.html
@@ -127,7 +127,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/refactoring.html
+++ b/website/docs/refactoring.html
@@ -155,7 +155,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/refactoring.html
+++ b/website/docs/refactoring.html
@@ -156,7 +156,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/refactoring.html
+++ b/website/docs/refactoring.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-backlinks.html
+++ b/website/docs/right-sidebar-backlinks.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-backlinks.html
+++ b/website/docs/right-sidebar-backlinks.html
@@ -147,7 +147,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-backlinks.html
+++ b/website/docs/right-sidebar-backlinks.html
@@ -148,7 +148,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-bookmarks.html
+++ b/website/docs/right-sidebar-bookmarks.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-bookmarks.html
+++ b/website/docs/right-sidebar-bookmarks.html
@@ -144,7 +144,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-bookmarks.html
+++ b/website/docs/right-sidebar-bookmarks.html
@@ -143,7 +143,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-citations.html
+++ b/website/docs/right-sidebar-citations.html
@@ -144,7 +144,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-citations.html
+++ b/website/docs/right-sidebar-citations.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-citations.html
+++ b/website/docs/right-sidebar-citations.html
@@ -145,7 +145,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-footnotes.html
+++ b/website/docs/right-sidebar-footnotes.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-footnotes.html
+++ b/website/docs/right-sidebar-footnotes.html
@@ -143,7 +143,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-footnotes.html
+++ b/website/docs/right-sidebar-footnotes.html
@@ -142,7 +142,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-heading-graph.html
+++ b/website/docs/right-sidebar-heading-graph.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-heading-graph.html
+++ b/website/docs/right-sidebar-heading-graph.html
@@ -152,7 +152,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-heading-graph.html
+++ b/website/docs/right-sidebar-heading-graph.html
@@ -153,7 +153,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-outgoing-links.html
+++ b/website/docs/right-sidebar-outgoing-links.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-outgoing-links.html
+++ b/website/docs/right-sidebar-outgoing-links.html
@@ -144,7 +144,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-outgoing-links.html
+++ b/website/docs/right-sidebar-outgoing-links.html
@@ -143,7 +143,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-outline.html
+++ b/website/docs/right-sidebar-outline.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-outline.html
+++ b/website/docs/right-sidebar-outline.html
@@ -136,7 +136,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-outline.html
+++ b/website/docs/right-sidebar-outline.html
@@ -137,7 +137,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-properties.html
+++ b/website/docs/right-sidebar-properties.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-properties.html
+++ b/website/docs/right-sidebar-properties.html
@@ -166,7 +166,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-properties.html
+++ b/website/docs/right-sidebar-properties.html
@@ -165,7 +165,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-proposals.html
+++ b/website/docs/right-sidebar-proposals.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-proposals.html
+++ b/website/docs/right-sidebar-proposals.html
@@ -162,7 +162,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-proposals.html
+++ b/website/docs/right-sidebar-proposals.html
@@ -163,7 +163,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-related.html
+++ b/website/docs/right-sidebar-related.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-related.html
+++ b/website/docs/right-sidebar-related.html
@@ -147,7 +147,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-related.html
+++ b/website/docs/right-sidebar-related.html
@@ -146,7 +146,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-tables.html
+++ b/website/docs/right-sidebar-tables.html
@@ -140,7 +140,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar-tables.html
+++ b/website/docs/right-sidebar-tables.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-tables.html
+++ b/website/docs/right-sidebar-tables.html
@@ -141,7 +141,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-tags.html
+++ b/website/docs/right-sidebar-tags.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar-tags.html
+++ b/website/docs/right-sidebar-tags.html
@@ -171,7 +171,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/right-sidebar-tags.html
+++ b/website/docs/right-sidebar-tags.html
@@ -170,7 +170,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar.html
+++ b/website/docs/right-sidebar.html
@@ -235,7 +235,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/right-sidebar.html
+++ b/website/docs/right-sidebar.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/right-sidebar.html
+++ b/website/docs/right-sidebar.html
@@ -236,7 +236,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-ai.html
+++ b/website/docs/settings-ai.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-ai.html
+++ b/website/docs/settings-ai.html
@@ -151,7 +151,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-ai.html
+++ b/website/docs/settings-ai.html
@@ -150,7 +150,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-appearance.html
+++ b/website/docs/settings-appearance.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-appearance.html
+++ b/website/docs/settings-appearance.html
@@ -156,7 +156,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-appearance.html
+++ b/website/docs/settings-appearance.html
@@ -157,7 +157,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-behaviors.html
+++ b/website/docs/settings-behaviors.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-behaviors.html
+++ b/website/docs/settings-behaviors.html
@@ -139,7 +139,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-behaviors.html
+++ b/website/docs/settings-behaviors.html
@@ -138,7 +138,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-bibliography.html
+++ b/website/docs/settings-bibliography.html
@@ -141,7 +141,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-bibliography.html
+++ b/website/docs/settings-bibliography.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-bibliography.html
+++ b/website/docs/settings-bibliography.html
@@ -142,7 +142,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-clipper.html
+++ b/website/docs/settings-clipper.html
@@ -131,7 +131,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-clipper.html
+++ b/website/docs/settings-clipper.html
@@ -132,7 +132,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-clipper.html
+++ b/website/docs/settings-clipper.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-compute.html
+++ b/website/docs/settings-compute.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-compute.html
+++ b/website/docs/settings-compute.html
@@ -154,7 +154,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-compute.html
+++ b/website/docs/settings-compute.html
@@ -153,7 +153,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-editor.html
+++ b/website/docs/settings-editor.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-editor.html
+++ b/website/docs/settings-editor.html
@@ -147,7 +147,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-editor.html
+++ b/website/docs/settings-editor.html
@@ -146,7 +146,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-formatter.html
+++ b/website/docs/settings-formatter.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-formatter.html
+++ b/website/docs/settings-formatter.html
@@ -165,7 +165,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-formatter.html
+++ b/website/docs/settings-formatter.html
@@ -164,7 +164,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-notes.html
+++ b/website/docs/settings-notes.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-notes.html
+++ b/website/docs/settings-notes.html
@@ -175,7 +175,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-notes.html
+++ b/website/docs/settings-notes.html
@@ -174,7 +174,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-skills.html
+++ b/website/docs/settings-skills.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-skills.html
+++ b/website/docs/settings-skills.html
@@ -128,7 +128,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-skills.html
+++ b/website/docs/settings-skills.html
@@ -129,7 +129,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-sources.html
+++ b/website/docs/settings-sources.html
@@ -155,7 +155,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-sources.html
+++ b/website/docs/settings-sources.html
@@ -156,7 +156,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings-sources.html
+++ b/website/docs/settings-sources.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-web.html
+++ b/website/docs/settings-web.html
@@ -140,7 +140,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/settings-web.html
+++ b/website/docs/settings-web.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings-web.html
+++ b/website/docs/settings-web.html
@@ -141,7 +141,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings.html
+++ b/website/docs/settings.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/settings.html
+++ b/website/docs/settings.html
@@ -231,7 +231,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/settings.html
+++ b/website/docs/settings.html
@@ -230,7 +230,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thinking-tools-analysis.html
+++ b/website/docs/thinking-tools-analysis.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/thinking-tools-analysis.html
+++ b/website/docs/thinking-tools-analysis.html
@@ -198,7 +198,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/thinking-tools-analysis.html
+++ b/website/docs/thinking-tools-analysis.html
@@ -197,7 +197,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thinking-tools-learning.html
+++ b/website/docs/thinking-tools-learning.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/thinking-tools-learning.html
+++ b/website/docs/thinking-tools-learning.html
@@ -182,7 +182,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/thinking-tools-learning.html
+++ b/website/docs/thinking-tools-learning.html
@@ -181,7 +181,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thinking-tools-managing-authoring.html
+++ b/website/docs/thinking-tools-managing-authoring.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/thinking-tools-managing-authoring.html
+++ b/website/docs/thinking-tools-managing-authoring.html
@@ -135,7 +135,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thinking-tools-managing-authoring.html
+++ b/website/docs/thinking-tools-managing-authoring.html
@@ -136,7 +136,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/thinking-tools-research.html
+++ b/website/docs/thinking-tools-research.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/thinking-tools-research.html
+++ b/website/docs/thinking-tools-research.html
@@ -209,7 +209,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thinking-tools-research.html
+++ b/website/docs/thinking-tools-research.html
@@ -210,7 +210,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/thinking-tools-running-a-skill.html
+++ b/website/docs/thinking-tools-running-a-skill.html
@@ -155,7 +155,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thinking-tools-running-a-skill.html
+++ b/website/docs/thinking-tools-running-a-skill.html
@@ -156,7 +156,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/thinking-tools-running-a-skill.html
+++ b/website/docs/thinking-tools-running-a-skill.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/thinking-tools-three-menus.html
+++ b/website/docs/thinking-tools-three-menus.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/thinking-tools-three-menus.html
+++ b/website/docs/thinking-tools-three-menus.html
@@ -135,7 +135,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thinking-tools-three-menus.html
+++ b/website/docs/thinking-tools-three-menus.html
@@ -136,7 +136,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/thinking-tools-what-they-are.html
+++ b/website/docs/thinking-tools-what-they-are.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/thinking-tools-what-they-are.html
+++ b/website/docs/thinking-tools-what-they-are.html
@@ -135,7 +135,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thinking-tools-what-they-are.html
+++ b/website/docs/thinking-tools-what-they-are.html
@@ -136,7 +136,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/thinking-tools.html
+++ b/website/docs/thinking-tools.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/thinking-tools.html
+++ b/website/docs/thinking-tools.html
@@ -177,7 +177,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thinking-tools.html
+++ b/website/docs/thinking-tools.html
@@ -178,7 +178,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/thoughtbase-operations.html
+++ b/website/docs/thoughtbase-operations.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/thoughtbase-operations.html
+++ b/website/docs/thoughtbase-operations.html
@@ -171,7 +171,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thoughtbase-operations.html
+++ b/website/docs/thoughtbase-operations.html
@@ -172,7 +172,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/thoughtbase.html
+++ b/website/docs/thoughtbase.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/thoughtbase.html
+++ b/website/docs/thoughtbase.html
@@ -192,7 +192,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/thoughtbase.html
+++ b/website/docs/thoughtbase.html
@@ -193,7 +193,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/viewing-options-font-size-zoom.html
+++ b/website/docs/viewing-options-font-size-zoom.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/viewing-options-font-size-zoom.html
+++ b/website/docs/viewing-options-font-size-zoom.html
@@ -130,7 +130,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/viewing-options-font-size-zoom.html
+++ b/website/docs/viewing-options-font-size-zoom.html
@@ -129,7 +129,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/viewing-options-operations.html
+++ b/website/docs/viewing-options-operations.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/viewing-options-operations.html
+++ b/website/docs/viewing-options-operations.html
@@ -192,7 +192,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/viewing-options-operations.html
+++ b/website/docs/viewing-options-operations.html
@@ -193,7 +193,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/viewing-options-split-panes-windows.html
+++ b/website/docs/viewing-options-split-panes-windows.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/viewing-options-split-panes-windows.html
+++ b/website/docs/viewing-options-split-panes-windows.html
@@ -175,7 +175,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/viewing-options-split-panes-windows.html
+++ b/website/docs/viewing-options-split-panes-windows.html
@@ -174,7 +174,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/viewing-options-themes.html
+++ b/website/docs/viewing-options-themes.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/viewing-options-themes.html
+++ b/website/docs/viewing-options-themes.html
@@ -154,7 +154,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/viewing-options-themes.html
+++ b/website/docs/viewing-options-themes.html
@@ -153,7 +153,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/viewing-options-view-modes.html
+++ b/website/docs/viewing-options-view-modes.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/viewing-options-view-modes.html
+++ b/website/docs/viewing-options-view-modes.html
@@ -147,7 +147,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/viewing-options-view-modes.html
+++ b/website/docs/viewing-options-view-modes.html
@@ -146,7 +146,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/docs/viewing-options.html
+++ b/website/docs/viewing-options.html
@@ -37,6 +37,7 @@
       <a href="../getting-started.html" class="hide-sm">Getting Started</a>
       <a href="index.html" class="active hide-sm">Docs</a>
       <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
       <a href="../getting-started.html" class="navcta">Download</a>
     </div>
   </div>

--- a/website/docs/viewing-options.html
+++ b/website/docs/viewing-options.html
@@ -166,7 +166,7 @@
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
       <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
-      <div class="col"><h4>Source</h4><a href="#">GitHub</a><a href="#">Releases</a><a href="#">License</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>
 </footer>

--- a/website/docs/viewing-options.html
+++ b/website/docs/viewing-options.html
@@ -165,7 +165,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/features.html
+++ b/website/features.html
@@ -66,6 +66,7 @@
     <div class="links">
       <a href="features.html" class="active hide-sm">Features</a>
       <a href="getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="docs/index.html" class="hide-sm">Docs</a>
       <a href="about.html" class="hide-sm">About</a>
       <a href="privacy.html" class="hide-sm">Privacy</a>
       <a href="getting-started.html" class="navcta">Download</a>

--- a/website/features.html
+++ b/website/features.html
@@ -392,7 +392,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -105,7 +105,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="https://github.com/dgriffith/ide-for-thought/releases/latest/download/Minerva-mac-arm64.dmg">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>

--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -49,6 +49,7 @@
     <div class="links">
       <a href="features.html" class="hide-sm">Features</a>
       <a href="getting-started.html" class="active hide-sm">Getting Started</a>
+      <a href="docs/index.html" class="hide-sm">Docs</a>
       <a href="about.html" class="hide-sm">About</a>
       <a href="privacy.html" class="hide-sm">Privacy</a>
       <a href="https://github.com/dgriffith/ide-for-thought/releases/latest/download/Minerva-mac-arm64.dmg" class="navcta">Download</a>

--- a/website/index.html
+++ b/website/index.html
@@ -211,7 +211,7 @@
         <a href="about.html">About</a>
         <a href="privacy.html">Privacy</a>
         <a href="docs/index.html">Docs</a>
-        <a href="#">Dancing with Robots</a>
+        <a href="https://davegriffith.substack.com/">Dancing with Robots</a>
       </div>
       <div class="col">
         <h4>Source</h4>

--- a/website/index.html
+++ b/website/index.html
@@ -51,6 +51,7 @@
     <div class="links">
       <a href="features.html" class="hide-sm">Features</a>
       <a href="getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="docs/index.html" class="hide-sm">Docs</a>
       <a href="about.html" class="hide-sm">About</a>
       <a href="privacy.html" class="hide-sm">Privacy</a>
       <a href="getting-started.html" class="navcta">Download</a>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -51,6 +51,7 @@
     <div class="links">
       <a href="features.html" class="hide-sm">Features</a>
       <a href="getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="docs/index.html" class="hide-sm">Docs</a>
       <a href="about.html" class="hide-sm">About</a>
       <a href="privacy.html" class="active hide-sm">Privacy</a>
       <a href="getting-started.html" class="navcta">Download</a>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -102,7 +102,7 @@
     </div>
     <div class="cols">
       <div class="col"><h4>Product</h4><a href="features.html">Features</a><a href="getting-started.html">Getting Started</a><a href="getting-started.html">Download</a></div>
-      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a></div>
+      <div class="col"><h4>Learn</h4><a href="about.html">About</a><a href="privacy.html">Privacy</a><a href="docs/index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
       <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
     </div>
   </div>


### PR DESCRIPTION
## What

Consistency gaps between the root site pages (`website/*.html`) and the docs pages (`website/docs/*.html`), all in shared chrome (nav + footer):

**1. Top nav** — each nav was missing one link the other had:
- Root pages: Features · Getting Started · **About · Privacy** — no **Docs**
- Docs pages: Features · Getting Started · **Docs · About** — no **Privacy**

Added the missing link to each so both read **Features · Getting Started · Docs · About · Privacy** (+ Download CTA).

**2. Footer Source column** — docs pages had placeholder `href="#"` for **GitHub / Releases / License**; root pages linked the real repo URLs. Pointed the docs footer at the same targets (`github.com/dgriffith/ide-for-thought`, `/releases`, `/blob/main/LICENSE`).

**3. Footer Learn column** — the root index page had a placeholder `href="#"` **Dancing with Robots** link; every other page (root + docs) omitted it. Added it to all pages and pointed it at `https://davegriffith.substack.com/`. Both footers' Learn columns now read **About · Privacy · Docs · Dancing with Robots**.

## Result

Root and docs pages now share the same nav and footer link sets (modulo relative-path prefixes and `active` state).

## Notes

- Nav and footer live outside `<main class="docs-content">`, so the help-docs corpus staleness snapshot is unaffected — `pnpm test tests/scripts/help-docs-corpus-staleness.test.ts` passes with no regeneration.
- Edits scoped to the exact chrome blocks (nav `hide-sm` links; footer column anchors); verified no double-inserts and every page ends with exactly one Substack link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)