### PR TITLE
feat(website): Getting Started download boxes + API key notice + dead-link fixes & guard

### DIFF
--- a/tests/scripts/website-no-placeholder-links.test.ts
+++ b/tests/scripts/website-no-placeholder-links.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Guard against dead `href="#"` placeholder links shipping on the marketing
+ * site / docs (website/**\/*.html).
+ *
+ * `href="#"` is the "I'll wire this up later" stub — it renders as a normal
+ * link but goes nowhere (jumps to the top of the page). Several shipped with
+ * early pages (blog link, build-from-source, footer Source/Learn columns) and
+ * were only caught by eye. This scans every website HTML page and fails with
+ * the exact file:line of any placeholder so the next one is caught at PR time
+ * instead of by a visitor clicking a dead link.
+ *
+ * Real in-page anchors (`href="#some-id"`) are fine — only the empty `#` is a
+ * placeholder. If you ever genuinely need an inert `#` link, use a <button> or
+ * give it a real target; don't loosen this test.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WEBSITE_DIR = path.join(ROOT, 'website');
+
+function htmlFiles(dir: string): string[] {
+  return fs
+    .readdirSync(dir, { recursive: true, encoding: 'utf-8' })
+    .filter((rel) => rel.endsWith('.html'))
+    .map((rel) => path.join(dir, rel));
+}
+
+/** Every `href="#"` occurrence as `website-relative-path:line`. */
+function placeholderLinks(): string[] {
+  const hits: string[] = [];
+  for (const file of htmlFiles(WEBSITE_DIR)) {
+    const lines = fs.readFileSync(file, 'utf-8').split('\n');
+    lines.forEach((line, i) => {
+      if (line.includes('href="#"')) {
+        hits.push(`${path.relative(WEBSITE_DIR, file)}:${i + 1}`);
+      }
+    });
+  }
+  return hits;
+}
+
+describe('website has no placeholder links', () => {
+  it('no page ships a dead href="#" (use a real target or a <button>)', () => {
+    expect(placeholderLinks()).toEqual([]);
+  });
+});

--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -18,6 +18,26 @@
   .step h3 { margin: 4px 0 6px; font-size: 1.12rem; }
   .step p { margin: 0; color: var(--text-muted); }
   .step code { background: var(--bg-inset); border:1px solid var(--border); border-radius: 5px; padding: 1px 6px; font-size: 0.9em; color: var(--text); }
+
+  /* Download boxes — one live platform (macOS), two on the way. */
+  .downloads { display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 30px; }
+  @media (max-width: 720px) { .downloads { grid-template-columns: 1fr; } }
+  .dl { display:flex; flex-direction:column; align-items:center; text-align:center; gap:8px;
+        padding: 30px 22px; border-radius: 16px; border:1px solid var(--border); background: var(--bg-elev); }
+  .dl .os-ico { font-size: 2.4rem; line-height: 1; }
+  .dl h3 { margin: 4px 0 0; font-size: 1.15rem; color: var(--text); }
+  .dl .sub { margin: 0; font-size: 0.9rem; color: var(--text-muted); }
+  /* macOS — the primary, clickable box */
+  a.dl-active { border-color: var(--accent); background: color-mix(in oklch, var(--accent) 10%, var(--bg-elev)); }
+  a.dl-active:hover { background: color-mix(in oklch, var(--accent) 18%, var(--bg-elev)); text-decoration: none; }
+  a.dl-active .cta { margin-top: 10px; display:inline-block; padding: 11px 24px; border-radius: 10px;
+        background: var(--accent); color: var(--accent-ink); font-weight: 650; font-size: 0.95rem; }
+  a.dl-active:hover .cta { background: var(--accent-dim); }
+  /* Linux / Windows — not yet available */
+  .dl-soon { opacity: 0.62; }
+  .dl-soon .badge { margin-top: 10px; display:inline-block; padding: 6px 15px; border-radius: 999px;
+        border:1px solid var(--border-strong); font-size: 0.76rem; letter-spacing: 0.08em;
+        text-transform: uppercase; color: var(--text-muted); }
 </style>
 </head>
 <body>
@@ -61,6 +81,27 @@
   <div class="wrap">
     <h1>Getting started</h1>
     <p>Free, open source, and local-first. Install it, tell it what you're thinking about, and you have your first thoughtbase in about a minute.</p>
+
+    <div class="downloads">
+      <a class="dl dl-active" href="https://github.com/dgriffith/ide-for-thought/releases/latest/download/Minerva-mac-arm64.dmg">
+        <div class="os-ico">🍎</div>
+        <h3>Download for macOS</h3>
+        <p class="sub">Apple Silicon · signed &amp; notarized</p>
+        <span class="cta">Download .dmg</span>
+      </a>
+      <div class="dl dl-soon">
+        <div class="os-ico">🐧</div>
+        <h3>Linux</h3>
+        <p class="sub">Coming eventually</p>
+        <span class="badge">Coming eventually</span>
+      </div>
+      <div class="dl dl-soon">
+        <div class="os-ico">🪟</div>
+        <h3>Windows</h3>
+        <p class="sub">Coming eventually</p>
+        <span class="badge">Coming eventually</span>
+      </div>
+    </div>
   </div>
 </header>
 
@@ -75,6 +116,11 @@
       <div class="step"><div class="n"></div><div><h3>Tell it what you're exploring</h3><p>The opening wizard asks what you want to build a thoughtbase <em>of</em>, who it's for, and how deep to go. A research topic, a book you're studying, a decision you're working through — anything.</p></div></div>
       <div class="step"><div class="n"></div><div><h3>Get a starting map, not a blank page</h3><p>Minerva generates an overview set of linked notes to orient you — the antidote to the blank canvas. Every note is yours to keep, rewrite, or delete.</p></div></div>
       <div class="step"><div class="n"></div><div><h3>Think, and let it hold the structure</h3><p>Write, ask, link, cite. When the AI suggests a claim or a source, you review and approve it. Your thoughtbase grows into a real map of what you know — and it's plain files on your disk the whole time.</p></div></div>
+    </div>
+
+    <div class="callout" style="margin-top: 26px;">
+      <p style="margin:0 0 6px; font-weight:650; color:var(--text);">🔑 Bring your own Anthropic API key</p>
+      <p style="margin:0; color:var(--text-muted);">Minerva is free and local-first, but its AI features — the onboarding wizard, chat, claim and source suggestions, and skills — run on Claude. Turning them on requires your own <a href="https://console.anthropic.com/settings/keys">Anthropic API key</a>, which you add in Settings; usage is billed to your Anthropic account. Everything else — writing, linking, the knowledge graph, search — works with no key at all.</p>
     </div>
 
     <div class="shot wide" style="margin-top:30px;">

--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -112,7 +112,7 @@
     <p class="lede">Minerva doesn't drop you in front of a blank page. Tell it what you want to think about, and it builds you a starting structure to grow from.</p>
 
     <div class="steps">
-      <div class="step"><div class="n"></div><div><h3>Install and open</h3><p><a href="https://github.com/dgriffith/ide-for-thought/releases/latest/download/Minerva-mac-arm64.dmg"><b>Download Minerva for macOS (Apple Silicon)</b></a> — or <a href="#">build it from source</a>. Drag it to Applications and launch. No account, no sign-up, no cloud; it runs entirely on your machine. The app is signed and notarized by Apple, so it opens without security warnings.</p></div></div>
+      <div class="step"><div class="n"></div><div><h3>Install and open</h3><p><a href="https://github.com/dgriffith/ide-for-thought/releases/latest/download/Minerva-mac-arm64.dmg"><b>Download Minerva for macOS (Apple Silicon)</b></a> — or <a href="https://github.com/dgriffith/ide-for-thought#development">build it from source</a>. Drag it to Applications and launch. No account, no sign-up, no cloud; it runs entirely on your machine. The app is signed and notarized by Apple, so it opens without security warnings.</p></div></div>
       <div class="step"><div class="n"></div><div><h3>Tell it what you're exploring</h3><p>The opening wizard asks what you want to build a thoughtbase <em>of</em>, who it's for, and how deep to go. A research topic, a book you're studying, a decision you're working through — anything.</p></div></div>
       <div class="step"><div class="n"></div><div><h3>Get a starting map, not a blank page</h3><p>Minerva generates an overview set of linked notes to orient you — the antidote to the blank canvas. Every note is yours to keep, rewrite, or delete.</p></div></div>
       <div class="step"><div class="n"></div><div><h3>Think, and let it hold the structure</h3><p>Write, ask, link, cite. When the AI suggests a claim or a source, you review and approve it. Your thoughtbase grows into a real map of what you know — and it's plain files on your disk the whole time.</p></div></div>
@@ -138,7 +138,7 @@
     <div class="grid">
       <div class="card"><span class="em">📖</span><h3>Read the docs</h3><p>Keyboard shortcuts, skills, query syntax, import and export. <a href="docs/index.html">Open the documentation →</a></p></div>
       <div class="card"><span class="em">🧰</span><h3>Explore the features</h3><p>The editor, the knowledge graph, sources, and the full skills library. <a href="features.html">See features →</a></p></div>
-      <div class="card"><span class="em">✍️</span><h3>Follow along</h3><p>Notes on building Minerva and thinking with AI, on the Dancing with Robots Substack. <a href="#">Read the blog →</a></p></div>
+      <div class="card"><span class="em">✍️</span><h3>Follow along</h3><p>Notes on building Minerva and thinking with AI, on the Dancing with Robots Substack. <a href="https://davegriffith.substack.com/">Read the blog →</a></p></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## What

Getting Started page improvements, plus a test to stop dead links recurring.

**1. Per-platform download boxes.** The only download affordance was a link buried in step 1's prose. Added a prominent three-box row under the header:
- **Download for macOS** — large, accent-bordered, clickable box (🍎 Apple Silicon `.dmg`, "signed & notarized") with a filled CTA.
- **Linux** (🐧) and **Windows** (🪟) — dimmed boxes with a "Coming eventually" badge.

Responsive (three columns → stacks ≤720px), reusing existing color tokens and button styling; scoped CSS in the page's `<style>` block.

**2. Anthropic API key notice.** A prominent `.callout` noting Minerva's AI features (wizard, chat, suggestions, skills) run on Claude and require the user's own [Anthropic API key](https://console.anthropic.com/settings/keys) in Settings, while non-AI features work with no key.

**3. Dead-link fixes + a guard.** The page's last two placeholder `href="#"` links are now wired up:
- "build it from source" → the repo's `#development` section (verified the README heading exists).
- "Read the blog →" → the Dancing with Robots Substack.

Added `tests/scripts/website-no-placeholder-links.test.ts`, which scans every `website/**/*.html` page and fails with the exact `file:line` of any dead `href="#"`. Verified it fails on an injected violation and passes on the current tree. Real in-page anchors (`href="#some-id"`) are unaffected — only empty `#` is flagged.

## Notes

- All on the root `website/getting-started.html` (+ a new test); not part of the docs corpus, no snapshot impact.
- Preview locally: `open website/getting-started.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)