### PR TITLE
test(trust): automate the integrity SPARQL query as a CI gate (#1101)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,9 @@ LLM-originated apply path the same way.**
 
 ### Integrity Query
 
-The integrity-check SPARQL below detects `thought:Component` nodes attributed to an LLM that lack a corresponding approved proposal. Run it (Graph > Query) after any LLM integration work to verify the trust principle holds. It used to ship as the "Trust: Unreviewed LLM writes" stock query, but the `Trust:` / `Claims:` / `Compute:` stock queries were pulled from the default set as too confusing for end users — keep this one handy for development:
+The integrity-check SPARQL below detects `thought:Component` nodes attributed to an LLM that lack a corresponding approved proposal. Run it (Graph > Query) after any LLM integration work to verify the trust principle holds. It used to ship as the "Trust: Unreviewed LLM writes" stock query, but the `Trust:` / `Claims:` / `Compute:` stock queries were pulled from the default set as too confusing for end users — keep this one handy for development.
+
+It's also promoted to an automated gate (#1101): `findUnreviewedLLMWrites` in `src/main/graph/integrity.ts` is the canonical executable copy, asserted on every PR by `tests/main/graph/trust-integrity.test.ts` (honest path → empty; bypass / pending-only proposal → flagged). Keep the query below in sync with `UNREVIEWED_LLM_WRITES_QUERY` there.
 
 ```sparql
 PREFIX thought: <https://minerva.dev/ontology/thought#>

--- a/src/main/graph/integrity.ts
+++ b/src/main/graph/integrity.ts
@@ -1,0 +1,61 @@
+/**
+ * Trust-Principle integrity auditor (#1101).
+ *
+ * The single source of truth for the "unreviewed LLM writes" integrity query
+ * that CLAUDE.md documents: find every `thought:Component` node attributed to an
+ * LLM (`thought:extractedBy` containing "llm") that lacks an *approved*
+ * `thought:Proposal` affecting it — i.e. a component that reached the graph
+ * without passing the approval gate.
+ *
+ * This is the runtime auditor for the Trust Principle ("the LLM proposes, the
+ * human confirms"). It complements the other defence-in-depth layers — the
+ * write guard (`checkLLMWriteGuard`), the proposal-survives-reindex snapshot,
+ * and the approval-engine contract tests — by checking the *resulting graph
+ * state* rather than the code path. Promoting it from a manual dev-run query
+ * (Graph ▸ Query) into `findUnreviewedLLMWrites` lets a vitest test gate it on
+ * every PR (`tests/main/graph/trust-integrity.test.ts`).
+ *
+ * Standard prefixes (thought, rdf, rdfs, …) are auto-injected by `queryGraph`,
+ * so the query text below carries none.
+ */
+import type { ProjectContext } from '../project-context-types';
+import { queryGraph } from './index';
+
+/**
+ * SPARQL: LLM-attributed `thought:Component` nodes with no approved proposal.
+ * An empty result set means the Trust Principle holds. Keep this in sync with
+ * the copy in CLAUDE.md (this is the canonical, executable version).
+ */
+export const UNREVIEWED_LLM_WRITES_QUERY = `
+SELECT ?component ?label ?extractedBy WHERE {
+  ?component rdf:type/rdfs:subClassOf* thought:Component .
+  ?component thought:extractedBy ?extractedBy .
+  FILTER(CONTAINS(LCASE(STR(?extractedBy)), "llm"))
+  OPTIONAL { ?component thought:label ?label }
+  FILTER NOT EXISTS {
+    ?proposal rdf:type thought:Proposal .
+    ?proposal thought:affectsNode ?component .
+    ?proposal thought:proposalStatus thought:approved .
+  }
+}
+ORDER BY ?component`;
+
+/** One offending node: an LLM-attributed component with no approved proposal. */
+export interface UnreviewedLLMWrite {
+  /** Component node URI. */
+  component: string;
+  /** `thought:label`, when present. */
+  label?: string;
+  /** The `thought:extractedBy` provenance value that matched "llm". */
+  extractedBy: string;
+}
+
+/**
+ * Run the integrity audit against the live graph. Returns the offending nodes
+ * (empty ⇒ the Trust Principle holds). Throws if the query itself errors.
+ */
+export async function findUnreviewedLLMWrites(ctx: ProjectContext): Promise<UnreviewedLLMWrite[]> {
+  const r = await queryGraph(ctx, UNREVIEWED_LLM_WRITES_QUERY);
+  if (r.error) throw new Error(`integrity query failed: ${r.error}`);
+  return r.results as UnreviewedLLMWrite[];
+}

--- a/tests/main/graph/trust-integrity.test.ts
+++ b/tests/main/graph/trust-integrity.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Trust-Principle integrity query, automated (#1101).
+ *
+ * The integrity query documented in CLAUDE.md — LLM-attributed
+ * `thought:Component` nodes lacking an approved `thought:Proposal` — was the one
+ * defect-prevention mechanism that stayed a manual dev-run query. This promotes
+ * it (via `findUnreviewedLLMWrites`) into a continuous gate: seed a graph, drive
+ * the real approval engine, and assert the audit is empty on the honest path and
+ * flags the offender on a bypass.
+ *
+ * The approve→graph half runs for real (`proposeWrite` → `approveProposal`); the
+ * bypass fixture writes a component straight into the store with `applyTurtle`,
+ * standing in for a hypothetical write that skipped the gate.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph } from '../../../src/main/graph/index';
+import { findUnreviewedLLMWrites } from '../../../src/main/graph/integrity';
+import { proposeWrite, approveProposal } from '../../../src/main/llm/approval';
+import { applyTurtle } from '../../../src/main/llm/proposal-persistence';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-trust-integrity-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+});
+
+afterEach(async () => {
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+/** Turtle for a `thought:Claim` (a `thought:Component` subclass) with LLM
+ *  provenance — the exact shape the integrity query hunts for. Prefixes are
+ *  injected by both `applyTurtle` and `queryGraph`. */
+function llmClaimTurtle(uri: string, label: string, extractedBy = 'llm:conversation:c1'): string {
+  return `<${uri}> a thought:Claim ; thought:label "${label}" ; thought:extractedBy "${extractedBy}" .`;
+}
+
+/** File + approve a claim component through the real approval engine, returning
+ *  the proposal URI. This is the honest path: the approved proposal's
+ *  `thought:affectsNode` points back at the component. */
+async function approveLlmClaim(uri: string, label: string): Promise<string> {
+  const proposal = await proposeWrite(ctx, {
+    operationType: 'new_claim',
+    payloads: [{ kind: 'graph-triples', turtle: llmClaimTurtle(uri, label), affectsNodeUris: [uri] }],
+    note: 'trust integrity test',
+    proposedBy: 'llm:conversation:c1',
+  });
+  const res = await approveProposal(ctx, proposal.uri);
+  expect(res.ok).toBe(true);
+  return proposal.uri;
+}
+
+describe('Trust-Principle integrity query', () => {
+  it('an empty graph has no unreviewed LLM writes', async () => {
+    expect(await findUnreviewedLLMWrites(ctx)).toEqual([]);
+  });
+
+  it('passes: an approved LLM claim is NOT flagged', async () => {
+    await approveLlmClaim('urn:trust:approved-claim', 'Approved LLM Claim');
+    expect(await findUnreviewedLLMWrites(ctx)).toEqual([]);
+  });
+
+  it('flags: a component written straight to the graph (approval bypassed)', async () => {
+    // No proposal — a component that skipped the gate.
+    await applyTurtle(ctx, llmClaimTurtle('urn:trust:bypass-claim', 'Sneaky LLM Claim'));
+
+    const offenders = await findUnreviewedLLMWrites(ctx);
+    expect(offenders).toHaveLength(1);
+    expect(offenders[0]!.component).toBe('urn:trust:bypass-claim');
+    expect(offenders[0]!.label).toBe('Sneaky LLM Claim');
+    expect(offenders[0]!.extractedBy).toContain('llm');
+  });
+
+  it('flags: a component present in the graph whose proposal is only PENDING', async () => {
+    // Only an *approved* proposal satisfies the gate. Put the component in the
+    // graph and file a proposal that affects it but never approve it — a merely
+    // pending proposal must not clear the audit. (In the normal flow a pending
+    // proposal hasn't applied its payload at all; this constructs the stricter
+    // "component exists + proposal still pending" state directly.)
+    await applyTurtle(ctx, llmClaimTurtle('urn:trust:pending-claim', 'Pending LLM Claim'));
+    await proposeWrite(ctx, {
+      operationType: 'new_claim',
+      payloads: [{
+        kind: 'graph-triples',
+        turtle: llmClaimTurtle('urn:trust:pending-claim', 'Pending LLM Claim'),
+        affectsNodeUris: ['urn:trust:pending-claim'],
+      }],
+      note: 'pending',
+      proposedBy: 'llm:conversation:c1',
+    });
+
+    const offenders = await findUnreviewedLLMWrites(ctx);
+    expect(offenders.map((o) => o.component)).toContain('urn:trust:pending-claim');
+  });
+
+  it('ignores a non-LLM component (human-authored) with no proposal', async () => {
+    // The audit is scoped to LLM-attributed provenance; a hand-authored
+    // component legitimately has no proposal and must not be flagged.
+    await applyTurtle(ctx, llmClaimTurtle('urn:trust:human-claim', 'Human Claim', 'human:dave'));
+    expect(await findUnreviewedLLMWrites(ctx)).toEqual([]);
+  });
+
+  it('mixed graph: flags only the bypass, not the approved sibling', async () => {
+    await approveLlmClaim('urn:trust:ok-claim', 'Approved Sibling');
+    await applyTurtle(ctx, llmClaimTurtle('urn:trust:leak-claim', 'Leaked Claim'));
+
+    const offenders = await findUnreviewedLLMWrites(ctx);
+    expect(offenders.map((o) => o.component)).toEqual(['urn:trust:leak-claim']);
+  });
+});


### PR DESCRIPTION
Closes #1101.

## Context

The integrity query documented in CLAUDE.md detects LLM-attributed `thought:Component` nodes lacking an approved `thought:Proposal` — the runtime auditor for the Trust Principle ("the LLM proposes, the human confirms"). It existed only as a manual dev-run query (Graph ▸ Query), making it the one defect-prevention mechanism still off the CI gate.

## What

- **`src/main/graph/integrity.ts`** — `UNREVIEWED_LLM_WRITES_QUERY` + `findUnreviewedLLMWrites(ctx)`: the canonical, executable copy of the query (single source of truth with CLAUDE.md). It complements the *code-path* trust layers (the `checkLLMWriteGuard`, the proposal-survives-reindex snapshot, the approval-engine contract tests) by auditing the *resulting graph state*.
- **`tests/main/graph/trust-integrity.test.ts`** (6 cases) — seeds a graph and drives the **real approval engine**:
  - empty graph → empty audit
  - honest path (`proposeWrite` → `approveProposal`) → **not flagged**
  - bypass (component written straight to the store via `applyTurtle`, no proposal) → **flagged**
  - component present but its proposal is only **pending** (not approved) → **flagged** (only an approved proposal clears the gate)
  - human-authored component with no proposal → **ignored** (audit is scoped to LLM provenance)
  - mixed graph → flags **only** the bypass, not its approved sibling
- **CLAUDE.md** — point the documented query at the executable copy; keep them in sync.

Lives alongside the existing trust-path tests (`tests/main/graph/`, `tests/main/llm/`), so it runs on every PR under `pnpm coverage`.

## Success criteria
- [x] Integrity query runs as an automated vitest test on a seeded graph
- [x] Passing case (approved proposal → empty result) asserted
- [x] Negative case (bypass → flagged node) asserted
- [x] Runs in CI on every PR

## Note on the test data builder
The issue optionally suggested a `Proposal`/`Claim` builder to avoid ad-hoc turtle. I kept two small local helpers (`llmClaimTurtle`, `approveLlmClaim`) in the test file rather than standing up shared fixture infra pre-emptively — enough to keep the turtle out of each case without a new framework.

## Verification
- `npx vitest run tests/main/graph/trust-integrity.test.ts` → 6 passed.
- Full `pnpm coverage` (CI-gating) → exit 0; the new `src/main/graph/integrity.ts` doesn't drop the `src/main/graph/**` floor.
- `tsc --noEmit` / `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)