### PR TITLE
test(e2e): retry Electron-boot flake twice in CI (#1097)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,8 +18,14 @@ export default defineConfig({
   // 60s per test gives headroom for the first BrowserWindow to load
   // on a cold CI runner; Electron boot alone is ~3-5s.
   timeout: 60_000,
-  // No HTML report on CI; failure output in stdout is enough.
-  reporter: process.env.CI ? 'list' : 'list',
+  // Electron boot is inherently flaky (transient BrowserWindow load
+  // failures on cold CI runners). Retry twice in CI so a single boot
+  // hiccup doesn't fail the job; keep 0 locally so real failures surface
+  // immediately (#1097).
+  retries: process.env.CI ? 2 : 0,
+  // `list` prints a "retry #N" line for every retried spec, so genuine
+  // flake stays visible in the CI log rather than being silently masked.
+  reporter: 'list',
   use: {
     actionTimeout: 10_000,
   },


### PR DESCRIPTION
Closes #1097.

## What

`playwright.config.ts` set `workers: 1` and 60s timeouts but no `retries`. Electron boot is inherently flaky — a single transient BrowserWindow load failure on a cold CI runner fails the entire `e2e` job with no automatic retry, eroding trust in the signal and encouraging re-run-until-green habits.

- Add `retries: process.env.CI ? 2 : 0` — retry twice in CI, 0 locally so real failures surface immediately.
- Keep `workers: 1` (acceptable given cost).
- The `list` reporter already prints a `retry #N` line per retried spec, so genuine flake stays visible in the CI log rather than being silently masked.
- Collapse the no-op `CI ? 'list' : 'list'` reporter ternary while here.

## Success criteria
- [x] `retries` set to 2 in CI, 0 locally
- [x] Transient Electron-boot failures no longer fail the e2e job on first flake
- [x] Retried tests remain observable (`list` reporter surfaces retries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)