### PR TITLE
test(renderer): cover the store/ops data-flow spine, ratchet floor (bucket B, #1452)

### DIFF
--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -32,6 +32,7 @@ vi.mock('../../../src/renderer/lib/stores/dialogs.svelte', () => ({ getDialogSto
 
 import { createNoteOps, type NoteOpsCtx } from '../../../src/renderer/lib/app/note-ops';
 import { getClipboardStore } from '../../../src/renderer/lib/stores/clipboard.svelte';
+import { CONFIRM_KEYS } from '../../../src/renderer/lib/confirm-keys';
 
 function dir(name: string, children: NoteFile[]): NoteFile {
   return { name, relativePath: name, isDirectory: true, children };
@@ -41,19 +42,29 @@ function file(relativePath: string): NoteFile {
 }
 
 const sidebar = { getSelectionPaths: vi.fn(() => [] as string[]), refreshTags: vi.fn(), clearSelection: vi.fn() };
+const editorComp = { restorePosition: vi.fn(), gotoLineColumn: vi.fn() };
+let editorCompRef: typeof editorComp | undefined;
 let ctx: NoteOpsCtx;
 let ops: ReturnType<typeof createNoteOps>;
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // resetAllMocks (not clearAllMocks): several tests install one-shot
+  // mockRejectedValue/mockResolvedValue implementations that would otherwise
+  // leak into later tests (clearAllMocks resets call history but not impls).
+  vi.resetAllMocks();
+  // Run requestAnimationFrame callbacks synchronously so the caret-restore /
+  // goto-line side effects (restorePosition / gotoLineColumn) are observable
+  // immediately after the awaited handler resolves.
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { cb(0); return 0; });
   h.notebase.meta = { rootPath: '/p', name: 'p' };
   h.notebase.files = [];
   h.editor.tabs = [];
   sidebar.getSelectionPaths.mockReturnValue([]);
+  editorCompRef = undefined;
   getClipboardStore().clear();
   ctx = {
     getSidebar: () => sidebar,
-    getEditorComponent: () => undefined,
+    getEditorComponent: () => editorCompRef,
     setSafeDeleteState: vi.fn(),
     setMergePickerSource: vi.fn(),
   };
@@ -174,5 +185,389 @@ describe('handleCopyWithPrompt', () => {
     await ops.handleCopyWithPrompt('a.md');
     expect(h.dialog.showConfirm).toHaveBeenCalled();
     expect(h.api.notebase.copy).not.toHaveBeenCalled();
+  });
+
+  it('treats a path-like input (dir/name) as project-root relative', async () => {
+    h.dialog.showPrompt.mockResolvedValue('sub/dup');
+    h.api.notebase.readFile.mockRejectedValue(new Error('ENOENT'));
+    await ops.handleCopyWithPrompt('notes/a.md');
+    // extension preserved on the last segment; leading dir is project-root
+    expect(h.api.notebase.copy).toHaveBeenCalledWith('notes/a.md', 'sub/dup.md');
+  });
+
+  it('does nothing on cancel or when no thoughtbase is open', async () => {
+    h.dialog.showPrompt.mockResolvedValue(null);
+    await ops.handleCopyWithPrompt('a.md');
+    expect(h.api.notebase.copy).not.toHaveBeenCalled();
+
+    h.dialog.showPrompt.mockClear();
+    h.notebase.meta = null;
+    h.dialog.showPrompt.mockResolvedValue('dup');
+    await ops.handleCopyWithPrompt('a.md');
+    expect(h.dialog.showPrompt).not.toHaveBeenCalled();
+    expect(h.api.notebase.copy).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleNewNote — template & guard paths', () => {
+  it('bails out when no thoughtbase is open', async () => {
+    h.notebase.meta = null;
+    await ops.handleNewNote('folder');
+    expect(h.dialog.showNewNoteDialog).not.toHaveBeenCalled();
+    expect(h.api.notebase.createFile).not.toHaveBeenCalled();
+  });
+
+  it('writes the substituted template body and restores the caret offset', async () => {
+    editorCompRef = editorComp;
+    h.dialog.showNewNoteDialog.mockResolvedValue({ name: 'fresh', ext: '.md', templateFilename: 'daily.md' });
+    h.api.templates.get.mockResolvedValue('Hello {{title}}{{cursor}} world');
+    await ops.handleNewNote('folder');
+    // Non-empty content routes through writeFile, not createFile.
+    expect(h.api.notebase.writeFile).toHaveBeenCalledWith('folder/fresh.md', 'Hello fresh world');
+    expect(h.api.notebase.createFile).not.toHaveBeenCalled();
+    expect(h.editor.openFile).toHaveBeenCalledWith('folder/fresh.md');
+    // {{cursor}} sits right after "Hello fresh" → offset 11.
+    expect(editorComp.restorePosition).toHaveBeenCalledWith(11, 0);
+  });
+
+  it('cancels silently (no write) when an interactive {{prompt:…}} is dismissed', async () => {
+    h.dialog.showNewNoteDialog.mockResolvedValue({ name: 'fresh', ext: '.md', templateFilename: 'daily.md' });
+    h.api.templates.get.mockResolvedValue('a{{prompt:Label}}b');
+    h.dialog.showPrompt.mockResolvedValue(null); // user cancels the template prompt
+    await ops.handleNewNote();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+    expect(h.api.notebase.createFile).not.toHaveBeenCalled();
+    expect(h.editor.openFile).not.toHaveBeenCalled();
+  });
+
+  it('falls back to createFile when the template file is missing', async () => {
+    h.dialog.showNewNoteDialog.mockResolvedValue({ name: 'fresh', ext: '.md', templateFilename: 'gone.md' });
+    h.api.templates.get.mockResolvedValue(null); // template not found
+    await ops.handleNewNote('');
+    expect(h.api.notebase.createFile).toHaveBeenCalledWith('fresh.md');
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleNewFolder', () => {
+  it('creates the folder under the target directory', async () => {
+    h.dialog.showPrompt.mockResolvedValue('Ideas');
+    await ops.handleNewFolder('notes');
+    expect(h.api.notebase.createFolder).toHaveBeenCalledWith('notes/Ideas');
+    expect(h.notebase.refresh).toHaveBeenCalled();
+  });
+
+  it('creates at the root when no directory is passed', async () => {
+    h.dialog.showPrompt.mockResolvedValue('Ideas');
+    await ops.handleNewFolder();
+    expect(h.api.notebase.createFolder).toHaveBeenCalledWith('Ideas');
+  });
+
+  it('does nothing on cancel or without a thoughtbase', async () => {
+    h.dialog.showPrompt.mockResolvedValue(null);
+    await ops.handleNewFolder('notes');
+    expect(h.api.notebase.createFolder).not.toHaveBeenCalled();
+
+    h.notebase.meta = null;
+    h.dialog.showPrompt.mockResolvedValue('Ideas');
+    await ops.handleNewFolder('notes');
+    expect(h.api.notebase.createFolder).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleDelete / executeDeletes — folders, multi-select, failures', () => {
+  it('routes a directory target through deleteFolder', async () => {
+    h.dialog.showConfirm.mockResolvedValue(true);
+    await ops.handleDelete('archive', true);
+    expect(h.api.notebase.deleteFolder).toHaveBeenCalledWith('archive');
+    expect(h.api.notebase.deleteFile).not.toHaveBeenCalled();
+    expect(sidebar.clearSelection).toHaveBeenCalled();
+  });
+
+  it('deletes every resolved selection target', async () => {
+    h.notebase.files = [dir('notes', [file('notes/a.md'), file('notes/b.md')])];
+    sidebar.getSelectionPaths.mockReturnValue(['notes/a.md', 'notes/b.md']);
+    h.api.links.externalInbound.mockResolvedValue([]); // no blockers
+    h.dialog.showConfirm.mockResolvedValue(true);
+    await ops.handleDelete('notes/a.md', false);
+    expect(h.api.notebase.deleteFile).toHaveBeenCalledWith('notes/a.md');
+    expect(h.api.notebase.deleteFile).toHaveBeenCalledWith('notes/b.md');
+  });
+
+  it('fails open (deletes) when the inbound-link probe throws', async () => {
+    h.notebase.files = [dir('notes', [file('notes/x.md')])];
+    sidebar.getSelectionPaths.mockReturnValue(['notes/x.md']);
+    h.api.links.externalInbound.mockRejectedValue(new Error('graph down'));
+    h.dialog.showConfirm.mockResolvedValue(true);
+    await ops.handleDelete('notes/x.md', false);
+    expect(ctx.setSafeDeleteState).not.toHaveBeenCalled();
+    expect(h.api.notebase.deleteFile).toHaveBeenCalledWith('notes/x.md');
+  });
+
+  it('reports a summary dialog when a delete fails mid-batch', async () => {
+    h.dialog.showConfirm.mockResolvedValue(true);
+    h.api.notebase.deleteFile.mockRejectedValueOnce(new Error('EBUSY'));
+    await ops.handleDelete('notes/locked.md', false);
+    // First showConfirm = delete confirmation; second = the failure summary.
+    expect(h.dialog.showConfirm).toHaveBeenLastCalledWith(
+      expect.stringContaining('EBUSY'),
+      CONFIRM_KEYS.deletePartialFailure,
+      'OK',
+    );
+    expect(h.notebase.refresh).toHaveBeenCalled();
+  });
+
+  it('bails out without a thoughtbase', async () => {
+    h.notebase.meta = null;
+    await ops.handleDelete('x.md', false);
+    expect(h.api.notebase.deleteFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('openFirstReferenceFromSafeDelete', () => {
+  it('clears the safe-delete state, opens the source, and jumps to the link site', async () => {
+    editorCompRef = editorComp;
+    h.api.notebase.readFile.mockResolvedValue('line one\nsee [[x]] here');
+    await ops.openFirstReferenceFromSafeDelete('notes/y.md', 'notes/x.md');
+    expect(ctx.setSafeDeleteState).toHaveBeenCalledWith(null);
+    expect(h.editor.openFile).toHaveBeenCalledWith('notes/y.md');
+    // "[[x]]" starts at column 5 of line 2 → gotoLineColumn(2, col+1).
+    expect(editorComp.gotoLineColumn).toHaveBeenCalledWith(2, 5);
+  });
+
+  it('still opens the source (offset 0) when the reference read fails', async () => {
+    editorCompRef = editorComp;
+    h.api.notebase.readFile.mockRejectedValue(new Error('gone'));
+    await ops.openFirstReferenceFromSafeDelete('notes/y.md', 'notes/x.md');
+    expect(h.editor.openFile).toHaveBeenCalledWith('notes/y.md');
+    expect(editorComp.gotoLineColumn).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleCut / handleCopy', () => {
+  it('cut captures the fallback item when nothing is selected', () => {
+    ops.handleCut('a.md', false);
+    expect(getClipboardStore().current).toEqual({
+      items: [{ relativePath: 'a.md', isDirectory: false }],
+      mode: 'cut',
+    });
+  });
+
+  it('cut captures the resolved sidebar selection when present', () => {
+    h.notebase.files = [dir('notes', [file('notes/a.md'), file('notes/b.md')])];
+    sidebar.getSelectionPaths.mockReturnValue(['notes/a.md', 'notes/b.md']);
+    ops.handleCut('notes/a.md', false);
+    expect(getClipboardStore().current?.mode).toBe('cut');
+    expect(getClipboardStore().current?.items).toEqual([
+      { relativePath: 'notes/a.md', isDirectory: false },
+      { relativePath: 'notes/b.md', isDirectory: false },
+    ]);
+  });
+
+  it('copy sets copy mode on the clipboard', () => {
+    ops.handleCopy('a.md', false);
+    expect(getClipboardStore().current?.mode).toBe('copy');
+  });
+});
+
+describe('handleMove (drag-move)', () => {
+  it('moves a single dragged file and retargets its open tab', async () => {
+    h.notebase.files = [file('a.md')];
+    h.editor.tabs = [{ type: 'note', relativePath: 'a.md', fileName: 'a.md' }];
+    await ops.handleMove('a.md', 'dest');
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('a.md', 'dest/a.md');
+    expect(h.editor.tabs[0]).toMatchObject({ relativePath: 'dest/a.md', fileName: 'a.md' });
+    expect(sidebar.clearSelection).toHaveBeenCalled();
+  });
+
+  it('moves the whole selection when the dragged path is part of a multi-selection', async () => {
+    h.notebase.files = [file('a.md'), file('b.md')];
+    sidebar.getSelectionPaths.mockReturnValue(['a.md', 'b.md']);
+    await ops.handleMove('a.md', 'dest');
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('a.md', 'dest/a.md');
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('b.md', 'dest/b.md');
+  });
+
+  it('skips a same-directory no-op move', async () => {
+    h.notebase.files = [dir('dir', [file('dir/a.md')])];
+    await ops.handleMove('dir/a.md', 'dir');
+    expect(h.api.notebase.rename).not.toHaveBeenCalled();
+    expect(h.notebase.refresh).toHaveBeenCalled();
+  });
+
+  it('collects a collision and surfaces the summary dialog', async () => {
+    h.notebase.files = [file('a.md'), dir('dest', [file('dest/a.md')])];
+    await ops.handleMove('a.md', 'dest');
+    expect(h.api.notebase.rename).not.toHaveBeenCalled();
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('Move complete'),
+      CONFIRM_KEYS.moveCollision,
+      'OK',
+    );
+  });
+
+  it('reports a failure summary when the rename rejects', async () => {
+    h.notebase.files = [file('a.md')];
+    h.api.notebase.rename.mockRejectedValue(new Error('EPERM'));
+    await ops.handleMove('a.md', 'dest');
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('EPERM'),
+      CONFIRM_KEYS.moveCollision,
+      'OK',
+    );
+  });
+
+  it('does nothing when the dragged path is not in the tree', async () => {
+    h.notebase.files = [];
+    await ops.handleMove('ghost.md', 'dest');
+    expect(h.api.notebase.rename).not.toHaveBeenCalled();
+  });
+
+  it('bails out without a thoughtbase', async () => {
+    h.notebase.meta = null;
+    await ops.handleMove('a.md', 'dest');
+    expect(h.api.notebase.rename).not.toHaveBeenCalled();
+  });
+});
+
+describe('handlePaste — collisions, failures, tab retarget', () => {
+  it('cut+paste retargets an open tab for the moved item', async () => {
+    h.editor.tabs = [{ type: 'note', relativePath: 'a.md', fileName: 'a.md' }];
+    getClipboardStore().set({ items: [{ relativePath: 'a.md', isDirectory: false }], mode: 'cut' });
+    await ops.handlePaste('dest');
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('a.md', 'dest/a.md');
+    expect(h.editor.tabs[0]).toMatchObject({ relativePath: 'dest/a.md', fileName: 'a.md' });
+  });
+
+  it('skips a collision and reports the Copy summary', async () => {
+    h.notebase.files = [dir('dest', [file('dest/a.md')])];
+    getClipboardStore().set({ items: [{ relativePath: 'a.md', isDirectory: false }], mode: 'copy' });
+    await ops.handlePaste('dest');
+    expect(h.api.notebase.copy).not.toHaveBeenCalled();
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('Copy complete'),
+      CONFIRM_KEYS.copyCollision,
+      'OK',
+    );
+  });
+
+  it('reports a per-item failure summary', async () => {
+    h.api.notebase.copy.mockRejectedValue(new Error('ENOSPC'));
+    getClipboardStore().set({ items: [{ relativePath: 'a.md', isDirectory: false }], mode: 'copy' });
+    await ops.handlePaste('dest');
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('ENOSPC'),
+      CONFIRM_KEYS.copyCollision,
+      'OK',
+    );
+  });
+
+  it('skips a same-directory no-op paste target', async () => {
+    getClipboardStore().set({ items: [{ relativePath: 'dir/a.md', isDirectory: false }], mode: 'copy' });
+    await ops.handlePaste('dir');
+    expect(h.api.notebase.copy).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleMerge / performMerge', () => {
+  it('handleMerge flushes autosave and opens the merge picker', () => {
+    ops.handleMerge('notes/a.md');
+    expect(h.editor.flushAutoSave).toHaveBeenCalled();
+    expect(ctx.setMergePickerSource).toHaveBeenCalledWith('notes/a.md');
+  });
+
+  it('handleMerge is a no-op without a thoughtbase', () => {
+    h.notebase.meta = null;
+    ops.handleMerge('notes/a.md');
+    expect(ctx.setMergePickerSource).not.toHaveBeenCalled();
+  });
+
+  it('performMerge returns early when source === target', async () => {
+    await ops.performMerge('a.md', 'a.md');
+    expect(h.api.notebase.mergePreview).not.toHaveBeenCalled();
+    expect(h.api.notebase.merge).not.toHaveBeenCalled();
+  });
+
+  it('performMerge previews, confirms, merges, and jumps to the merge point', async () => {
+    editorCompRef = editorComp;
+    h.api.notebase.mergePreview.mockResolvedValue({ linkOccurrences: 2, affectedFiles: 1 });
+    h.dialog.showConfirm.mockResolvedValue(true);
+    h.api.notebase.merge.mockResolvedValue({ targetPath: 'notes/target.md', mergeLine: 12 });
+    await ops.performMerge('notes/src.md', 'notes/target.md');
+    expect(h.api.notebase.mergePreview).toHaveBeenCalledWith('notes/src.md', 'notes/target.md');
+    expect(h.api.notebase.merge).toHaveBeenCalledWith('notes/src.md', 'notes/target.md');
+    expect(h.editor.openFile).toHaveBeenCalledWith('notes/target.md');
+    expect(editorComp.gotoLineColumn).toHaveBeenCalledWith(12, 1);
+    expect(h.notebase.refresh).toHaveBeenCalled();
+  });
+
+  it('performMerge handles the no-incoming-links preview branch', async () => {
+    h.api.notebase.mergePreview.mockResolvedValue({ linkOccurrences: 0, affectedFiles: 0 });
+    h.dialog.showConfirm.mockResolvedValue(true);
+    h.api.notebase.merge.mockResolvedValue({ targetPath: 'notes/target.md', mergeLine: 1 });
+    await ops.performMerge('notes/src.md', 'notes/target.md');
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('No incoming links'),
+      CONFIRM_KEYS.mergeNote,
+      'Merge',
+    );
+    expect(h.api.notebase.merge).toHaveBeenCalled();
+  });
+
+  it('performMerge aborts when the confirm is declined', async () => {
+    h.api.notebase.mergePreview.mockResolvedValue({ linkOccurrences: 1, affectedFiles: 1 });
+    h.dialog.showConfirm.mockResolvedValue(false);
+    await ops.performMerge('notes/src.md', 'notes/target.md');
+    expect(h.api.notebase.merge).not.toHaveBeenCalled();
+  });
+
+  it('performMerge surfaces a failure dialog when the IPC throws', async () => {
+    h.api.notebase.mergePreview.mockRejectedValue(new Error('merge boom'));
+    await ops.performMerge('notes/src.md', 'notes/target.md');
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('merge boom'),
+      CONFIRM_KEYS.mergeFailed,
+      'OK',
+    );
+    expect(h.api.notebase.merge).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleMoveWithPrompt', () => {
+  it('moves to the prompted folder when there is no collision', async () => {
+    h.notebase.files = [file('a.md')];
+    h.dialog.showPrompt.mockResolvedValue('dest');
+    h.api.notebase.readFile.mockRejectedValue(new Error('ENOENT')); // dest free
+    await ops.handleMoveWithPrompt('a.md');
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('a.md', 'dest/a.md');
+  });
+
+  it('aborts with a notice when the destination already exists', async () => {
+    h.dialog.showPrompt.mockResolvedValue('dest');
+    h.api.notebase.readFile.mockResolvedValue('existing'); // collision
+    await ops.handleMoveWithPrompt('a.md');
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('already exists'),
+      CONFIRM_KEYS.moveCollision,
+      'OK',
+    );
+    expect(h.api.notebase.rename).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on cancel (null prompt) or an unchanged directory', async () => {
+    h.dialog.showPrompt.mockResolvedValue(null);
+    await ops.handleMoveWithPrompt('a.md');
+    expect(h.api.notebase.rename).not.toHaveBeenCalled();
+
+    // currentDir '' === destDir '' → no-op
+    h.dialog.showPrompt.mockResolvedValue('');
+    await ops.handleMoveWithPrompt('a.md');
+    expect(h.api.notebase.rename).not.toHaveBeenCalled();
+  });
+
+  it('bails out without a thoughtbase', async () => {
+    h.notebase.meta = null;
+    await ops.handleMoveWithPrompt('a.md');
+    expect(h.dialog.showPrompt).not.toHaveBeenCalled();
   });
 });

--- a/tests/renderer/app/refactor-ops.test.ts
+++ b/tests/renderer/app/refactor-ops.test.ts
@@ -19,6 +19,7 @@ const h = vi.hoisted(() => {
     },
     notebase: { readFile: vi.fn(), writeFile: vi.fn() },
     tags: { list: vi.fn() },
+    graph: { frontmatterKeys: vi.fn() },
     formatter: { formatFile: vi.fn(), formatContent: vi.fn() },
     bibliography: { generate: vi.fn() },
   };
@@ -37,7 +38,7 @@ const h = vi.hoisted(() => {
     openFile: vi.fn().mockResolvedValue(undefined),
     setContent: vi.fn(),
   };
-  const dialog = { showPrompt: vi.fn(), showConfirm: vi.fn() };
+  const dialog = { showPrompt: vi.fn(), showConfirm: vi.fn(), showAddPropertyDialog: vi.fn() };
   return { api, notebase, editor, dialog };
 });
 
@@ -70,6 +71,9 @@ beforeEach(() => {
   h.notebase.files = [];
   h.editor.activeNoteTab = null;
   h.editor.activeTab = null;
+  // clearAllMocks() resets call history but not a mockReturnValue override, so
+  // re-pin the isPathDirty default (a later test flips it to true).
+  h.editor.isPathDirty.mockReturnValue(false);
   sidebar.getSelectionPaths.mockReturnValue([]);
   resetFlow();
   maybeMissing = vi.fn().mockResolvedValue(false);
@@ -218,5 +222,432 @@ describe('handleBibliography', () => {
     });
     await ops.handleBibliography();
     expect(h.api.bibliography.generate).toHaveBeenCalledWith('note.md');
+  });
+
+  it('saves the unsaved buffer before generating (disk-read generator)', async () => {
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: 'edited', savedContent: 'old' };
+    h.api.bibliography.generate.mockResolvedValue({
+      entriesCount: 0, changed: false, styleId: 'apa', missingIds: [],
+    });
+    await ops.handleBibliography();
+    expect(h.editor.save).toHaveBeenCalled();
+    // "No citations found" branch still confirms.
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+  });
+
+  it('surfaces the failure dialog when generate throws', async () => {
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: 'c', savedContent: 'c' };
+    h.api.bibliography.generate.mockRejectedValue(new Error('citeproc blew up'));
+    await ops.handleBibliography();
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Bibliography failed');
+    expect(msg).toContain('citeproc blew up');
+  });
+});
+
+describe('handleExtractSelection', () => {
+  it('writes the new note + rewritten source and navigates to the extract', async () => {
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: 'alpha beta gamma' };
+    editorComponent.getSelectionRange.mockReturnValue({ from: 0, to: 5 }); // "alpha" → derived title
+    h.api.notebase.writeFile.mockResolvedValue(undefined);
+    await ops.handleExtractSelection();
+    expect(h.editor.flushAutoSave).toHaveBeenCalled();
+    // Two writes: the new note first, then the rewritten source.
+    expect(h.api.notebase.writeFile).toHaveBeenCalledTimes(2);
+    expect(h.api.notebase.writeFile.mock.calls[0][0]).toBe('alpha.md');
+    expect(h.api.notebase.writeFile.mock.calls[1][0]).toBe('note.md');
+    expect(h.editor.reloadTabFromDisk).toHaveBeenCalledWith('note.md');
+    expect(h.notebase.refresh).toHaveBeenCalled();
+    expect(h.editor.openFile).toHaveBeenCalledWith('alpha.md');
+    expect(sidebar.refreshTags).toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no selection', async () => {
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: 'x' };
+    editorComponent.getSelectionRange.mockReturnValue(null);
+    await ops.handleExtractSelection();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('aborts when the user cancels the title prompt', async () => {
+    // Long single line with no heading → deriveProposedTitle returns null → prompt.
+    const longLine = 'x'.repeat(80);
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: longLine };
+    editorComponent.getSelectionRange.mockReturnValue({ from: 0, to: longLine.length });
+    h.dialog.showPrompt.mockResolvedValue(null); // cancel
+    await ops.handleExtractSelection();
+    expect(h.dialog.showPrompt).toHaveBeenCalled();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleSplitByHeading', () => {
+  it('writes one note per heading plus the rewritten source', async () => {
+    h.editor.activeNoteTab = {
+      relativePath: 'note.md',
+      content: '# Title\n\n## First\naaa\n\n## Second\nbbb\n',
+    };
+    h.dialog.showPrompt.mockResolvedValue('2');
+    h.api.notebase.writeFile.mockResolvedValue(undefined);
+    await ops.handleSplitByHeading();
+    expect(h.editor.flushAutoSave).toHaveBeenCalled();
+    // 2 new section notes + 1 source rewrite.
+    expect(h.api.notebase.writeFile).toHaveBeenCalledTimes(3);
+    // The last write is the source note (Contents index).
+    expect(h.api.notebase.writeFile.mock.calls.at(-1)?.[0]).toBe('note.md');
+    expect(h.editor.reloadTabFromDisk).toHaveBeenCalledWith('note.md');
+    expect(h.notebase.refresh).toHaveBeenCalled();
+    expect(sidebar.refreshTags).toHaveBeenCalled();
+  });
+
+  it('aborts on an invalid heading level', async () => {
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: '## H\n' };
+    h.dialog.showPrompt.mockResolvedValue('9'); // not 1/2/3
+    await ops.handleSplitByHeading();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no headings exist at that level', async () => {
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: 'no headings here\n' };
+    h.dialog.showPrompt.mockResolvedValue('2');
+    await ops.handleSplitByHeading();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleSplitHere', () => {
+  it('writes the tail note + truncated source and opens the new note', async () => {
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: 'head\n\ntail line here' };
+    editorComponent.getOffset.mockReturnValue(6); // start of "tail line here"
+    h.api.notebase.writeFile.mockResolvedValue(undefined);
+    await ops.handleSplitHere();
+    expect(h.editor.flushAutoSave).toHaveBeenCalled();
+    expect(h.api.notebase.writeFile).toHaveBeenCalledTimes(2);
+    expect(h.api.notebase.writeFile.mock.calls[0][0]).toBe('tail-line-here.md');
+    expect(h.api.notebase.writeFile.mock.calls[1][0]).toBe('note.md');
+    expect(h.editor.reloadTabFromDisk).toHaveBeenCalledWith('note.md');
+    expect(h.editor.openFile).toHaveBeenCalledWith('tail-line-here.md');
+  });
+
+  it('does nothing when the cursor is at/after EOF', async () => {
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: 'abc' };
+    editorComponent.getOffset.mockReturnValue(999);
+    await ops.handleSplitHere();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleAutoLinkInbound', () => {
+  it('sets the inbound review state when suggestions are found', async () => {
+    h.api.refactor.autoLinkInboundSuggest.mockResolvedValue({ suggestions: [{ anchor: 'a' }] });
+    await ops.handleAutoLinkInbound('note.md');
+    expect(h.api.refactor.autoLinkInboundSuggest).toHaveBeenCalledWith('note.md');
+    expect(flow.autoLinkInboundReview?.relativePath).toBe('note.md');
+    expect(flow.autoLinkInboundReview?.suggestions).toHaveLength(1);
+    expect(flow.autoLinkBusy).toBe(false);
+  });
+
+  it('shows a notice and leaves review null when none found', async () => {
+    h.api.refactor.autoLinkInboundSuggest.mockResolvedValue({ suggestions: [] });
+    await ops.handleAutoLinkInbound('note.md');
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+    expect(flow.autoLinkInboundReview).toBeNull();
+  });
+
+  it('routes a missing API key to the ctx handler instead of the failure dialog', async () => {
+    h.api.refactor.autoLinkInboundSuggest.mockRejectedValue(new Error('no key'));
+    maybeMissing.mockResolvedValue(true);
+    await ops.handleAutoLinkInbound('note.md');
+    expect(maybeMissing).toHaveBeenCalled();
+    expect(h.dialog.showConfirm).not.toHaveBeenCalled();
+    expect(flow.autoLinkBusy).toBe(false);
+  });
+
+  it('shows the failure dialog on a non-key error', async () => {
+    h.api.refactor.autoLinkInboundSuggest.mockRejectedValue(new Error('boom'));
+    await ops.handleAutoLinkInbound('note.md');
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Auto-link failed');
+    expect(msg).toContain('boom');
+  });
+
+  it('is a no-op while a suggest is already in flight', async () => {
+    flow.setAutoLinkBusy(true);
+    await ops.handleAutoLinkInbound('note.md');
+    expect(h.api.refactor.autoLinkInboundSuggest).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleAutoLinkInboundApply', () => {
+  it('clears the review and applies the accepted snapshot', async () => {
+    flow.setAutoLinkInboundReview({ relativePath: 'note.md', suggestions: [] });
+    h.api.refactor.autoLinkInboundApply.mockResolvedValue({ applied: [{}], skipped: [] });
+    await ops.handleAutoLinkInboundApply([{ anchor: 'a' }] as never);
+    expect(flow.autoLinkInboundReview).toBeNull();
+    expect(h.api.refactor.autoLinkInboundApply).toHaveBeenCalledWith('note.md', [{ anchor: 'a' }]);
+  });
+
+  it('warns when nothing could be applied (anchors drifted)', async () => {
+    flow.setAutoLinkInboundReview({ relativePath: 'note.md', suggestions: [] });
+    h.api.refactor.autoLinkInboundApply.mockResolvedValue({ applied: [], skipped: [{}] });
+    await ops.handleAutoLinkInboundApply([{ anchor: 'a' }] as never);
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no pending review', async () => {
+    await ops.handleAutoLinkInboundApply([] as never);
+    expect(h.api.refactor.autoLinkInboundApply).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleAutoLinkApply (error / skipped branches)', () => {
+  it('warns when every suggestion was skipped', async () => {
+    flow.setAutoLinkReview({ relativePath: 'note.md', suggestions: [], activeBody: '' });
+    h.api.refactor.autoLinkApply.mockResolvedValue({ applied: [], skipped: [{}] });
+    await ops.handleAutoLinkApply([{ anchor: 'a' }] as never);
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+  });
+
+  it('surfaces a failure dialog when apply throws', async () => {
+    flow.setAutoLinkReview({ relativePath: 'note.md', suggestions: [], activeBody: '' });
+    h.api.refactor.autoLinkApply.mockRejectedValue(new Error('nope'));
+    await ops.handleAutoLinkApply([{ anchor: 'a' }] as never);
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Auto-link failed');
+    expect(msg).toContain('nope');
+  });
+});
+
+describe('handleAutoLink (error branch)', () => {
+  it('shows the failure dialog on a non-key error', async () => {
+    h.api.refactor.autoLinkSuggest.mockRejectedValue(new Error('kaboom'));
+    await ops.handleAutoLink('note.md');
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Auto-link failed');
+    expect(msg).toContain('kaboom');
+    expect(flow.autoLinkBusy).toBe(false);
+  });
+});
+
+describe('handleAutoTag (failure branch)', () => {
+  it('shows the failure dialog on a non-key error', async () => {
+    h.api.refactor.autoTag.mockRejectedValue(new Error('rate limit'));
+    await ops.handleAutoTag('note.md');
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Auto-tag failed');
+    expect(msg).toContain('rate limit');
+    expect(flow.autoTagBusy).toBe(false);
+  });
+});
+
+describe('handleAutoTagApply (failure branch)', () => {
+  it('surfaces a failure dialog when apply throws', async () => {
+    flow.setAutoTagReview({ relativePath: 'note.md', tags: ['x'] });
+    h.api.refactor.autoTagApply.mockRejectedValue(new Error('apply failed'));
+    await ops.handleAutoTagApply(['x']);
+    expect(flow.autoTagReview).toBeNull();
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Auto-tag failed');
+  });
+});
+
+describe('handleAddTag (vocab failure)', () => {
+  it('aborts with a failure dialog when the tag vocabulary fetch throws', async () => {
+    h.api.tags.list.mockRejectedValue(new Error('graph down'));
+    await ops.handleAddTag('note.md', false);
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Add Tag failed');
+    expect(h.dialog.showPrompt).not.toHaveBeenCalled();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('collects per-note failures into the summary without aborting', async () => {
+    h.notebase.files = [{ relativePath: 'a.md', isDirectory: false }];
+    h.api.tags.list.mockResolvedValue([]);
+    h.dialog.showPrompt.mockResolvedValue('bar');
+    h.api.notebase.readFile.mockRejectedValue(new Error('read fail'));
+    await ops.handleAddTag('a.md', false);
+    // No write happened, but the summary confirm still runs.
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('tagged 0 of 1');
+    expect(msg).toContain('read fail');
+  });
+});
+
+describe('handleRemoveTag', () => {
+  it('removes a tag present on the target and syncs the open tab', async () => {
+    h.dialog.showPrompt.mockResolvedValue('foo');
+    h.api.notebase.readFile.mockResolvedValue('---\ntags:\n  - foo\n  - bar\n---\nbody');
+    h.api.notebase.writeFile.mockResolvedValue(undefined);
+    await ops.handleRemoveTag('note.md', false);
+    expect(h.dialog.showPrompt).toHaveBeenCalled();
+    expect(h.api.notebase.writeFile).toHaveBeenCalled();
+    expect(h.api.notebase.writeFile.mock.calls[0][0]).toBe('note.md');
+    expect(sidebar.refreshTags).toHaveBeenCalled();
+    expect(h.editor.reloadTabFromDisk).toHaveBeenCalledWith('note.md');
+  });
+
+  it('confirms and writes nothing when the selection has no tags', async () => {
+    h.api.notebase.readFile.mockResolvedValue('no frontmatter body');
+    await ops.handleRemoveTag('note.md', false);
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('tags to remove');
+    expect(h.dialog.showPrompt).not.toHaveBeenCalled();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('confirms "no .md files" for an empty selection with no fallback', async () => {
+    await ops.handleRemoveTag();
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleAddProperty', () => {
+  it('upserts the property, writes, and syncs the open tab', async () => {
+    h.api.graph.frontmatterKeys.mockResolvedValue(['status', 'tags']);
+    h.dialog.showAddPropertyDialog.mockResolvedValue({ name: 'status', value: 'active' });
+    h.api.notebase.readFile.mockResolvedValue('body');
+    h.api.notebase.writeFile.mockResolvedValue(undefined);
+    await ops.handleAddProperty('note.md', false);
+    // 'tags' is filtered out of the vocab offered to the dialog.
+    expect(h.dialog.showAddPropertyDialog).toHaveBeenCalledWith('Add property to 1 note', ['status']);
+    expect(h.api.notebase.writeFile).toHaveBeenCalled();
+    expect(h.api.notebase.writeFile.mock.calls[0][0]).toBe('note.md');
+    expect(h.editor.reloadTabFromDisk).toHaveBeenCalledWith('note.md');
+  });
+
+  it('routes a "tags" key to the Add Tag action instead of writing', async () => {
+    h.api.graph.frontmatterKeys.mockResolvedValue([]);
+    h.dialog.showAddPropertyDialog.mockResolvedValue({ name: 'tags', value: 'x' });
+    await ops.handleAddProperty('note.md', false);
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Add Tag');
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the dialog is cancelled', async () => {
+    h.api.graph.frontmatterKeys.mockResolvedValue([]);
+    h.dialog.showAddPropertyDialog.mockResolvedValue(null);
+    await ops.handleAddProperty('note.md', false);
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('confirms "no .md files" for an empty selection with no fallback', async () => {
+    await ops.handleAddProperty();
+    expect(h.dialog.showConfirm).toHaveBeenCalled();
+    expect(h.dialog.showAddPropertyDialog).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleRemoveProperty', () => {
+  it('removes a property present on the target and writes', async () => {
+    h.api.notebase.readFile.mockResolvedValue('---\nstatus: active\n---\nbody');
+    h.dialog.showPrompt.mockResolvedValue('status');
+    h.api.notebase.writeFile.mockResolvedValue(undefined);
+    await ops.handleRemoveProperty('note.md', false);
+    expect(h.dialog.showPrompt).toHaveBeenCalled();
+    expect(h.api.notebase.writeFile).toHaveBeenCalled();
+    expect(h.api.notebase.writeFile.mock.calls[0][0]).toBe('note.md');
+    expect(h.editor.reloadTabFromDisk).toHaveBeenCalledWith('note.md');
+  });
+
+  it('confirms and writes nothing when the selection has no properties', async () => {
+    h.api.notebase.readFile.mockResolvedValue('plain body no frontmatter');
+    await ops.handleRemoveProperty('note.md', false);
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('properties to remove');
+    expect(h.dialog.showPrompt).not.toHaveBeenCalled();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleToggleEntrypoint', () => {
+  it('adds the entrypoint tag when absent and refreshes tags', async () => {
+    h.api.notebase.readFile.mockResolvedValue('body');
+    h.api.notebase.writeFile.mockResolvedValue(undefined);
+    await ops.handleToggleEntrypoint('note.md', false);
+    expect(h.api.notebase.writeFile).toHaveBeenCalled();
+    expect(h.api.notebase.writeFile.mock.calls[0][0]).toBe('note.md');
+    // The written content carries the entrypoint tag.
+    expect(h.api.notebase.writeFile.mock.calls[0][1]).toContain('entrypoint');
+    expect(sidebar.refreshTags).toHaveBeenCalled();
+    expect(h.editor.reloadTabFromDisk).toHaveBeenCalledWith('note.md');
+  });
+
+  it('removes the entrypoint tag when already present', async () => {
+    h.api.notebase.readFile.mockResolvedValue('---\ntags:\n  - entrypoint\n---\nbody');
+    h.api.notebase.writeFile.mockResolvedValue(undefined);
+    await ops.handleToggleEntrypoint('note.md', true);
+    expect(h.api.notebase.writeFile).toHaveBeenCalled();
+    // Removing the sole tag drops the frontmatter entirely.
+    expect(h.api.notebase.writeFile.mock.calls[0][1]).not.toContain('entrypoint');
+  });
+
+  it('surfaces a failure dialog when the read throws', async () => {
+    h.api.notebase.readFile.mockRejectedValue(new Error('io error'));
+    await ops.handleToggleEntrypoint('note.md', false);
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Toggle entrypoint failed');
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleFormat', () => {
+  it('bulk-formats the sidebar selection via formatFile and reports the summary', async () => {
+    h.notebase.files = [{ relativePath: 'a.md', isDirectory: false }];
+    sidebar.getSelectionPaths.mockReturnValue(['a.md']);
+    h.api.formatter.formatFile.mockResolvedValue({ changed: true });
+    await ops.handleFormat();
+    expect(h.api.formatter.formatFile).toHaveBeenCalledWith('a.md', expect.anything());
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Formatting complete');
+    expect(msg).toContain('Changed 1 of 1');
+  });
+
+  it('confirms when the selection resolves to no .md files', async () => {
+    h.notebase.files = [{ relativePath: 'a.csv', isDirectory: false }];
+    sidebar.getSelectionPaths.mockReturnValue(['a.csv']);
+    await ops.handleFormat();
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('no .md files to format');
+    expect(h.api.formatter.formatFile).not.toHaveBeenCalled();
+  });
+
+  it('falls back to formatting the active tab in-buffer when nothing is selected', async () => {
+    sidebar.getSelectionPaths.mockReturnValue([]);
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: 'raw' };
+    h.api.formatter.formatContent.mockResolvedValue('formatted');
+    await ops.handleFormat();
+    expect(h.api.formatter.formatContent).toHaveBeenCalledWith('raw', expect.anything(), 'note.md');
+    expect(h.editor.setContent).toHaveBeenCalledWith('formatted');
+  });
+
+  it('leaves the buffer untouched when the formatter returns identical content', async () => {
+    sidebar.getSelectionPaths.mockReturnValue([]);
+    h.editor.activeNoteTab = { relativePath: 'note.md', content: 'same' };
+    h.api.formatter.formatContent.mockResolvedValue('same');
+    await ops.handleFormat();
+    expect(h.editor.setContent).not.toHaveBeenCalled();
+  });
+
+  it('confirms when there is neither a selection nor an active tab', async () => {
+    sidebar.getSelectionPaths.mockReturnValue([]);
+    h.editor.activeNoteTab = null;
+    await ops.handleFormat();
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Open a note');
+    expect(h.api.formatter.formatContent).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failure dialog when the bulk formatter throws', async () => {
+    h.notebase.files = [{ relativePath: 'a.md', isDirectory: false }];
+    sidebar.getSelectionPaths.mockReturnValue(['a.md']);
+    h.api.formatter.formatFile.mockRejectedValue(new Error('fmt error'));
+    await ops.handleFormat();
+    const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
+    expect(msg).toContain('Formatting failed');
+    expect(msg).toContain('fmt error');
   });
 });

--- a/tests/renderer/app/source-ops.test.ts
+++ b/tests/renderer/app/source-ops.test.ts
@@ -169,4 +169,517 @@ describe('handleImportBibtex', () => {
     expect(ctx.refreshSourcesCache).toHaveBeenCalled();
     expect(h.dialog.showConfirm).toHaveBeenCalled();
   });
+
+  it('previews the first failures when some entries fail', async () => {
+    const failed = Array.from({ length: 7 }, (_, i) => ({ key: `k${i}`, reason: 'bad' }));
+    h.api.sources.importBibtex.mockResolvedValue({
+      imported: [], duplicate: [], failed, parseErrors: 2,
+    });
+    await ops.handleImportBibtex();
+    const msg = h.dialog.showConfirm.mock.calls[0][0] as string;
+    expect(msg).toContain('Failed: 7');
+    expect(msg).toContain('Parse errors: 2');
+    expect(msg).toContain('First failures:');
+    expect(msg).toContain('…and 2 more');
+  });
+
+  it('reports the api error and does not refresh', async () => {
+    h.api.sources.importBibtex.mockRejectedValue(new Error('boom'));
+    await ops.handleImportBibtex();
+    expect(ctx.refreshSourcesCache).not.toHaveBeenCalled();
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('boom'), expect.any(String), 'OK',
+    );
+  });
+
+  it('does nothing when there is no open notebase', async () => {
+    h.notebase.meta = null;
+    await ops.handleImportBibtex();
+    expect(h.api.sources.importBibtex).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleImportZoteroRdf', () => {
+  it('does nothing more when the picker is cancelled', async () => {
+    h.api.sources.importZoteroRdf.mockResolvedValue(null);
+    await ops.handleImportZoteroRdf();
+    expect(ctx.refreshSourcesCache).not.toHaveBeenCalled();
+    expect(sidebar.refreshSources).not.toHaveBeenCalled();
+  });
+
+  it('refreshes and reports a successful import, counting attached PDFs', async () => {
+    h.api.sources.importZoteroRdf.mockResolvedValue({
+      imported: [{ pdfAttached: true }, { pdfAttached: false }],
+      duplicate: [{}], failed: [],
+    });
+    await ops.handleImportZoteroRdf();
+    expect(sidebar.refreshSources).toHaveBeenCalled();
+    expect(ctx.refreshSourcesCache).toHaveBeenCalled();
+    const msg = h.dialog.showConfirm.mock.calls[0][0] as string;
+    expect(msg).toContain('Imported: 2 (1 with PDF)');
+    expect(msg).toContain('Duplicate (skipped): 1');
+  });
+
+  it('previews the first failures when some entries fail', async () => {
+    const failed = Array.from({ length: 6 }, (_, i) => ({ subject: `s${i}`, reason: 'nope' }));
+    h.api.sources.importZoteroRdf.mockResolvedValue({
+      imported: [], duplicate: [], failed,
+    });
+    await ops.handleImportZoteroRdf();
+    const msg = h.dialog.showConfirm.mock.calls[0][0] as string;
+    expect(msg).toContain('Failed: 6');
+    expect(msg).toContain('First failures:');
+    expect(msg).toContain('…and 1 more');
+  });
+
+  it('reports the api error', async () => {
+    h.api.sources.importZoteroRdf.mockRejectedValue(new Error('rdf-boom'));
+    await ops.handleImportZoteroRdf();
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('rdf-boom'), expect.any(String), 'OK',
+    );
+  });
+
+  it('does nothing when there is no open notebase', async () => {
+    h.notebase.meta = null;
+    await ops.handleImportZoteroRdf();
+    expect(h.api.sources.importZoteroRdf).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleIngestUrlAsSource (extra branches)', () => {
+  it('does nothing when there is no open notebase', async () => {
+    h.notebase.meta = null;
+    await ops.handleIngestUrlAsSource();
+    expect(h.dialog.showPrompt).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the prompt is dismissed (null)', async () => {
+    h.dialog.showPrompt.mockResolvedValue(null);
+    await ops.handleIngestUrlAsSource();
+    expect(h.api.sources.ingestUrl).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the URL is only whitespace', async () => {
+    h.dialog.showPrompt.mockResolvedValue('   ');
+    await ops.handleIngestUrlAsSource();
+    expect(h.api.sources.ingestUrl).not.toHaveBeenCalled();
+  });
+
+  it('trims the prompted URL before ingesting', async () => {
+    h.dialog.showPrompt.mockResolvedValue('  https://ex.com/z  ');
+    h.api.sources.ingestUrl.mockResolvedValue({ sourceId: 's', title: 'T', duplicate: false });
+    await ops.handleIngestUrlAsSource();
+    expect(h.api.sources.ingestUrl).toHaveBeenCalledWith('https://ex.com/z');
+  });
+
+  it('reports an ingest failure via confirm', async () => {
+    h.dialog.showPrompt.mockResolvedValue('https://ex.com/bad');
+    h.api.sources.ingestUrl.mockRejectedValue(new Error('net down'));
+    await ops.handleIngestUrlAsSource();
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('net down'), expect.any(String), 'OK',
+    );
+  });
+});
+
+describe('handleIngestFileAsSource', () => {
+  it('does nothing when there is no open notebase', async () => {
+    h.notebase.meta = null;
+    await ops.handleIngestFileAsSource();
+    expect(h.api.sources.ingestFile).not.toHaveBeenCalled();
+  });
+
+  it('does nothing more when the picker is cancelled', async () => {
+    h.api.sources.ingestFile.mockResolvedValue(null);
+    await ops.handleIngestFileAsSource();
+    expect(ctx.openSource).not.toHaveBeenCalled();
+    expect(flow.ocrSession).toBeNull();
+  });
+
+  it('opens a plain ingested source after the settle delay', async () => {
+    vi.useFakeTimers();
+    h.api.sources.ingestFile.mockResolvedValue({ sourceId: 'f1', title: 'Doc', duplicate: false });
+    await ops.handleIngestFileAsSource();
+    vi.advanceTimersByTime(200);
+    expect(ctx.openSource).toHaveBeenCalledWith('f1');
+  });
+
+  it('routes a scanned PDF into the OCR flow', async () => {
+    const bytes = new Uint8Array([9]);
+    h.api.sources.readPdf.mockResolvedValue(bytes);
+    h.api.sources.ingestFile.mockResolvedValue({
+      sourceId: 'f2', title: 'Scan', duplicate: false, needsOcr: true, pageCount: 3,
+    });
+    await ops.handleIngestFileAsSource();
+    expect(flow.ocrSession).toEqual({ sourceId: 'f2', title: 'Scan', pageCount: 3 });
+    expect(flow.ocrPdfBytes).toBe(bytes);
+  });
+
+  it('reports an ingest failure via confirm', async () => {
+    h.api.sources.ingestFile.mockRejectedValue(new Error('read err'));
+    await ops.handleIngestFileAsSource();
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('read err'), expect.any(String), 'OK',
+    );
+  });
+});
+
+describe('handleIngestedSourceResult (plain + defaults)', () => {
+  it('defaults pageCount to 0 when needsOcr with no page count', async () => {
+    h.api.sources.readPdf.mockResolvedValue(new Uint8Array());
+    await ops.handleIngestedSourceResult({ sourceId: 's', title: 'T', duplicate: false, needsOcr: true });
+    expect(flow.ocrSession).toEqual({ sourceId: 's', title: 'T', pageCount: 0 });
+  });
+
+  it('opens the tab for a plain result', async () => {
+    vi.useFakeTimers();
+    await ops.handleIngestedSourceResult({ sourceId: 'plain', title: 'P', duplicate: false });
+    vi.advanceTimersByTime(200);
+    expect(ctx.openSource).toHaveBeenCalledWith('plain');
+  });
+
+  it('falls back to sourceId in the duplicate message when title is empty', async () => {
+    await ops.handleIngestedSourceResult({ sourceId: 'onlyid', title: '', duplicate: true });
+    expect(h.dialog.showConfirm.mock.calls[0][0]).toContain('onlyid');
+  });
+});
+
+describe('handleIngestIdentifier', () => {
+  it('does nothing when there is no open notebase', async () => {
+    h.notebase.meta = null;
+    await ops.handleIngestIdentifier();
+    expect(h.dialog.showPrompt).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on an empty/whitespace identifier', async () => {
+    h.dialog.showPrompt.mockResolvedValue('  ');
+    await ops.handleIngestIdentifier();
+    expect(h.api.sources.ingestIdentifier).not.toHaveBeenCalled();
+  });
+
+  it('looks up a trimmed identifier and opens the source', async () => {
+    vi.useFakeTimers();
+    h.dialog.showPrompt.mockResolvedValue(' 10.1/abc ');
+    h.api.sources.ingestIdentifier.mockResolvedValue({ sourceId: 'i1', title: 'T', duplicate: false });
+    await ops.handleIngestIdentifier();
+    expect(h.api.sources.ingestIdentifier).toHaveBeenCalledWith('10.1/abc');
+    vi.advanceTimersByTime(200);
+    expect(ctx.openSource).toHaveBeenCalledWith('i1');
+  });
+
+  it('confirms a duplicate after opening it', async () => {
+    h.dialog.showPrompt.mockResolvedValue('10.1/dup');
+    h.api.sources.ingestIdentifier.mockResolvedValue({ sourceId: 'i2', title: 'Dup', duplicate: true });
+    await ops.handleIngestIdentifier();
+    expect(h.dialog.showConfirm.mock.calls[0][0]).toContain('Already ingested');
+  });
+
+  it('warns when the open-access PDF fetch failed', async () => {
+    h.dialog.showPrompt.mockResolvedValue('10.1/pdf');
+    h.api.sources.ingestIdentifier.mockResolvedValue({
+      sourceId: 'i3', title: 'Paper', duplicate: false, pdfError: 'HTTP 403',
+    });
+    await ops.handleIngestIdentifier();
+    expect(h.dialog.showConfirm.mock.calls[0][0]).toContain('HTTP 403');
+  });
+
+  it('reports a lookup failure via confirm', async () => {
+    h.dialog.showPrompt.mockResolvedValue('10.1/err');
+    h.api.sources.ingestIdentifier.mockRejectedValue(new Error('lookup boom'));
+    await ops.handleIngestIdentifier();
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('lookup boom'), expect.any(String), 'OK',
+    );
+  });
+});
+
+describe('handleOcrDone (extra branches)', () => {
+  it('does nothing when there is no active OCR session', async () => {
+    await ops.handleOcrDone(['x']);
+    expect(h.api.sources.finishPdfOcr).not.toHaveBeenCalled();
+  });
+
+  it('reports a save failure and does not open the tab', async () => {
+    vi.useFakeTimers();
+    flow.setOcrSession({ sourceId: 's9', title: 'T', pageCount: 1 });
+    h.api.sources.finishPdfOcr.mockRejectedValue(new Error('save boom'));
+    await ops.handleOcrDone(['p']);
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('save boom'), expect.any(String), 'OK',
+    );
+    vi.advanceTimersByTime(200);
+    expect(ctx.openSource).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleOcrCancel', () => {
+  it('does nothing when there is no active OCR session', () => {
+    ops.handleOcrCancel();
+    expect(ctx.openSource).not.toHaveBeenCalled();
+  });
+
+  it('clears the session and opens the source tab', () => {
+    vi.useFakeTimers();
+    flow.setOcrSession({ sourceId: 's10', title: 'T', pageCount: 2 });
+    flow.setOcrPdfBytes(new Uint8Array([1]));
+    ops.handleOcrCancel();
+    expect(flow.ocrSession).toBeNull();
+    expect(flow.ocrPdfBytes).toBeNull();
+    vi.advanceTimersByTime(200);
+    expect(ctx.openSource).toHaveBeenCalledWith('s10');
+  });
+});
+
+describe('handleMineReferences (error branch)', () => {
+  it('reports a mining failure via confirm and leaves review null', async () => {
+    h.api.sources.mineReferences.mockRejectedValue(new Error('mine boom'));
+    await ops.handleMineReferences({ sourceId: 'p', title: 'T' } as never);
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('mine boom'), expect.any(String), 'OK',
+    );
+    expect(flow.mineReview).toBeNull();
+  });
+
+  it('falls back to sourceId for the parent title when unset', async () => {
+    h.api.sources.mineReferences.mockResolvedValue([{ raw: 'a' }]);
+    await ops.handleMineReferences({ sourceId: 'p3' } as never);
+    expect(flow.mineReview?.parentTitle).toBe('p3');
+  });
+});
+
+describe('handleMineReferencesApply', () => {
+  it('does nothing when there is no active review state', async () => {
+    flow.setMineReview(null);
+    await ops.handleMineReferencesApply([{ raw: 'a' } as never]);
+    expect(h.api.sources.createReferenceStubs).not.toHaveBeenCalled();
+  });
+
+  it('creates stubs for the parent and reports the outcome', async () => {
+    flow.setMineReview({ parentId: 'par', parentTitle: 'Par', refs: [] });
+    h.api.sources.createReferenceStubs.mockResolvedValue({
+      created: [{}, {}], matchedExisting: [{}], skipped: [{}],
+    });
+    const accepted = [{ raw: 'r1' }] as never;
+    await ops.handleMineReferencesApply(accepted);
+    expect(h.api.sources.createReferenceStubs).toHaveBeenCalledWith('par', accepted);
+    expect(ctx.refreshSourcesCache).toHaveBeenCalled();
+    expect(flow.mineReview).toBeNull();
+    const msg = h.dialog.showConfirm.mock.calls[0][0] as string;
+    expect(msg).toContain('Created 2 new stubs.');
+    expect(msg).toContain('1 matched existing sources.');
+    expect(msg).toContain('1 skipped (id collision).');
+  });
+
+  it('uses singular wording for a single created stub', async () => {
+    flow.setMineReview({ parentId: 'par', parentTitle: 'Par', refs: [] });
+    h.api.sources.createReferenceStubs.mockResolvedValue({
+      created: [{}], matchedExisting: [], skipped: [],
+    });
+    await ops.handleMineReferencesApply([]);
+    expect(h.dialog.showConfirm.mock.calls[0][0]).toContain('Created 1 new stub.');
+  });
+
+  it('shows no confirm when nothing changed', async () => {
+    flow.setMineReview({ parentId: 'par', parentTitle: 'Par', refs: [] });
+    h.api.sources.createReferenceStubs.mockResolvedValue({
+      created: [], matchedExisting: [], skipped: [],
+    });
+    await ops.handleMineReferencesApply([]);
+    expect(h.dialog.showConfirm).not.toHaveBeenCalled();
+  });
+
+  it('reports a stub-creation failure via confirm', async () => {
+    flow.setMineReview({ parentId: 'par', parentTitle: 'Par', refs: [] });
+    h.api.sources.createReferenceStubs.mockRejectedValue(new Error('stub boom'));
+    await ops.handleMineReferencesApply([]);
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('stub boom'), expect.any(String), 'OK',
+    );
+  });
+});
+
+describe('handleResolveStub (extra branches)', () => {
+  it('does nothing when there is no open notebase', async () => {
+    h.notebase.meta = null;
+    await ops.handleResolveStub('s');
+    expect(h.api.sources.resolveStub).not.toHaveBeenCalled();
+  });
+
+  it('reports a CrossRef search failure via confirm', async () => {
+    h.api.sources.resolveStub.mockRejectedValue(new Error('crossref boom'));
+    await ops.handleResolveStub('s');
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('crossref boom'), expect.any(String), 'OK',
+    );
+  });
+
+  it('confirms when CrossRef returns no candidates', async () => {
+    h.api.sources.resolveStub.mockResolvedValue([]);
+    await ops.handleResolveStub('s');
+    expect(h.dialog.showConfirm.mock.calls[0][0]).toContain('CrossRef returned no matches');
+    expect(flow.resolveStub).toBeNull();
+  });
+
+  it('auto-apply reports success and refreshes the cache', async () => {
+    h.api.sources.resolveStub.mockResolvedValue([
+      { doi: '10.1/hi', title: 'Match', confidence: 0.9 },
+    ]);
+    await ops.handleResolveStub('sX');
+    expect(h.api.sources.applyStubResolution).toHaveBeenCalledWith('sX', '10.1/hi');
+    expect(ctx.refreshSourcesCache).toHaveBeenCalled();
+    expect(h.dialog.showConfirm.mock.calls[0][0]).toContain('Resolved to "Match"');
+  });
+
+  it('reports a failure when auto-apply of the resolution throws', async () => {
+    h.api.sources.resolveStub.mockResolvedValue([
+      { doi: '10.1/hi', title: 'Match', confidence: 0.9 },
+    ]);
+    h.api.sources.applyStubResolution.mockRejectedValue(new Error('apply boom'));
+    await ops.handleResolveStub('sY');
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('apply boom'), expect.any(String), 'OK',
+    );
+  });
+
+  it('uses the sourceId as picker title when no detail is available', async () => {
+    h.api.sources.resolveStub.mockResolvedValue([
+      { doi: '10.1/lo', title: 'Maybe', confidence: 0.4 },
+    ]);
+    h.api.graph.sourceDetail.mockResolvedValue(null);
+    await ops.handleResolveStub('sZ');
+    expect(flow.resolveStub?.stubTitle).toBe('sZ');
+  });
+});
+
+describe('handleResolveStubApply', () => {
+  it('does nothing when there is no active resolve state', async () => {
+    flow.setResolveStub(null);
+    await ops.handleResolveStubApply('10.1/x');
+    expect(h.api.sources.applyStubResolution).not.toHaveBeenCalled();
+  });
+
+  it('applies the picked candidate and clears the state', async () => {
+    h.api.sources.applyStubResolution.mockResolvedValue(undefined);
+    flow.setResolveStub({
+      sourceId: 'src', stubTitle: 'Stub',
+      candidates: [{ doi: '10.1/a', title: 'Picked' } as never],
+    });
+    await ops.handleResolveStubApply('10.1/a');
+    expect(h.api.sources.applyStubResolution).toHaveBeenCalledWith('src', '10.1/a');
+    expect(flow.resolveStub).toBeNull();
+    expect(h.dialog.showConfirm.mock.calls[0][0]).toContain('Picked');
+  });
+
+  it('falls back to the stub title when the doi is not among candidates', async () => {
+    h.api.sources.applyStubResolution.mockResolvedValue(undefined);
+    flow.setResolveStub({ sourceId: 'src', stubTitle: 'StubTitle', candidates: [] });
+    await ops.handleResolveStubApply('10.1/missing');
+    expect(h.api.sources.applyStubResolution).toHaveBeenCalledWith('src', '10.1/missing');
+    expect(h.dialog.showConfirm.mock.calls[0][0]).toContain('StubTitle');
+  });
+});
+
+describe('handleDoiClick', () => {
+  it('does nothing when there is no open notebase', async () => {
+    h.notebase.meta = null;
+    await ops.handleDoiClick('10.1/x');
+    expect(ctx.findSourceByDoi).not.toHaveBeenCalled();
+  });
+
+  it('opens an already-ingested source (case-folding the DOI) without prompting', async () => {
+    ctx.findSourceByDoi = vi.fn(() => ({ sourceId: 'have-it' }));
+    await ops.handleDoiClick('10.1/ABC');
+    expect(ctx.findSourceByDoi).toHaveBeenCalledWith('10.1/abc');
+    expect(ctx.openSource).toHaveBeenCalledWith('have-it');
+    expect(h.dialog.showConfirm).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the ingest confirmation is declined', async () => {
+    ctx.findSourceByDoi = vi.fn(() => undefined);
+    h.dialog.showConfirm.mockResolvedValue(false);
+    await ops.handleDoiClick('10.1/new');
+    expect(h.api.sources.ingestIdentifier).not.toHaveBeenCalled();
+  });
+
+  it('ingests and opens the source when confirmed', async () => {
+    vi.useFakeTimers();
+    ctx.findSourceByDoi = vi.fn(() => undefined);
+    h.dialog.showConfirm.mockResolvedValue(true);
+    h.api.sources.ingestIdentifier.mockResolvedValue({ sourceId: 'doi-src' });
+    await ops.handleDoiClick('10.1/new');
+    expect(h.api.sources.ingestIdentifier).toHaveBeenCalledWith('10.1/new');
+    vi.advanceTimersByTime(200);
+    expect(ctx.openSource).toHaveBeenCalledWith('doi-src');
+  });
+
+  it('reports an ingest failure via confirm', async () => {
+    ctx.findSourceByDoi = vi.fn(() => undefined);
+    h.dialog.showConfirm.mockResolvedValueOnce(true).mockResolvedValue(undefined);
+    h.api.sources.ingestIdentifier.mockRejectedValue(new Error('doi boom'));
+    await ops.handleDoiClick('10.1/new');
+    expect(h.dialog.showConfirm).toHaveBeenLastCalledWith(
+      expect.stringContaining('doi boom'), expect.any(String), 'OK',
+    );
+  });
+});
+
+describe('handleExternalDrop', () => {
+  it('does nothing when there is no open notebase', async () => {
+    h.notebase.meta = null;
+    await ops.handleExternalDrop('/dest', [] as unknown as FileList);
+    expect(h.api.files.dropImport).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no local paths resolve', async () => {
+    h.api.files.getPathForFile.mockReturnValue(undefined);
+    await ops.handleExternalDrop('/dest', ['a'] as unknown as FileList);
+    expect(h.api.files.dropImport).not.toHaveBeenCalled();
+  });
+
+  it('imports resolved paths and opens the first non-duplicate PDF', async () => {
+    vi.useFakeTimers();
+    h.api.files.getPathForFile.mockImplementation((f: string) => `/abs/${f}`);
+    h.api.files.dropImport.mockResolvedValue({
+      ingestedPdfs: [{ sourceId: 'dup', duplicate: true }, { sourceId: 'fresh', duplicate: false }],
+      rejected: [],
+    });
+    await ops.handleExternalDrop('/dest', ['x.pdf', 'y.pdf'] as unknown as FileList);
+    expect(h.api.files.dropImport).toHaveBeenCalledWith('/dest', ['/abs/x.pdf', '/abs/y.pdf']);
+    vi.advanceTimersByTime(200);
+    expect(ctx.openSource).toHaveBeenCalledWith('fresh');
+  });
+
+  it('falls back to the first PDF when all are duplicates', async () => {
+    vi.useFakeTimers();
+    h.api.files.getPathForFile.mockReturnValue('/abs/z.pdf');
+    h.api.files.dropImport.mockResolvedValue({
+      ingestedPdfs: [{ sourceId: 'only-dup', duplicate: true }],
+      rejected: [],
+    });
+    await ops.handleExternalDrop('/dest', ['z.pdf'] as unknown as FileList);
+    vi.advanceTimersByTime(200);
+    expect(ctx.openSource).toHaveBeenCalledWith('only-dup');
+  });
+
+  it('reports rejected files via confirm', async () => {
+    h.api.files.getPathForFile.mockReturnValue('/abs/bad.txt');
+    h.api.files.dropImport.mockResolvedValue({
+      ingestedPdfs: [],
+      rejected: [{ localPath: '/some/bad.txt', reason: 'unsupported' }],
+    });
+    await ops.handleExternalDrop('/dest', ['bad.txt'] as unknown as FileList);
+    const msg = h.dialog.showConfirm.mock.calls[0][0] as string;
+    expect(msg).toContain('bad.txt');
+    expect(msg).toContain('unsupported');
+  });
+
+  it('reports an import failure via confirm', async () => {
+    h.api.files.getPathForFile.mockReturnValue('/abs/x.pdf');
+    h.api.files.dropImport.mockRejectedValue(new Error('drop boom'));
+    await ops.handleExternalDrop('/dest', ['x.pdf'] as unknown as FileList);
+    expect(h.dialog.showConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('drop boom'), expect.any(String), 'OK',
+    );
+  });
 });

--- a/tests/renderer/stores/conversations-store.test.ts
+++ b/tests/renderer/stores/conversations-store.test.ts
@@ -1,0 +1,642 @@
+/**
+ * Complementary coverage for the conversations singleton store
+ * (`src/renderer/lib/stores/conversations.svelte.ts`). The four sibling
+ * `conversation-*.test.ts` files already cover `/clear`, `/compact`, the
+ * uniform draft-subscription plumbing, and the propose_note_body flow; this
+ * file fills in the rest of the public surface WITHOUT duplicating them:
+ *
+ *   - lifecycle: init / reset / openConversationTab / closeTab
+ *   - the send() turn (happy path, missing-key path, no-op guards)
+ *   - cancel / setModel / setEffort / setComposer / UI state (show/hide/
+ *     toggle/setHeight/setActiveTab)
+ *   - ask_user round-trip (onAskUser subscription → answerQuestion)
+ *   - EVERY remaining draft-filing path (the Trust Principle spine): each
+ *     `propose_*` draft arrives over its subscription, then Approve routes
+ *     through the matching `api.conversations.file*` (the approval engine)
+ *     and mutates the store's draft/result state, while Discard writes
+ *     nothing. Covers fileDraft, fileSourceDraft, filePropertyDraft,
+ *     fileClaimsDraft, fileSourcePropertyDraft, fileRefactorDraft,
+ *     fileReorgDraft, fileDeleteDraft, and the compute Run/Insert paths.
+ *
+ * Drives the real runes store with a mocked api client that captures every
+ * subscription callback (so drafts can be injected) and records every
+ * mutation call.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Conversation } from '../../../src/shared/types';
+import type { AskUserRequest } from '../../../src/shared/conversation-tools';
+
+type Cb = (payload: { draftId: string; conversationId: string }) => void;
+
+const h = vi.hoisted(() => {
+  const cbs: Record<string, (arg: unknown) => void> = {};
+  const cap = (name: string) => vi.fn((cb: (arg: unknown) => void) => { cbs[name] = cb; });
+  let nextId = 1;
+  const makeConv = (
+    contextBundle: unknown,
+    triggerNodeUri?: string,
+    options?: { systemPrompt?: string; model?: string },
+  ): Conversation => ({
+    id: `conv-${nextId++}`,
+    contextBundle: contextBundle as Conversation['contextBundle'],
+    triggerNodeUri,
+    messages: [],
+    status: 'active',
+    startedAt: 't',
+    ...(options?.systemPrompt ? { systemPrompt: options.systemPrompt } : {}),
+    ...(options?.model ? { model: options.model } : {}),
+  });
+  const api = {
+    conversations: {
+      // subscriptions — captured so tests can inject drafts / questions.
+      onStream: cap('onStream'),
+      onDraft: cap('onDraft'),
+      onSourceDraft: cap('onSourceDraft'),
+      onPropertyDraft: cap('onPropertyDraft'),
+      onSourcePropertyDraft: cap('onSourcePropertyDraft'),
+      onClaimsDraft: cap('onClaimsDraft'),
+      onComputeDraft: cap('onComputeDraft'),
+      onRefactorDraft: cap('onRefactorDraft'),
+      onReorgDraft: cap('onReorgDraft'),
+      onDeleteDraft: cap('onDeleteDraft'),
+      onNoteBodyDraft: cap('onNoteBodyDraft'),
+      onAskUser: cap('onAskUser'),
+      // lifecycle / persistence
+      loadUIState: vi.fn().mockResolvedValue({ visible: false, height: 320, activeTabId: null }),
+      saveUIState: vi.fn().mockResolvedValue(undefined),
+      listActive: vi.fn().mockResolvedValue([] as Conversation[]),
+      create: vi.fn(async (bundle: unknown, trigger?: string, options?: { systemPrompt?: string; model?: string }) =>
+        makeConv(bundle, trigger, options)),
+      load: vi.fn(async (_id: string) => null as Conversation | null),
+      archive: vi.fn().mockResolvedValue(undefined),
+      // turn
+      send: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn().mockResolvedValue(undefined),
+      setModel: vi.fn(),
+      setEffort: vi.fn(),
+      askUserReply: vi.fn().mockResolvedValue(undefined),
+      // draft-filing (the approval-engine hand-off)
+      fileDraft: vi.fn().mockResolvedValue({ proposalUri: 'urn:p', applied: true, filedPaths: ['notes/a.md'] }),
+      fileSourceDraft: vi.fn().mockResolvedValue({ outcomes: [{ input: { url: 'https://x' }, sourceId: 's1', title: 'X' }] }),
+      filePropertyDraft: vi.fn().mockResolvedValue({ outcomes: [{ relativePath: 'notes/a.md', changedKeys: ['status'], deletedKeys: [] }] }),
+      fileSourcePropertyDraft: vi.fn().mockResolvedValue({ outcome: { sourceId: 's1', changedPredicates: ['thought:tldr'] } }),
+      fileClaimsDraft: vi.fn().mockResolvedValue({ outcome: { sourceId: 's1', claimPaths: ['notes/claim.md'], excerptIds: ['e1'] } }),
+      fileRefactorDraft: vi.fn().mockResolvedValue(undefined),
+      fileReorgDraft: vi.fn().mockResolvedValue(undefined),
+      fileDeleteDraft: vi.fn().mockResolvedValue(undefined),
+      fileNoteBodyDraft: vi.fn().mockResolvedValue({ proposalUri: 'urn:p', applied: true }),
+      // compute
+      runComputeDraft: vi.fn().mockResolvedValue({ result: { ok: true, format: 'text', value: '42' } }),
+      insertComputeDraft: vi.fn().mockResolvedValue({ destinationPath: 'notes/inbox/out.md' }),
+    },
+  };
+  // Neutralize the eyes-on-code consent gate so runComputeDraft's IPC path is
+  // what we exercise, not the dialog. Tests flip it to false to cover decline.
+  const ensureComputeConsent = vi.fn().mockResolvedValue(true);
+  return { api, cbs, ensureComputeConsent };
+});
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/compute/run-cell-with-trust', () => ({ ensureComputeConsent: h.ensureComputeConsent }));
+
+const ensureComputeConsent = h.ensureComputeConsent;
+
+import { getConversationsStore } from '../../../src/renderer/lib/stores/conversations.svelte';
+
+const store = getConversationsStore();
+const conv = () => h.api.conversations;
+
+/** Open a fresh freeform tab and return it (already the active tab). */
+async function freshTab() {
+  await store.openFreeform('notes/origin.md');
+  return store.activeTab!;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ensureComputeConsent.mockResolvedValue(true);
+});
+
+// ────────────────────────────── lifecycle ──────────────────────────────
+
+describe('init / reset', () => {
+  it('init restores tabs from listActive and honors persisted height + active tab (but launches hidden)', async () => {
+    const active: Conversation[] = [
+      { id: 'lc-1', contextBundle: {}, messages: [], status: 'active', startedAt: 't' },
+      { id: 'lc-2', contextBundle: {}, messages: [], status: 'active', startedAt: 't' },
+    ];
+    conv().loadUIState.mockResolvedValueOnce({ visible: true, height: 500, activeTabId: 'lc-2' });
+    conv().listActive.mockResolvedValueOnce(active);
+
+    await store.init();
+
+    expect(conv().loadUIState).toHaveBeenCalledTimes(1);
+    expect(conv().listActive).toHaveBeenCalledTimes(1);
+    expect(store.initialized).toBe(true);
+    expect(store.tabs.map((t) => t.id)).toEqual(expect.arrayContaining(['lc-1', 'lc-2']));
+    expect(store.height).toBe(500);
+    expect(store.activeTabId).toBe('lc-2');
+    // Persisted `visible:true` is deliberately ignored — panel launches hidden.
+    expect(store.visible).toBe(false);
+  });
+
+  it('init is idempotent — a second call does not re-query', async () => {
+    await store.init();
+    expect(conv().listActive).not.toHaveBeenCalled(); // already initialized from the prior test
+  });
+
+  it('reset re-initializes from the new project and falls back to the first tab', async () => {
+    conv().loadUIState.mockResolvedValueOnce({ visible: false, height: 333, activeTabId: null });
+    conv().listActive.mockResolvedValueOnce([
+      { id: 'r-1', contextBundle: {}, messages: [], status: 'active', startedAt: 't' },
+    ]);
+
+    await store.reset();
+
+    expect(store.tabs.map((t) => t.id)).toEqual(['r-1']);
+    expect(store.height).toBe(333);
+    expect(store.activeTabId).toBe('r-1');
+  });
+
+  it('init falls back to safe defaults when loadUIState rejects', async () => {
+    conv().loadUIState.mockRejectedValueOnce(new Error('disk gone'));
+    await store.reset(); // reset flips initialized off then calls init()
+    expect(store.tabs).toEqual([]);
+    expect(store.activeTabId).toBeNull();
+    expect(store.height).toBe(320);
+  });
+});
+
+// ─────────────────────────── tab lifecycle ───────────────────────────
+
+describe('openConversationTab / closeTab', () => {
+  it('creates a tab with system prompt + model + extraTools and auto-sends the initial message', async () => {
+    conv().load.mockResolvedValueOnce({
+      id: 'ignored', contextBundle: { notePath: 'notes/seed.md' },
+      messages: [{ role: 'user', content: 'seed', timestamp: 't' }, { role: 'assistant', content: 'ok', timestamp: 't' }],
+      status: 'active', startedAt: 't',
+    });
+    const tab = await store.openConversationTab({
+      notePath: 'notes/seed.md',
+      systemPrompt: 'SYS',
+      model: 'claude-x',
+      initialMessage: 'discuss this',
+      extraTools: ['ask_user'],
+    });
+
+    expect(conv().create).toHaveBeenCalledWith(
+      { notePath: 'notes/seed.md' },
+      undefined,
+      { systemPrompt: 'SYS', model: 'claude-x' },
+    );
+    expect(tab.extraTools).toEqual(['ask_user']);
+    expect(store.tabs.some((t) => t.id === tab.id)).toBe(true);
+    expect(store.activeTabId).toBe(tab.id);
+    expect(store.visible).toBe(true);
+
+    // initialMessage fired a send() carrying the template tools.
+    await vi.waitFor(() => expect(conv().send).toHaveBeenCalled());
+    const [id, text, , notePath, tools] = conv().send.mock.calls[0];
+    expect(id).toBe(tab.id);
+    expect(text).toBe('discuss this');
+    expect(notePath).toBe('notes/seed.md');
+    expect(tools).toEqual(['ask_user']);
+  });
+
+  it('closeTab archives the conversation and drops it from the tab list', async () => {
+    const a = await freshTab();
+    const b = await freshTab();
+    expect(store.activeTabId).toBe(b.id);
+
+    await store.closeTab(b.id);
+
+    expect(conv().archive).toHaveBeenCalledWith(b.id);
+    expect(store.tabs.some((t) => t.id === b.id)).toBe(false);
+    // Active tab moved to a surviving neighbor.
+    expect(store.activeTabId).toBe(a.id);
+  });
+
+  it('closeTab still drops the tab locally when archive fails', async () => {
+    const t = await freshTab();
+    conv().archive.mockRejectedValueOnce(new Error('already archived'));
+    await store.closeTab(t.id);
+    expect(store.tabs.some((x) => x.id === t.id)).toBe(false);
+  });
+});
+
+// ───────────────────────────── send() turn ─────────────────────────────
+
+describe('send()', () => {
+  it('echoes the user turn, routes through api.conversations.send, then reloads the canonical transcript', async () => {
+    const tab = await freshTab();
+    const reloaded: Conversation = {
+      id: tab.id, contextBundle: { notePath: 'notes/origin.md' },
+      messages: [
+        { role: 'user', content: 'hello', timestamp: 't' },
+        { role: 'assistant', content: 'hi there', timestamp: 't' },
+      ],
+      status: 'active', startedAt: 't',
+    };
+    conv().load.mockResolvedValueOnce(reloaded);
+
+    await store.send('hello', 'notes/origin.md');
+
+    expect(conv().send).toHaveBeenCalledWith(tab.id, 'hello', undefined, 'notes/origin.md', undefined);
+    expect(conv().load).toHaveBeenCalledWith(tab.id);
+    // Transcript replaced with the canonical reloaded version; streaming cleared.
+    expect(tab.conversation.messages.map((m) => m.content)).toEqual(['hello', 'hi there']);
+    expect(tab.streaming).toBe(false);
+    expect(tab.composer).toBe('');
+  });
+
+  it('surfaces a missing-API-key error: restores the composer, drops the optimistic turn, flips needsApiKey', async () => {
+    const tab = await freshTab();
+    conv().send.mockRejectedValueOnce(new Error('Anthropic API key not configured'));
+
+    await store.send('needs a key');
+
+    expect(store.needsApiKey).toBe(true);
+    expect(tab.composer).toBe('needs a key');       // restored for retry
+    expect(tab.conversation.messages).toHaveLength(0); // optimistic insert removed
+    expect(tab.streaming).toBe(false);
+
+    store.dismissApiKeyDialog();
+    expect(store.needsApiKey).toBe(false);
+  });
+
+  it('no-ops on empty content and while already streaming', async () => {
+    const tab = await freshTab();
+    await store.send('   ');
+    expect(conv().send).not.toHaveBeenCalled();
+
+    tab.streaming = true;
+    await store.send('while busy');
+    expect(conv().send).not.toHaveBeenCalled();
+    tab.streaming = false;
+  });
+});
+
+// ───────────────────── cancel / model / effort / composer ─────────────────────
+
+describe('cancel / setModel / setEffort / setComposer', () => {
+  it('cancel routes through api and clears the streaming flags', async () => {
+    const tab = await freshTab();
+    tab.streaming = true;
+    tab.streamedChunks = 'partial';
+    await store.cancel();
+    expect(conv().cancel).toHaveBeenCalledTimes(1);
+    expect(tab.streaming).toBe(false);
+    expect(tab.streamedChunks).toBe('');
+  });
+
+  it('setModel routes through api and swaps in the updated conversation', async () => {
+    const tab = await freshTab();
+    const updated: Conversation = { ...tab.conversation, model: 'claude-opus-4-8' };
+    conv().setModel.mockResolvedValueOnce(updated);
+    await store.setModel(tab.id, 'claude-opus-4-8');
+    expect(conv().setModel).toHaveBeenCalledWith(tab.id, 'claude-opus-4-8');
+    expect(tab.conversation.model).toBe('claude-opus-4-8');
+  });
+
+  it('setEffort routes through api and swaps in the updated conversation', async () => {
+    const tab = await freshTab();
+    const updated: Conversation = { ...tab.conversation, effort: 'high' };
+    conv().setEffort.mockResolvedValueOnce(updated);
+    await store.setEffort(tab.id, 'high');
+    expect(conv().setEffort).toHaveBeenCalledWith(tab.id, 'high');
+    expect(tab.conversation.effort).toBe('high');
+  });
+
+  it('setModel is a no-op for an unknown tab id', async () => {
+    await store.setModel('no-such-tab', 'claude-x');
+    expect(conv().setModel).not.toHaveBeenCalled();
+  });
+
+  it('setComposer writes onto the active tab', async () => {
+    const tab = await freshTab();
+    store.setComposer('half-written thought');
+    expect(tab.composer).toBe('half-written thought');
+  });
+});
+
+// ─────────────────────── ask_user round-trip ───────────────────────
+
+describe('ask_user (onAskUser → answerQuestion)', () => {
+  it('surfaces a pending question and answerQuestion replies through api + clears it', async () => {
+    const tab = await freshTab();
+    const req: AskUserRequest = { questionId: 'q1', conversationId: tab.id, question: 'Proceed?' };
+    (h.cbs.onAskUser as (r: AskUserRequest) => void)(req);
+    expect(tab.pendingQuestion).toEqual(req);
+
+    await store.answerQuestion(tab.id, 'yes');
+    expect(conv().askUserReply).toHaveBeenCalledWith('q1', 'yes');
+    expect(tab.pendingQuestion).toBeNull();
+  });
+
+  it('answers empty when the question targets a tab that no longer exists', async () => {
+    await freshTab();
+    const req: AskUserRequest = { questionId: 'q-ghost', conversationId: 'no-such-tab', question: '?' };
+    (h.cbs.onAskUser as (r: AskUserRequest) => void)(req);
+    expect(conv().askUserReply).toHaveBeenCalledWith('q-ghost', '');
+  });
+});
+
+// ─────────────────── UI state (show/hide/toggle/height/active) ───────────────────
+
+describe('UI state', () => {
+  it('show / hide / toggle move visibility and persist', async () => {
+    store.hide();
+    expect(store.visible).toBe(false);
+    store.show();
+    expect(store.visible).toBe(true);
+    store.toggle();
+    expect(store.visible).toBe(false);
+    await vi.waitFor(() => expect(conv().saveUIState).toHaveBeenCalled());
+  });
+
+  it('setHeight clamps to the sane range', () => {
+    store.setHeight(50);   // below MIN_PANEL_HEIGHT (120)
+    expect(store.height).toBe(120);
+    store.setHeight(9999); // above MAX_PANEL_HEIGHT (1200)
+    expect(store.height).toBe(1200);
+    store.setHeight(400);
+    expect(store.height).toBe(400);
+  });
+
+  it('setActiveTab switches the active tab', async () => {
+    const a = await freshTab();
+    const b = await freshTab();
+    store.setActiveTab(a.id);
+    expect(store.activeTabId).toBe(a.id);
+    store.setActiveTab(b.id);
+    expect(store.activeTabId).toBe(b.id);
+  });
+});
+
+// ══════════════════ Trust Principle: draft filing (LLM proposes → human files) ══════════════════
+
+describe('propose_notes draft (fileDraft)', () => {
+  it('Approve files through the approval engine and replaces the card with a Filed: summary', async () => {
+    const tab = await freshTab();
+    (h.cbs.onDraft as Cb)({ draftId: 'd1', conversationId: tab.id });
+    expect(tab.drafts.map((d) => d.draftId)).toEqual(['d1']);
+
+    const result = await store.approveDraft(tab.id, tab.drafts[0]!);
+
+    expect(conv().fileDraft).toHaveBeenCalledTimes(1);
+    expect(result.filedPaths).toEqual(['notes/a.md']);
+    expect(tab.drafts).toHaveLength(0);
+    expect(tab.noteDraftResults['d1']!.filedPaths).toEqual(['notes/a.md']);
+  });
+
+  it('Discard removes the card without writing anything', async () => {
+    const tab = await freshTab();
+    (h.cbs.onDraft as Cb)({ draftId: 'd2', conversationId: tab.id });
+    store.discardDraft(tab.id, 'd2');
+    expect(tab.drafts).toHaveLength(0);
+    expect(conv().fileDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe('propose_sources draft (fileSourceDraft)', () => {
+  it('Approve ingests through the approval engine, drops the card, stashes outcomes; dismiss clears them', async () => {
+    const tab = await freshTab();
+    (h.cbs.onSourceDraft as Cb)({ draftId: 's-d1', conversationId: tab.id });
+
+    await store.approveSourceDraft(tab.id, tab.sourceDrafts[0]!);
+
+    expect(conv().fileSourceDraft).toHaveBeenCalledTimes(1);
+    expect(tab.sourceDrafts).toHaveLength(0);
+    expect(tab.sourceDraftResults['s-d1']!.outcomes[0]!.sourceId).toBe('s1');
+
+    store.dismissSourceDraftResult(tab.id, 's-d1');
+    expect(tab.sourceDraftResults['s-d1']).toBeUndefined();
+  });
+
+  it('Discard removes the card without ingesting', async () => {
+    const tab = await freshTab();
+    (h.cbs.onSourceDraft as Cb)({ draftId: 's-d2', conversationId: tab.id });
+    store.discardSourceDraft(tab.id, 's-d2');
+    expect(tab.sourceDrafts).toHaveLength(0);
+    expect(conv().fileSourceDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe('set_properties draft (filePropertyDraft)', () => {
+  it('Approve files a plain (proxy-shed) payload and records the per-note outcome', async () => {
+    const tab = await freshTab();
+    (h.cbs.onPropertyDraft as Cb)({ draftId: 'p-d1', conversationId: tab.id });
+    // give the draft realistic nested payload so the JSON round-trip is exercised.
+    (tab.propertyDrafts[0] as unknown as { updates: unknown[] }).updates = [
+      { relativePath: 'notes/a.md', properties: { status: 'done' } },
+    ];
+
+    await store.approvePropertyDraft(tab.id, tab.propertyDrafts[0]!);
+
+    expect(conv().filePropertyDraft).toHaveBeenCalledTimes(1);
+    const [sent] = conv().filePropertyDraft.mock.calls[0];
+    expect(sent.updates[0].properties.status).toBe('done'); // keys survived serialization
+    expect(tab.propertyDrafts).toHaveLength(0);
+    expect(tab.propertyDraftResults['p-d1']!.outcomes[0]!.changedKeys).toEqual(['status']);
+  });
+
+  it('Discard removes the card without writing', async () => {
+    const tab = await freshTab();
+    (h.cbs.onPropertyDraft as Cb)({ draftId: 'p-d2', conversationId: tab.id });
+    store.discardPropertyDraft(tab.id, 'p-d2');
+    expect(tab.propertyDrafts).toHaveLength(0);
+    expect(conv().filePropertyDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe('propose_source_properties draft (fileSourcePropertyDraft)', () => {
+  it('Approve upserts meta.ttl through the approval engine and records the outcome', async () => {
+    const tab = await freshTab();
+    (h.cbs.onSourcePropertyDraft as Cb)({ draftId: 'sp-d1', conversationId: tab.id });
+
+    await store.approveSourcePropertyDraft(tab.id, tab.sourcePropertyDrafts[0]!);
+
+    expect(conv().fileSourcePropertyDraft).toHaveBeenCalledTimes(1);
+    expect(tab.sourcePropertyDrafts).toHaveLength(0);
+    expect(tab.sourcePropertyDraftResults['sp-d1']!.outcome.changedPredicates).toEqual(['thought:tldr']);
+  });
+
+  it('Discard removes the card without writing', async () => {
+    const tab = await freshTab();
+    (h.cbs.onSourcePropertyDraft as Cb)({ draftId: 'sp-d2', conversationId: tab.id });
+    store.discardSourcePropertyDraft(tab.id, 'sp-d2');
+    expect(tab.sourcePropertyDrafts).toHaveLength(0);
+    expect(conv().fileSourcePropertyDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe('propose_claims draft (fileClaimsDraft)', () => {
+  it('Approve files claims + excerpts through the approval engine and records the outcome', async () => {
+    const tab = await freshTab();
+    (h.cbs.onClaimsDraft as Cb)({ draftId: 'c-d1', conversationId: tab.id });
+
+    await store.approveClaimsDraft(tab.id, tab.claimsDrafts[0]!);
+
+    expect(conv().fileClaimsDraft).toHaveBeenCalledTimes(1);
+    expect(tab.claimsDrafts).toHaveLength(0);
+    expect(tab.claimsDraftResults['c-d1']!.outcome.claimPaths).toEqual(['notes/claim.md']);
+  });
+
+  it('Discard removes the card without writing', async () => {
+    const tab = await freshTab();
+    (h.cbs.onClaimsDraft as Cb)({ draftId: 'c-d2', conversationId: tab.id });
+    store.discardClaimsDraft(tab.id, 'c-d2');
+    expect(tab.claimsDrafts).toHaveLength(0);
+    expect(conv().fileClaimsDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe('propose_note_rename/move draft (fileRefactorDraft)', () => {
+  it('Approve files the move through the approval engine and drops the card', async () => {
+    const tab = await freshTab();
+    (h.cbs.onRefactorDraft as Cb)({ draftId: 'rf-d1', conversationId: tab.id });
+    await store.approveRefactorDraft(tab.id, tab.refactorDrafts[0]!);
+    expect(conv().fileRefactorDraft).toHaveBeenCalledTimes(1);
+    expect(tab.refactorDrafts).toHaveLength(0);
+  });
+
+  it('Discard removes the card without moving', async () => {
+    const tab = await freshTab();
+    (h.cbs.onRefactorDraft as Cb)({ draftId: 'rf-d2', conversationId: tab.id });
+    store.discardRefactorDraft(tab.id, 'rf-d2');
+    expect(tab.refactorDrafts).toHaveLength(0);
+    expect(conv().fileRefactorDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe('propose_reorganization draft (fileReorgDraft)', () => {
+  it('Approve files the SELECTED moves through the approval engine and drops the card', async () => {
+    const tab = await freshTab();
+    (h.cbs.onReorgDraft as Cb)({ draftId: 'ro-d1', conversationId: tab.id });
+    const selected = [{ fromPath: 'a.md', toPath: 'b.md' }];
+    await store.approveReorgDraft(tab.id, tab.reorgDrafts[0]!, selected);
+    expect(conv().fileReorgDraft).toHaveBeenCalledTimes(1);
+    const [, sent] = conv().fileReorgDraft.mock.calls[0];
+    expect(sent).toEqual(selected);
+    expect(tab.reorgDrafts).toHaveLength(0);
+  });
+
+  it('Discard removes the card without moving', async () => {
+    const tab = await freshTab();
+    (h.cbs.onReorgDraft as Cb)({ draftId: 'ro-d2', conversationId: tab.id });
+    store.discardReorgDraft(tab.id, 'ro-d2');
+    expect(tab.reorgDrafts).toHaveLength(0);
+    expect(conv().fileReorgDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe('propose_note_delete draft (fileDeleteDraft)', () => {
+  it('Approve files the SELECTED deletions through the approval engine and drops the card', async () => {
+    const tab = await freshTab();
+    (h.cbs.onDeleteDraft as Cb)({ draftId: 'del-d1', conversationId: tab.id });
+    const selected = ['notes/gone.md'];
+    await store.approveDeleteDraft(tab.id, tab.deleteDrafts[0]!, selected);
+    expect(conv().fileDeleteDraft).toHaveBeenCalledTimes(1);
+    const [, sent] = conv().fileDeleteDraft.mock.calls[0];
+    expect(sent).toEqual(selected);
+    expect(tab.deleteDrafts).toHaveLength(0);
+  });
+
+  it('Discard removes the card without deleting', async () => {
+    const tab = await freshTab();
+    (h.cbs.onDeleteDraft as Cb)({ draftId: 'del-d2', conversationId: tab.id });
+    store.discardDeleteDraft(tab.id, 'del-d2');
+    expect(tab.deleteDrafts).toHaveLength(0);
+    expect(conv().fileDeleteDraft).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────── compute drafts (Run / Insert / Discard) ───────────────────────
+
+/** Seed a compute draft on the tab via its subscription (also seeds state). */
+function seedComputeDraft(tab: { id: string }, draftId: string) {
+  (h.cbs.onComputeDraft as Cb)({ draftId, conversationId: tab.id });
+}
+const computeDraft = (tab: { id: string }, draftId: string) => ({
+  draftId, conversationId: tab.id, createdAt: 't',
+  language: 'sql' as const, code: 'SELECT 1', rationale: 'why', safetyFlags: [],
+});
+
+describe('propose_compute draft (runComputeDraft / insertComputeDraft)', () => {
+  it('Run gates on consent, executes through api, stores the result, and reloads the transcript', async () => {
+    const tab = await freshTab();
+    seedComputeDraft(tab, 'cp-1');
+    conv().load.mockResolvedValueOnce({ ...tab.conversation, messages: [{ role: 'user', content: 'ctx', timestamp: 't' }] });
+
+    await store.runComputeDraft(tab.id, computeDraft(tab, 'cp-1'));
+
+    expect(ensureComputeConsent).toHaveBeenCalledTimes(1);
+    expect(conv().runComputeDraft).toHaveBeenCalledTimes(1);
+    const state = (tab as unknown as { computeDraftState: Record<string, { result: unknown; running: boolean }> })
+      .computeDraftState['cp-1'];
+    expect(state.running).toBe(false);
+    expect(state.result).toEqual({ ok: true, format: 'text', value: '42' });
+    expect(conv().load).toHaveBeenCalledWith(tab.id);
+  });
+
+  it('Run does nothing when the user declines the eyes-on-code consent', async () => {
+    const tab = await freshTab();
+    seedComputeDraft(tab, 'cp-2');
+    ensureComputeConsent.mockResolvedValueOnce(false);
+    await store.runComputeDraft(tab.id, computeDraft(tab, 'cp-2'));
+    expect(conv().runComputeDraft).not.toHaveBeenCalled();
+  });
+
+  it('Run records a failure result when the executor throws', async () => {
+    const tab = await freshTab();
+    seedComputeDraft(tab, 'cp-3');
+    conv().runComputeDraft.mockRejectedValueOnce(new Error('boom'));
+    await store.runComputeDraft(tab.id, computeDraft(tab, 'cp-3'));
+    const state = (tab as unknown as { computeDraftState: Record<string, { result: { ok: boolean; error?: string }; running: boolean }> })
+      .computeDraftState['cp-3'];
+    expect(state.running).toBe(false);
+    expect(state.result.ok).toBe(false);
+    expect(state.result.error).toContain('boom');
+  });
+
+  it('Insert files the cell into a note and records the destination', async () => {
+    const tab = await freshTab();
+    seedComputeDraft(tab, 'cp-4');
+    const where = await store.insertComputeDraft(tab.id, computeDraft(tab, 'cp-4'), undefined, 'notes/dest.md');
+    expect(conv().insertComputeDraft).toHaveBeenCalledTimes(1);
+    expect(where).toBe('notes/inbox/out.md');
+    const state = (tab as unknown as { computeDraftState: Record<string, { insertedAt: string | null }> })
+      .computeDraftState['cp-4'];
+    expect(state.insertedAt).toBe('notes/inbox/out.md');
+  });
+
+  it('Insert returns null when the write fails', async () => {
+    const tab = await freshTab();
+    seedComputeDraft(tab, 'cp-5');
+    conv().insertComputeDraft.mockRejectedValueOnce(new Error('nope'));
+    const where = await store.insertComputeDraft(tab.id, computeDraft(tab, 'cp-5'));
+    expect(where).toBeNull();
+  });
+
+  it('Discard removes the compute card and its state entry', async () => {
+    const tab = await freshTab();
+    seedComputeDraft(tab, 'cp-6');
+    expect(tab.computeDrafts.map((d) => d.draftId)).toEqual(['cp-6']);
+    store.discardComputeDraft(tab.id, 'cp-6');
+    expect(tab.computeDrafts).toHaveLength(0);
+    const state = (tab as unknown as { computeDraftState: Record<string, unknown> }).computeDraftState['cp-6'];
+    expect(state).toBeUndefined();
+  });
+});
+
+// ─────────────────────── misc ───────────────────────
+
+describe('runBuiltinCommand', () => {
+  it('no-ops loudly on an unknown built-in command', async () => {
+    await freshTab();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    store.runBuiltinCommand('not-a-real-command');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/tests/renderer/stores/editor-store.test.ts
+++ b/tests/renderer/stores/editor-store.test.ts
@@ -1,0 +1,678 @@
+/**
+ * Editor store — coverage for the paths the group-model suite
+ * (`tests/renderer/editor-store.test.ts`) doesn't exercise: query tabs,
+ * neighborhood/pdf/source tabs, autosave/persist timers, dirty tracking +
+ * reload-from-disk, non-markdown (plain-text / unsupported) opens, source-tab
+ * teardown, and the query/pdf/graph/source round-trips through save + restore.
+ *
+ * Same mock pattern as the sibling suite: `window.api` (`../ipc/client`) is
+ * replaced with configurable slices, the singleton store is driven directly,
+ * and both the reactive state transition AND the routed `api.*` call are
+ * asserted for mutations. The singleton is reset via `editor.clear()` between
+ * tests.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { LayoutSession } from '../../../src/shared/types';
+
+const h = vi.hoisted(() => ({
+  readFile: vi.fn(async (p: string) => `# ${p}\nbody`),
+  writeFile: vi.fn(async () => {}),
+  tabsSave: vi.fn(async () => {}),
+  tabsLoad: vi.fn(async (): Promise<unknown> => null),
+  graphQuery: vi.fn(),
+  tablesQuery: vi.fn(),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    notebase: { readFile: h.readFile, writeFile: h.writeFile },
+    tabs: { save: h.tabsSave, load: h.tabsLoad },
+    graph: { query: h.graphQuery },
+    tables: { query: h.tablesQuery },
+  },
+}));
+
+import { getEditorStore } from '../../../src/renderer/lib/stores/editor.svelte';
+
+const editor = getEditorStore();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.readFile.mockImplementation(async (p: string) => `# ${p}\nbody`);
+  editor.onAutoSaved = null;
+  editor.clear(); // collapse to a single empty group
+});
+
+// ── Query tabs ──────────────────────────────────────────────────────────────
+
+describe('query tabs — open / edit / language', () => {
+  it('openQuery creates a focused SPARQL tab; activeQueryTab exposes it', () => {
+    editor.openQuery('SELECT * WHERE { ?s ?p ?o }', 'sparql');
+    expect(editor.tabs).toHaveLength(1);
+    const t = editor.activeQueryTab;
+    expect(t?.type).toBe('query');
+    expect(t?.language).toBe('sparql');
+    expect(t?.title).toMatch(/^Query \d+$/);
+    expect(t?.query).toBe('SELECT * WHERE { ?s ?p ?o }');
+    // Non-query getters read null for a query tab.
+    expect(editor.activeNoteTab).toBeNull();
+    expect(editor.activeSourceTab).toBeNull();
+    expect(editor.activeFilePath).toBeNull();
+    expect(editor.content).toBe('');
+  });
+
+  it('openQuery in SQL mode titles the tab "SQL Query N"', () => {
+    editor.openQuery('SELECT 1', 'sql');
+    expect(editor.activeQueryTab?.title).toMatch(/^SQL Query \d+$/);
+    expect(editor.activeQueryTab?.language).toBe('sql');
+  });
+
+  it('setQueryText updates the active query buffer', () => {
+    editor.openQuery('', 'sparql');
+    editor.setQueryText('ASK { ?s ?p ?o }');
+    expect(editor.activeQueryTab?.query).toBe('ASK { ?s ?p ?o }');
+  });
+
+  it('setQueryText is a no-op when no query tab is active', async () => {
+    await editor.openFile('a.md');
+    editor.setQueryText('ignored'); // active tab is a note
+    expect(editor.activeQueryTab).toBeNull();
+  });
+
+  it('setQueryLanguage switches language, auto-renames the default title, and clears stale results', () => {
+    editor.openQuery('SELECT 1', 'sparql');
+    const t = editor.activeQueryTab!;
+    // Seed prior-language results so we can watch them clear.
+    t.results = [{ x: '1' }];
+    t.columns = ['x'];
+    t.error = 'stale';
+    t.executionTime = 42;
+
+    editor.setQueryLanguage('sql');
+    expect(editor.activeQueryTab?.language).toBe('sql');
+    expect(editor.activeQueryTab?.title).toMatch(/^SQL Query \d+$/);
+    expect(editor.activeQueryTab?.results).toBeNull();
+    expect(editor.activeQueryTab?.columns).toEqual([]);
+    expect(editor.activeQueryTab?.error).toBeNull();
+    expect(editor.activeQueryTab?.executionTime).toBeNull();
+  });
+
+  it('setQueryLanguage is a no-op when the language is unchanged', () => {
+    editor.openQuery('SELECT 1', 'sparql');
+    const before = editor.activeQueryTab?.title;
+    editor.setQueryLanguage('sparql');
+    expect(editor.activeQueryTab?.title).toBe(before);
+  });
+
+  it('setQueryLanguage keeps a customized (non-default) title', async () => {
+    // A restored query tab can carry a hand-set title; the rename must skip it.
+    h.tabsLoad.mockResolvedValueOnce({
+      version: 2,
+      activeGroupId: 'group-1',
+      groups: [{
+        id: 'group-1', activeIndex: 0, viewMode: 'source',
+        tabs: [{ type: 'query', title: 'My Analysis', query: 'SELECT 1', language: 'sparql' }],
+      }],
+      layout: { kind: 'leaf', groupId: 'group-1' },
+    });
+    await editor.restoreTabs();
+    expect(editor.activeQueryTab?.title).toBe('My Analysis');
+
+    editor.setQueryLanguage('sql');
+    expect(editor.activeQueryTab?.language).toBe('sql');
+    expect(editor.activeQueryTab?.title).toBe('My Analysis'); // untouched
+  });
+});
+
+describe('executeQuery', () => {
+  it('runs a SQL query and normalizes rows through the tables api', async () => {
+    editor.openQuery('SELECT * FROM t', 'sql');
+    h.tablesQuery.mockResolvedValueOnce({
+      ok: true,
+      columns: ['n', 'name'],
+      rows: [{ n: 1n, name: 'a' }, { n: 2n, name: null }],
+    });
+    await editor.executeQuery();
+
+    expect(h.tablesQuery).toHaveBeenCalledWith('SELECT * FROM t');
+    const t = editor.activeQueryTab!;
+    expect(t.executing).toBe(false);
+    expect(t.error).toBeNull();
+    expect(t.columns).toEqual(['n', 'name']);
+    // BigInt → string, null → '' (normalizeSqlRows contract).
+    expect(t.results).toEqual([{ n: '1', name: 'a' }, { n: '2', name: '' }]);
+    expect(typeof t.executionTime).toBe('number');
+  });
+
+  it('records a SQL error without results', async () => {
+    editor.openQuery('bad sql', 'sql');
+    h.tablesQuery.mockResolvedValueOnce({ ok: false, error: 'syntax error' });
+    await editor.executeQuery();
+    const t = editor.activeQueryTab!;
+    expect(t.error).toBe('syntax error');
+    expect(t.results).toBeNull();
+    expect(t.executing).toBe(false);
+  });
+
+  it('runs a SPARQL query, using the engine column projection when present', async () => {
+    editor.openQuery('SELECT ?s ?o WHERE {}', 'sparql');
+    h.graphQuery.mockResolvedValueOnce({
+      results: [{ s: 'x' }], // ?o unbound in this row
+      columns: ['s', 'o'],   // projection keeps the empty column
+    });
+    await editor.executeQuery();
+
+    expect(h.graphQuery).toHaveBeenCalledWith('SELECT ?s ?o WHERE {}');
+    const t = editor.activeQueryTab!;
+    expect(t.columns).toEqual(['s', 'o']);
+    expect(t.results).toEqual([{ s: 'x' }]);
+    expect(t.error).toBeNull();
+  });
+
+  it('falls back to the union of row keys when the projection is absent', async () => {
+    editor.openQuery('SELECT * WHERE {}', 'sparql');
+    h.graphQuery.mockResolvedValueOnce({
+      results: [{ a: '1' }, { b: '2' }], // no columns field / older main
+      columns: [],
+    });
+    await editor.executeQuery();
+    expect(editor.activeQueryTab?.columns).toEqual(['a', 'b']);
+  });
+
+  it('records a SPARQL engine error', async () => {
+    editor.openQuery('bad sparql', 'sparql');
+    h.graphQuery.mockResolvedValueOnce({ results: [], columns: [], error: 'parse error' });
+    await editor.executeQuery();
+    expect(editor.activeQueryTab?.error).toBe('parse error');
+    expect(editor.activeQueryTab?.results).toBeNull();
+  });
+
+  it('captures a thrown exception as the tab error', async () => {
+    editor.openQuery('SELECT 1', 'sparql');
+    h.graphQuery.mockRejectedValueOnce(new Error('boom'));
+    await editor.executeQuery();
+    const t = editor.activeQueryTab!;
+    expect(t.error).toContain('boom');
+    expect(t.executing).toBe(false);
+    expect(typeof t.executionTime).toBe('number');
+  });
+
+  it('is a no-op when there is no active query tab', async () => {
+    await editor.openFile('a.md');
+    await editor.executeQuery();
+    expect(h.graphQuery).not.toHaveBeenCalled();
+    expect(h.tablesQuery).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op while a query is already executing', async () => {
+    editor.openQuery('SELECT 1', 'sparql');
+    editor.activeQueryTab!.executing = true;
+    await editor.executeQuery();
+    expect(h.graphQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ── Neighborhood (graph) tabs ─────────────────────────────────────────────────
+
+describe('neighborhood graph tabs (#847)', () => {
+  it('openNeighborhood opens a focused graph tab with the requested depth', () => {
+    editor.openNeighborhood('note.md', { depth: 2 });
+    expect(editor.tabs).toHaveLength(1);
+    const t = editor.activeTab;
+    expect(t?.type).toBe('graph');
+    expect(t?.type === 'graph' && t.relativePath).toBe('note.md');
+    expect(t?.type === 'graph' && t.depth).toBe(2);
+  });
+
+  it('defaults depth to 1 and refocuses instead of duplicating', () => {
+    editor.openNeighborhood('note.md'); // depth default 1
+    const first = editor.activeTab;
+    expect(first?.type === 'graph' && first.depth).toBe(1);
+
+    // Open a second, different tab, then reopen the neighborhood — refocus.
+    editor.openQuery('SELECT 1');
+    expect(editor.tabs).toHaveLength(2);
+    editor.openNeighborhood('note.md');
+    expect(editor.tabs).toHaveLength(2); // no duplicate
+    expect(editor.activeTab?.type).toBe('graph');
+  });
+
+  it('setGraphDepth updates the tab depth and floors it at 1', () => {
+    editor.openNeighborhood('note.md', { depth: 1 });
+    editor.setGraphDepth('note.md', 4);
+    expect(editor.activeTab?.type === 'graph' && editor.activeTab.depth).toBe(4);
+    editor.setGraphDepth('note.md', 0); // clamped up to 1
+    expect(editor.activeTab?.type === 'graph' && editor.activeTab.depth).toBe(1);
+  });
+
+  it('setGraphDepth is a no-op for a path with no graph tab', () => {
+    editor.setGraphDepth('missing.md', 3); // nothing open — should not throw
+    expect(editor.tabs).toHaveLength(0);
+  });
+});
+
+// ── PDF tabs ──────────────────────────────────────────────────────────────────
+
+describe('pdf tabs', () => {
+  it('openPdf opens a focused pdf tab at page 1 by default', () => {
+    editor.openPdf('src-1');
+    const t = editor.activeTab;
+    expect(t?.type).toBe('pdf');
+    expect(t?.type === 'pdf' && t.page).toBe(1);
+  });
+
+  it('setPdfPage updates the persisted page and persists', () => {
+    editor.openPdf('src-1', { page: 3 });
+    h.tabsSave.mockClear();
+    editor.setPdfPage('src-1', 9);
+    expect(editor.activeTab?.type === 'pdf' && editor.activeTab.page).toBe(9);
+  });
+
+  it('setPdfPage is a no-op when the page is unchanged', () => {
+    editor.openPdf('src-1', { page: 5 });
+    h.tabsSave.mockClear();
+    editor.setPdfPage('src-1', 5); // same page → early return, no persist
+    expect(h.tabsSave).not.toHaveBeenCalled();
+  });
+
+  it('setPdfPage is a no-op for an unknown source', () => {
+    editor.setPdfPage('nope', 2); // nothing open
+    expect(editor.tabs).toHaveLength(0);
+  });
+});
+
+// ── Source tabs + teardown ────────────────────────────────────────────────────
+
+describe('source tabs', () => {
+  it('openSource opens a focused source tab; activeSourceTab exposes it', () => {
+    editor.openSource('src-1', { highlightExcerptId: 'ex-1' });
+    expect(editor.activeSourceTab?.sourceId).toBe('src-1');
+    expect(editor.activeSourceTab?.highlightExcerptId).toBe('ex-1');
+  });
+
+  it('closeTabsForSource closes both the source detail and its pdf, across groups', () => {
+    editor.openSource('src-1');            // g1
+    const g1 = editor.groups[0].id;
+    const g2 = editor.addGroup();
+    editor.openPdf('src-1', { page: 2, groupId: g2 }); // g2
+    editor.openQuery('SELECT 1', 'sparql', g2);        // unrelated tab stays
+    expect(editor.groups[1].tabs).toHaveLength(2);
+
+    const closed = editor.closeTabsForSource('src-1');
+    expect(closed).toBe(2);
+    // g1's source is gone; g2 keeps only the query.
+    expect(editor.groups.find((g) => g.id === g1)?.tabs).toHaveLength(0);
+    const remaining = editor.groups.find((g) => g.id === g2)?.tabs ?? [];
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.type).toBe('query');
+  });
+
+  it('closeTabsForSource returns 0 and persists nothing when nothing matches', () => {
+    editor.openSource('src-1');
+    h.tabsSave.mockClear();
+    const closed = editor.closeTabsForSource('other');
+    expect(closed).toBe(0);
+    expect(h.tabsSave).not.toHaveBeenCalled();
+  });
+
+  it('closeTabsForSource re-homes the active index when an earlier tab is removed', () => {
+    editor.openSource('keep-src'); // index 0
+    editor.openPdf('gone-src');    // index 1 (active)
+    editor.openQuery('SELECT 1');  // index 2 (active)
+    expect(editor.activeIndex).toBe(2);
+    editor.closeTabsForSource('gone-src'); // removes index 1
+    // Active index shifts down by one to still point at the query tab.
+    expect(editor.activeIndex).toBe(1);
+    expect(editor.activeTab?.type).toBe('query');
+  });
+
+  it('closeTabsForSource re-homes onto a survivor when the ACTIVE tab is the one removed', async () => {
+    await editor.openFile('a.md'); // index 0
+    editor.openSource('gone');     // index 1 (active)
+    expect(editor.activeIndex).toBe(1);
+    editor.closeTabsForSource('gone'); // active tab removed → activeIndex reset then re-homed
+    expect(editor.tabs).toHaveLength(1);
+    expect(editor.activeIndex).toBe(0);
+    expect(editor.activeTab?.type).toBe('note');
+  });
+});
+
+// ── openFile: non-markdown capabilities ──────────────────────────────────────
+
+describe('openFile capability routing (#1130)', () => {
+  it('opens a plain-text file with the plainText flag, still reading it as text', async () => {
+    await editor.openFile('script.ts');
+    const t = editor.activeNoteTab;
+    expect(t?.type).toBe('note');
+    expect(t?.plainText).toBe(true);
+    expect(h.readFile).toHaveBeenCalledWith('script.ts');
+    expect(editor.content).toContain('script.ts');
+  });
+
+  it('routes an unsupported (binary) file to an unsupported tab and never reads it', async () => {
+    await editor.openFile('image.png');
+    const t = editor.activeTab;
+    expect(t?.type).toBe('unsupported');
+    expect(t?.type === 'unsupported' && t.ext).toBe('.png');
+    expect(t?.type === 'unsupported' && t.fileName).toBe('image.png');
+    expect(h.readFile).not.toHaveBeenCalled();
+    // Note-shaped getters degrade gracefully for a non-note active tab.
+    expect(editor.activeFilePath).toBeNull();
+    expect(editor.activeFileName).toBe('');
+    expect(editor.isDirty).toBe(false);
+  });
+
+  it('re-opening an already-open unsupported file refocuses it', async () => {
+    await editor.openFile('image.png');
+    await editor.openFile('other.md');
+    expect(editor.tabs).toHaveLength(2);
+    await editor.openFile('image.png'); // dup → refocus, no read
+    expect(editor.tabs).toHaveLength(2);
+    expect(editor.activeTab?.type).toBe('unsupported');
+  });
+});
+
+// ── save guard / dirty / reload ──────────────────────────────────────────────
+
+describe('save guard, dirty tracking, reload-from-disk', () => {
+  it('save is a no-op when the active tab is not a note', async () => {
+    editor.openQuery('SELECT 1');
+    await editor.save();
+    expect(h.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('isPathDirty reflects unsaved edits for a specific path', async () => {
+    await editor.openFile('a.md');
+    expect(editor.isPathDirty('a.md')).toBe(false);
+    editor.setContent('changed');
+    expect(editor.isPathDirty('a.md')).toBe(true);
+    expect(editor.isPathDirty('not-open.md')).toBe(false);
+  });
+
+  it('reloadTabFromDisk refreshes content and resets the saved baseline (clears dirty)', async () => {
+    await editor.openFile('a.md');
+    editor.setContent('local edit');
+    expect(editor.isPathDirty('a.md')).toBe(true);
+
+    h.readFile.mockResolvedValueOnce('# fresh from disk');
+    await editor.reloadTabFromDisk('a.md');
+    expect(editor.content).toBe('# fresh from disk');
+    expect(editor.isPathDirty('a.md')).toBe(false); // content === savedContent
+  });
+
+  it('reloadTabFromDisk swallows a read error (file deleted since notification)', async () => {
+    await editor.openFile('a.md');
+    editor.setContent('local');
+    h.readFile.mockRejectedValueOnce(new Error('ENOENT'));
+    await editor.reloadTabFromDisk('a.md'); // must not throw
+    // Buffer is left as-is (the local edit survives the failed reload).
+    expect(editor.content).toBe('local');
+  });
+
+  it('reloadTabFromDisk is a no-op for a path with no open tab', async () => {
+    await editor.reloadTabFromDisk('nowhere.md');
+    expect(h.readFile).not.toHaveBeenCalled();
+  });
+});
+
+// ── rename transitions edge cases ─────────────────────────────────────────────
+
+describe('applyRenameTransitions edge cases', () => {
+  it('is a no-op for an empty transition list', () => {
+    editor.applyRenameTransitions([]);
+    expect(h.tabsSave).not.toHaveBeenCalled();
+  });
+
+  it('rewrites an unsupported tab path and refreshes its extension', async () => {
+    await editor.openFile('diagram.png'); // unsupported tab
+    editor.applyRenameTransitions([{ old: 'diagram.png', new: 'sub/pic.jpg' }]);
+    const t = editor.activeTab;
+    expect(t?.type === 'unsupported' && t.relativePath).toBe('sub/pic.jpg');
+    expect(t?.type === 'unsupported' && t.fileName).toBe('pic.jpg');
+    expect(t?.type === 'unsupported' && t.ext).toBe('.jpg');
+  });
+});
+
+// ── autosave / persist timers ─────────────────────────────────────────────────
+
+describe('autosave + persist timers', () => {
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('setContent schedules an autosave that fires save() and the onAutoSaved callback', async () => {
+    vi.useFakeTimers();
+    await editor.openFile('a.md');
+    let saved = false;
+    editor.onAutoSaved = () => { saved = true; };
+
+    editor.setContent('auto edited');
+    expect(h.writeFile).not.toHaveBeenCalled(); // debounced, not yet
+    await vi.advanceTimersByTimeAsync(1000);    // AUTO_SAVE_DELAY
+
+    expect(h.writeFile).toHaveBeenCalledWith('a.md', 'auto edited');
+    expect(saved).toBe(true);
+    expect(editor.isDirty).toBe(false);
+  });
+
+  it('a second edit debounces — only the latest content is written once', async () => {
+    vi.useFakeTimers();
+    await editor.openFile('a.md');
+    editor.setContent('first');
+    await vi.advanceTimersByTimeAsync(400);
+    editor.setContent('second'); // resets the timer
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.writeFile).toHaveBeenCalledTimes(1);
+    expect(h.writeFile).toHaveBeenCalledWith('a.md', 'second');
+  });
+
+  it('schedulePersistTabs debounces to a single tabs.save', async () => {
+    vi.useFakeTimers();
+    await editor.openFile('a.md');
+    h.tabsSave.mockClear();
+    editor.schedulePersistTabs();
+    editor.schedulePersistTabs();
+    await vi.advanceTimersByTimeAsync(500); // TAB_PERSIST_DELAY
+    expect(h.tabsSave).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── generic tab op guards ─────────────────────────────────────────────────────
+
+describe('generic tab op guards', () => {
+  it('closeTab ignores an out-of-range index', async () => {
+    await editor.openFile('a.md');
+    editor.closeTab(99);
+    expect(editor.tabs).toHaveLength(1);
+    editor.closeTab(-1);
+    expect(editor.tabs).toHaveLength(1);
+  });
+
+  it('closeOthers ignores an out-of-range index (keeps every tab)', async () => {
+    await editor.openFile('a.md');
+    await editor.openFile('b.md');
+    editor.closeOthers(99);
+    expect(editor.tabs).toHaveLength(2);
+  });
+
+  it('closeTab flushes a pending autosave when closing the active note tab', async () => {
+    vi.useFakeTimers();
+    try {
+      await editor.openFile('a.md');
+      editor.setContent('dirty'); // schedules autosave
+      editor.closeTab(editor.activeIndex); // flushes → immediate save
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(h.writeFile).toHaveBeenCalledWith('a.md', 'dirty');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('closeTabsForDeletedPath re-homes the active index across a mid-list deletion', async () => {
+    await editor.openFile('keep-a.md'); // 0
+    await editor.openFile('gone.md');   // 1
+    await editor.openFile('keep-b.md'); // 2 (active)
+    const closed = editor.closeTabsForDeletedPath('gone.md');
+    expect(closed).toBe(1);
+    expect(editor.tabs).toHaveLength(2);
+    // Active pointer follows the surviving tabs (no dangling index).
+    expect(editor.activeIndex).toBeGreaterThanOrEqual(0);
+    expect(editor.activeIndex).toBeLessThan(2);
+  });
+
+  it('closeTabsForDeletedPath re-homes onto a survivor when the ACTIVE tab is deleted', () => {
+    editor.openSource('keep-src'); // 0
+    // Manually append a note after the source so the active (index 1) note is deleted.
+    // openFile forbids duplicate; here a single note deletion with a non-note survivor.
+    return editor.openFile('gone.md').then(() => {
+      expect(editor.activeIndex).toBe(1);
+      const closed = editor.closeTabsForDeletedPath('gone.md');
+      expect(closed).toBe(1);
+      expect(editor.tabs).toHaveLength(1);
+      expect(editor.activeIndex).toBe(0); // re-homed onto the surviving source tab
+      expect(editor.activeTab?.type).toBe('source');
+    });
+  });
+
+  it('exposes the active group object via the activeGroup getter', async () => {
+    await editor.openFile('a.md');
+    expect(editor.activeGroup.id).toBe(editor.activeGroupId);
+    expect(editor.activeGroup.tabs).toBe(editor.tabs);
+  });
+});
+
+// ── moveTab guards ────────────────────────────────────────────────────────────
+
+describe('moveTab / moveTabToSplit guards', () => {
+  it('moveTab is a no-op for unknown source or destination groups', async () => {
+    await editor.openFile('a.md');
+    editor.moveTab('nope', 0, editor.groups[0].id);
+    editor.moveTab(editor.groups[0].id, 0, 'nowhere');
+    expect(editor.tabs).toHaveLength(1);
+  });
+
+  it('moveTab is a no-op for an out-of-range source index', async () => {
+    await editor.openFile('a.md');
+    editor.moveTab(editor.groups[0].id, 5, editor.groups[0].id, 0);
+    expect(editor.tabs).toHaveLength(1);
+  });
+
+  it('moveTab reorders within a pane (toIndex past the source is adjusted down)', async () => {
+    await editor.openFile('a.md'); // 0
+    await editor.openFile('b.md'); // 1
+    await editor.openFile('c.md'); // 2
+    const g = editor.groups[0].id;
+    // Move a.md (0) to index 2 — with the removal-shift it lands between b and c.
+    editor.moveTab(g, 0, g, 2);
+    const paths = editor.tabs.map((t) => (t.type === 'note' ? t.relativePath : t.type));
+    expect(paths).toEqual(['b.md', 'a.md', 'c.md']);
+  });
+
+  it('moveTabToSplit is a no-op for a bad source', async () => {
+    await editor.openFile('a.md');
+    editor.moveTabToSplit('nope', 0, editor.groups[0].id, 'horizontal', false);
+    expect(editor.groups).toHaveLength(1);
+  });
+});
+
+// ── save / restore round-trips for every tab kind ─────────────────────────────
+
+describe('persist + restore across every tab kind', () => {
+  it('toSavedTab serializes note (with plainText/cursor), query, pdf, graph, source, unsupported', async () => {
+    await editor.openFile('code.ts');   // plain-text note
+    editor.saveEditorState('code.ts', 12, 120); // cursor/scroll fields
+    editor.openQuery('SELECT 1', 'sql');
+    editor.openPdf('src-1', { page: 4 });
+    editor.openNeighborhood('code.ts', { depth: 3 });
+    editor.openSource('src-2', { highlightExcerptId: 'ex-2' });
+    await editor.openFile('bin.dat');   // unsupported
+
+    editor.persistTabs();
+    const saved = h.tabsSave.mock.calls.at(-1)?.[0] as LayoutSession;
+    const kinds = saved.groups[0].tabs.map((t) => t.type);
+    expect(kinds).toEqual(['note', 'query', 'pdf', 'graph', 'source', 'unsupported']);
+
+    const note = saved.groups[0].tabs[0];
+    expect(note).toMatchObject({ type: 'note', relativePath: 'code.ts', plainText: true, cursorOffset: 12, scrollTop: 120 });
+    expect(saved.groups[0].tabs[1]).toMatchObject({ type: 'query', title: expect.stringMatching(/SQL Query/), language: 'sql' });
+    expect(saved.groups[0].tabs[2]).toMatchObject({ type: 'pdf', sourceId: 'src-1', page: 4 });
+    expect(saved.groups[0].tabs[3]).toMatchObject({ type: 'graph', relativePath: 'code.ts', depth: 3 });
+    expect(saved.groups[0].tabs[4]).toMatchObject({ type: 'source', sourceId: 'src-2', highlightExcerptId: 'ex-2' });
+    expect(saved.groups[0].tabs[5]).toMatchObject({ type: 'unsupported', relativePath: 'bin.dat' });
+  });
+
+  it('reconstructTab rebuilds query, pdf, graph, source, and unsupported tabs on restore', async () => {
+    h.tabsLoad.mockResolvedValueOnce({
+      version: 2,
+      activeGroupId: 'group-1',
+      groups: [{
+        id: 'group-1', activeIndex: 0, viewMode: 'source',
+        tabs: [
+          { type: 'query', title: 'Q', query: 'SELECT 1', language: 'sql' },
+          { type: 'pdf', sourceId: 'p-1', page: 6 },
+          { type: 'graph', relativePath: 'g.md', depth: 5 },
+          { type: 'source', sourceId: 's-1', highlightExcerptId: 'ex' },
+          { type: 'unsupported', relativePath: 'blob.bin' },
+        ],
+      }],
+      layout: { kind: 'leaf', groupId: 'group-1' },
+    });
+    await editor.restoreTabs();
+
+    const tabs = editor.groups[0].tabs;
+    expect(tabs.map((t) => t.type)).toEqual(['query', 'pdf', 'graph', 'source', 'unsupported']);
+    expect(tabs[0].type === 'query' && tabs[0].language).toBe('sql');
+    expect(tabs[1].type === 'pdf' && tabs[1].page).toBe(6);
+    expect(tabs[2].type === 'graph' && tabs[2].depth).toBe(5);
+    expect(tabs[3].type === 'source' && tabs[3].highlightExcerptId).toBe('ex');
+    expect(tabs[4].type === 'unsupported' && tabs[4].ext).toBe('.bin');
+  });
+
+  it('reconstructTab defaults a legacy query language to sparql, pdf page to 1, graph depth to 1', async () => {
+    h.tabsLoad.mockResolvedValueOnce({
+      version: 2,
+      activeGroupId: 'group-1',
+      groups: [{
+        id: 'group-1', activeIndex: 0, viewMode: 'source',
+        tabs: [
+          { type: 'query', title: 'Q', query: 'x' },   // no language
+          { type: 'pdf', sourceId: 'p' },               // no page
+          { type: 'graph', relativePath: 'g.md' },      // no depth
+        ],
+      }],
+      layout: { kind: 'leaf', groupId: 'group-1' },
+    });
+    await editor.restoreTabs();
+    const tabs = editor.groups[0].tabs;
+    expect(tabs[0].type === 'query' && tabs[0].language).toBe('sparql');
+    expect(tabs[1].type === 'pdf' && tabs[1].page).toBe(1);
+    expect(tabs[2].type === 'graph' && tabs[2].depth).toBe(1);
+  });
+
+  it('dedups a pdf/source that appears in two panes on restore (savedTabIdentity)', async () => {
+    h.tabsLoad.mockResolvedValueOnce({
+      version: 2,
+      activeGroupId: 'group-1',
+      groups: [
+        { id: 'group-1', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'pdf', sourceId: 'dup', page: 1 }, { type: 'source', sourceId: 'sdup' }] },
+        { id: 'group-2', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'pdf', sourceId: 'dup', page: 2 }, { type: 'source', sourceId: 'sdup' }] },
+      ],
+      layout: {
+        kind: 'split', direction: 'horizontal', sizes: [0.5, 0.5],
+        children: [{ kind: 'leaf', groupId: 'group-1' }, { kind: 'leaf', groupId: 'group-2' }],
+      },
+    });
+    await editor.restoreTabs();
+    const all = editor.groups.flatMap((g) => g.tabs);
+    expect(all.filter((t) => t.type === 'pdf')).toHaveLength(1);
+    expect(all.filter((t) => t.type === 'source')).toHaveLength(1);
+    // Both survivors live in the first pane (dedup keeps the earliest).
+    expect(editor.groups.find((g) => g.id === 'group-2')?.tabs).toHaveLength(0);
+  });
+
+  it('treats a legacy flat session with zero tabs as empty (keeps the default group)', async () => {
+    h.tabsLoad.mockResolvedValueOnce({ activeIndex: 0, tabs: [] });
+    await editor.restoreTabs();
+    expect(editor.groups).toHaveLength(1);
+    expect(editor.tabs).toHaveLength(0);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -138,12 +138,13 @@ export default defineConfig({
         // QA C1). Floors sit below the measured-at-floor numbers with extra
         // headroom because this tree is volatile (a single new component moves
         // the needle): a mass test deletion or a large untested addition still
-        // fails CI. Ratcheted at #1451 after unit-testing bucket A (pure-lib
-        // helpers: preview/markdown-config + hydrate, editor/formatting +
-        // sparql-autocomplete, tools/context, find-excerpt-range) lifted the
-        // measured numbers to ~42% L / ~41% F / ~43% S / ~35% B (from ~36/39/
-        // 35/31). Ratchet upward again as bucket B (store/ops spine, #1452) and
-        // the approval-proposal UI gain tests.
+        // fails CI. Ratcheted twice: #1451 (bucket A, pure-lib helpers) →
+        // ~42% L, then #1452 (bucket B, the store/ops data-flow spine:
+        // app/refactor-ops + note-ops + source-ops, stores/conversations +
+        // editor — incl. the Trust-Principle propose_*→file*Draft paths) →
+        // measured ~48% L / ~46% F / ~48% S / ~41% B (from ~36/39/35/31 pre-A).
+        // Ratchet upward again as the approval-proposal UI + remaining
+        // components gain tests.
         //
         // NOTE: src/preload is deliberately NOT given a line-coverage floor.
         // It's a declarative contextBridge passthrough (~326 lines of
@@ -152,10 +153,10 @@ export default defineConfig({
         // #676), not line execution. Calling every passthrough to hit a line
         // floor would verify nothing the snapshot doesn't already pin.
         'src/renderer/**': {
-          lines: 34,
-          functions: 34,
-          statements: 34,
-          branches: 28,
+          lines: 42,
+          functions: 40,
+          statements: 42,
+          branches: 34,
         },
       },
     },


### PR DESCRIPTION
Closes #1452. **Stacked on #1480 (bucket A, #1451)** — base is that branch so this diff shows only bucket-B changes; it rebases onto `main` once #1480 lands.

The highest-architectural-value bucket: the exact modules CLAUDE.md designates as the single state-mutation path (stores + App ops), including the Trust-Principle draft-filing paths. Every test asserts **both** the reactive state transition **and** that the mutation routed through `api.*` — the renderer-data-flow invariant.

## Coverage lift (line %)

Each module's existing `vi.hoisted` mock harness was reused/extended (or a complementary store-test file added):

| module | before → after | tests added |
|---|---|---|
| `app/source-ops.ts` | 37% → **100%** | +52 |
| `app/note-ops.ts` | 45% → **99%** | +41 |
| `app/refactor-ops.svelte.ts` | 28% → **95%** | +36 |
| `stores/editor.svelte.ts` | 68% → **100%** | +56 (new `editor-store.test.ts`) |
| `stores/conversations.svelte.ts` | 31% → **97%** | +43 (new `conversations-store.test.ts`) |

## Trust Principle (draft-filing)

The conversations suite covers every `propose_*` → `file*Draft` path — `fileDraft`, `fileSourceDraft`, `filePropertyDraft`, `fileClaimsDraft`, `fileRefactorDraft`, `fileReorgDraft`, `fileDeleteDraft`, and the compute paths — asserting **Approve routes through the approval engine** (the right `api.conversations.*` call, with SELECTED items/paths passed through) and **Discard writes nothing**. That reinforces "LLM proposes, human confirms" at the renderer boundary — a named success criterion.

## Coverage + floor ratchet

Measured `src/renderer` line coverage: **~42% (post bucket A) → 48.0%** (functions 46.1, statements 48.5, branches 41.1).

| metric | old (bucket A) | new | measured | headroom |
|---|---|---|---|---|
| lines | 34 | **42** | 48.0 | 6.0 |
| functions | 34 | **40** | 46.1 | 6.1 |
| statements | 34 | **42** | 48.5 | 6.5 |
| branches | 28 | **34** | 41.1 | 7.1 |

Landed at 48% (just short of the ~50-52% aspiration — the remaining gap is the approval-proposal UI components + the rest of the tree). Floor set to the issue's ~42-45 low end with ~6-7pt headroom.

## Success criteria
- [x] Store/ops tests asserting state transitions + `api.*` routing
- [x] Draft-filing paths (propose_* → fileDraft) covered
- [x] Renderer measured line coverage rises materially (~42% → **48.0%**)
- [x] Bump the `src/renderer/**` floor in the same PR (34 → **42** lines)
- [x] `pnpm coverage` green with headroom

## Verification
Full `pnpm coverage` (CI-gating) → **exit 0** with the new floor. `tsc --noEmit` / `eslint` clean. 228 new tests across 5 files (all state mutations assert the `api.*` route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)