### PR TITLE
chore(deps): ignore @retorquere/bibtex-parser@10.0.0 (broken types release)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,15 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
+    ignore:
+      # @retorquere/bibtex-parser@10.0.0 is an upstream packaging bug: its
+      # package.json advertises `types: ./dist/types/index.d.ts` but the
+      # published tarball ships zero .d.ts files, so `tsc --noEmit` fails
+      # (TS7016) at src/main/sources/import-bibtex.ts. Pin out this exact
+      # broken release only — a fixed 10.0.1+/10.1.0 will still be proposed.
+      # Remove this entry once upstream republishes with declarations. (#1464)
+      - dependency-name: "@retorquere/bibtex-parser"
+        versions: ["10.0.0"]
 
   # ── GitHub Actions themselves ────────────────────────────────────────────
   # The workflows pin actions by major tag (actions/checkout@v4, …); those


### PR DESCRIPTION
Stops Dependabot re-proposing a known-broken release. Follow-up to closed #1464.

## Why
`@retorquere/bibtex-parser@10.0.0` is an **upstream packaging bug**: its `package.json` advertises `types: ./dist/types/index.d.ts` (same as v9), but the published tarball ships **zero `.d.ts` files** (verified against the npm tarball). So `tsc --noEmit` fails:
```
src/main/sources/import-bibtex.ts(23,38): error TS7016:
Could not find a declaration file for module '@retorquere/bibtex-parser'
```
There's no clean fix on our side — a `declare module` shim would type the whole parser API as `any`, discarding type safety on the BibTeX import path. Only 10.0.0 exists (no fixed patch yet).

## What
Adds a **version-pinned** ignore to `dependabot.yml` — blocks exactly `10.0.0`, so a fixed `10.0.1`/`10.1.0` will still be proposed. We stay on `9.0.29` until upstream republishes with declarations, at which point this entry gets removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)