### PR TITLE
perf(graph): incremental N3 mirror maintenance — the flagship graph fix (#1110)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -15,7 +15,7 @@ import type { ProjectContext } from '../project-context-types';
 import {
   type GraphState,
   getEngine,
-  getState, setState, deleteState, invalidate,
+  getState, setState, deleteState, invalidate, instrumentStoreMirror,
 } from './state';
 
 // ── Public read API (#671) ───────────────────────────────────────────────────
@@ -121,6 +121,10 @@ export async function initGraph(ctx: ProjectContext): Promise<void> {
     frontmatterKeysPerNote: new Map(),
     neighborhoodCache: new Map(),
   };
+  // Wrap the store's mutation methods so the N3 mirror is maintained
+  // incrementally for this store's whole life (#1110). n3Cache is null now, so
+  // the load below isn't mirrored — the first query rebuilds it from scratch.
+  instrumentStoreMirror(state);
 
   // Load persisted graph if it exists
   const graphPath = path.join(metaDir, 'graph.ttl');

--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -31,7 +31,7 @@ import type { ProjectContext } from '../project-context-types';
 
 import {
   type GraphState, type HeadingSnapshot,
-  getState, invalidate,
+  getState, invalidate, resetN3Mirror, instrumentStoreMirror,
   MINERVA, DC, RDF, RDFS, XSD, CSVW, OWL, BIBO, SCHEMA, PROV, THOUGHT,
   STANDARD_PREFIXES,
   noteUri, tagUri, folderUri, sourceUri, excerptUri, tableUri, projectUri,
@@ -1347,8 +1347,12 @@ export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
   // Carry proposals across the from-scratch reset below (see the helper's note).
   const preservedProposals = captureProposalStatements(state.store);
 
-  // Reset and rebuild from scratch with ontology
+  // Reset and rebuild from scratch with ontology. The wholesale store swap is
+  // the one mutation the incremental N3 mirror can't track, so drop the mirror
+  // (rebuilt lazily on the next query) and re-instrument the fresh store (#1110).
   state.store = $rdf.graph();
+  instrumentStoreMirror(state);
+  resetN3Mirror(state);
   invalidate(state);
   addOntologyToStore(state);
   state.aliasesPerNote.clear();

--- a/src/main/graph/state.ts
+++ b/src/main/graph/state.ts
@@ -219,9 +219,146 @@ export function deleteState(ctx: ProjectContext): void {
 }
 
 export function invalidate(state: GraphState): void {
-  state.n3Cache = null;
+  // NOTE (#1110): this no longer nulls `n3Cache`. The N3 mirror is now
+  // maintained incrementally by `instrumentStoreMirror` — every rdflib
+  // add/removeMatches applies the same delta to the live mirror — so a write no
+  // longer discards a mirror that may hold 100k triples for the next query to
+  // rebuild from scratch. The only path that must drop the mirror is a
+  // wholesale store swap (`indexAllNotes`), which calls `resetN3Mirror`.
   // Any triple change can alter some note's neighborhood; drop the memo (#1113).
   state.neighborhoodCache.clear();
+}
+
+// ── Incremental N3 mirror maintenance (#1110) ────────────────────────────────
+//
+// rdflib's mutable IndexedFormula is the source of truth; the N3.Store mirror
+// (`state.n3Cache`) is what Comunica reads. Rather than null-and-full-rebuild on
+// every write (O(all triples) on the next query), we wrap the store's two
+// mutation methods so each write applies the equivalent delta to the live
+// mirror — O(changed triples). The mirror flattens every named graph into the
+// default graph, exactly as `buildN3Store` does, so query semantics are
+// unchanged. Correctness on removal leans on rdflib itself as the reference
+// count: a flattened quad is dropped only when rdflib no longer asserts that
+// (s,p,o) in ANY graph — provably identical to a from-scratch `buildN3Store`.
+
+/** Belt-and-suspenders: force a fresh full rebuild after this many incremental
+ *  mirror mutations, so any unforeseen drift self-heals within a bounded window
+ *  (#1110 asks for a periodic/fallback rebuild). Generous — the amortized cost
+ *  of one O(n) rebuild per N writes is negligible next to N incremental deltas. */
+const N3_PERIODIC_REBUILD_EVERY = 1000;
+
+interface MirrorMarker {
+  /** Set once per store instance so we never double-wrap. */
+  __minervaMirrored?: boolean;
+  /** Incremental mutations applied since the last full build (periodic reset). */
+  __minervaN3Writes?: number;
+}
+
+/** The two rdflib mutation methods + the read used to snapshot removals, viewed
+ *  with loose params so we can wrap them without fighting rdflib's Quad_* types. */
+interface MutableStore {
+  add(s: RdflibTermLike, p: RdflibTermLike, o: RdflibTermLike, g?: unknown): unknown;
+  removeMatches(s?: unknown, p?: unknown, o?: unknown, g?: unknown): unknown;
+  statementsMatching(s?: unknown, p?: unknown, o?: unknown, g?: unknown): $rdf.Statement[];
+}
+
+/** Null the mirror so the next `queryGraph` rebuilds it from scratch. Use on a
+ *  wholesale store swap or as the periodic/fallback rebuild. */
+export function resetN3Mirror(state: GraphState): void {
+  state.n3Cache = null;
+  (state.store as unknown as MirrorMarker).__minervaN3Writes = 0;
+}
+
+function mirrorAdd(state: GraphState, s: RdflibTermLike, p: RdflibTermLike, o: RdflibTermLike): void {
+  const n3 = state.n3Cache;
+  if (!n3) return;
+  const df = N3.DataFactory;
+  try {
+    const subject = convertTerm(s, df);
+    const predicate = convertTerm(p, df) as N3.NamedNode | null;
+    const object = convertTerm(o, df);
+    // Same guard + default-graph flattening as buildN3Store; addQuad is
+    // idempotent, so re-asserting an existing triple is a no-op.
+    if (subject && predicate && object) {
+      n3.addQuad(subject as N3.Quad_Subject, predicate, object as N3.Quad_Object, df.defaultGraph());
+    }
+  } catch { /* mirror buildN3Store's skip-malformed resilience */ }
+}
+
+function mirrorRemove(state: GraphState, removed: $rdf.Statement[]): void {
+  const n3 = state.n3Cache;
+  if (!n3) return;
+  const df = N3.DataFactory;
+  for (const st of removed) {
+    try {
+      // Drop the flattened quad ONLY when rdflib no longer asserts this (s,p,o)
+      // in any graph — otherwise a sibling named graph still needs it (rdflib is
+      // the reference count). `undefined` graph = match across all graphs.
+      if (state.store.statementsMatching(st.subject, st.predicate, st.object, undefined).length > 0) continue;
+      const subject = convertTerm(st.subject, df);
+      const predicate = convertTerm(st.predicate, df) as N3.NamedNode | null;
+      const object = convertTerm(st.object, df);
+      if (!subject || !predicate || !object) continue;
+      // Remove the ACTUAL stored quad(s), located by value via getQuads, rather
+      // than a freshly-reconstructed term — literal datatype/canonicalization
+      // can differ just enough that removeQuad(reconstructed) misses. getQuads
+      // matches by term value; removeQuad(quad) mutates synchronously (unlike
+      // removeMatches, which returns a stream and wouldn't mutate in place).
+      for (const q of n3.getQuads(subject, predicate, object, df.defaultGraph())) {
+        n3.removeQuad(q);
+      }
+    } catch { /* skip malformed, same as buildN3Store */ }
+  }
+}
+
+/**
+ * Wrap `state.store`'s `add` / `removeMatches` so every rdflib mutation applies
+ * the matching delta to the live N3 mirror. Idempotent per store instance; call
+ * after each `state.store = $rdf.graph()`. When `n3Cache` is null (cold, or
+ * during a bulk load before the first query) mirroring is skipped and the next
+ * query rebuilds from scratch — so this adds only a cheap null-check per write
+ * on the cold path.
+ */
+export function instrumentStoreMirror(state: GraphState): void {
+  const store = state.store;
+  const marker = store as unknown as MirrorMarker;
+  if (marker.__minervaMirrored) return;
+  marker.__minervaMirrored = true;
+  marker.__minervaN3Writes = 0;
+
+  // rdflib's method signatures use Quad_* subtypes we don't satisfy at this
+  // boundary; view the store through a loose interface so the wrapping stays
+  // type-clean without `any`.
+  const m = store as unknown as MutableStore;
+  const origAdd = m.add.bind(m);
+  const origRemoveMatches = m.removeMatches.bind(m);
+  const matchAny = m.statementsMatching.bind(m);
+
+  function bumpAndMaybeRebuild(): void {
+    if (!state.n3Cache) return;
+    marker.__minervaN3Writes = (marker.__minervaN3Writes ?? 0) + 1;
+    if (marker.__minervaN3Writes >= N3_PERIODIC_REBUILD_EVERY) resetN3Mirror(state);
+  }
+
+  m.add = function (s: RdflibTermLike, p: RdflibTermLike, o: RdflibTermLike, g?: unknown) {
+    const ret = origAdd(s, p, o, g);
+    mirrorAdd(state, s, p, o);
+    bumpAndMaybeRebuild();
+    return ret;
+  };
+
+  m.removeMatches = function (s?: unknown, p?: unknown, o?: unknown, g?: unknown) {
+    if (!state.n3Cache) return origRemoveMatches(s, p, o, g);
+    // Snapshot (.slice) the statements about to be removed BEFORE the rdflib
+    // removal: rdflib's statementsMatching can return a live reference to its
+    // internal array, which origRemoveMatches then splices in place — so without
+    // the copy `removed` would be empty by the time we reconcile the mirror.
+    const removed = matchAny(s ?? undefined, p ?? undefined, o ?? undefined, g ?? undefined).slice();
+    const ret = origRemoveMatches(s, p, o, g);
+    mirrorRemove(state, removed);
+    bumpAndMaybeRebuild();
+    return ret;
+  };
 }
 
 // ── URI helpers (delegate to uri-helpers module) ────────────────────────────

--- a/tests/main/graph/n3-cold-rebuild.bench.ts
+++ b/tests/main/graph/n3-cold-rebuild.bench.ts
@@ -1,19 +1,20 @@
 /**
- * Cold N3-rebuild benchmark (perf #1109 — proves the need for #1110). Not run
- * by `pnpm test` — invoke with `pnpm bench`.
+ * Save→query benchmark (perf #1109 → #1110). Not run by `pnpm test` — invoke
+ * with `pnpm bench`.
  *
- * `n3-cache.bench.ts` measures the warm cache-hit cost. This measures the
- * opposite: the full O(triples) `buildN3Store` rebuild that `queryGraph` pays
- * whenever a write invalidated the cache — `indexNote` calls `invalidate` on
- * every edit (see `state.ts`), nulling `state.n3Cache` so the very next query
- * rebuilds the whole N3 mirror from scratch before it can run.
+ * HISTORY: this measured the full O(triples) `buildN3Store` rebuild that
+ * `queryGraph` used to pay after every write — `invalidate` nulled the whole N3
+ * mirror, so the very next query rebuilt it from scratch (hundreds of ms at 5k
+ * notes). #1110 made the mirror INCREMENTAL: `invalidate` no longer nulls it;
+ * `instrumentStoreMirror` applies each write's delta to the live mirror. So this
+ * bench now measures the incremental save→query path — O(changed triples), not
+ * O(all triples). The cliff it was written to expose is removed: at 5k notes it
+ * dropped from ~148ms to ~6ms. (The name/keys are kept stable so the committed
+ * bench baseline still lines up; re-bless to lock in the win.)
  *
- * Each iteration pairs one trivial re-index (invalidates the cache, exactly
- * like any real edit does) with the query that follows it — the "write then
- * query" pattern `buildN3Store`'s own comment already flags as the expensive
- * case (`N3_REBUILD_WARN_MS` in `state.ts`). Run at three vault scales so the
- * O(n) growth is visible, and so an eventual incremental-N3 fix (#1110) has a
- * baseline to beat.
+ * Each iteration pairs one trivial re-index with the query that follows it — the
+ * "write then query" pattern. Run at three vault scales so the (now near-flat)
+ * growth is visible.
  *
  * Seeding runs as a top-level `await` per scale, ahead of any `describe`/
  * `bench` call, rather than inside `beforeAll` — vitest's benchmark runner
@@ -50,9 +51,10 @@ for (const scale of SCALES) {
 
   describe(`cold N3 rebuild — ${scale}-note store`, () => {
     bench(`re-index (invalidates) + queryGraph (cold rebuild) at ${scale} notes`, async () => {
-      // A no-op re-index of the same note with the same content — it still
-      // invalidates the N3 cache the same way any real save does, without
-      // changing what the query below actually matches.
+      // A no-op re-index of the same note with the same content — the same
+      // write path any real save takes (post-#1110 it applies its delta to the
+      // live mirror rather than nulling it), without changing what the query
+      // below matches. (Bench name kept verbatim for baseline-key stability.)
       await indexNote(ctx, 'note-0.md', `# Note 0\n\n${'lorem ipsum '.repeat(50)}\n\n#tag-0\n`);
       await queryGraph(ctx, 'SELECT ?n WHERE { ?n a minerva:Note } LIMIT 50');
     });

--- a/tests/main/graph/n3-mirror-incremental.test.ts
+++ b/tests/main/graph/n3-mirror-incremental.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Incremental N3 mirror equivalence (#1110).
+ *
+ * The N3.Store mirror is now maintained incrementally on every write instead of
+ * nulled-and-rebuilt (state.ts `instrumentStoreMirror`). The one failure mode
+ * that matters is DRIFT — the incremental mirror disagreeing with a from-scratch
+ * `buildN3Store`, which would silently produce WRONG SPARQL results. These tests
+ * are the guard: after varied add/remove/reindex sequences, the live mirror must
+ * hold exactly the same flattened quads as a fresh rebuild, and queries against
+ * it must match queries against a rebuild.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import * as $rdf from 'rdflib';
+import type * as N3 from 'n3';
+import { initGraph, indexNote, removeNote, queryGraph, indexAllNotes } from '../../../src/main/graph/index';
+import { buildN3Store, getState, resetN3Mirror, MINERVA, RDF } from '../../../src/main/graph/state';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function termKey(t: N3.Term): string {
+  if (t.termType === 'Literal') {
+    return `L${t.value}${t.datatype?.value ?? ''}${t.language ?? ''}`;
+  }
+  return `${t.termType}${t.value}`;
+}
+
+/** The flattened triple set of an N3.Store (graph ignored — the mirror flattens
+ *  everything into the default graph, and buildN3Store does the same). */
+function tripleSet(store: N3.Store): Set<string> {
+  const keys = new Set<string>();
+  for (const q of store.getQuads(null, null, null, null)) {
+    keys.add(`${termKey(q.subject)}${termKey(q.predicate)}${termKey(q.object)}`);
+  }
+  return keys;
+}
+
+/** Assert the live incremental mirror equals a from-scratch rebuild of the same
+ *  rdflib store — the core anti-drift invariant. */
+function expectMirrorMatchesRebuild(ctx: ProjectContext): void {
+  const state = getState(ctx)!;
+  expect(state.n3Cache, 'mirror should be live after a query').not.toBeNull();
+  const fresh = buildN3Store(state.store);
+  expect([...tripleSet(state.n3Cache!)].sort()).toEqual([...tripleSet(fresh)].sort());
+}
+
+describe('incremental N3 mirror (#1110)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-n3mirror-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  it('matches a fresh rebuild after a mixed index / remove / reindex sequence', async () => {
+    await indexNote(ctx, 'a.md', '---\ntitle: A\ntags: [x, y]\n---\n# A\n\n[[b]] and [[c]]\n');
+    await indexNote(ctx, 'b.md', '---\ntitle: B\ntags: [y]\n---\n# B\n\n[[a]]\n');
+    await indexNote(ctx, 'c.md', '---\ntitle: C\n---\n# C\n');
+    // Build the mirror.
+    await queryGraph(ctx, 'SELECT ?s WHERE { ?s a minerva:Note } LIMIT 10');
+    expectMirrorMatchesRebuild(ctx);
+
+    // More writes on top of the live mirror.
+    await indexNote(ctx, 'd.md', '---\ntitle: D\ntags: [x]\n---\n# D\n\n[[a]]\n');
+    removeNote(ctx, 'c.md');
+    // Reindex a.md with different content (tags/links change).
+    await indexNote(ctx, 'a.md', '---\ntitle: A2\ntags: [z]\n---\n# A2\n\n[[d]]\n');
+    expectMirrorMatchesRebuild(ctx);
+  });
+
+  it('produces identical SPARQL results from the live mirror and a fresh rebuild', async () => {
+    await indexNote(ctx, 'a.md', '---\ntitle: A\ntags: [x, y]\n---\n# A\n\n[[b]]\n');
+    await indexNote(ctx, 'b.md', '---\ntitle: B\ntags: [y]\n---\n# B\n');
+    const q = 'SELECT ?note ?title WHERE { ?note a minerva:Note ; dc:title ?title } ORDER BY ?title';
+
+    const live = await queryGraph(ctx, q);          // builds + uses the live mirror
+    resetN3Mirror(getState(ctx)!);                  // force a from-scratch rebuild
+    const rebuilt = await queryGraph(ctx, q);
+    expect(live.error).toBeFalsy();
+    expect(live.results).toEqual(rebuilt.results);
+
+    // After a further incremental write, the two paths still agree.
+    await indexNote(ctx, 'c.md', '---\ntitle: C\n---\n# C\n');
+    const live2 = await queryGraph(ctx, q);
+    resetN3Mirror(getState(ctx)!);
+    const rebuilt2 = await queryGraph(ctx, q);
+    expect(live2.results).toEqual(rebuilt2.results);
+  });
+
+  it('keeps a triple shared across two named graphs until the LAST graph drops it (rdflib refcount)', async () => {
+    // Build a live mirror first so the wrapped mutations maintain it.
+    await queryGraph(ctx, 'SELECT ?s WHERE { ?s ?p ?o } LIMIT 1');
+    const state = getState(ctx)!;
+    const s = $rdf.sym('urn:x:shared'); const p = RDF('type'); const o = MINERVA('Widget');
+    const g1 = $rdf.sym('urn:x:g1'); const g2 = $rdf.sym('urn:x:g2');
+
+    state.store.add(s, p, o, g1);
+    state.store.add(s, p, o, g2); // same flattened (s,p,o), different named graph
+    expectMirrorMatchesRebuild(ctx);
+    const key = `NamedNodeurn:x:sharedNamedNode${RDF('type').value}NamedNode${MINERVA('Widget').value}`;
+    expect(tripleSet(state.n3Cache!).has(key)).toBe(true);
+
+    // Removing g1's copy must NOT drop the flattened quad — g2 still asserts it.
+    state.store.removeMatches(s, p, o, g1);
+    expect(tripleSet(state.n3Cache!).has(key)).toBe(true);
+    expectMirrorMatchesRebuild(ctx);
+
+    // Removing the last copy drops it.
+    state.store.removeMatches(s, p, o, g2);
+    expect(tripleSet(state.n3Cache!).has(key)).toBe(false);
+    expectMirrorMatchesRebuild(ctx);
+  });
+
+  it('is correct when writes happen while the mirror is cold (no query yet)', async () => {
+    // No query → n3Cache stays null → these writes are NOT mirrored incrementally.
+    await indexNote(ctx, 'a.md', '---\ntitle: A\ntags: [x]\n---\n# A\n');
+    await indexNote(ctx, 'b.md', '---\ntitle: B\n---\n# B\n\n[[a]]\n');
+    // First query builds from scratch — must be correct, and equal a rebuild.
+    await queryGraph(ctx, 'SELECT ?s WHERE { ?s a minerva:Note }');
+    expectMirrorMatchesRebuild(ctx);
+  });
+
+  it('rebuilds a correct mirror after indexAllNotes swaps the store', async () => {
+    fs.writeFileSync(path.join(root, 'one.md'), '---\ntitle: One\ntags: [k]\n---\n# One\n\n[[two]]\n');
+    fs.writeFileSync(path.join(root, 'two.md'), '---\ntitle: Two\n---\n# Two\n');
+    await indexNote(ctx, 'one.md', fs.readFileSync(path.join(root, 'one.md'), 'utf-8'));
+    await queryGraph(ctx, 'SELECT ?s WHERE { ?s a minerva:Note }'); // live mirror on old store
+
+    await indexAllNotes(ctx); // swaps state.store, resets + re-instruments the mirror
+    await queryGraph(ctx, 'SELECT ?s WHERE { ?s a minerva:Note }');
+    expectMirrorMatchesRebuild(ctx);
+
+    // And an incremental write on the new store still tracks.
+    await indexNote(ctx, 'three.md', '---\ntitle: Three\n---\n# Three\n\n[[one]]\n');
+    expectMirrorMatchesRebuild(ctx);
+  });
+
+  it('stays correct across many small writes (exercises the periodic-rebuild fallback)', async () => {
+    await queryGraph(ctx, 'SELECT ?s WHERE { ?s ?p ?o } LIMIT 1'); // go live
+    // Enough reindexes to cross the periodic-rebuild threshold at least once.
+    for (let i = 0; i < 60; i++) {
+      await indexNote(ctx, `n${i % 8}.md`, `---\ntitle: N${i}\ntags: [t${i % 4}]\n---\n# N${i}\n\n[[n${(i + 1) % 8}]]\n`);
+    }
+    await queryGraph(ctx, 'SELECT ?s WHERE { ?s a minerva:Note }');
+    expectMirrorMatchesRebuild(ctx);
+  });
+});


### PR DESCRIPTION
Closes #1110.

## Problem (findings C1 + C2)

rdflib's mutable `IndexedFormula` is the source of truth; Comunica reads a separate immutable `N3.Store` mirror. Every write called `invalidate()`, which **nulled the whole mirror**, and the next `queryGraph` rebuilt it statement-by-statement via `buildN3Store` — **O(all triples), synchronous, on the main thread**. At ~5k notes that was a **~148ms stall on the first query after every save**; invalidation was all-or-nothing (approving one proposal discarded a 100k-triple mirror).

## Fix

The mirror is now **maintained incrementally**. `instrumentStoreMirror` wraps the store's only two mutation methods (`add` / `removeMatches` — confirmed the entire codebase uses just these) so each write applies the equivalent delta to the *live* mirror — **O(changed triples)**. `invalidate()` no longer nulls it; the one path that must drop it (the wholesale `state.store` swap in `indexAllNotes`) calls `resetN3Mirror` + re-instruments the fresh store.

### Correctness (the risky part — drift → *wrong* results)

The mirror still flattens every named graph into the default graph exactly as `buildN3Store` does, so **query semantics are unchanged** (queries hit `{ sources: [n3Store] }`, no GRAPH clauses anywhere).

- **Removal uses rdflib as the reference count**: a flattened quad is dropped only when rdflib no longer asserts that `(s,p,o)` in *any* graph — so a triple shared across named graphs (e.g. a tag membership) survives until its last holder is removed. This makes the incremental mirror **provably equal to a from-scratch flatten**, with no separate refcount state to drift.
- **Periodic full rebuild** every 1000 mutations self-heals any unforeseen drift (the fallback the issue asks for).
- **Equivalence tests** (`n3-mirror-incremental.test.ts`, 6 cases): after mixed index/remove/reindex sequences the live mirror holds exactly the same quads as a fresh `buildN3Store`; SPARQL results match a rebuild; plus the cross-graph-shared triple, the cold path, and the `indexAllNotes` store swap.

### Two rdflib gotchas found & handled
- `statementsMatching` returns a **live reference** to the internal array that `removeMatches` then splices in place — so the removed set is snapshotted with `.slice()` before removal (this was the subtle bug the equivalence tests caught).
- `N3.Store.removeMatches` returns a **stream** rather than mutating in place — removal uses `removeQuad` on the actual stored quads (found via `getQuads`).

## Results

save→query (the "write then query" pattern) at three vault scales:

| notes | before (baseline) | after | speedup |
|---|---|---|---|
| 500 | ~20 ms | **1.5 ms** | ~13× |
| 2000 | ~60 ms | **2.7 ms** | ~22× |
| 5000 | **~148 ms** | **6.1 ms** | **~24×** |

Scaling is now near-flat instead of the O(triples) cliff.

## Success criteria
- [x] Writes apply deltas to the N3 mirror instead of nulling it
- [x] save→query no longer triggers a full O(triples) rebuild
- [x] Full-vs-incremental equivalence tests pass (mixed add/remove/reindex sequences)
- [x] Fallback full rebuild path retained (periodic + `resetN3Mirror`)
- [x] Cold-rebuild bench shows the cliff removed (~148ms → ~6ms at 5k)
- [x] `pnpm lint` and `pnpm test` pass

## Verification
- `pnpm test` → **4963 pass** (the entire graph / SPARQL / LLM query suite produces identical results). `tsc` / `eslint` clean.
- `pnpm bench` (cold-rebuild + n3-cache) → the numbers above.
- `pnpm build:e2e && npx playwright test happy-paths journeys smoke` → **8 pass**, including the real **write→reindex→SPARQL** flow through the incremental mirror.

## Re: #1473
This does **not** change `indexAllNotes` bulk cost — #1473 is a separate rdflib-allocation issue on the from-scratch rebuild path. What #1110 removes is the repeated full rebuild on the *incremental* save→query path, which also makes "large vault + many small edits" cheap. I'd keep #1473 open for the bulk-rebuild allocation profiling. The committed bench baseline can be re-blessed (`pnpm bench:baseline`) to lock in this win against future regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)