### PR TITLE
test(security): guard login + PDF-render window hardening flags (#1102 follow-up)

### DIFF
--- a/tests/main/privileged-sites.test.ts
+++ b/tests/main/privileged-sites.test.ts
@@ -243,4 +243,17 @@ describe('openLoginWindow', () => {
     await done;
     expect(listSites()[0]!.lastLoginAt).not.toBeNull();
   });
+
+  it('hardens the third-party login window: isolated, sandboxed, no node, no preload (#1102)', () => {
+    // This window loads real third-party HTML, so a flag regression here is
+    // higher-risk than the app's own renderer. Guard the construction site.
+    addSite('arxiv.org', 'arXiv');
+    openLoginWindow('arxiv.org');
+    const wp = (h.windows[0]!.options as { webPreferences: Record<string, unknown> }).webPreferences;
+    expect(wp.contextIsolation).toBe(true);
+    expect(wp.nodeIntegration).toBe(false);
+    expect(wp.sandbox).toBe(true);
+    // A preload would expose Minerva's bridge to an untrusted remote page.
+    expect(wp.preload).toBeUndefined();
+  });
 });

--- a/tests/main/publish/note-pdf-render-security.test.ts
+++ b/tests/main/publish/note-pdf-render-security.test.ts
@@ -1,0 +1,49 @@
+/**
+ * PDF-render BrowserWindow security-flag guard (#1102 follow-up).
+ *
+ * `renderPdfFromHtml` opens an off-screen BrowserWindow to paint exported HTML
+ * for `printToPDF`. That window renders note content (potentially with
+ * user-embedded HTML), so it hardens its `webPreferences` inline. This guards
+ * the construction site against drift: electron's BrowserWindow is mocked to
+ * capture the options, and the window's paint/print calls are stubbed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PrintToPdfArgs } from '../../../src/main/publish/exporters/note-pdf/options';
+
+const h = vi.hoisted(() => ({ constructed: [] as Array<Record<string, unknown>> }));
+
+vi.mock('electron', () => {
+  class BrowserWindow {
+    webContents = {
+      executeJavaScript: () => Promise.resolve(),
+      printToPDF: () => Promise.resolve(Buffer.from('%PDF-1.4 stub')),
+    };
+    constructor(options: { webPreferences: Record<string, unknown> }) {
+      h.constructed.push(options.webPreferences);
+    }
+    loadFile() { return Promise.resolve(); }
+    isDestroyed() { return false; }
+    destroy() { /* no-op */ }
+  }
+  return { BrowserWindow };
+});
+
+import { renderPdfFromHtml } from '../../../src/main/publish/exporters/note-pdf/electron-render';
+
+beforeEach(() => {
+  h.constructed = [];
+});
+
+describe('PDF-render BrowserWindow security flags (#1102)', () => {
+  it('paints the export HTML in an isolated, sandboxed, node-free, preload-free window', async () => {
+    await renderPdfFromHtml('<!doctype html><html><body>hi</body></html>', {} as PrintToPdfArgs);
+    expect(h.constructed).toHaveLength(1);
+    const wp = h.constructed[0]!;
+    expect(wp.contextIsolation).toBe(true);
+    expect(wp.nodeIntegration).toBe(false);
+    expect(wp.sandbox).toBe(true);
+    // No preload — this window only needs to paint HTML; a bridge would be an
+    // unnecessary attack surface for user-embedded content.
+    expect(wp.preload).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Follow-up to #1102 / #1476, which guarded the **main** window's `webPreferences`. This extends the same construction-site drift guard to the other two BrowserWindow sites so every window that ships is fenced.

## What

- **Login window** (`privileged-sites.ts` `openLoginWindow`) — loads *real third-party HTML*, so a flag regression here is higher-risk than the app's own renderer. Extended the existing `openLoginWindow` test to assert `contextIsolation: true` / `nodeIntegration: false` / `sandbox: true` and — crucially — **no preload** (a bridge would expose Minerva's APIs to an untrusted remote page).
- **PDF-render window** (`note-pdf/electron-render.ts` `renderPdfFromHtml`) — paints exported note HTML for `printToPDF`. New `tests/main/publish/note-pdf-render-security.test.ts` mocks electron's BrowserWindow to capture the `webPreferences` and stubs the paint/print calls, asserting the same hardened, preload-free config. This module previously had no test at all.

Test-only; no source changes. Both windows already harden inline — these tests lock that in against drift.

## Verification
`npx vitest run tests/main/publish/note-pdf-render-security.test.ts tests/main/privileged-sites.test.ts` → 24 passed. `tsc --noEmit` / `eslint` clean. (Adds coverage to `electron-render.ts`, so it only raises the `src/main/publish/**` aggregate.)

Independent of #1476 at the code level (different test files) — bases cleanly on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)