### PR TITLE
test(renderer): render mid-size dialogs/panels, exclude App/Editor, ratchet floor (bucket C, #1453)

### DIFF
--- a/tests/renderer/components/CollectionPickerDialog.test.ts
+++ b/tests/renderer/components/CollectionPickerDialog.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Component-interaction coverage for the collection quick-picker (#470).
+ *
+ * CollectionPickerDialog is a pure props-and-callbacks leaf — no `window.api`,
+ * no store. It builds breadcrumb labels for nested collections, filters them by
+ * a typed query, drives selection with the keyboard, and (when handed an
+ * `onCreate`) offers a one-shot "make + pick" create row. These tests render the
+ * real component and assert the visible list + that pick/create/cancel reach the
+ * callbacks with the right ids — so a broken $derived (labels not narrowing, the
+ * create-row offset drifting from the rendered rows) fails the suite.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, within, waitFor } from '@testing-library/svelte';
+import type { Collection } from '../../../src/shared/types';
+import CollectionPickerDialog from '../../../src/renderer/lib/components/CollectionPickerDialog.svelte';
+
+afterEach(cleanup);
+
+function makeCollections(): Collection[] {
+  return [
+    { id: 'work', name: 'Work', parent: null, members: ['s1', 's2'] },
+    { id: 'personal', name: 'Personal', parent: null, members: [] },
+    // Nested under Work → breadcrumb "Work / Project X".
+    { id: 'proj', name: 'Project X', parent: 'work', members: ['s3'] },
+  ];
+}
+
+function renderDialog(
+  over: {
+    collections?: Collection[];
+    onSelect?: (id: string) => void;
+    onCancel?: () => void;
+    onCreate?: (name: string) => Promise<string>;
+    title?: string;
+  } = {},
+) {
+  const onSelect = over.onSelect ?? vi.fn();
+  const onCancel = over.onCancel ?? vi.fn();
+  const props: Record<string, unknown> = {
+    collections: over.collections ?? makeCollections(),
+    onSelect,
+    onCancel,
+    title: over.title ?? 'Add to collection',
+  };
+  if (over.onCreate) props.onCreate = over.onCreate;
+  const r = render(CollectionPickerDialog, props);
+  return { ...r, onSelect, onCancel };
+}
+
+/** Visible non-create result rows, in DOM order, by their rendered label. */
+function resultNames(container: HTMLElement): string[] {
+  return [
+    ...container.querySelectorAll('.cp-results .result-item:not(.create-row) .result-name'),
+  ].map((el) => (el.textContent ?? '').trim());
+}
+
+function selectedName(container: HTMLElement): string | null {
+  const el = container.querySelector('.result-item.selected .result-name');
+  return el ? (el.textContent ?? '').trim() : null;
+}
+
+async function type(input: Element, value: string) {
+  await fireEvent.input(input, { target: { value } });
+}
+
+describe('CollectionPickerDialog — pick / filter / create (#470)', () => {
+  it('lists collections alphabetically by breadcrumb label with member counts', () => {
+    const { container } = renderDialog();
+    // Sorted by full label: "Personal", "Work", "Work / Project X".
+    expect(resultNames(container)).toEqual(['Personal', 'Work', 'Work / Project X']);
+
+    const counts = [...container.querySelectorAll('.cp-results .result-count')].map(
+      (el) => (el.textContent ?? '').trim(),
+    );
+    // Personal(0), Work(2), Work / Project X(1).
+    expect(counts).toEqual(['0', '2', '1']);
+  });
+
+  it('renders the dialog title', () => {
+    const { getByText } = renderDialog({ title: 'Move source to…' });
+    expect(getByText('Move source to…')).toBeTruthy();
+  });
+
+  it('typing filters against the full breadcrumb label ($derived)', async () => {
+    const { container, getByRole } = renderDialog();
+    const input = getByRole('textbox');
+
+    // "project" matches only the nested collection's label.
+    await type(input, 'project');
+    expect(resultNames(container)).toEqual(['Work / Project X']);
+
+    // "work" matches Work AND its nested child (breadcrumb contains "Work").
+    await type(input, 'work');
+    expect(resultNames(container)).toEqual(['Work', 'Work / Project X']);
+  });
+
+  it('clicking a row selects that collection id', async () => {
+    const onSelect = vi.fn();
+    const { container } = renderDialog({ onSelect });
+    const list = container.querySelector('.cp-results') as HTMLElement;
+
+    await fireEvent.click(within(list).getByText('Work / Project X'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('proj');
+  });
+
+  it('ArrowDown moves the highlight; Enter selects the highlighted row', async () => {
+    const onSelect = vi.fn();
+    const { container } = renderDialog({ onSelect });
+    const overlay = container.querySelector('.overlay')!;
+
+    // Row 0 (Personal) is highlighted initially by the reset $effect.
+    expect(selectedName(container)).toBe('Personal');
+
+    await fireEvent.keyDown(overlay, { key: 'ArrowDown' }); // → Work
+    expect(selectedName(container)).toBe('Work');
+
+    await fireEvent.keyDown(overlay, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledWith('work');
+  });
+
+  it('Escape cancels without selecting', async () => {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    const { container } = renderDialog({ onSelect, onCancel });
+
+    await fireEvent.keyDown(container.querySelector('.overlay')!, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('mousedown on the backdrop cancels; mousedown inside the dialog does not', async () => {
+    const onCancel = vi.fn();
+    const { container } = renderDialog({ onCancel });
+    const overlay = container.querySelector('.overlay') as HTMLElement;
+    const dialog = container.querySelector('.dialog') as HTMLElement;
+
+    await fireEvent.mouseDown(dialog);
+    expect(onCancel).not.toHaveBeenCalled();
+
+    await fireEvent.mouseDown(overlay);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the "No matching collections" empty state when a filter matches nothing', async () => {
+    const { container, getByText } = renderDialog();
+    await type(container.querySelector('.input')!, 'zzzqqq');
+    expect(resultNames(container)).toEqual([]);
+    expect(getByText('No matching collections.')).toBeTruthy();
+  });
+
+  it('with no collections and no onCreate, shows the Sources-panel hint', () => {
+    const { getByText } = renderDialog({ collections: [] });
+    expect(getByText(/No collections yet\. Create one from the Sources panel first\./)).toBeTruthy();
+  });
+
+  it('with no collections but an onCreate, invites typing a name', () => {
+    const { getByText } = renderDialog({ collections: [], onCreate: vi.fn() });
+    expect(getByText(/No collections yet\. Type a name to create one\./)).toBeTruthy();
+  });
+
+  describe('inline create row (onCreate provided)', () => {
+    it('offers a create row when the typed name matches no existing collection', async () => {
+      const { container, getByText } = renderDialog({ onCreate: vi.fn() });
+      await type(container.querySelector('.input')!, 'Reading List');
+
+      const createRow = container.querySelector('.create-row');
+      expect(createRow).toBeTruthy();
+      expect(getByText('Create new collection:')).toBeTruthy();
+      expect(within(createRow as HTMLElement).getByText('Reading List')).toBeTruthy();
+    });
+
+    it('hides the create row when the typed name equals an existing collection (case-insensitive)', async () => {
+      const { container } = renderDialog({ onCreate: vi.fn() });
+      await type(container.querySelector('.input')!, 'work');
+      expect(container.querySelector('.create-row')).toBeNull();
+    });
+
+    it('clicking the create row calls onCreate then auto-selects the new id', async () => {
+      const onCreate = vi.fn().mockResolvedValue('new-collection-id');
+      const onSelect = vi.fn();
+      const { container } = renderDialog({ onCreate, onSelect });
+
+      await type(container.querySelector('.input')!, 'Reading List');
+      await fireEvent.click(container.querySelector('.create-row') as HTMLElement);
+
+      expect(onCreate).toHaveBeenCalledWith('Reading List');
+      await waitFor(() => expect(onSelect).toHaveBeenCalledWith('new-collection-id'));
+    });
+
+    it('the create row sits at index 0 and Enter activates it', async () => {
+      const onCreate = vi.fn().mockResolvedValue('minted-id');
+      const onSelect = vi.fn();
+      const { container } = renderDialog({ onCreate, onSelect });
+
+      await type(container.querySelector('.input')!, 'Reading List');
+      // The reset $effect puts selection at 0 (the create row).
+      await fireEvent.keyDown(container.querySelector('.overlay')!, { key: 'Enter' });
+
+      expect(onCreate).toHaveBeenCalledWith('Reading List');
+      await waitFor(() => expect(onSelect).toHaveBeenCalledWith('minted-id'));
+    });
+  });
+});

--- a/tests/renderer/components/EditSavedQueriesDialog.test.ts
+++ b/tests/renderer/components/EditSavedQueriesDialog.test.ts
@@ -1,0 +1,392 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Component-interaction coverage for the Edit Saved Queries dialog (#314/#315).
+ *
+ * The dialog reads the saved-query catalog from `window.api.queries.list()` on
+ * mount, buckets it by (scope, group), and exposes per-row actions — inline
+ * rename, delete, move-between-scopes, per-row group edit — plus a group-header
+ * rename and drag-to-reorder. These tests render the real component against a
+ * stubbed `window.api.queries` boundary and assert the visible DOM plus that
+ * each interaction reaches the IPC layer with the right arguments.
+ *
+ * Drag-to-reorder uses HTML5 DnD; happy-dom dispatches the drag/drop events but
+ * has no real DataTransfer. The component keeps the dragged path in component
+ * state (`draggingPath`), not on the event, so the reorder + group-header-drop
+ * handlers are still exercisable via fireEvent.dragStart/drop.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+import type { SavedQuery } from '../../../src/shared/types';
+import EditSavedQueriesDialog from '../../../src/renderer/lib/components/EditSavedQueriesDialog.svelte';
+
+// ── stubbed IPC boundary ─────────────────────────────────────────────────────
+const q = vi.hoisted(() => ({
+  list: vi.fn(),
+  rename: vi.fn(),
+  delete: vi.fn(),
+  move: vi.fn(),
+  setGroup: vi.fn(),
+  setOrder: vi.fn(),
+}));
+
+function query(over: Partial<SavedQuery> = {}): SavedQuery {
+  return {
+    id: over.filePath ?? 'id',
+    name: 'Query',
+    description: '',
+    query: 'SELECT * WHERE {}',
+    language: 'sparql',
+    scope: 'project',
+    filePath: 'p/query',
+    group: null,
+    order: null,
+    ...over,
+  };
+}
+
+// Project ungrouped: Alpha, Delta; Project group "Reports": Beta; Global: Gamma.
+// Both project+global buckets present → scope labels shown; a group header
+// ("Reports") is rendered for the grouped bucket.
+function catalog(): SavedQuery[] {
+  return [
+    query({ name: 'Alpha', filePath: 'p/alpha', scope: 'project', group: null, order: 0 }),
+    query({ name: 'Delta', filePath: 'p/delta', scope: 'project', group: null, order: 1 }),
+    query({ name: 'Beta', filePath: 'p/beta', scope: 'project', group: 'Reports' }),
+    query({ name: 'Gamma', filePath: 'g/gamma', scope: 'global', group: null }),
+  ];
+}
+
+beforeEach(() => {
+  q.list.mockResolvedValue(catalog());
+  q.rename.mockResolvedValue('p/alpha');
+  q.delete.mockResolvedValue(undefined);
+  q.move.mockResolvedValue('g/alpha');
+  q.setGroup.mockResolvedValue(undefined);
+  q.setOrder.mockResolvedValue(undefined);
+  vi.stubGlobal('api', { queries: q });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+async function renderDialog(over: { projectOpen?: boolean; onClose?: () => void } = {}) {
+  const onClose = over.onClose ?? vi.fn();
+  const utils = render(EditSavedQueriesDialog, {
+    projectOpen: over.projectOpen ?? true,
+    onClose,
+  });
+  // Wait for the onMount list() to resolve into rows.
+  await utils.findByText('Alpha');
+  return { ...utils, onClose };
+}
+
+/** Find the <li class="row"> whose visible name matches. */
+function rowByName(container: HTMLElement, name: string): HTMLElement {
+  const row = [...container.querySelectorAll('li.row')].find(
+    (li) => li.querySelector('.name')?.textContent === name,
+  );
+  if (!row) throw new Error(`row "${name}" not found`);
+  return row as HTMLElement;
+}
+
+describe('EditSavedQueriesDialog (#314/#315)', () => {
+  it('renders the queries from api.queries.list, split by scope with labels + group header', async () => {
+    const { container, getByText } = await renderDialog();
+
+    expect(q.list).toHaveBeenCalled();
+    // Both scopes present → the scope section labels are shown.
+    expect(getByText('Thoughtbase')).toBeTruthy();
+    expect(getByText('Global')).toBeTruthy();
+    // Group header for the grouped bucket.
+    expect(container.querySelector('.group-name')?.textContent).toBe('Reports');
+    // All four rows rendered.
+    const names = [...container.querySelectorAll('li.row .name')].map((n) => n.textContent);
+    expect(names).toEqual(expect.arrayContaining(['Alpha', 'Delta', 'Beta', 'Gamma']));
+  });
+
+  it('sorts the ungrouped bucket first even when a grouped query is listed first', async () => {
+    // Grouped query precedes the ungrouped one → exercises the b.name===null
+    // arm of the bucket sort comparator.
+    // "Reports" listed before "Analytics" and the ungrouped "Alpha": exercises
+    // both the b.name===null arm and the localeCompare arm of the sort.
+    q.list.mockResolvedValue([
+      query({ name: 'Beta', filePath: 'p/beta', scope: 'project', group: 'Reports' }),
+      query({ name: 'Cara', filePath: 'p/cara', scope: 'project', group: 'Analytics' }),
+      query({ name: 'Alpha', filePath: 'p/alpha', scope: 'project', group: null }),
+    ]);
+    const { container, findByText } = render(EditSavedQueriesDialog, {
+      projectOpen: true,
+      onClose: vi.fn(),
+    });
+    await findByText('Alpha');
+    // Ungrouped first, then groups alphabetically (Analytics before Reports).
+    const html = container.innerHTML;
+    expect(html.indexOf('Alpha')).toBeLessThan(html.indexOf('Analytics'));
+    expect(html.indexOf('Analytics')).toBeLessThan(html.indexOf('Reports'));
+  });
+
+  it('shows the empty state when there are no saved queries', async () => {
+    q.list.mockResolvedValue([]);
+    const { findByText, container } = render(EditSavedQueriesDialog, {
+      projectOpen: true,
+      onClose: vi.fn(),
+    });
+    expect(await findByText('No saved queries yet.')).toBeTruthy();
+    expect(container.querySelectorAll('li.row').length).toBe(0);
+  });
+
+  it('renames a query inline (Enter commits to api.queries.rename)', async () => {
+    const { container } = await renderDialog();
+    const row = rowByName(container, 'Alpha');
+
+    await fireEvent.click(row.querySelector('.row-btn')!); // "Rename" is the first .row-btn after group-btn? no — click by text
+    // The Rename button is the one labelled "Rename".
+    // (re-query to be explicit)
+    const renameBtn = [...row.querySelectorAll('button')].find((b) => b.textContent === 'Rename')!;
+    await fireEvent.click(renameBtn);
+
+    const input = row.querySelector('input.name-input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    await fireEvent.input(input, { target: { value: 'Alpha Renamed' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(q.rename).toHaveBeenCalledWith('p/alpha', 'Alpha Renamed'));
+    expect(q.list).toHaveBeenCalledTimes(2); // initial load + reload after rename
+  });
+
+  it('does not call rename when the value is unchanged or blank', async () => {
+    const { container } = await renderDialog();
+    const row = rowByName(container, 'Alpha');
+    const renameBtn = [...row.querySelectorAll('button')].find((b) => b.textContent === 'Rename')!;
+    await fireEvent.click(renameBtn);
+
+    const input = row.querySelector('input.name-input') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: '   ' } }); // blank after trim
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(container.querySelector('input.name-input')).toBeNull());
+    expect(q.rename).not.toHaveBeenCalled();
+  });
+
+  it('Escape in the rename input cancels without committing', async () => {
+    const { container } = await renderDialog();
+    const row = rowByName(container, 'Alpha');
+    const renameBtn = [...row.querySelectorAll('button')].find((b) => b.textContent === 'Rename')!;
+    await fireEvent.click(renameBtn);
+
+    const input = row.querySelector('input.name-input') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'Nope' } });
+    await fireEvent.keyDown(input, { key: 'Escape' });
+
+    await waitFor(() => expect(container.querySelector('input.name-input')).toBeNull());
+    expect(q.rename).not.toHaveBeenCalled();
+  });
+
+  it('deletes a query via api.queries.delete', async () => {
+    const { container } = await renderDialog();
+    const row = rowByName(container, 'Delta');
+    const delBtn = [...row.querySelectorAll('button')].find((b) => b.textContent === 'Delete')!;
+    await fireEvent.click(delBtn);
+
+    await waitFor(() => expect(q.delete).toHaveBeenCalledWith('p/delta'));
+  });
+
+  it('moves a project query to Global scope', async () => {
+    const { container } = await renderDialog();
+    const row = rowByName(container, 'Alpha');
+    const moveBtn = [...row.querySelectorAll('button')].find((b) => b.textContent?.trim() === 'Move to Global')!;
+    await fireEvent.click(moveBtn);
+
+    await waitFor(() => expect(q.move).toHaveBeenCalledWith('p/alpha', 'global'));
+  });
+
+  it('moves a global query to Thoughtbase when a project is open', async () => {
+    const { container } = await renderDialog({ projectOpen: true });
+    const row = rowByName(container, 'Gamma');
+    const moveBtn = [...row.querySelectorAll('button')].find((b) => b.textContent?.trim() === 'Move to Thoughtbase')!;
+    expect(moveBtn.hasAttribute('disabled')).toBe(false);
+    await fireEvent.click(moveBtn);
+
+    await waitFor(() => expect(q.move).toHaveBeenCalledWith('g/gamma', 'project'));
+  });
+
+  it('disables Move-to-Thoughtbase for a global query when no project is open', async () => {
+    const { container } = await renderDialog({ projectOpen: false });
+    const row = rowByName(container, 'Gamma');
+    const moveBtn = [...row.querySelectorAll('button')].find((b) => b.textContent?.trim() === 'Move to Thoughtbase')!;
+    expect(moveBtn.hasAttribute('disabled')).toBe(true);
+    // Clicking the disabled button must not reach IPC (moveScope also guards).
+    await fireEvent.click(moveBtn);
+    expect(q.move).not.toHaveBeenCalled();
+  });
+
+  it('edits a row group via the group button (Enter commits setGroup)', async () => {
+    const { container } = await renderDialog();
+    const row = rowByName(container, 'Alpha');
+    const groupBtn = row.querySelector('.group-btn') as HTMLButtonElement;
+    expect(groupBtn.textContent?.trim()).toBe('No group');
+    await fireEvent.click(groupBtn);
+
+    const input = row.querySelector('input.group-input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    await fireEvent.input(input, { target: { value: 'Reports' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(q.setGroup).toHaveBeenCalledWith('p/alpha', 'Reports'));
+  });
+
+  it('clearing a row group commits null; Escape cancels the group edit', async () => {
+    const { container } = await renderDialog();
+    // Cancel path: Beta already has group "Reports"; open + Escape → no call.
+    const beta = rowByName(container, 'Beta');
+    await fireEvent.click(beta.querySelector('.group-btn') as HTMLButtonElement);
+    const betaInput = beta.querySelector('input.group-input') as HTMLInputElement;
+    await fireEvent.input(betaInput, { target: { value: 'Changed' } });
+    await fireEvent.keyDown(betaInput, { key: 'Escape' });
+    await waitFor(() => expect(beta.querySelector('input.group-input')).toBeNull());
+    expect(q.setGroup).not.toHaveBeenCalled();
+
+    // Commit-null path: clear Beta's group to empty → setGroup(path, null).
+    await fireEvent.click(beta.querySelector('.group-btn') as HTMLButtonElement);
+    const betaInput2 = beta.querySelector('input.group-input') as HTMLInputElement;
+    await fireEvent.input(betaInput2, { target: { value: '' } });
+    await fireEvent.keyDown(betaInput2, { key: 'Enter' });
+    await waitFor(() => expect(q.setGroup).toHaveBeenCalledWith('p/beta', null));
+  });
+
+  it('renames a group via the header, re-tagging every query in it', async () => {
+    const { container } = await renderDialog();
+    const header = container.querySelector('.group-name') as HTMLButtonElement;
+    await fireEvent.click(header);
+
+    const input = container.querySelector('input.group-name-input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    await fireEvent.input(input, { target: { value: 'Analytics' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    // Only Beta is in project/Reports → one setGroup call re-tagging it.
+    await waitFor(() => expect(q.setGroup).toHaveBeenCalledWith('p/beta', 'Analytics'));
+  });
+
+  it('Escape on the group-rename header input cancels', async () => {
+    const { container } = await renderDialog();
+    await fireEvent.click(container.querySelector('.group-name') as HTMLButtonElement);
+    const input = container.querySelector('input.group-name-input') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'X' } });
+    await fireEvent.keyDown(input, { key: 'Escape' });
+    await waitFor(() => expect(container.querySelector('input.group-name-input')).toBeNull());
+    expect(q.setGroup).not.toHaveBeenCalled();
+  });
+
+  it('drag-reordering within a bucket applies a new @order via setOrder', async () => {
+    const { container } = await renderDialog();
+    const alpha = rowByName(container, 'Alpha');
+    const delta = rowByName(container, 'Delta');
+
+    await fireEvent.dragStart(alpha);
+    await fireEvent.dragOver(delta);
+    await fireEvent.drop(delta);
+
+    await waitFor(() => expect(q.setOrder).toHaveBeenCalled());
+    const entries = q.setOrder.mock.calls[0][0] as Array<{ filePath: string; order: number }>;
+    // Alpha dropped onto Delta → Alpha reinserted at Delta's (post-removal)
+    // index 0, i.e. before Delta; contiguous @order reassigned from 0.
+    expect(entries.map((e) => e.filePath)).toEqual(['p/alpha', 'p/delta']);
+    expect(entries.map((e) => e.order)).toEqual([0, 1]);
+  });
+
+  it('dragStart populates the dataTransfer payload when one is present', async () => {
+    const { container } = await renderDialog();
+    const alpha = rowByName(container, 'Alpha');
+    const setData = vi.fn();
+    // happy-dom omits dataTransfer; supply one to exercise the effectAllowed/
+    // setData branch of handleDragStart.
+    await fireEvent.dragStart(alpha, { dataTransfer: { effectAllowed: 'none', setData } });
+    expect(setData).toHaveBeenCalledWith('text/plain', 'p/alpha');
+  });
+
+  it('dragging a row across groups re-tags it, then reorders in the target bucket', async () => {
+    const { container } = await renderDialog();
+    const beta = rowByName(container, 'Beta'); // project / "Reports"
+    const alpha = rowByName(container, 'Alpha'); // project / ungrouped
+
+    // After the cross-group re-tag, the reload sees Beta as ungrouped so the
+    // reorder step can find it in the target bucket.
+    q.list.mockResolvedValue(
+      catalog().map((x) => (x.filePath === 'p/beta' ? { ...x, group: null } : x)),
+    );
+
+    await fireEvent.dragStart(beta);
+    await fireEvent.drop(alpha);
+
+    // Cross-group drop first re-tags the source to the target's group (null),
+    // then applies a contiguous @order across the target bucket.
+    await waitFor(() => expect(q.setGroup).toHaveBeenCalledWith('p/beta', null));
+    await waitFor(() => expect(q.setOrder).toHaveBeenCalled());
+  });
+
+  it('dropping a row onto a group header re-tags it into that group', async () => {
+    const { container } = await renderDialog();
+    const alpha = rowByName(container, 'Alpha'); // project, ungrouped
+    const header = container.querySelector('.group-header') as HTMLElement;
+
+    await fireEvent.dragStart(alpha);
+    await fireEvent.drop(header);
+
+    await waitFor(() => expect(q.setGroup).toHaveBeenCalledWith('p/alpha', 'Reports'));
+  });
+
+  it('blur commits each inline editor (rename, row-group, group-header)', async () => {
+    const { container } = await renderDialog();
+
+    // Row rename via blur.
+    const alpha = rowByName(container, 'Alpha');
+    await fireEvent.click([...alpha.querySelectorAll('button')].find((b) => b.textContent === 'Rename')!);
+    const nameInput = alpha.querySelector('input.name-input') as HTMLInputElement;
+    await fireEvent.input(nameInput, { target: { value: 'Alpha B' } });
+    await fireEvent.blur(nameInput);
+    await waitFor(() => expect(q.rename).toHaveBeenCalledWith('p/alpha', 'Alpha B'));
+
+    // Row group edit via blur.
+    const delta = rowByName(container, 'Delta');
+    await fireEvent.click(delta.querySelector('.group-btn') as HTMLButtonElement);
+    const groupInput = delta.querySelector('input.group-input') as HTMLInputElement;
+    await fireEvent.input(groupInput, { target: { value: 'Ops' } });
+    await fireEvent.blur(groupInput);
+    await waitFor(() => expect(q.setGroup).toHaveBeenCalledWith('p/delta', 'Ops'));
+
+    // Group-header rename via blur.
+    await fireEvent.click(container.querySelector('.group-name') as HTMLButtonElement);
+    const headerInput = container.querySelector('input.group-name-input') as HTMLInputElement;
+    await fireEvent.input(headerInput, { target: { value: 'Renamed' } });
+    await fireEvent.blur(headerInput);
+    await waitFor(() => expect(q.setGroup).toHaveBeenCalledWith('p/beta', 'Renamed'));
+  });
+
+  it('Close button and Escape (with no inline edit open) both fire onClose', async () => {
+    const onClose = vi.fn();
+    const { container, getByText } = await renderDialog({ onClose });
+
+    await fireEvent.keyDown(container.querySelector('.overlay')!, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await fireEvent.click(getByText('Close'));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('mousedown on the overlay backdrop closes; on the dialog it does not', async () => {
+    const onClose = vi.fn();
+    const { container } = await renderDialog({ onClose });
+
+    await fireEvent.mouseDown(container.querySelector('.dialog')!);
+    expect(onClose).not.toHaveBeenCalled();
+
+    await fireEvent.mouseDown(container.querySelector('.overlay')!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/renderer/components/ExportDialog.test.ts
+++ b/tests/renderer/components/ExportDialog.test.ts
@@ -1,0 +1,320 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render + interaction coverage for the format-first export dialog
+ * (ExportDialog, #export-menu-redesign). The dialog is a knot of runes: a
+ * mount `$effect` that loads the launched format family from
+ * `api.publish.listExporters`, `$derived` scope/variant resolution, and a
+ * re-resolving `$effect` that calls `api.publish.resolvePlan` whenever any
+ * plan input (scope, variant, depth, link policy, overrides, deselections)
+ * changes.
+ *
+ * These tests drive the real component against a mocked
+ * `api.publish` boundary and assert the visible DOM (scope radios, variant
+ * picker, Including/Excluded/Citations audit) plus the calls that reach the
+ * IPC layer (resolvePlan args, runExport args, onExported/onCancel callbacks).
+ * Nothing in the component logic is stubbed — the derived scope filtering and
+ * override/deselection set plumbing run for real.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+import type { ExporterInfo, ExportPreviewPlan } from '../../../src/renderer/lib/ipc/client';
+
+const { listExportersMock, resolvePlanMock, runExportMock } = vi.hoisted(() => ({
+  listExportersMock: vi.fn(),
+  resolvePlanMock: vi.fn(),
+  runExportMock: vi.fn(),
+}));
+
+// Mocking the client module also covers the publish store — it imports `api`
+// from this same module, so `publish.runExport` funnels into runExportMock.
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    publish: {
+      listExporters: listExportersMock,
+      resolvePlan: resolvePlanMock,
+      runExport: runExportMock,
+    },
+  },
+}));
+
+import ExportDialog from '../../../src/renderer/lib/components/ExportDialog.svelte';
+
+const GROUP = {
+  id: 'markdown' as const,
+  label: 'Markdown',
+  category: 'document' as const,
+  order: 0,
+};
+
+// Two exporters in the same family that both accept every scope, so the
+// variant picker (scopeCandidates.length > 1) always renders.
+function makeExporters(): ExporterInfo[] {
+  return [
+    {
+      id: 'md-clean',
+      label: 'Markdown (Cleaned)',
+      acceptedKinds: ['single-note', 'folder', 'tree', 'project'],
+      group: GROUP,
+      variantLabel: 'Cleaned',
+      variantOrder: 0,
+    },
+    {
+      id: 'md-verbatim',
+      label: 'Markdown (Verbatim)',
+      acceptedKinds: ['single-note', 'folder', 'tree', 'project'],
+      group: GROUP,
+      variantLabel: 'Verbatim',
+      variantOrder: 1,
+    },
+    // A different family that must be filtered out by the group id.
+    {
+      id: 'html-basic',
+      label: 'HTML',
+      acceptedKinds: ['project'],
+      group: { id: 'html', label: 'HTML', category: 'document', order: 1 },
+      variantOrder: 0,
+    },
+  ];
+}
+
+function makePlan(over: Partial<ExportPreviewPlan> = {}): ExportPreviewPlan {
+  return {
+    exporterId: 'md-clean',
+    exporterLabel: 'Markdown (Cleaned)',
+    inputs: [
+      { relativePath: 'notes/a.md', kind: 'note', title: 'Note A', overridden: false },
+      { relativePath: 'notes/b.md', kind: 'note', title: 'Note B', overridden: true },
+    ],
+    excluded: [
+      { relativePath: 'private/secret.md', reason: 'private' },
+      { relativePath: 'notes/dropped.md', reason: 'manually excluded' },
+    ],
+    citations: {
+      availableStyles: [
+        { id: 'apa', label: 'APA' },
+        { id: 'mla', label: 'MLA' },
+      ],
+      availableLocales: [
+        { id: 'en-US', label: 'English (US)' },
+        { id: 'fr-FR', label: 'French' },
+      ],
+      bySource: [{ sourceId: 'src-1', title: 'Source One', refCount: 2 }],
+      missing: [{ id: 'ghost', kind: 'cite', refCount: 1 }],
+    },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  listExportersMock.mockReset().mockResolvedValue(makeExporters());
+  resolvePlanMock.mockReset().mockResolvedValue(makePlan());
+  runExportMock.mockReset().mockResolvedValue({
+    filesWritten: 2,
+    summary: 'Exported 2 notes',
+    outputDir: '/out',
+    writtenPaths: ['/out/a.md', '/out/b.md'],
+  });
+});
+
+afterEach(cleanup);
+
+function renderDialog(over: {
+  group?: string;
+  activeFilePath?: string | null;
+  activeSourceId?: string | null;
+  onCancel?: () => void;
+  onExported?: (r: {
+    filesWritten: number;
+    summary: string;
+    outputDir: string;
+    writtenPaths: string[];
+  }) => void;
+} = {}) {
+  const onCancel = over.onCancel ?? vi.fn();
+  const onExported = over.onExported ?? vi.fn();
+  const utils = render(ExportDialog, {
+    group: over.group ?? 'markdown',
+    activeFilePath: over.activeFilePath ?? 'notes/current.md',
+    activeSourceId: over.activeSourceId ?? null,
+    onCancel,
+    onExported,
+  });
+  return { ...utils, onCancel, onExported };
+}
+
+/** The most recent resolvePlan call's [input, opts] args. */
+function lastResolveCall() {
+  return resolvePlanMock.mock.calls[resolvePlanMock.mock.calls.length - 1];
+}
+
+describe('ExportDialog — render + interaction (#export-menu-redesign)', () => {
+  it('loads the launched family and renders scope radios + variant picker', async () => {
+    const { container, findByText } = renderDialog();
+
+    // Title reads the family label off the first group exporter.
+    expect(await findByText('Export as Markdown')).toBeTruthy();
+
+    await waitFor(() => expect(listExportersMock).toHaveBeenCalled());
+
+    // Every scope the family accepts, given a note is open, is offered.
+    const scopeValues = [...container.querySelectorAll('input[name="scope"]')].map(
+      (el) => (el as HTMLInputElement).value,
+    );
+    expect(scopeValues).toEqual(['single-note', 'folder', 'tree', 'project']);
+
+    // Two markdown variants → variant picker renders (html-basic filtered out).
+    expect(await findByText('Cleaned')).toBeTruthy();
+    expect(await findByText('Verbatim')).toBeTruthy();
+  });
+
+  it('resolves a plan on mount and renders the Including / Excluded / Citations audit', async () => {
+    const { findByText, getByText } = renderDialog();
+
+    // Default scope is 'project' (initial state is in availableScopes).
+    await waitFor(() => expect(resolvePlanMock).toHaveBeenCalled());
+    expect(lastResolveCall()[0]).toEqual({ kind: 'project' });
+
+    // Including list.
+    expect(await findByText('Note A')).toBeTruthy();
+    expect(getByText('Note B')).toBeTruthy();
+    // Excluded list with reasons.
+    expect(getByText('private/secret.md')).toBeTruthy();
+    expect(getByText('private')).toBeTruthy();
+    // Citations audit (bySource + missing).
+    expect(getByText('Source One')).toBeTruthy();
+    expect(getByText(/missing cite: ghost/)).toBeTruthy();
+  });
+
+  it('changing scope to Linked notes reveals the depth control and re-resolves as a tree', async () => {
+    const { container, findByText } = renderDialog({ activeFilePath: 'notes/current.md' });
+
+    await findByText('Note A'); // wait for first resolve
+
+    const treeRadio = container.querySelector('input[name="scope"][value="tree"]')!;
+    await fireEvent.click(treeRadio);
+
+    // Depth <select> now renders.
+    await findByText(/how far to follow links out/);
+
+    await waitFor(() => {
+      const [input] = lastResolveCall();
+      expect(input).toEqual({ kind: 'tree', relativePath: 'notes/current.md', maxDepth: 3 });
+    });
+  });
+
+  it('unchecking an Including row force-excludes it in the next resolvePlan', async () => {
+    const { container, findByText } = renderDialog();
+
+    await findByText('Note A');
+    resolvePlanMock.mockClear();
+
+    // First Including-row checkbox → toggleDeselection('notes/a.md').
+    const rowCheck = container.querySelector('.audit-section .row-check') as HTMLInputElement;
+    await fireEvent.click(rowCheck);
+
+    await waitFor(() => {
+      const [, opts] = lastResolveCall();
+      expect(opts.forceExclude).toContain('notes/a.md');
+    });
+  });
+
+  it('clicking a privately-excluded row force-includes it (override) on re-resolve', async () => {
+    const { getByText, findByText } = renderDialog();
+
+    await findByText('Note A');
+    resolvePlanMock.mockClear();
+
+    // 'private/secret.md' has reason 'private' → toggleOverride → forceInclude.
+    await fireEvent.click(getByText('private/secret.md'));
+
+    await waitFor(() => {
+      const [, opts] = lastResolveCall();
+      expect(opts.forceInclude).toContain('private/secret.md');
+    });
+  });
+
+  it('Cancel button invokes onCancel and does not export', async () => {
+    const { getByText, findByText, onCancel } = renderDialog();
+    await findByText('Note A');
+
+    await fireEvent.click(getByText('Cancel'));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(runExportMock).not.toHaveBeenCalled();
+  });
+
+  it('Export routes through the publish store with the resolved args and reports the result up', async () => {
+    const { getByText, findByText, onExported } = renderDialog();
+    await findByText('Note A');
+
+    // Export button is enabled once a non-empty plan is resolved.
+    const exportBtn = getByText('Export…').closest('button') as HTMLButtonElement;
+    await waitFor(() => expect(exportBtn.disabled).toBe(false));
+
+    await fireEvent.click(exportBtn);
+
+    await waitFor(() => expect(runExportMock).toHaveBeenCalledTimes(1));
+    expect(runExportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        exporterId: 'md-clean',
+        input: { kind: 'project' },
+        linkPolicy: 'inline-title',
+        citationStyle: 'apa',
+        citationLocale: 'en-US',
+      }),
+    );
+    await waitFor(() =>
+      expect(onExported).toHaveBeenCalledWith(
+        expect.objectContaining({ filesWritten: 2, summary: 'Exported 2 notes' }),
+      ),
+    );
+  });
+
+  it('a cancelled directory picker (runExport → null) does not call onExported', async () => {
+    runExportMock.mockResolvedValue(null);
+    const { getByText, findByText, onExported } = renderDialog();
+    await findByText('Note A');
+
+    const exportBtn = getByText('Export…').closest('button') as HTMLButtonElement;
+    await waitFor(() => expect(exportBtn.disabled).toBe(false));
+    await fireEvent.click(exportBtn);
+
+    await waitFor(() => expect(runExportMock).toHaveBeenCalledTimes(1));
+    expect(onExported).not.toHaveBeenCalled();
+  });
+
+  it('a resolvePlan failure surfaces the error banner', async () => {
+    resolvePlanMock.mockRejectedValue(new Error('boom while resolving'));
+    const { findByText } = renderDialog();
+
+    expect(await findByText('boom while resolving')).toBeTruthy();
+  });
+
+  it('offers only project + source scopes when no note is open but a source is active', async () => {
+    // Family that accepts project + source; no note open, source tab active.
+    listExportersMock.mockResolvedValue([
+      {
+        id: 'md-src',
+        label: 'Markdown',
+        acceptedKinds: ['project', 'source'],
+        group: GROUP,
+        variantOrder: 0,
+      },
+    ]);
+    const { container, findByText } = renderDialog({
+      activeFilePath: null,
+      activeSourceId: 'src-42',
+    });
+
+    await findByText('Export as Markdown');
+
+    await waitFor(() => {
+      const scopeValues = [...container.querySelectorAll('input[name="scope"]')].map(
+        (el) => (el as HTMLInputElement).value,
+      );
+      expect(scopeValues).toEqual(['project', 'source']);
+    });
+  });
+});

--- a/tests/renderer/components/FindInNotesDialog.test.ts
+++ b/tests/renderer/components/FindInNotesDialog.test.ts
@@ -1,0 +1,318 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Component-interaction coverage for the project-wide Find / Find & Replace
+ * dialog (#306 / #307). FindInNotesDialog was ~0% covered: a debounced
+ * search $effect, a per-match/per-file selection model, a two-mode
+ * (find/replace) layout, and jump/replace callbacks all went unexercised.
+ *
+ * These tests render the real component and drive it the way a user does —
+ * type a pattern, toggle the case/regex flags, click a match to jump, toggle
+ * match/file checkboxes, and run Replace Selected / Replace All — asserting
+ * the mocked `api.notebase.searchInNotes` and store `replaceInNotes` boundary
+ * receive the right options, and that the visible DOM reflects the results.
+ *
+ * The 200ms search debounce runs under real timers; `waitFor` polls the DOM
+ * / mock until the deferred search resolves, so the reactive path is proven
+ * end to end rather than stubbed.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+import type {
+  SearchInNotesFileResult,
+  ReplaceInNotesResult,
+} from '../../../src/shared/types';
+
+const { searchMock, replaceMock } = vi.hoisted(() => ({
+  searchMock: vi.fn(),
+  replaceMock: vi.fn(),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { notebase: { searchInNotes: searchMock } },
+}));
+
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({
+  getNotebaseStore: () => ({ replaceInNotes: replaceMock }),
+}));
+
+import FindInNotesDialog from '../../../src/renderer/lib/components/FindInNotesDialog.svelte';
+
+type Mode = 'find' | 'replace';
+
+/** Two files, three matches total. */
+function makeResults(): SearchInNotesFileResult[] {
+  return [
+    {
+      relativePath: 'notes/alpha.md',
+      matches: [
+        { line: 3, startCol: 4, endCol: 7, lineText: 'the foo is here' },
+        { line: 7, startCol: 0, endCol: 3, lineText: 'foo again on this line' },
+      ],
+    },
+    {
+      relativePath: 'notes/beta.md',
+      matches: [{ line: 1, startCol: 2, endCol: 5, lineText: 'a foo b' }],
+    },
+  ];
+}
+
+const REPLACE_RESULT: ReplaceInNotesResult = {
+  changedPaths: ['notes/alpha.md', 'notes/beta.md'],
+  replacedCount: 3,
+};
+
+function renderDialog(over: {
+  initialMode?: Mode;
+  onJumpTo?: (rel: string, line: number, col: number) => void;
+  onClose?: () => void;
+} = {}) {
+  const onJumpTo = over.onJumpTo ?? vi.fn();
+  const onClose = over.onClose ?? vi.fn();
+  const r = render(FindInNotesDialog, {
+    initialMode: over.initialMode ?? 'find',
+    onJumpTo,
+    onClose,
+  });
+  return { ...r, onJumpTo, onClose };
+}
+
+function patternInput(container: HTMLElement): HTMLInputElement {
+  return container.querySelector('input.input') as HTMLInputElement;
+}
+
+async function typePattern(container: HTMLElement, value: string) {
+  await fireEvent.input(patternInput(container), { target: { value } });
+}
+
+beforeEach(() => {
+  searchMock.mockReset();
+  replaceMock.mockReset();
+  searchMock.mockResolvedValue(makeResults());
+  replaceMock.mockResolvedValue(REPLACE_RESULT);
+});
+
+afterEach(cleanup);
+
+describe('FindInNotesDialog — find mode (#306)', () => {
+  it('does not search while the pattern is blank', async () => {
+    const { container } = renderDialog();
+    // The mount $effect fires runSearch, but the debounced body returns
+    // early for a blank pattern — searchInNotes is never called.
+    await new Promise((r) => setTimeout(r, 250));
+    expect(searchMock).not.toHaveBeenCalled();
+    expect(container.querySelectorAll('.file-group')).toHaveLength(0);
+  });
+
+  it('typing a pattern searches with the current flags and renders results', async () => {
+    const { container, getByText } = renderDialog();
+    await typePattern(container, 'foo');
+
+    await waitFor(() =>
+      expect(searchMock).toHaveBeenLastCalledWith({
+        pattern: 'foo',
+        caseSensitive: false,
+        regex: false,
+      }),
+    );
+
+    // File groups + the match excerpts render.
+    await waitFor(() => expect(getByText('notes/alpha.md')).toBeTruthy());
+    expect(getByText('notes/beta.md')).toBeTruthy();
+    // Match location label "line:col+1" (3:5) and the highlighted <mark>.
+    expect(getByText('3:5')).toBeTruthy();
+    expect(container.querySelectorAll('.match-jump')).toHaveLength(3);
+    expect(container.querySelectorAll('mark')[0].textContent).toBe('foo');
+    // Footer status summarizes the totals.
+    expect(getByText('3 matches in 2 files')).toBeTruthy();
+    // Find mode: no replacement input, no checkboxes, no replace actions.
+    expect(container.querySelector('.match-check')).toBeNull();
+    expect(container.querySelector('.replace-actions')).toBeNull();
+  });
+
+  it('toggling the case-sensitive and regex flags re-runs the search', async () => {
+    const { container, getByTitle } = renderDialog();
+    await typePattern(container, 'foo');
+    await waitFor(() => expect(searchMock).toHaveBeenCalled());
+
+    await fireEvent.click(getByTitle('Match case'));
+    await waitFor(() =>
+      expect(searchMock).toHaveBeenLastCalledWith({
+        pattern: 'foo',
+        caseSensitive: true,
+        regex: false,
+      }),
+    );
+
+    await fireEvent.click(getByTitle('Regular expression'));
+    await waitFor(() =>
+      expect(searchMock).toHaveBeenLastCalledWith({
+        pattern: 'foo',
+        caseSensitive: true,
+        regex: true,
+      }),
+    );
+  });
+
+  it('clicking a match jumps to its path/line/col', async () => {
+    const onJumpTo = vi.fn();
+    const { container } = renderDialog({ onJumpTo });
+    await typePattern(container, 'foo');
+    await waitFor(() =>
+      expect(container.querySelectorAll('.match-jump').length).toBe(3),
+    );
+
+    const jumps = container.querySelectorAll('.match-jump');
+    await fireEvent.click(jumps[0]);
+    expect(onJumpTo).toHaveBeenCalledWith('notes/alpha.md', 3, 4);
+
+    await fireEvent.click(jumps[2]);
+    expect(onJumpTo).toHaveBeenCalledWith('notes/beta.md', 1, 2);
+  });
+
+  it('collapsing a file header hides its match list', async () => {
+    const { container, getByText } = renderDialog();
+    await typePattern(container, 'foo');
+    await waitFor(() =>
+      expect(container.querySelectorAll('.match-list').length).toBe(2),
+    );
+
+    await fireEvent.click(getByText('notes/alpha.md'));
+    // alpha collapses → one match-list remains (beta's).
+    await waitFor(() =>
+      expect(container.querySelectorAll('.match-list').length).toBe(1),
+    );
+
+    // Toggling back expands it again.
+    await fireEvent.click(getByText('notes/alpha.md'));
+    await waitFor(() =>
+      expect(container.querySelectorAll('.match-list').length).toBe(2),
+    );
+  });
+
+  it('shows the "No matches" status when the search returns nothing', async () => {
+    searchMock.mockResolvedValue([]);
+    const { container, getByText } = renderDialog();
+    await typePattern(container, 'zzznope');
+    await waitFor(() => expect(getByText('No matches')).toBeTruthy());
+    expect(container.querySelectorAll('.file-group')).toHaveLength(0);
+  });
+
+  it('Escape and the close button both invoke onClose', async () => {
+    const onClose = vi.fn();
+    const { container, getByLabelText } = renderDialog({ onClose });
+
+    await fireEvent.keyDown(container.querySelector('.overlay')!, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await fireEvent.click(getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('clicking the overlay backdrop closes the dialog', async () => {
+    const onClose = vi.fn();
+    const { container } = renderDialog({ onClose });
+    const overlay = container.querySelector('.overlay') as HTMLElement;
+    // mousedown where target === overlay itself (not a child) closes.
+    await fireEvent.mouseDown(overlay);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('the mode segments switch between find and replace', async () => {
+    const { container, getByText, getByPlaceholderText } = renderDialog();
+    // Starts in find mode → no replacement input.
+    expect(container.querySelector('input[placeholder="Replace with…"]')).toBeNull();
+
+    await fireEvent.click(getByText('Find & Replace'));
+    expect(getByPlaceholderText('Replace with…')).toBeTruthy();
+
+    await fireEvent.click(getByText('Find'));
+    expect(container.querySelector('input[placeholder="Replace with…"]')).toBeNull();
+  });
+});
+
+describe('FindInNotesDialog — replace mode (#307)', () => {
+  async function renderWithResults(over: Parameters<typeof renderDialog>[0] = {}) {
+    const r = renderDialog({ initialMode: 'replace', ...over });
+    await typePattern(r.container, 'foo');
+    await waitFor(() =>
+      expect(r.container.querySelectorAll('.match-jump').length).toBe(3),
+    );
+    return r;
+  }
+
+  it('renders per-match checkboxes and the replace action bar', async () => {
+    const { container, getByText } = await renderWithResults();
+    expect(container.querySelectorAll('.match-check')).toHaveLength(3);
+    expect(container.querySelectorAll('.file-check')).toHaveLength(2);
+    expect(getByText('Replace Selected')).toBeTruthy();
+    expect(getByText('Replace All')).toBeTruthy();
+    // Preview column shows the post-replacement line.
+    expect(container.querySelector('.preview')).toBeTruthy();
+  });
+
+  it('Replace All sends every match as a selection with the replacement', async () => {
+    const { getByText, getByPlaceholderText } = await renderWithResults();
+    await fireEvent.input(getByPlaceholderText('Replace with…'), {
+      target: { value: 'BAR' },
+    });
+
+    await fireEvent.click(getByText('Replace All'));
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledTimes(1));
+    const opts = replaceMock.mock.calls[0][0];
+    expect(opts.pattern).toBe('foo');
+    expect(opts.replacement).toBe('BAR');
+    expect(opts.selections).toHaveLength(3);
+    expect(opts.selections[0]).toEqual({
+      relativePath: 'notes/alpha.md',
+      line: 3,
+      startCol: 4,
+      endCol: 7,
+    });
+    // Post-replace status is reported.
+    await waitFor(() => expect(getByText('Replaced 3 matches in 2 files')).toBeTruthy());
+  });
+
+  it('Replace Selected excludes unchecked matches', async () => {
+    const { container, getByText } = await renderWithResults();
+    // Uncheck the first match, then replace only the selected ones.
+    const checks = container.querySelectorAll('.match-check');
+    await fireEvent.click(checks[0]);
+
+    await fireEvent.click(getByText('Replace Selected'));
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledTimes(1));
+    expect(replaceMock.mock.calls[0][0].selections).toHaveLength(2);
+  });
+
+  it('the file checkbox toggles every match in that file at once', async () => {
+    const { container, getByText } = await renderWithResults();
+    const fileChecks = container.querySelectorAll<HTMLInputElement>('.file-check');
+    // alpha.md has 2 matches → its file-check starts fully checked.
+    expect(fileChecks[0].checked).toBe(true);
+
+    // Unchecking the file clears both of its matches from the selection.
+    await fireEvent.click(fileChecks[0]);
+    await fireEvent.click(getByText('Replace Selected'));
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledTimes(1));
+    // Only beta.md's single match survives.
+    const sel = replaceMock.mock.calls[0][0].selections;
+    expect(sel).toHaveLength(1);
+    expect(sel[0].relativePath).toBe('notes/beta.md');
+  });
+
+  it('Replace Selected with nothing checked reports "Nothing selected"', async () => {
+    const { container, getByText } = await renderWithResults();
+    // Uncheck all three matches.
+    for (const c of container.querySelectorAll('.match-check')) {
+      await fireEvent.click(c);
+    }
+    await fireEvent.click(getByText('Replace Selected'));
+
+    await waitFor(() => expect(getByText('Nothing selected')).toBeTruthy());
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/renderer/components/PublishDialog.test.ts
+++ b/tests/renderer/components/PublishDialog.test.ts
@@ -1,0 +1,264 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Component-interaction coverage for the "Publish → git remote" dialog (#254).
+ *
+ * PublishDialog reads exporter/target metadata directly (reads are allowed in
+ * components) but routes every mutation — add/remove a target, preview, publish —
+ * through the publish store, which is a thin passthrough to `api.publish.*`. We
+ * mock the ipc-client boundary (the store gets the same mock, so the real
+ * store-→api wiring is exercised) and assert:
+ *   - the target cards / empty state / add-target form render,
+ *   - Save builds the right PublishTarget and reaches upsertTarget,
+ *   - Remove reaches removeTarget,
+ *   - Preview/Publish call toGit with the correct dryRun flag (the network push
+ *     is never run — the mock returns canned data) and render the outcome,
+ *   - Close / Escape / backdrop invoke onClose.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+
+const { listExporters, listTargets, upsertTarget, removeTarget, toGit } = vi.hoisted(() => ({
+  listExporters: vi.fn(),
+  listTargets: vi.fn(),
+  upsertTarget: vi.fn(),
+  removeTarget: vi.fn(),
+  toGit: vi.fn(),
+}));
+
+// The publish store imports `api` from this same module, so mocking here means
+// the real store passes through to these mocks — no separate store stub needed.
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    publish: { listExporters, listTargets, upsertTarget, removeTarget, toGit },
+  },
+}));
+
+import PublishDialog from '../../../src/renderer/lib/components/PublishDialog.svelte';
+import type { PublishTarget, PublishGitResponse } from '../../../src/renderer/lib/ipc/client';
+
+function exporter(id: string, label: string, kinds: string[] = ['project']) {
+  return { id, label, acceptedKinds: kinds, group: { id: 'g', label: 'G' }, variantOrder: 0 };
+}
+
+function target(over: Partial<PublishTarget> = {}): PublishTarget {
+  return {
+    id: 'my-garden',
+    label: 'My Garden',
+    exporter: 'static-site',
+    gitRemote: 'git@github.com:you/garden.git',
+    gitBranch: 'gh-pages',
+    subdir: '.',
+    commitMessageTemplate: 'Publish {{date}} from Minerva',
+    ...over,
+  };
+}
+
+function previewResponse(): PublishGitResponse {
+  return {
+    ok: true,
+    result: {
+      targetId: 'my-garden',
+      dryRun: true,
+      branch: 'gh-pages',
+      branchCreated: false,
+      changes: [
+        { path: 'index.html', status: 'added' },
+        { path: 'about.html', status: 'modified' },
+      ],
+      committed: false,
+      pushed: false,
+    },
+  };
+}
+
+function publishedResponse(): PublishGitResponse {
+  return {
+    ok: true,
+    result: {
+      targetId: 'my-garden',
+      dryRun: false,
+      branch: 'gh-pages',
+      branchCreated: false,
+      changes: [{ path: 'index.html', status: 'added' }],
+      committed: true,
+      pushed: true,
+      sha: 'abcdef1234567',
+      commitMessage: 'Publish 2026 from Minerva',
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  listExporters.mockReset();
+  listTargets.mockReset();
+  upsertTarget.mockReset();
+  removeTarget.mockReset();
+  toGit.mockReset();
+});
+
+/** Render, then wait for onMount (listTargets + listExporters) to settle —
+ *  the "Add target…" button only appears once `loaded` flips true. */
+async function renderDialog(
+  over: { targets?: PublishTarget[]; exporters?: ReturnType<typeof exporter>[]; onClose?: () => void } = {},
+) {
+  listTargets.mockResolvedValue(over.targets ?? []);
+  listExporters.mockResolvedValue(over.exporters ?? [exporter('static-site', 'Static Site')]);
+  const onClose = over.onClose ?? vi.fn();
+  const utils = render(PublishDialog, { onClose });
+  await utils.findByText('Add target…');
+  return { ...utils, onClose };
+}
+
+describe('PublishDialog — publish → git remote (#254)', () => {
+  it('shows the empty state when there are no targets', async () => {
+    const { getByText } = await renderDialog({ targets: [] });
+    expect(getByText('No publish targets yet.')).toBeTruthy();
+    expect(listTargets).toHaveBeenCalled();
+  });
+
+  it('renders a card per configured target with its exporter/remote/branch', async () => {
+    const { getByText, container } = await renderDialog({ targets: [target()] });
+
+    expect(getByText('My Garden')).toBeTruthy();
+    // "static-site → git@github.com:you/garden.git (gh-pages)" spread across nodes.
+    const detail = container.querySelector('.target-detail')!;
+    expect(detail.textContent).toContain('static-site');
+    expect(detail.textContent).toContain('git@github.com:you/garden.git');
+    expect(detail.textContent).toContain('gh-pages');
+    expect(getByText('Preview')).toBeTruthy();
+    expect(getByText('Publish')).toBeTruthy();
+  });
+
+  it('opens the add-target form and Save builds the right PublishTarget through upsertTarget', async () => {
+    upsertTarget.mockResolvedValue([]);
+    const { getByText, getByPlaceholderText } = await renderDialog({ targets: [] });
+
+    await fireEvent.click(getByText('Add target…'));
+
+    await fireEvent.input(getByPlaceholderText('My Garden'), { target: { value: 'My Garden' } });
+    await fireEvent.input(getByPlaceholderText('git@github.com:you/garden.git'), {
+      target: { value: 'git@github.com:me/site.git' },
+    });
+
+    await fireEvent.click(getByText('Save target'));
+
+    await waitFor(() => expect(upsertTarget).toHaveBeenCalledTimes(1));
+    expect(upsertTarget).toHaveBeenCalledWith({
+      id: 'my-garden', // slug(label), unique
+      label: 'My Garden',
+      exporter: 'static-site',
+      gitRemote: 'git@github.com:me/site.git',
+      gitBranch: 'gh-pages',
+      subdir: '.',
+      commitMessageTemplate: 'Publish {{date}} from Minerva',
+    });
+  });
+
+  it('disables Save until label and remote are filled ($derived canSave)', async () => {
+    const { getByText, getByPlaceholderText } = await renderDialog({ targets: [] });
+    await fireEvent.click(getByText('Add target…'));
+
+    const save = getByText('Save target') as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    await fireEvent.input(getByPlaceholderText('My Garden'), { target: { value: 'Site' } });
+    expect(save.disabled).toBe(true); // remote still empty
+
+    await fireEvent.input(getByPlaceholderText('git@github.com:you/garden.git'), {
+      target: { value: 'git@github.com:me/site.git' },
+    });
+    expect(save.disabled).toBe(false);
+  });
+
+  it('newly saved target shows in the list (upsert returns the updated list)', async () => {
+    upsertTarget.mockResolvedValue([target({ id: 'blog', label: 'Blog' })]);
+    const { getByText, getByPlaceholderText, findByText } = await renderDialog({ targets: [] });
+
+    await fireEvent.click(getByText('Add target…'));
+    await fireEvent.input(getByPlaceholderText('My Garden'), { target: { value: 'Blog' } });
+    await fireEvent.input(getByPlaceholderText('git@github.com:you/garden.git'), {
+      target: { value: 'git@github.com:me/blog.git' },
+    });
+    await fireEvent.click(getByText('Save target'));
+
+    expect(await findByText('Blog')).toBeTruthy();
+  });
+
+  it('Remove (✕) routes through removeTarget with the target id', async () => {
+    removeTarget.mockResolvedValue([]);
+    const { getByTitle } = await renderDialog({ targets: [target()] });
+
+    await fireEvent.click(getByTitle('Remove target'));
+
+    await waitFor(() => expect(removeTarget).toHaveBeenCalledWith('my-garden'));
+  });
+
+  it('Preview calls toGit with dryRun:true and renders the change summary', async () => {
+    toGit.mockResolvedValue(previewResponse());
+    const { getByText, findByText } = await renderDialog({ targets: [target()] });
+
+    await fireEvent.click(getByText('Preview'));
+
+    await waitFor(() => expect(toGit).toHaveBeenCalledWith('my-garden', { dryRun: true }));
+    // counts(): "1 added · 1 modified · 0 deleted"
+    expect(await findByText(/Preview — 1 added · 1 modified · 0 deleted/)).toBeTruthy();
+  });
+
+  it('Publish calls toGit with dryRun:false and renders the published outcome', async () => {
+    toGit.mockResolvedValue(publishedResponse());
+    const { getByText, findByText } = await renderDialog({ targets: [target()] });
+
+    await fireEvent.click(getByText('Publish'));
+
+    await waitFor(() => expect(toGit).toHaveBeenCalledWith('my-garden', { dryRun: false }));
+    expect(await findByText(/Published — 1 added · 0 modified · 0 deleted/)).toBeTruthy();
+  });
+
+  it('a failed publish renders the raw git error and a Copy error affordance', async () => {
+    toGit.mockResolvedValue({ ok: false, error: 'fatal: could not read Username' });
+    const { getByText, findByText } = await renderDialog({ targets: [target()] });
+
+    await fireEvent.click(getByText('Publish'));
+
+    expect(await findByText('Publish failed')).toBeTruthy();
+    expect(getByText('fatal: could not read Username')).toBeTruthy();
+    expect(getByText('Copy error')).toBeTruthy();
+  });
+
+  it('Close invokes onClose', async () => {
+    const onClose = vi.fn();
+    const { getByText } = await renderDialog({ targets: [], onClose });
+    await fireEvent.click(getByText('Close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape and backdrop mousedown invoke onClose', async () => {
+    const onClose = vi.fn();
+    const { container } = await renderDialog({ targets: [], onClose });
+    const backdrop = container.querySelector('.publish-backdrop') as HTMLElement;
+
+    await fireEvent.keyDown(backdrop, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await fireEvent.mouseDown(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('only project-scoped exporters populate the form select', async () => {
+    const { getByText, container } = await renderDialog({
+      targets: [],
+      exporters: [
+        exporter('static-site', 'Static Site', ['project']),
+        exporter('single-md', 'Single Markdown', ['note']),
+      ],
+    });
+    await fireEvent.click(getByText('Add target…'));
+
+    const opts = [...container.querySelectorAll('.form select option')].map((o) => o.textContent);
+    expect(opts).toContain('Static Site');
+    expect(opts).not.toContain('Single Markdown');
+  });
+});

--- a/tests/renderer/components/conversations/Composer.test.ts
+++ b/tests/renderer/components/conversations/Composer.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render + interaction coverage for the conversation Composer (~0% covered).
+ * Drives the real component the way a user does — type into the textarea,
+ * ⏎ to send, ⇧⏎ for a newline, Cancel while streaming, and the `/` slash
+ * launcher — and asserts the visible DOM plus the store methods the composer
+ * is wired to (`setComposer` / `send` / `cancel` / `runBuiltinCommand`).
+ *
+ * The composer is a *controlled* textarea (`value={tab.composer}`, not a
+ * two-way bind): the input handler forwards each keystroke to `store.setComposer`
+ * and the send path reads `tab.composer`, so the meaningful assertions are the
+ * store calls, and the fixture seeds `tab.composer` for the send tests.
+ *
+ * The conversations / voice stores and the slash-command registry are mocked;
+ * the pure slash helpers (buildSlashMenu → the reserved `/clear` `/compact`
+ * built-ins) and the cost-badge formatter run for real.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import type { ConversationMessage } from '../../../../src/shared/types';
+
+// ── Store mocks ───────────────────────────────────────────────────────────
+const send = vi.fn();
+const cancel = vi.fn();
+const setComposer = vi.fn();
+const runBuiltinCommand = vi.fn();
+
+vi.mock('../../../../src/renderer/lib/stores/conversations.svelte', () => ({
+  getConversationsStore: () => ({
+    send,
+    cancel,
+    setComposer,
+    runBuiltinCommand,
+    answerQuestion: vi.fn(),
+  }),
+}));
+
+// Voice disabled by default → the mic UI stays out of the way. A per-test
+// override re-mocks `voiceSettings.enabled`/the voice store where needed.
+vi.mock('../../../../src/renderer/lib/voice/voice.svelte', () => ({
+  getVoiceStore: () => ({
+    status: 'idle',
+    surface: null,
+    error: null,
+    modelProgress: null,
+    recording: false,
+    busy: false,
+    start: vi.fn(),
+    stopAndTranscribe: vi.fn(),
+    cancel: vi.fn(),
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../../src/renderer/lib/voice/voice-settings.svelte', () => ({
+  voiceSettings: { enabled: false },
+}));
+
+// Empty skill registry — the slash menu then shows only the reserved
+// built-ins (`/clear`, `/compact`), which come from the real pure helpers.
+vi.mock('../../../../src/renderer/lib/tools/tool-registry', () => ({
+  getSlashCommands: () => [],
+}));
+
+import Composer from '../../../../src/renderer/lib/components/conversations/Composer.svelte';
+
+afterEach(cleanup);
+beforeEach(() => {
+  send.mockClear();
+  cancel.mockClear();
+  setComposer.mockClear();
+  runBuiltinCommand.mockClear();
+});
+
+type TabLike = Record<string, unknown>;
+
+function makeTab(over: {
+  composer?: string;
+  streaming?: boolean;
+  notePath?: string | null;
+  messages?: ConversationMessage[];
+} = {}): TabLike {
+  return {
+    id: 'tab-1',
+    title: null,
+    composer: over.composer ?? '',
+    streaming: over.streaming ?? false,
+    streamedChunks: '',
+    pendingQuestion: null,
+    extraTools: [],
+    conversation: {
+      messages: over.messages ?? [],
+      contextBundle: { notePath: over.notePath ?? null },
+    },
+  };
+}
+
+function renderComposer(over: Parameters<typeof makeTab>[0] & { currentNotePath?: string | null } = {}) {
+  const { currentNotePath, ...tabOver } = over;
+  const r = render(Composer, {
+    tab: makeTab(tabOver) as never,
+    currentNotePath: currentNotePath ?? null,
+    onInvokeSkill: vi.fn(),
+  });
+  const textarea = r.container.querySelector('textarea') as HTMLTextAreaElement;
+  return { ...r, textarea };
+}
+
+describe('Composer — render + interaction (~0% covered)', () => {
+  it('renders the textarea and the send hint, defaulting to the no-note placeholder', () => {
+    const { textarea, getByText } = renderComposer();
+    expect(textarea).toBeTruthy();
+    expect(textarea.placeholder).toBe('Ask anything, or type / for skills…');
+    expect(getByText('⏎ send · ⇧⏎ newline')).toBeTruthy();
+    expect(getByText('Send')).toBeTruthy();
+  });
+
+  it('shows the note-scoped placeholder + context chip when the conversation has an anchor note', () => {
+    const { textarea, getByText } = renderComposer({ notePath: 'notes/topic.md' });
+    expect(textarea.placeholder).toBe('Ask about this note, or type / for skills…');
+    expect(getByText('notes/topic.md')).toBeTruthy();
+  });
+
+  it('typing forwards the value to store.setComposer and does NOT open the slash menu for prose', async () => {
+    const { textarea, container } = renderComposer();
+    await fireEvent.input(textarea, { target: { value: 'hello world' } });
+    expect(setComposer).toHaveBeenCalledWith('hello world');
+    expect(container.querySelector('.slash-menu')).toBeNull();
+  });
+
+  it('⏎ (no shift) sends the composer text with the current note path', async () => {
+    const { textarea } = renderComposer({ composer: 'what is this?', currentNotePath: 'notes/active.md' });
+    await fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('what is this?', 'notes/active.md');
+  });
+
+  it('⇧⏎ inserts a newline and does NOT send', async () => {
+    const { textarea } = renderComposer({ composer: 'line one' });
+    await fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('clicking Send fires store.send with the composer text', async () => {
+    const { getByText } = renderComposer({ composer: 'ship it', currentNotePath: 'notes/x.md' });
+    await fireEvent.click(getByText('Send'));
+    expect(send).toHaveBeenCalledWith('ship it', 'notes/x.md');
+  });
+
+  it('an empty composer disables Send, so clicking it is a no-op', async () => {
+    const { getByText } = renderComposer({ composer: '   ' });
+    const btn = getByText('Send').closest('button') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    await fireEvent.click(btn);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('while streaming: the textarea is disabled, Send is replaced by Cancel, and Cancel fires store.cancel', async () => {
+    const { textarea, getByText, queryByText } = renderComposer({ streaming: true, composer: 'in flight' });
+    expect(textarea.disabled).toBe(true);
+    expect(queryByText('Send')).toBeNull();
+    await fireEvent.click(getByText('Cancel'));
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the running cost badge once a turn reports usage', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'user', content: 'hi', timestamp: '2026-07-28T00:00:00Z' },
+      {
+        role: 'assistant',
+        content: 'hello',
+        timestamp: '2026-07-28T00:00:01Z',
+        usage: { inputTokens: 1000, outputTokens: 500, cacheCreationTokens: 0, cacheReadTokens: 0 },
+        usageModel: 'claude-opus-5',
+      },
+    ];
+    const { container } = renderComposer({ messages });
+    const badge = container.querySelector('.composer-cost');
+    expect(badge).toBeTruthy();
+    expect(badge?.textContent).toContain('tok');
+  });
+
+  it('no cost badge renders before any turn reports usage', () => {
+    const { container } = renderComposer();
+    expect(container.querySelector('.composer-cost')).toBeNull();
+  });
+
+  it('typing a bare "/" opens the slash launcher with the reserved built-ins', async () => {
+    const { textarea, getByText, container } = renderComposer();
+    await fireEvent.input(textarea, { target: { value: '/' } });
+    expect(container.querySelector('.slash-menu')).toBeTruthy();
+    expect(getByText('/clear')).toBeTruthy();
+    expect(getByText('/compact')).toBeTruthy();
+  });
+
+  it('⏎ in the open slash menu runs the highlighted built-in and does not send', async () => {
+    const { textarea } = renderComposer();
+    await fireEvent.input(textarea, { target: { value: '/' } });
+    await fireEvent.keyDown(textarea, { key: 'Enter' });
+    // First built-in alphabetically is `clear`.
+    expect(runBuiltinCommand).toHaveBeenCalledWith('clear');
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('ArrowDown moves the slash selection to the second built-in before Enter selects it', async () => {
+    const { textarea } = renderComposer();
+    await fireEvent.input(textarea, { target: { value: '/' } });
+    await fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+    await fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(runBuiltinCommand).toHaveBeenCalledWith('compact');
+  });
+});

--- a/tests/renderer/components/conversations/MessageList.test.ts
+++ b/tests/renderer/components/conversations/MessageList.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Render + interaction coverage for the conversation MessageList (~0% covered).
+ * Renders the real transcript component with representative
+ * `ConversationMessage[]` and asserts the visible DOM: each turn's role label
+ * (user turns keep their role, the assistant turn is relabelled "Minerva"),
+ * markdown-rendered assistant prose, system turns hidden, an assistant turn's
+ * citations (via the real MessageCitations child), the per-turn usage/cost
+ * line (present only when a turn reports usage), the streaming "thinking"
+ * interstitial, and the ask-user card whose choice/Reply actions call
+ * `store.answerQuestion`.
+ *
+ * The conversations / editor / notebase / source-data stores and the IPC
+ * client are mocked; markdown-it and MessageCitations run for real. With no
+ * drafts on the tab the DraftCards child renders nothing.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import type { ConversationMessage, Citation } from '../../../../src/shared/types';
+import type { AskUserRequest } from '../../../../src/shared/conversation-tools';
+
+// ── Store + IPC mocks ─────────────────────────────────────────────────────
+const answerQuestion = vi.fn();
+
+vi.mock('../../../../src/renderer/lib/stores/conversations.svelte', () => ({
+  getConversationsStore: () => ({
+    answerQuestion,
+    // Draft approve/discard methods DraftCards would call — never reached here
+    // because the fixture tab carries no drafts, but present so the child mounts.
+    approveDraft: vi.fn(),
+    discardDraft: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../../src/renderer/lib/stores/editor.svelte', () => ({
+  getEditorStore: () => ({
+    activeFilePath: null,
+    save: vi.fn(),
+    reloadTabFromDisk: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../../src/renderer/lib/stores/notebase.svelte', () => ({
+  getNotebaseStore: () => ({ writeFile: vi.fn() }),
+}));
+
+vi.mock('../../../../src/renderer/lib/stores/source-data.svelte', () => ({
+  getSourceDataStore: () => ({ ingestUrl: vi.fn() }),
+}));
+
+vi.mock('../../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    shell: { openExternal: vi.fn() },
+    notebase: { readFile: vi.fn() },
+  },
+}));
+
+import MessageList from '../../../../src/renderer/lib/components/conversations/MessageList.svelte';
+
+afterEach(cleanup);
+
+type TabLike = Record<string, unknown>;
+
+function makeTab(over: {
+  messages?: ConversationMessage[];
+  streaming?: boolean;
+  streamedChunks?: string;
+  pendingQuestion?: AskUserRequest | null;
+  notePath?: string | null;
+} = {}): TabLike {
+  return {
+    id: 'tab-1',
+    title: null,
+    composer: '',
+    streaming: over.streaming ?? false,
+    streamedChunks: over.streamedChunks ?? '',
+    pendingQuestion: over.pendingQuestion ?? null,
+    extraTools: [],
+    // Every draft collection empty → DraftCards renders nothing.
+    drafts: [],
+    sourceDrafts: [],
+    sourceDraftResults: {},
+    noteDraftResults: {},
+    propertyDrafts: [],
+    propertyDraftResults: {},
+    sourcePropertyDrafts: [],
+    sourcePropertyDraftResults: {},
+    claimsDrafts: [],
+    claimsDraftResults: {},
+    computeDrafts: [],
+    refactorDrafts: [],
+    reorgDrafts: [],
+    deleteDrafts: [],
+    noteBodyDrafts: [],
+    computeDraftState: {},
+    conversation: {
+      messages: over.messages ?? [],
+      contextBundle: { notePath: over.notePath ?? null },
+    },
+  };
+}
+
+function renderList(over: Parameters<typeof makeTab>[0] & { currentNotePath?: string | null } = {}) {
+  const { currentNotePath, ...tabOver } = over;
+  return render(MessageList, {
+    tab: makeTab(tabOver) as never,
+    currentNotePath: currentNotePath ?? null,
+  });
+}
+
+const ts = '2026-07-28T00:00:00Z';
+
+describe('MessageList — render + interaction (~0% covered)', () => {
+  it('renders a user turn (role kept) and an assistant turn (relabelled "Minerva") with markdown', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'user', content: 'Hello there', timestamp: ts },
+      { role: 'assistant', content: 'Hi **friend**', timestamp: ts },
+    ];
+    const { getByText, container } = renderList({ messages });
+
+    expect(getByText('Hello there')).toBeTruthy();
+    // User role label is the raw role; assistant is presented as "Minerva".
+    expect(getByText('user')).toBeTruthy();
+    expect(getByText('Minerva')).toBeTruthy();
+    // Assistant prose is markdown-rendered → **friend** becomes <strong>.
+    const strong = container.querySelector('.msg.assistant .msg-content strong');
+    expect(strong?.textContent).toBe('friend');
+  });
+
+  it('does not render system turns', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'system', content: 'SECRET SYSTEM PROMPT', timestamp: ts },
+      { role: 'user', content: 'visible question', timestamp: ts },
+    ];
+    const { queryByText, getByText } = renderList({ messages });
+    expect(getByText('visible question')).toBeTruthy();
+    expect(queryByText('SECRET SYSTEM PROMPT')).toBeNull();
+  });
+
+  it('renders an assistant turn\'s citations through MessageCitations', () => {
+    const citations: Citation[] = [
+      { url: 'https://www.nature.com/articles/x', title: 'A Nature paper', citedText: 'quoted' },
+    ];
+    const messages: ConversationMessage[] = [
+      { role: 'assistant', content: 'See the paper.', timestamp: ts, citations },
+    ];
+    const { getByText } = renderList({ messages, currentNotePath: 'notes/active.md' });
+    expect(getByText('[1]')).toBeTruthy();
+    expect(getByText('A Nature paper')).toBeTruthy();
+    expect(getByText('nature.com')).toBeTruthy();
+  });
+
+  it('shows the per-turn cost line when the assistant turn reports usage', () => {
+    const messages: ConversationMessage[] = [
+      {
+        role: 'assistant',
+        content: 'answer',
+        timestamp: ts,
+        usage: { inputTokens: 2000, outputTokens: 1000, cacheCreationTokens: 0, cacheReadTokens: 0 },
+        usageModel: 'claude-opus-5',
+      },
+    ];
+    const { container } = renderList({ messages });
+    const cost = container.querySelector('.msg.assistant .msg-cost');
+    expect(cost).toBeTruthy();
+    expect(cost?.getAttribute('title')).toBe('Token usage / cost for this turn');
+    expect(cost?.textContent).toContain('tok');
+  });
+
+  it('omits the cost line for an assistant turn with no usage', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'assistant', content: 'no usage here', timestamp: ts },
+    ];
+    const { container } = renderList({ messages });
+    expect(container.querySelector('.msg-cost')).toBeNull();
+  });
+
+  it('renders the streaming block with partial text and the "thinking" interstitial', () => {
+    const { container, getByLabelText } = renderList({
+      streaming: true,
+      streamedChunks: 'partial answer so far',
+    });
+    expect(getByLabelText('Thinking')).toBeTruthy();
+    const streaming = container.querySelector('.msg.assistant.streaming .msg-content');
+    expect(streaming?.textContent).toContain('partial answer so far');
+  });
+
+  it('renders the ask-user card; clicking a choice calls store.answerQuestion with the tab id + choice', async () => {
+    answerQuestion.mockClear();
+    const pendingQuestion: AskUserRequest = {
+      questionId: 'q1',
+      question: 'Which direction?',
+      choices: ['Left', 'Right'],
+    };
+    const { getByText } = renderList({ pendingQuestion });
+
+    expect(getByText('Which direction?')).toBeTruthy();
+    await fireEvent.click(getByText('Left'));
+    expect(answerQuestion).toHaveBeenCalledWith('tab-1', 'Left');
+  });
+
+  it('the ask-user Reply button is disabled until an answer is typed, then submits it', async () => {
+    answerQuestion.mockClear();
+    const pendingQuestion: AskUserRequest = { questionId: 'q2', question: 'Free text?' };
+    const { getByText, getByPlaceholderText } = renderList({ pendingQuestion });
+
+    const reply = getByText('Reply').closest('button') as HTMLButtonElement;
+    expect(reply.disabled).toBe(true);
+
+    const input = getByPlaceholderText('Type your answer (Enter to send)');
+    await fireEvent.input(input, { target: { value: 'my answer' } });
+    expect(reply.disabled).toBe(false);
+
+    await fireEvent.click(reply);
+    expect(answerQuestion).toHaveBeenCalledWith('tab-1', 'my answer');
+  });
+});

--- a/tests/renderer/components/right-sidebar/InspectionsPanel.test.ts
+++ b/tests/renderer/components/right-sidebar/InspectionsPanel.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Right-sidebar InspectionsPanel interaction coverage (~0% before this). The
+ * panel lists graph health-check results loaded via `api.graph.inspections()`,
+ * groups them by severity (or by type), filters them by a search ribbon, and
+ * hands a clicked inspection to `onOpenConversation`. The "Run" button re-runs
+ * the checks through the review store (the #1086 mutation chokepoint).
+ *
+ * These tests render the real component against a mocked `api.graph` boundary
+ * and a mocked review store, asserting the grouped DOM, the empty state, the
+ * onOpenConversation payload, the search + sort affordances, the Run action,
+ * and the reload-on-revision-change path. The grouping/derived logic runs for
+ * real; only IPC + the store passthrough are stubbed.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+
+interface Inspection {
+  id: string;
+  type: string;
+  severity: string;
+  nodeUri: string;
+  nodeLabel: string;
+  message: string;
+  suggestedAction?: string;
+}
+
+const { inspectionsMock, runInspectionsMock } = vi.hoisted(() => ({
+  inspectionsMock: vi.fn(),
+  runInspectionsMock: vi.fn(),
+}));
+
+vi.mock('../../../../src/renderer/lib/ipc/client', () => ({
+  api: { graph: { inspections: inspectionsMock } },
+}));
+
+vi.mock('../../../../src/renderer/lib/stores/review.svelte', () => ({
+  getReviewStore: () => ({ runInspections: runInspectionsMock }),
+}));
+
+import InspectionsPanel from '../../../../src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte';
+
+afterEach(() => {
+  cleanup();
+  inspectionsMock.mockReset();
+  runInspectionsMock.mockReset();
+});
+
+function fixtures(): Inspection[] {
+  return [
+    { id: 'c1', type: 'missing_grounds', severity: 'concern', nodeUri: 'urn:c', nodeLabel: 'Claim A', message: 'Claim A lacks grounds', suggestedAction: 'Add grounds' },
+    { id: 'w1', type: 'stale_note', severity: 'warning', nodeUri: 'urn:w', nodeLabel: 'Note B', message: 'Note B is stale' },
+    { id: 'i1', type: 'orphan_node', severity: 'info', nodeUri: 'urn:i', nodeLabel: 'Node C', message: 'Node C is orphaned' },
+  ];
+}
+
+function renderPanel(over: { revision?: number; onOpenConversation?: (m: string) => void } = {}) {
+  const onOpenConversation = over.onOpenConversation ?? vi.fn();
+  const utils = render(InspectionsPanel, { revision: over.revision ?? 0, onOpenConversation });
+  return { ...utils, onOpenConversation };
+}
+
+describe('right-sidebar InspectionsPanel', () => {
+  it('renders inspections grouped by severity with counts', async () => {
+    inspectionsMock.mockResolvedValue(fixtures());
+    const { findByText, getByText } = renderPanel();
+
+    expect(await findByText('Claim A lacks grounds')).toBeTruthy();
+    expect(getByText('Note B is stale')).toBeTruthy();
+    expect(getByText('Node C is orphaned')).toBeTruthy();
+
+    expect(getByText('Concerns (1)')).toBeTruthy();
+    expect(getByText('Warnings (1)')).toBeTruthy();
+    expect(getByText('Info (1)')).toBeTruthy();
+    expect(getByText('3 inspections')).toBeTruthy();
+  });
+
+  it('shows the empty state when there are no inspections', async () => {
+    inspectionsMock.mockResolvedValue([]);
+    const { findByText } = renderPanel();
+
+    expect(await findByText('No inspections')).toBeTruthy();
+  });
+
+  it('clicking an inspection opens a conversation seeded with its message + suggested action', async () => {
+    inspectionsMock.mockResolvedValue(fixtures());
+    const onOpenConversation = vi.fn();
+    const { findByText } = renderPanel({ onOpenConversation });
+
+    await fireEvent.click(await findByText('Claim A lacks grounds'));
+
+    expect(onOpenConversation).toHaveBeenCalledWith(
+      'I\'d like to discuss this inspection: "Claim A lacks grounds". Add grounds',
+    );
+  });
+
+  it('the search ribbon filters the visible inspections', async () => {
+    inspectionsMock.mockResolvedValue(fixtures());
+    const { findByText, getByPlaceholderText, queryByText } = renderPanel();
+
+    await findByText('Claim A lacks grounds');
+    await fireEvent.input(getByPlaceholderText('Find inspection…'), { target: { value: 'Note B' } });
+
+    await waitFor(() => expect(queryByText('Claim A lacks grounds')).toBeNull());
+    expect(queryByText('Note B is stale')).toBeTruthy();
+    expect(queryByText('Node C is orphaned')).toBeNull();
+  });
+
+  it('sorting "by type" regroups the list under type headings', async () => {
+    inspectionsMock.mockResolvedValue(fixtures());
+    const { findByText, container, getByText } = renderPanel();
+
+    await findByText('Claim A lacks grounds');
+    const sort = container.querySelector('select.sort') as HTMLSelectElement;
+    await fireEvent.change(sort, { target: { value: 'type' } });
+
+    // Type headings replace the severity headings (underscores → spaces).
+    expect(await findByText('missing grounds (1)')).toBeTruthy();
+    expect(getByText('stale note (1)')).toBeTruthy();
+    expect(getByText('orphan node (1)')).toBeTruthy();
+  });
+
+  it('the Run button re-runs the checks through the review store and shows fresh results', async () => {
+    inspectionsMock.mockResolvedValue(fixtures());
+    runInspectionsMock.mockResolvedValue([
+      { id: 'x1', type: 'fresh_check', severity: 'warning', nodeUri: 'urn:x', nodeLabel: 'Fresh', message: 'Fresh finding', suggestedAction: '' },
+    ] as Inspection[]);
+
+    const { findByText, getByText } = renderPanel();
+    await findByText('Claim A lacks grounds');
+
+    await fireEvent.click(getByText('Run'));
+
+    expect(runInspectionsMock).toHaveBeenCalledTimes(1);
+    expect(await findByText('Fresh finding')).toBeTruthy();
+  });
+
+  it('reloads inspections when the revision prop changes', async () => {
+    inspectionsMock.mockResolvedValue(fixtures());
+    const { findByText, rerender } = renderPanel({ revision: 0 });
+    await findByText('Claim A lacks grounds');
+
+    inspectionsMock.mockResolvedValue([
+      { id: 'r1', type: 'reindexed', severity: 'info', nodeUri: 'urn:r', nodeLabel: 'Reindexed', message: 'A brand new finding' },
+    ] as Inspection[]);
+    await rerender({ revision: 1, onOpenConversation: vi.fn() });
+
+    expect(await findByText('A brand new finding')).toBeTruthy();
+  });
+});

--- a/tests/renderer/components/right-sidebar/TagsPanel.test.ts
+++ b/tests/renderer/components/right-sidebar/TagsPanel.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Right-sidebar TagsPanel interaction coverage (~0% before this). The panel
+ * shows only the *active note's* tags: it loads the project-wide `TagInfo[]`
+ * via `api.tags.list()` and intersects it with the tags parsed out of the
+ * note's content (body `#hashtags` + frontmatter `tags:`). Clicking a leaf tag
+ * fetches its notes/sources; clicking a parent (prefix) tag fetches the subtree.
+ *
+ * These tests render the real component against a mocked `api.tags` boundary and
+ * assert the visible tree, the tagged-things list, the onFileSelect/onSourceSelect
+ * callbacks, the search filter, and that content changes re-run the load. The
+ * tag-tree helpers and the content tag-parser run for real; only IPC is stubbed.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+import type { TagInfo, TaggedNote, TaggedSource } from '../../../../src/shared/types';
+
+const { listMock, notesByTagMock, sourcesByTagMock, notesByTagPrefixMock } = vi.hoisted(() => ({
+  listMock: vi.fn(),
+  notesByTagMock: vi.fn(),
+  sourcesByTagMock: vi.fn(),
+  notesByTagPrefixMock: vi.fn(),
+}));
+
+vi.mock('../../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    tags: {
+      list: listMock,
+      notesByTag: notesByTagMock,
+      sourcesByTag: sourcesByTagMock,
+      notesByTagPrefix: notesByTagPrefixMock,
+    },
+  },
+}));
+
+import TagsPanel from '../../../../src/renderer/lib/components/right-sidebar/TagsPanel.svelte';
+
+afterEach(() => {
+  cleanup();
+  listMock.mockReset();
+  notesByTagMock.mockReset();
+  sourcesByTagMock.mockReset();
+  notesByTagPrefixMock.mockReset();
+});
+
+/** Flat leaf/prefix tags: gamma is project-wide but NOT in the note. */
+function flatTags(): TagInfo[] {
+  return [
+    { tag: 'alpha', noteCount: 3, sourceCount: 1 },
+    { tag: 'beta', noteCount: 2, sourceCount: 0 },
+    { tag: 'gamma', noteCount: 9, sourceCount: 0 },
+  ];
+}
+
+/** Visible tag-name button labels, in DOM order, whitespace-stripped. */
+function tagNames(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('.tag-name')].map(
+    (el) => (el.textContent ?? '').replace(/\s+/g, ''),
+  );
+}
+
+function renderPanel(over: {
+  content?: string;
+  onFileSelect?: (p: string) => void;
+  onSourceSelect?: (id: string) => void;
+} = {}) {
+  const onFileSelect = over.onFileSelect ?? vi.fn();
+  const onSourceSelect = over.onSourceSelect ?? vi.fn();
+  const utils = render(TagsPanel, {
+    content: over.content ?? 'This note has #alpha and #beta tags.',
+    onFileSelect,
+    onSourceSelect,
+  });
+  return { ...utils, onFileSelect, onSourceSelect };
+}
+
+describe('right-sidebar TagsPanel', () => {
+  it("renders only the active note's tags from api.tags.list (project-only tags filtered out)", async () => {
+    listMock.mockResolvedValue(flatTags());
+    const { container } = renderPanel();
+
+    // alpha + beta are parsed from the note body; gamma is project-wide only.
+    await waitFor(() => expect(tagNames(container)).toEqual(['#alpha', '#beta']));
+    expect(tagNames(container)).not.toContain('#gamma');
+  });
+
+  it('shows the empty state when the note carries no tags', async () => {
+    listMock.mockResolvedValue(flatTags());
+    const { findByText } = renderPanel({ content: 'Plain prose with no tags at all.' });
+
+    expect(await findByText('No tags in this note')).toBeTruthy();
+  });
+
+  it('clicking a leaf tag loads its notes + sources and routes clicks to the callbacks', async () => {
+    listMock.mockResolvedValue(flatTags());
+    notesByTagMock.mockResolvedValue([
+      { title: 'Note One', relativePath: 'one.md' },
+    ] as TaggedNote[]);
+    sourcesByTagMock.mockResolvedValue([
+      { title: 'Source One', sourceId: 's1' },
+    ] as TaggedSource[]);
+
+    const onFileSelect = vi.fn();
+    const onSourceSelect = vi.fn();
+    const { container, findByText } = renderPanel({ onFileSelect, onSourceSelect });
+
+    await waitFor(() => expect(tagNames(container)).toContain('#alpha'));
+
+    const alpha = [...container.querySelectorAll('.tag-name')].find(
+      (el) => (el.textContent ?? '').replace(/\s+/g, '') === '#alpha',
+    )!;
+    await fireEvent.click(alpha);
+
+    expect(notesByTagMock).toHaveBeenCalledWith('alpha');
+    expect(sourcesByTagMock).toHaveBeenCalledWith('alpha');
+
+    // The tagged-things list renders; clicking a note fires onFileSelect.
+    await fireEvent.click(await findByText('Note One'));
+    expect(onFileSelect).toHaveBeenCalledWith('one.md');
+
+    // Clicking a tagged source fires onSourceSelect.
+    await fireEvent.click(await findByText('Source One'));
+    expect(onSourceSelect).toHaveBeenCalledWith('s1');
+  });
+
+  it('the search ribbon narrows the visible tags', async () => {
+    listMock.mockResolvedValue(flatTags());
+    const { container, getByPlaceholderText } = renderPanel();
+
+    await waitFor(() => expect(tagNames(container)).toEqual(['#alpha', '#beta']));
+
+    await fireEvent.input(getByPlaceholderText('Find tag…'), { target: { value: 'beta' } });
+    expect(tagNames(container)).toEqual(['#beta']);
+  });
+
+  it('re-loads api.tags.list and re-derives the tree when the note content changes', async () => {
+    listMock.mockResolvedValue(flatTags());
+    const { container, rerender } = renderPanel({ content: 'only #alpha here' });
+
+    await waitFor(() => expect(tagNames(container)).toEqual(['#alpha']));
+    const callsAfterMount = listMock.mock.calls.length;
+
+    // A save that swaps the note's tags re-runs refresh() and re-filters.
+    await rerender({ content: 'now only #beta here', onFileSelect: vi.fn(), onSourceSelect: vi.fn() });
+
+    await waitFor(() => expect(tagNames(container)).toEqual(['#beta']));
+    expect(listMock.mock.calls.length).toBeGreaterThan(callsAfterMount);
+  });
+
+  it('a parent (prefix) tag is collapsible and loads its subtree via notesByTagPrefix', async () => {
+    listMock.mockResolvedValue([
+      { tag: 'proj/a', noteCount: 1, sourceCount: 0 },
+      { tag: 'proj/b', noteCount: 1, sourceCount: 0 },
+    ] as TagInfo[]);
+    notesByTagPrefixMock.mockResolvedValue([
+      { title: 'Proj Note', relativePath: 'proj.md' },
+    ] as TaggedNote[]);
+
+    const { container, findByText, getByLabelText } = renderPanel({
+      content: 'work on #proj/a and #proj/b',
+    });
+
+    // Collapsed by default: only the synthesized parent row is visible.
+    await waitFor(() => expect(tagNames(container)).toEqual(['#proj/']));
+
+    // Expanding the chevron reveals the two leaf children.
+    await fireEvent.click(getByLabelText('Expand'));
+    await waitFor(() => expect(tagNames(container)).toEqual(['#proj/', '#a', '#b']));
+
+    // Clicking the parent tag loads the whole subtree via the prefix endpoint.
+    const parent = [...container.querySelectorAll('.tag-name')].find(
+      (el) => (el.textContent ?? '').replace(/\s+/g, '') === '#proj/',
+    )!;
+    await fireEvent.click(parent);
+
+    expect(notesByTagPrefixMock).toHaveBeenCalledWith('proj');
+    expect(await findByText('Proj Note')).toBeTruthy();
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -40,6 +40,19 @@ export default defineConfig({
         'src/main/publish/csl/bundled/**',
         // Ontology turtle blobs aren't code.
         '**/*.ttl',
+        // Effectively unrenderable in jsdom, so unit coverage can't reach them
+        // and their 0% would misrepresent the testable-code percentage (#1453):
+        //   - App.svelte is the composition root — `<svelte:window>`, every
+        //     store + ops cluster, IPC orchestration; there's no meaningful
+        //     unit render.
+        //   - Editor.svelte hosts a live CodeMirror EditorView, which needs a
+        //     real DOM/layout jsdom doesn't provide.
+        // Both ARE exercised at runtime by the Playwright e2e suite (smoke /
+        // a11y / journeys / focus-trap) in real Electron — that, not a line
+        // floor, is their gate. Excluding them makes `src/renderer/**` reflect
+        // code that unit tests can actually cover.
+        'src/renderer/App.svelte',
+        'src/renderer/lib/components/Editor.svelte',
       ],
       // Floors per area (#679). Set below the current numbers with headroom
       // so a small refactor won't flap CI, but a real regression on the trust
@@ -138,13 +151,17 @@ export default defineConfig({
         // QA C1). Floors sit below the measured-at-floor numbers with extra
         // headroom because this tree is volatile (a single new component moves
         // the needle): a mass test deletion or a large untested addition still
-        // fails CI. Ratcheted twice: #1451 (bucket A, pure-lib helpers) →
-        // ~42% L, then #1452 (bucket B, the store/ops data-flow spine:
-        // app/refactor-ops + note-ops + source-ops, stores/conversations +
-        // editor — incl. the Trust-Principle propose_*→file*Draft paths) →
-        // measured ~48% L / ~46% F / ~48% S / ~41% B (from ~36/39/35/31 pre-A).
-        // Ratchet upward again as the approval-proposal UI + remaining
-        // components gain tests.
+        // fails CI. Ratcheted three times: #1451 (bucket A, pure-lib helpers)
+        // → ~42% L; #1452 (bucket B, the store/ops data-flow spine) → ~48% L;
+        // #1453 (bucket C, mid-size dialogs/panels rendered via @testing-
+        // library/svelte: Export/Publish/FindInNotes/EditSavedQueries/Collection
+        // Picker dialogs, Tags/Inspections panels, conversation Composer +
+        // MessageList) → measured ~58% L / ~56% F / ~58% S / ~48% B (from
+        // ~36/39/35/31 pre-A). Note: #1453 also excluded App.svelte +
+        // Editor.svelte from the coverage `include` (unrenderable in jsdom,
+        // e2e-covered — see the exclude block above), so this % now reflects
+        // unit-testable renderer code. Ratchet upward as the approval-proposal
+        // UI + remaining components gain tests.
         //
         // NOTE: src/preload is deliberately NOT given a line-coverage floor.
         // It's a declarative contextBridge passthrough (~326 lines of
@@ -153,10 +170,10 @@ export default defineConfig({
         // #676), not line execution. Calling every passthrough to hit a line
         // floor would verify nothing the snapshot doesn't already pin.
         'src/renderer/**': {
-          lines: 42,
-          functions: 40,
-          statements: 42,
-          branches: 34,
+          lines: 50,
+          functions: 48,
+          statements: 50,
+          branches: 40,
         },
       },
     },


### PR DESCRIPTION
Closes #1453. **Stacked on #1481 (bucket B, #1452)** — base is that branch so this diff shows only bucket-C changes; the stack rebases onto `main` in order (#1480 → #1481 → this).

The last, priciest bucket: `@testing-library/svelte` render + interaction tests for mid-size dialogs/panels, prioritized by user-facing risk (not raw line count). Each test renders the **real** component, mocks only its `api`/store boundary, drives interactions, and asserts visible DOM + the routed `api` call.

## New render tests (105 cases, all green)

| component | before → after | tests |
|---|---|---|
| `ExportDialog.svelte` | 0% → **94.6%** | 10 |
| `PublishDialog.svelte` | 0% → **95.4%** | 11 |
| `CollectionPickerDialog.svelte` | 0% → **94.3%** | 15 |
| `FindInNotesDialog.svelte` | 0% → **98.6%** | 14 |
| `EditSavedQueriesDialog.svelte` | 0% → **100%** | 21 |
| `right-sidebar/TagsPanel.svelte` | 0% → **81.8%** | 6 |
| `right-sidebar/InspectionsPanel.svelte` | 0% → **100%** | 7 |
| `conversations/Composer.svelte` | 0% → **~63%** | 14 |
| `conversations/MessageList.svelte` | 0% → **~69%** | 7 |

(The two conversation components land lower: their controlled-input reactivity + voice/ingest paths need a live singleton store, out of a `.ts` render test's reach — noted in the tests.)

## The config call: exclude App.svelte + Editor.svelte

The issue flagged this as a decision to make. Both are **effectively unrenderable in jsdom** — `App.svelte` is the composition root (`<svelte:window>`, every store + ops cluster, IPC orchestration); `Editor.svelte` hosts a live CodeMirror `EditorView` needing real DOM/layout. Their 0% wasn't a testing gap — it was a tooling limit — and it dragged the metric down (they're 880 lines). Both **are** exercised at runtime by the Playwright e2e suite (smoke / a11y / journeys / focus-trap) in real Electron, so that — not a unit line floor — is their gate. Excluding them from the coverage `include` (with a documented justification) makes `src/renderer/**` reflect code unit tests can actually cover.

## Coverage + floor ratchet

Measured `src/renderer` line coverage (post-exclude): **~48% → 57.9%** (functions 56.1, statements 57.9, branches 47.8).

| metric | old (bucket B) | new | measured | headroom |
|---|---|---|---|---|
| lines | 42 | **50** | 57.9 | 7.9 |
| functions | 40 | **48** | 56.1 | 8.1 |
| statements | 42 | **50** | 57.9 | 7.9 |
| branches | 34 | **40** | 47.8 | 7.8 |

Past the issue's ">55%" target, with the conventional ~8pt headroom.

## Success criteria
- [x] Render/interaction tests for the listed mid-size components
- [x] Renderer measured line coverage rises past ~55% (**57.9%**)
- [x] Bump the `src/renderer/**` floor accordingly (42 → **50** lines)
- [x] `pnpm coverage` green with headroom

## Verification
Full `pnpm coverage` (CI-gating) → **exit 0** with the exclude + new floor. `tsc --noEmit` / `eslint` clean. 105 new tests across 9 files.

> Note: a couple of interim coverage runs flaked on `Hook/Test timed out` in unrelated heavy main-process tests (graph/publish) under local machine contention from back-to-back coverage runs — no threshold error, and a settled clean run is green. CI's dedicated runner won't hit that.

This completes the #1094 bucket sequence: A (#1451, pure-lib) → B (#1452, store/ops spine) → C (#1453, components). Renderer line coverage ~36% → **~58%** across the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)