### PR TITLE
test(a11y): harden editor gate + extend axe to source/proposals, fix 2 WCAG bugs (#1104)

### DIFF
--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -525,6 +525,7 @@
           <input
             type="date"
             class="due-input"
+            aria-label="Due by"
             value={detail.metadata.readDueBy ?? ''}
             onchange={(e) => handleSetReadDueBy((e.target as HTMLInputElement).value)}
           />

--- a/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/ProposalsPanel.svelte
@@ -432,7 +432,10 @@
     gap: 4px;
     font-family: var(--font-mono);
     font-size: 10px;
-    color: var(--text-faint);
+    /* --text-muted, not --text-faint: the byline sits on the selected item's
+       tinted background where --text-faint falls to 3.9:1 (below WCAG AA);
+       --text-muted clears 4.5:1 there (#1104). */
+    color: var(--text-muted);
     max-width: 12em;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -49,6 +49,21 @@ const KNOWN_WORKSPACE = new Set<string>([
   //     buttons (switch + sibling close), no half-applied role=tab widget.
 ]);
 
+// Extending the real-browser axe net to two more primary surfaces (#1104
+// stretch): the source viewer (a major read surface) and the proposals panel
+// (the trust-review surface). Same baseline-not-zero discipline — each carries
+// an allowlist of the currently-known serious/critical rule ids so the net
+// lands without a full product-a11y sweep; a NEW rule id fails CI.
+const KNOWN_SOURCE = new Set<string>([
+  // Clean: the source viewer (SourceDetail) has no tolerated serious violations
+  // — the unlabeled reading-due date input surfaced by this pass was fixed
+  // (aria-label added), not allowlisted. Strict gate.
+]);
+const KNOWN_PROPOSALS = new Set<string>([
+  // The proposal diff renders in a CodeMirror view too.
+  'scrollable-region-focusable',
+]);
+
 /** Serious/critical violations whose rule id isn't in the tolerated set. */
 function unexpected(violations: AxeViolation[], allow: Set<string>): AxeViolation[] {
   return seriousOrWorse(violations).filter((v) => !allow.has(v.id));
@@ -64,7 +79,7 @@ function reportKnown(surface: string, violations: AxeViolation[], allow: Set<str
 
 /** Launch the dev build with an isolated userData dir (optionally seeded to
  *  auto-open the sample project on boot via session restore). */
-async function launchApp(seedProjectDir?: string) {
+async function launchApp(seedProjectDir?: string, extraEnv?: Record<string, string>) {
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-a11y-userdata-'));
   if (seedProjectDir) {
     fs.writeFileSync(
@@ -76,7 +91,7 @@ async function launchApp(seedProjectDir?: string) {
     args: [projectRoot, `--user-data-dir=${userDataDir}`],
     cwd: projectRoot,
     timeout: 60_000,
-    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1' },
+    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1', ...extraEnv },
   });
   return { app, userDataDir };
 }
@@ -141,7 +156,113 @@ test('workspace (sidebar + editor): no NEW serious a11y violations (real-browser
       reportKnown('workspace+editor', withEditor, KNOWN_WORKSPACE);
       const editorRegressions = unexpected(withEditor, KNOWN_WORKSPACE);
       expect(editorRegressions, `NEW workspace+editor a11y violations:\n${formatViolations(editorRegressions)}`).toHaveLength(0);
+
+      // Justify the one allowlisted editor finding (`scrollable-region-focusable`
+      // on CM's `.cm-scroller`, which carries tabindex=-1) with a POSITIVE check
+      // rather than a bare comment: the editable content is keyboard-reachable,
+      // so there is no real keyboard trap — the axe rule is a false positive for
+      // CodeMirror's split scroller/content structure (#1104).
+      const editorKeyboardReachable = await win.evaluate(() => {
+        const content = document.querySelector('.cm-content');
+        if (!content) return { found: false, focusable: false, notInert: false };
+        content.focus();
+        return {
+          found: true,
+          focusable: document.activeElement === content,
+          // The scroller opts itself out of the tab order (tabindex=-1); the
+          // content must NOT, or the editor would be unreachable by keyboard.
+          notInert: content.getAttribute('tabindex') !== '-1',
+        };
+      });
+      expect(editorKeyboardReachable.found, '.cm-content should be present').toBe(true);
+      expect(editorKeyboardReachable.focusable, '.cm-content must accept keyboard focus').toBe(true);
+      expect(editorKeyboardReachable.notInert, '.cm-content must stay in the tab order').toBe(true);
     }
+  } finally {
+    await app.close().catch(() => { /* already exited */ });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test('source viewer: no NEW serious a11y violations (real-browser, incl. color-contrast)', async () => {
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-a11y-source-'));
+  fs.cpSync(path.join(projectRoot, 'tests', 'fixtures', 'sample-project'), projectDir, { recursive: true });
+  const { app, userDataDir } = await launchApp(projectDir);
+  try {
+    const win: Page = await app.firstWindow({ timeout: 20_000 });
+    await win.waitForLoadState('domcontentloaded');
+    await bootDarkTheme(win);
+    await expect(win.getByRole('button', { name: 'Open Thoughtbase' })).toHaveCount(0, { timeout: 25_000 });
+
+    // Switch the left sidebar to Sources and open the first source into the
+    // SourceDetail viewer (`.source-item` click → editor.openSource → tab).
+    await win.getByTitle('Sources', { exact: true }).click();
+    await win.waitForTimeout(400);
+    const firstSource = win.locator('.source-item').first();
+    await firstSource.click();
+    await expect(win.locator('.source-detail')).toBeVisible({ timeout: 10_000 });
+    await win.waitForTimeout(500); // let the excerpt list + preview settle
+
+    const violations = await runAxe(win);
+    reportKnown('source viewer', violations, KNOWN_SOURCE);
+    const regressions = unexpected(violations, KNOWN_SOURCE);
+    expect(regressions, `NEW source-viewer a11y violations:\n${formatViolations(regressions)}`).toHaveLength(0);
+  } finally {
+    await app.close().catch(() => { /* already exited */ });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test('proposals panel: no NEW serious a11y violations (real-browser, incl. color-contrast)', async () => {
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-a11y-proposals-'));
+  fs.cpSync(path.join(projectRoot, 'tests', 'fixtures', 'sample-project'), projectDir, { recursive: true });
+  // MINERVA_E2E exposes the seedProposal hook so the panel has a real pending
+  // proposal to review (see src/main/e2e-hooks.ts), not just its empty state.
+  const { app, userDataDir } = await launchApp(projectDir, { MINERVA_E2E: '1' });
+  try {
+    const win: Page = await app.firstWindow({ timeout: 20_000 });
+    await win.waitForLoadState('domcontentloaded');
+    await bootDarkTheme(win);
+    await expect(win.getByRole('button', { name: 'Open Thoughtbase' })).toHaveCount(0, { timeout: 25_000 });
+
+    // Open a note and WAIT for the editor to mount: the right sidebar only
+    // renders for an active note tab (App.svelte `rightSidebarVisible &&
+    // activeTab?.type === 'note'`), and waiting on `.cm-content` also guarantees
+    // the renderer is fully live so its toggle-IPC listener is registered.
+    await win.locator('[data-relative-path$=".md"]').first().click();
+    await expect(win.locator('.cm-content')).toBeVisible({ timeout: 10_000 });
+
+    // Seed a pending proposal into the open project through the main-process hook.
+    await app.evaluate(async () => {
+      const g = globalThis as typeof globalThis & { __minervaE2E?: { seedProposal(): Promise<string | null> } };
+      if (!g.__minervaE2E) throw new Error('e2e hook missing — MINERVA_E2E not set?');
+      await g.__minervaE2E.seedProposal();
+    });
+
+    // Open the right sidebar by firing the same menu IPC its menu item sends
+    // (native menus can't be clicked in Playwright, and there's no title-bar
+    // toggle button). Then navigate Activity group → Proposals sub-tab.
+    await app.evaluate(({ BrowserWindow }) => {
+      for (const w of BrowserWindow.getAllWindows()) w.webContents.send('menu:toggleRightSidebar');
+    });
+    await expect(win.locator('aside.right-sidebar')).toBeVisible({ timeout: 8000 });
+    await win.locator('.group-tab[title="Activity"]').first().click();
+    await win.waitForTimeout(200);
+    await win.locator('.sub-tab[title="Proposals"]').first().click();
+    await win.waitForTimeout(400);
+    // Expand the seeded proposal's review detail (payloads + Approve/Reject).
+    const firstProposal = win.locator('.proposal-item').first();
+    if (await firstProposal.count()) {
+      await firstProposal.click();
+      await win.waitForTimeout(400);
+    }
+
+    const violations = await runAxe(win);
+    reportKnown('proposals panel', violations, KNOWN_PROPOSALS);
+    const regressions = unexpected(violations, KNOWN_PROPOSALS);
+    expect(regressions, `NEW proposals-panel a11y violations:\n${formatViolations(regressions)}`).toHaveLength(0);
   } finally {
     await app.close().catch(() => { /* already exited */ });
     fs.rmSync(userDataDir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #1104.

## Context

The core of M1 — the editor `color-contrast` debt — was **already paid** before this issue: #1117 replaced the CodeMirror oneDark theme with the token-driven highlight style, and `color-contrast` is now *enforced* on the workspace surface, not allowlisted. So criteria 1 & 2 were already met. This PR finishes the rest.

## What

**Criterion 3 — `scrollable-region-focusable` justified with a positive check.** The one allowlisted editor finding (axe flags CM's `.cm-scroller`, which carries `tabindex="-1"`) is a false positive for CodeMirror's split scroller/content DOM. Rather than justify it in a comment alone, the workspace test now *asserts* the editable content is keyboard-reachable — `.cm-content` accepts focus and stays in the tab order — proving there's no real keyboard trap.

**Criterion 4 (stretch) — extend the real-browser axe pass to two more primary surfaces:**
- **Source viewer** (`SourceDetail`) — opened by clicking a fixture source. Lands as a **strict gate** (empty allowlist).
- **Proposals panel** — the trust-review surface, seeded with a real pending proposal via the `MINERVA_E2E` hook, opened through the `menu:toggleRightSidebar` IPC. Allowlists only the benign CM `scrollable-region-focusable`.

## Real WCAG bugs fixed (paid, not allowlisted)

The two new passes each surfaced a genuine AA failure:

1. **`SourceDetail`** — the reading-due `<input type="date">` had no accessible name (critical `label` violation) → added `aria-label="Due by"`.
2. **`ProposalsPanel`** — the `.proposal-by` byline used `--text-faint`, which drops to **3.9:1** on the selected item's tinted background → switched to `--text-muted` (~4.7:1, clears AA). Theme-agnostic.

## Success criteria
- [x] Editor theme meets WCAG AA color-contrast (already enforced via #1117; unchanged here)
- [x] `color-contrast` removed from the workspace allowlist / hard gate (already done)
- [x] `scrollable-region-focusable` explicitly justified — now with a positive keyboard-reachability assertion
- [x] (Stretch) real-browser axe extended to proposals panel + source viewer

## Verification
`pnpm build:e2e && npx playwright test a11y` → **4 passed** (welcome, workspace+editor, source viewer, proposals panel). `pnpm lint` clean.

Modal focus-trap/tab-order test (also floated under the stretch bullet) is left as a further follow-up — it's a distinct piece and this PR already lands the surface-coverage + real fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)