### PR TITLE
test(main): cover privileged-sites trust boundary + fence main modules (QA H1, #1100)

### DIFF
--- a/src/main/privileged-sites.ts
+++ b/src/main/privileged-sites.ts
@@ -13,15 +13,19 @@ import path from 'node:path';
 import { app, BrowserWindow, session, type Session } from 'electron';
 import type { PrivilegedSite } from '../shared/types';
 
-const FILE = path.join(app.getPath('userData'), 'privileged-sites.json');
-
 interface FileShape {
   sites: PrivilegedSite[];
 }
 
+// Resolved lazily (not captured at module load) so `app.getPath` is read at
+// call time — keeps the module importable under test with a mocked userData dir.
+function configFile(): string {
+  return path.join(app.getPath('userData'), 'privileged-sites.json');
+}
+
 function readFile(): FileShape {
   try {
-    const data = fs.readFileSync(FILE, 'utf-8');
+    const data = fs.readFileSync(configFile(), 'utf-8');
     const parsed = JSON.parse(data) as FileShape;
     if (!parsed || !Array.isArray(parsed.sites)) return { sites: [] };
     return parsed;
@@ -31,7 +35,7 @@ function readFile(): FileShape {
 }
 
 function writeFile(data: FileShape): void {
-  fs.writeFileSync(FILE, JSON.stringify(data, null, 2), 'utf-8');
+  fs.writeFileSync(configFile(), JSON.stringify(data, null, 2), 'utf-8');
 }
 
 /** Bare hostname normaliser: strips leading dot, lowercases, drops port. */

--- a/tests/main/privileged-sites.test.ts
+++ b/tests/main/privileged-sites.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Privileged-sites trust boundary (QA H1, #1100).
+ *
+ * `privileged-sites.ts` decides which URLs get fetched through a logged-in
+ * Electron session partition (carrying the user's cookies) versus a plain
+ * anonymous fetch — a genuine remote-content trust boundary. The security-
+ * critical pieces are `partitionForUrl` (host matching: a more specific site
+ * wins, and a look-alike domain must NOT match) and `privilegedFetch` (only
+ * privileged hosts get the cookie'd session; everything else falls back to
+ * `globalThis.fetch`). This locks both down, plus the persisted add/remove/
+ * logout lifecycle.
+ *
+ * `electron` is mocked: `app.getPath('userData')` points at a per-test temp dir
+ * (the JSON config is real fs), and `session.fromPartition` / `BrowserWindow`
+ * are fakes we can assert against.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// Mutable holders the electron mock reads — set per test. `userData.value`
+// backs the config-file path; `partitions` records every session partition
+// touched (clearStorageData / fetch), so we can assert routing decisions.
+const h = vi.hoisted(() => ({
+  userData: { value: '' },
+  fetchCalls: [] as Array<{ partition: string; target: unknown }>,
+  clearedPartitions: [] as string[],
+  globalFetchCalls: [] as unknown[],
+  windows: [] as Array<{ options: unknown; url: string; close: () => void }>,
+}));
+
+vi.mock('electron', () => ({
+  app: { getPath: (k: string) => (k === 'userData' ? h.userData.value : '') },
+  session: {
+    fromPartition: (partition: string) => ({
+      clearStorageData: () => {
+        h.clearedPartitions.push(partition);
+        return Promise.resolve();
+      },
+      fetch: (target: unknown) => {
+        h.fetchCalls.push({ partition, target });
+        return Promise.resolve(new Response('privileged'));
+      },
+    }),
+  },
+  BrowserWindow: class {
+    options: unknown;
+    private closeCb: (() => void) | null = null;
+    constructor(options: unknown) {
+      this.options = options;
+      h.windows.push({ options, url: '', close: () => this.closeCb?.() });
+    }
+    loadURL(url: string) {
+      h.windows[h.windows.length - 1]!.url = url;
+      return Promise.resolve();
+    }
+    on(evt: string, cb: () => void) {
+      if (evt === 'closed') this.closeCb = cb;
+    }
+  },
+}));
+
+import {
+  partitionFor,
+  listSites,
+  addSite,
+  removeSite,
+  logoutSite,
+  partitionForUrl,
+  privilegedFetch,
+  openLoginWindow,
+} from '../../src/main/privileged-sites';
+
+beforeEach(() => {
+  h.userData.value = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-privsites-'));
+  h.fetchCalls = [];
+  h.clearedPartitions = [];
+  h.globalFetchCalls = [];
+  h.windows = [];
+});
+
+afterEach(() => {
+  fs.rmSync(h.userData.value, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('partitionFor', () => {
+  it('prefixes with persist: so cookies survive on disk', () => {
+    expect(partitionFor('arxiv.org')).toBe('persist:site-arxiv.org');
+  });
+});
+
+describe('addSite / listSites', () => {
+  it('starts empty and persists an added site', () => {
+    expect(listSites()).toEqual([]);
+    const site = addSite('arxiv.org');
+    expect(site.domain).toBe('arxiv.org');
+    expect(site.id).toBe('arxiv.org');
+    expect(site.label).toBe('arxiv.org'); // defaults to the domain
+    expect(site.lastLoginAt).toBeNull();
+    expect(listSites()).toHaveLength(1);
+  });
+
+  it('normalises a pasted full URL down to the bare hostname', () => {
+    const site = addSite('HTTPS://www.Nature.com/articles/foo?x=1');
+    expect(site.domain).toBe('www.nature.com');
+  });
+
+  it('strips a leading dot and a port', () => {
+    expect(addSite('.example.com').domain).toBe('example.com');
+    expect(addSite('localhost:3000').domain).toBe('localhost');
+  });
+
+  it('uses a provided label, trimmed', () => {
+    expect(addSite('arxiv.org', '  arXiv  ').label).toBe('arXiv');
+  });
+
+  it('is idempotent — re-adding the same domain returns the existing entry', () => {
+    const first = addSite('arxiv.org', 'arXiv');
+    const second = addSite('arxiv.org', 'ignored second label');
+    expect(second).toEqual(first);
+    expect(listSites()).toHaveLength(1);
+  });
+
+  it('rejects input that has no hostname', () => {
+    expect(() => addSite('   ')).toThrow(/valid domain/i);
+  });
+});
+
+describe('partitionForUrl — the routing trust boundary', () => {
+  beforeEach(() => {
+    addSite('arxiv.org');
+    addSite('nature.com');
+  });
+
+  it('routes an exact host match through its partition', () => {
+    expect(partitionForUrl('https://arxiv.org/abs/2401.00001')).toBe('persist:site-arxiv.org');
+  });
+
+  it('routes a subdomain through the parent site partition', () => {
+    expect(partitionForUrl('https://www.nature.com/articles/x')).toBe('persist:site-nature.com');
+  });
+
+  it('returns null for an unconfigured host', () => {
+    expect(partitionForUrl('https://example.com/')).toBeNull();
+  });
+
+  it('does NOT match a look-alike suffix (evilarxiv.org ≠ arxiv.org)', () => {
+    // The endsWith guard requires a dot boundary, so a bare suffix collision
+    // must not leak the user's cookies to an attacker-controlled host.
+    expect(partitionForUrl('https://evilarxiv.org/steal')).toBeNull();
+    expect(partitionForUrl('https://arxiv.org.evil.com/steal')).toBeNull();
+  });
+
+  it('returns null for an unparseable URL', () => {
+    expect(partitionForUrl('not a url')).toBeNull();
+  });
+
+  it('prefers the longest matching domain when sites nest', () => {
+    addSite('org'); // deliberately broad
+    addSite('sub.arxiv.org'); // most specific
+    // arxiv.org and org both suffix-match, but the most specific wins.
+    expect(partitionForUrl('https://sub.arxiv.org/x')).toBe('persist:site-sub.arxiv.org');
+    // A host under the broad `org` site with no more-specific match uses `org`.
+    expect(partitionForUrl('https://random.org/x')).toBe('persist:site-org');
+  });
+});
+
+describe('privilegedFetch', () => {
+  beforeEach(() => {
+    addSite('arxiv.org');
+  });
+
+  it('routes a privileged URL through the site session partition', async () => {
+    await privilegedFetch('https://arxiv.org/abs/1');
+    expect(h.fetchCalls).toHaveLength(1);
+    expect(h.fetchCalls[0]!.partition).toBe('persist:site-arxiv.org');
+  });
+
+  it('coerces a URL input to a string for Session.fetch', async () => {
+    await privilegedFetch(new URL('https://arxiv.org/abs/2'));
+    expect(h.fetchCalls[0]!.target).toBe('https://arxiv.org/abs/2');
+  });
+
+  it('falls back to global fetch for a non-privileged host', async () => {
+    const globalFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('anon'));
+    await privilegedFetch('https://example.com/');
+    expect(globalFetch).toHaveBeenCalledOnce();
+    expect(h.fetchCalls).toHaveLength(0); // never touched a privileged partition
+  });
+});
+
+describe('removeSite', () => {
+  it('removes the entry and clears its partition storage', async () => {
+    addSite('arxiv.org');
+    await removeSite('arxiv.org');
+    expect(listSites()).toEqual([]);
+    expect(h.clearedPartitions).toContain('persist:site-arxiv.org');
+  });
+
+  it('is a no-op for an unknown id (no storage wipe)', async () => {
+    addSite('arxiv.org');
+    await removeSite('nope');
+    expect(listSites()).toHaveLength(1);
+    expect(h.clearedPartitions).toEqual([]);
+  });
+});
+
+describe('logoutSite', () => {
+  it('clears storage and resets lastLoginAt', async () => {
+    addSite('arxiv.org');
+    // Simulate a prior login stamping lastLoginAt.
+    const data = JSON.parse(fs.readFileSync(path.join(h.userData.value, 'privileged-sites.json'), 'utf-8'));
+    data.sites[0].lastLoginAt = '2026-01-01T00:00:00.000Z';
+    fs.writeFileSync(path.join(h.userData.value, 'privileged-sites.json'), JSON.stringify(data));
+
+    await logoutSite('arxiv.org');
+    expect(h.clearedPartitions).toContain('persist:site-arxiv.org');
+    expect(listSites()[0]!.lastLoginAt).toBeNull();
+  });
+
+  it('is a no-op for an unknown id', async () => {
+    await logoutSite('nope');
+    expect(h.clearedPartitions).toEqual([]);
+  });
+});
+
+describe('openLoginWindow', () => {
+  it('throws for an unknown site', () => {
+    expect(() => openLoginWindow('nope')).toThrow(/unknown site/i);
+  });
+
+  it('opens the site in its own persistent partition and stamps lastLoginAt on close', async () => {
+    addSite('arxiv.org', 'arXiv');
+    const done = openLoginWindow('arxiv.org');
+    const win = h.windows[0]!;
+    expect((win.options as { webPreferences: { partition: string } }).webPreferences.partition).toBe('persist:site-arxiv.org');
+    expect(win.url).toBe('https://arxiv.org/');
+    win.close(); // fire the 'closed' handler → resolves the promise
+    await done;
+    expect(listSites()[0]!.lastLoginAt).not.toBeNull();
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -99,6 +99,40 @@ export default defineConfig({
           statements: 74,
           branches: 60,
         },
+        // Neglected top-level main modules — previously unfenced (#1100 / QA
+        // H1). These sit at `src/main/*.ts` (no directory of their own), so
+        // each gets its own per-file floor set ~10pts below the measured-at-
+        // floor-time numbers (in parens). The security trio is a genuine
+        // remote-content trust boundary, so its floors run high.
+        // security.ts ~100 L / 100 F / 100 S / 86 B.
+        'src/main/security.ts': {
+          lines: 90,
+          functions: 90,
+          statements: 90,
+          branches: 72,
+        },
+        // security-helpers.ts ~100 across the board.
+        'src/main/security-helpers.ts': {
+          lines: 92,
+          functions: 90,
+          statements: 92,
+          branches: 88,
+        },
+        // privileged-sites.ts ~97 L / 100 F / 96 S / 92 B (#1100 added the test).
+        'src/main/privileged-sites.ts': {
+          lines: 88,
+          functions: 90,
+          statements: 86,
+          branches: 80,
+        },
+        // auto-update.ts ~85 L / 89 F / 82 S / 69 B (the Squirrel apply path
+        // can't run without two published releases, hence the lower floors).
+        'src/main/auto-update.ts': {
+          lines: 75,
+          functions: 78,
+          statements: 72,
+          branches: 58,
+        },
         // Renderer tree — 93 components + both reactive stores, the largest
         // user-facing defect surface and previously the least-gated (#1094 /
         // QA C1). Floors sit ~10pts below the measured-at-floor numbers with


### PR DESCRIPTION
Closes #1100.

## Context

The review flagged several substantial top-level `src/main/` modules as having thin/indirect coverage behind no coverage floor, so their state was invisible to CI (finding **H1**). Since the review (2026-07-05), most had already gained dedicated tests:

- `menu.ts` menu-config logic → `tests/shared/skills-menu-config.test.ts` covers `applyMenuConfig` (menu-config.ts at ~98% statements).
- `auto-update.ts` → `tests/main/auto-update.test.ts` mocks `update-electron-app` and covers wiring/guards/feed-events.
- `security.ts` / `security-helpers.ts` → `tests/main/security*.test.ts` cover the CSP / nav / origin boundary.

The two genuine remaining gaps were **`privileged-sites.ts`** (the remote-content trust boundary — untested) and the **coverage floors** none of these had.

## What

**New `tests/main/privileged-sites.test.ts`** (22 cases) — locks down the trust boundary that decides which URLs get fetched through a logged-in session partition (carrying the user's cookies) vs. an anonymous fetch:
- `partitionForUrl` host matching: exact, subdomain, and longest-suffix-wins — and crucially that a **look-alike suffix does NOT match** (`evilarxiv.org` / `arxiv.org.evil.com` must not route through `arxiv.org`'s cookie jar).
- `privilegedFetch`: privileged host → the site session partition; every other host → plain `globalThis.fetch` (never touches a privileged partition).
- `addSite` (domain normalisation from pasted URLs, idempotency, validation), `removeSite` / `logoutSite` (storage wipe + `lastLoginAt` reset), `openLoginWindow` (correct partition, stamps on close).

electron is mocked (`app.getPath` → per-test temp `userData`; `session.fromPartition` / `BrowserWindow` are fakes we assert against); the JSON config is real fs.

**`privileged-sites.ts`** — resolve the config path lazily (`configFile()`) instead of capturing it at module load, so `app.getPath` is read at call time. Small, sensible change that makes the module importable under test (mirrors `saved-queries.ts`).

**`vitest.config.mts`** — per-file coverage floors for the four now-tested modules (they sit at `src/main/*.ts`, no directory of their own), each set ~10pts below measured:

| module | measured L/F/S/B | floor L/F/S/B |
|---|---|---|
| security.ts | 100/100/100/86 | 90/90/90/72 |
| security-helpers.ts | 100/100/100/100 | 92/90/92/88 |
| privileged-sites.ts | 97/100/96/92 | 88/90/86/80 |
| auto-update.ts | 85/89/82/69 | 75/78/72/58 |

## Success criteria
- [x] Dedicated test for `menu.ts` menu-config application (existing `applyMenuConfig` test)
- [x] `auto-update.ts` covered with `update-electron-app` mocked (existing)
- [x] `security.ts` / `privileged-sites.ts` covered (privileged-sites is new here)
- [x] These areas added to coverage floors in `vitest.config.mts`

## Verification
- `npx vitest run tests/main/privileged-sites.test.ts` → 22 passed.
- Full `pnpm coverage` (the CI-gating command) → exit 0 with the four new per-file floors in place; no threshold failures.
- `pnpm lint` / `tsc --noEmit` clean.

## Not in scope
The issue's overview also mentions near-zero `session.ts` / `window-manager.ts` / `app-icon.ts`. Those aren't in the success criteria and are heavily electron-lifecycle-bound (thin pure-logic surface); left for a separate pass rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)