### PR TITLE
feat(a11y): modal focus trap + tab-order test (#1104 follow-up)

### DIFF
--- a/src/renderer/lib/components/CommandPaletteDialog.svelte
+++ b/src/renderer/lib/components/CommandPaletteDialog.svelte
@@ -10,6 +10,7 @@
   import type { Command } from '../command-palette/types';
   import { scoreCommand } from '../command-palette/scoring';
   import { loadRecent, recordRecent } from '../command-palette/recent';
+  import { trapFocus } from '../trap-focus';
   import Icon from './Icon.svelte';
 
   interface Props {
@@ -115,7 +116,7 @@
   onkeydown={handleKeydown}
   onmousedown={(e) => { if (e.target === e.currentTarget) onClose(); }}
 >
-  <div class="dialog" role="dialog" aria-modal="true" aria-label="Command palette">
+  <div class="dialog" role="dialog" aria-modal="true" aria-label="Command palette" use:trapFocus>
     <div class="input-row">
       <Icon name="search" size={14} color="var(--text-muted)" />
       <input

--- a/src/renderer/lib/trap-focus.ts
+++ b/src/renderer/lib/trap-focus.ts
@@ -1,0 +1,71 @@
+/**
+ * `use:trapFocus` — keep keyboard focus inside a modal while it's mounted
+ * (#1104). The app's dialogs render as `<div role="dialog" aria-modal="true">`
+ * overlays, which announce modality to assistive tech but do NOT actually trap
+ * the browser's Tab focus (only a native `<dialog>.showModal()` or JS does). So
+ * without this, Tab from the last control escapes to the app behind the overlay
+ * — a keyboard-first tool's worst a11y failure mode.
+ *
+ * Behaviour:
+ *   - On mount, pulls focus into the dialog if it isn't already there (a no-op
+ *     when the dialog already autofocuses a field).
+ *   - Intercepts Tab / Shift+Tab only at the ends, wrapping first↔last, so
+ *     native Tab still moves between controls in between.
+ *   - On destroy, restores focus to whatever held it before the dialog opened.
+ *
+ * Do NOT apply to a dialog that gives Tab a non-navigation meaning (e.g.
+ * PromptDialog's Tab-to-accept-suggestion) — the trap would swallow it.
+ */
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export function trapFocus(node: HTMLElement): { destroy(): void } {
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+
+  const getFocusable = (): HTMLElement[] =>
+    // Post-filter tabindex="-1": `button:not([disabled])` etc. still match an
+    // element the author explicitly pulled out of the tab order.
+    Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+      .filter((el) => el.getAttribute('tabindex') !== '-1');
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key !== 'Tab') return;
+    const items = getFocusable();
+    if (items.length === 0) {
+      // Nothing to focus — keep Tab from leaking to the background anyway.
+      e.preventDefault();
+      return;
+    }
+    const first = items[0]!;
+    const last = items[items.length - 1]!;
+    const active = document.activeElement;
+    const outside = !node.contains(active);
+    if (e.shiftKey) {
+      if (outside || active === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else if (outside || active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+    // Otherwise let the browser advance focus natively within the dialog.
+  }
+
+  if (!node.contains(document.activeElement)) getFocusable()[0]?.focus();
+  node.addEventListener('keydown', onKeydown);
+
+  return {
+    destroy() {
+      node.removeEventListener('keydown', onKeydown);
+      previouslyFocused?.focus?.();
+    },
+  };
+}

--- a/tests/e2e/focus-trap.spec.ts
+++ b/tests/e2e/focus-trap.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Real-browser modal focus-trap / tab-order test (#1104).
+ *
+ * The app's dialogs render as `<div role="dialog" aria-modal="true">` overlays,
+ * which don't natively trap Tab focus — so `use:trapFocus` (src/renderer/lib/
+ * trap-focus.ts) does it in JS. This drives the flagship keyboard-first modal,
+ * the Command Palette, in real Chromium (where Tab actually moves focus) and
+ * asserts focus never escapes to the app behind the overlay, and is restored to
+ * the editor when the palette closes.
+ *
+ * Boots the in-tree `.vite/build` app (like the other e2e specs), so it needs
+ * `pnpm build:e2e` first.
+ */
+import { test, expect, _electron as electron, type Page } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+async function launch() {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-e2e-focustrap-userdata-'));
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-e2e-focustrap-project-'));
+  fs.cpSync(path.join(projectRoot, 'tests', 'fixtures', 'sample-project'), projectDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDataDir, 'session.json'),
+    JSON.stringify([{ x: 80, y: 80, width: 1200, height: 800, rootPath: projectDir }]),
+  );
+  const app = await electron.launch({
+    args: [projectRoot, `--user-data-dir=${userDataDir}`],
+    cwd: projectRoot,
+    timeout: 60_000,
+    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1' },
+  });
+  return { app, userDataDir, projectDir };
+}
+
+/** Is the renderer's focus currently inside the given selector's element? */
+async function focusInside(win: Page, selector: string): Promise<boolean> {
+  return win.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    return !!el && el.contains(document.activeElement);
+  }, selector);
+}
+
+test('command palette traps Tab focus and restores it to the editor on close', async () => {
+  const { app, userDataDir, projectDir } = await launch();
+  try {
+    const win: Page = await app.firstWindow({ timeout: 20_000 });
+    await win.waitForLoadState('domcontentloaded');
+    await expect(win.getByRole('button', { name: 'Open Thoughtbase' })).toHaveCount(0, { timeout: 25_000 });
+
+    // Open a note and put focus in the editor, so we have a known place for the
+    // palette to restore focus to on close.
+    await win.locator('[data-relative-path$=".md"]').first().click();
+    await expect(win.locator('.cm-content')).toBeVisible({ timeout: 10_000 });
+    await win.locator('.cm-content').click();
+    expect(await focusInside(win, '.cm-content'), 'editor should be focused before opening the palette').toBe(true);
+
+    const palette = '.dialog[aria-label="Command palette"]';
+
+    // Open the palette (⌘K). Its input autofocuses, so focus starts inside.
+    await win.keyboard.press('Meta+KeyK');
+    await expect(win.locator(palette)).toBeVisible({ timeout: 5000 });
+    expect(await focusInside(win, palette), 'focus should start inside the palette').toBe(true);
+
+    // Tab forward many times — focus must never escape to the app behind it.
+    for (let i = 0; i < 20; i++) {
+      await win.keyboard.press('Tab');
+      expect(await focusInside(win, palette), `focus escaped after ${i + 1} Tab(s)`).toBe(true);
+    }
+    // …and Shift+Tab backward.
+    for (let i = 0; i < 20; i++) {
+      await win.keyboard.press('Shift+Tab');
+      expect(await focusInside(win, palette), `focus escaped after ${i + 1} Shift+Tab(s)`).toBe(true);
+    }
+
+    // Escape closes the palette and focus returns to the editor (not stranded
+    // on the now-removed dialog node).
+    await win.keyboard.press('Escape');
+    await expect(win.locator(palette)).toHaveCount(0, { timeout: 5000 });
+    expect(await focusInside(win, '.cm-content'), 'focus should return to the editor after close').toBe(true);
+  } finally {
+    await app.close().catch(() => { /* already exited */ });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+});

--- a/tests/renderer/trap-focus.test.ts
+++ b/tests/renderer/trap-focus.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Unit coverage for the `trapFocus` modal focus-trap action (#1104). Exercises
+ * the boundary/mount/destroy behaviour the action drives itself (explicit
+ * `.focus()` calls) — the parts that don't depend on the browser's native Tab
+ * traversal. Intermediate native Tab moves are covered by the real-browser
+ * e2e test (tests/e2e/focus-trap.spec.ts).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { trapFocus } from '../../src/renderer/lib/trap-focus';
+
+function build(html: string): HTMLElement {
+  document.body.innerHTML = html;
+  return document.body.firstElementChild as HTMLElement;
+}
+
+function pressTab(node: HTMLElement, shift = false): KeyboardEvent {
+  const ev = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: shift, bubbles: true, cancelable: true });
+  node.dispatchEvent(ev);
+  return ev;
+}
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('trapFocus', () => {
+  it('pulls focus into the dialog on mount when nothing inside is focused', () => {
+    const dialog = build('<div><button id="a">A</button><button id="b">B</button></div>');
+    const handle = trapFocus(dialog);
+    expect(document.activeElement?.id).toBe('a');
+    handle.destroy();
+  });
+
+  it('wraps Tab from the last control back to the first', () => {
+    const dialog = build('<div><button id="a">A</button><button id="b">B</button></div>');
+    const handle = trapFocus(dialog);
+    document.getElementById('b')!.focus();
+    const ev = pressTab(dialog);
+    expect(ev.defaultPrevented).toBe(true);
+    expect(document.activeElement?.id).toBe('a');
+    handle.destroy();
+  });
+
+  it('wraps Shift+Tab from the first control back to the last', () => {
+    const dialog = build('<div><button id="a">A</button><button id="b">B</button></div>');
+    const handle = trapFocus(dialog);
+    document.getElementById('a')!.focus();
+    const ev = pressTab(dialog, true);
+    expect(ev.defaultPrevented).toBe(true);
+    expect(document.activeElement?.id).toBe('b');
+    handle.destroy();
+  });
+
+  it('pulls stray focus back in when Tab fires with focus outside the dialog', () => {
+    document.body.innerHTML = '<button id="outside">out</button><div id="d"><button id="a">A</button></div>';
+    const dialog = document.getElementById('d')!;
+    document.getElementById('outside')!.focus();
+    const handle = trapFocus(dialog);
+    document.getElementById('outside')!.focus(); // escape behind the modal
+    pressTab(dialog);
+    expect(document.activeElement?.id).toBe('a');
+    handle.destroy();
+  });
+
+  it('does not let Tab leak out of a dialog with no focusable content', () => {
+    const dialog = build('<div><span>no controls</span></div>');
+    const handle = trapFocus(dialog);
+    const ev = pressTab(dialog);
+    expect(ev.defaultPrevented).toBe(true);
+    handle.destroy();
+  });
+
+  it('ignores disabled and tabindex="-1" controls when finding the ends', () => {
+    const dialog = build(
+      '<div><button id="a">A</button><button disabled>x</button>' +
+      '<button id="skip" tabindex="-1">y</button><button id="z">Z</button></div>',
+    );
+    const handle = trapFocus(dialog);
+    document.getElementById('z')!.focus(); // last *tabbable* → wraps to a
+    pressTab(dialog);
+    expect(document.activeElement?.id).toBe('a');
+    handle.destroy();
+  });
+
+  it('does NOT intercept an intermediate Tab (lets the browser advance natively)', () => {
+    const dialog = build('<div><button id="a">A</button><button id="b">B</button><button id="c">C</button></div>');
+    const handle = trapFocus(dialog);
+    document.getElementById('a')!.focus(); // not the last control
+    const ev = pressTab(dialog);
+    expect(ev.defaultPrevented).toBe(false);
+    handle.destroy();
+  });
+
+  it('restores focus to the previously-focused element on destroy', () => {
+    document.body.innerHTML = '<button id="trigger">open</button><div id="d"><button id="a">A</button></div>';
+    document.getElementById('trigger')!.focus();
+    const handle = trapFocus(document.getElementById('d')!);
+    expect(document.activeElement?.id).toBe('a'); // focus moved in
+    handle.destroy();
+    expect(document.activeElement?.id).toBe('trigger'); // …and back out
+  });
+});


### PR DESCRIPTION
Follow-up to #1104 / #1478, delivering the last stretch bullet: a focus-trap / tab-order test for modal dialogs.

## The gap

The app's dialogs render as `<div role="dialog" aria-modal="true">` overlays. `aria-modal` announces modality to assistive tech, but it does **not** trap the browser's Tab focus (only a native `<dialog>.showModal()` or JS does). So Tab from the last control in a dialog escapes to the app behind the overlay — the worst a11y failure mode for a keyboard-first tool. No dialog implemented a trap.

## What

- **`src/renderer/lib/trap-focus.ts`** — a reusable `use:trapFocus` Svelte action:
  - pulls focus into the dialog on mount (no-op when it already autofocuses a field),
  - intercepts Tab / Shift+Tab **only at the ends**, wrapping first↔last (native Tab still advances between controls in between),
  - restores focus to the previously-focused element on destroy.
- **Applied to the Command Palette** — the flagship keyboard-first modal, and Tab-safe (it navigates with arrows, not Tab).
- **`tests/renderer/trap-focus.test.ts`** — 8 unit cases (happy-dom) covering mount / boundary-wrap / disabled+`tabindex=-1` skipping / no-focusable / intermediate-Tab-passthrough / destroy-restore. Runs on **every PR** under `pnpm coverage`.
- **`tests/e2e/focus-trap.spec.ts`** — a real-Chromium tab-order test: 20× Tab + 20× Shift+Tab never escape the palette, and Escape restores focus to the editor.

## Scope / safety

Deliberately **not** a blanket rollout: `PromptDialog` gives Tab a non-navigation meaning (Tab-to-accept-suggestion), and a trap would swallow it. The action is written to be adopted across the other Tab-safe modals (Confirm, Settings, pickers…) as a mechanical follow-up; this PR lands the mechanism, the tests, and the flagship surface.

## Verification
- `npx vitest run tests/renderer/trap-focus.test.ts` → 8 passed.
- `pnpm build:e2e && npx playwright test focus-trap` → 1 passed.
- `pnpm lint` clean. `trap-focus.ts` is fully covered by its unit test (raises the renderer coverage aggregate).

Independent of #1478 at the code level (new files + a one-line palette change) — bases cleanly on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)