### PR TITLE
test(coverage): add renderer line-coverage floor (QA C1, #1094)

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -99,6 +99,27 @@ export default defineConfig({
           statements: 74,
           branches: 60,
         },
+        // Renderer tree — 93 components + both reactive stores, the largest
+        // user-facing defect surface and previously the least-gated (#1094 /
+        // QA C1). Floors sit ~10pts below the measured-at-floor numbers with
+        // extra headroom because this tree is volatile (a single new component
+        // moves the needle): a mass test deletion or a large untested addition
+        // still fails CI. Measured at floor-time: ~36% L / ~39% F / ~35% S /
+        // ~31% B. Ratchet upward as notebase.svelte.ts / editor.svelte.ts /
+        // the approval-proposal UI gain tests.
+        //
+        // NOTE: src/preload is deliberately NOT given a line-coverage floor.
+        // It's a declarative contextBridge passthrough (~326 lines of
+        // `invoke(Channels.X, …)` arrows); its correct gate is the shape +
+        // full-surface snapshot contract test (tests/preload/preload-bridge.test.ts,
+        // #676), not line execution. Calling every passthrough to hit a line
+        // floor would verify nothing the snapshot doesn't already pin.
+        'src/renderer/**': {
+          lines: 26,
+          functions: 28,
+          statements: 26,
+          branches: 21,
+        },
       },
     },
   },


### PR DESCRIPTION
Closes #1094 (renderer half; see note on preload below).

## What
Adds a `src/renderer/**` line-coverage floor to `vitest.config.mts` — the renderer tree (93 components + both reactive stores, `App.svelte`) was the largest user-facing defect surface and the only major `src/**` area with no floor. A PR that deleted renderer tests or shipped a big untested component passed CI today.

## Floors
Set ~10pts below the measured-at-floor numbers, with extra headroom because this tree is volatile (a single new component moves the needle):

| metric | measured today | floor |
|---|---|---|
| lines | ~36% | 26 |
| functions | ~39% | 28 |
| statements | ~35% | 26 |
| branches | ~31% | 21 |

No new tests required — `pnpm coverage` lands green with headroom (verified, exit 0). Ratchet upward over the quarter as `notebase.svelte.ts` / `editor.svelte.ts` / the approval-proposal UI gain tests.

## Deviation from the ticket: preload gets no line floor
The ticket assumed `src/preload` sits at ~80% and asked for an ~80% floor. **That measurement was wrong** — real preload line coverage is **2.76%**. `preload.ts` is a declarative contextBridge passthrough (~326 lines of `invoke(Channels.X, …)` arrows); the existing contract test `tests/preload/preload-bridge.test.ts` (#676) imports it and pins the **shape** (every leaf is a function) plus a **full-surface snapshot**, but never *calls* the passthroughs — so v8 sees the arrow bodies as uncovered.

A line-coverage floor is the wrong instrument here: calling all 300+ passthroughs to hit a number would verify nothing the snapshot doesn't already pin. The bridge is already gated — by a stronger *contract* test than any line floor. This is documented inline in the config comment so the reasoning isn't lost.

If we'd rather still nominally gate the directory, I can add a token floor, but I'd argue against it as coverage theater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)