### PR TITLE
perf(graph): yield during the cold N3 rebuild (#1115 down-payment)

### DIFF
--- a/src/main/graph/queries.ts
+++ b/src/main/graph/queries.ts
@@ -21,7 +21,7 @@ import type {
 } from '../../shared/types';
 import {
   type GraphState, type HeadingSnapshot,
-  getState, getEngine, buildN3Store,
+  getState, getEngine, ensureN3Cache,
   MINERVA, DC, RDF, BIBO, PROV, THOUGHT,
   STANDARD_PREFIXES,
   noteUri, tagUri, sourceUri, excerptUri,
@@ -293,11 +293,10 @@ export async function queryGraph(
   const state = getState(ctx);
   if (!state) return { results: [], columns: [] };
   const engine = getEngine();
-  const { store } = state;
-
   try {
-    if (!state.n3Cache) state.n3Cache = buildN3Store(store);
-    const n3Store = state.n3Cache;
+    // Build the mirror if cold, yielding so a large rebuild doesn't jank the
+    // main thread (#1115). Warm queries return the live mirror with no yield.
+    const n3Store = await ensureN3Cache(state);
     const prefixed = injectSparqlPrefixes(sparql);
 
     // Use the full query() API (not queryBindings) so we can read the result

--- a/src/main/graph/state.ts
+++ b/src/main/graph/state.ts
@@ -40,26 +40,32 @@ export function getEngine(): QueryEngine {
  *  the current ~5–10k-triple working size. */
 const N3_REBUILD_WARN_MS = 75;
 
-/** Build an N3.Store from rdflib's IndexedFormula for Comunica to query.
- *  O(n) in `s.statements.length`; see `N3_REBUILD_WARN_MS`. */
+/** Flatten one rdflib statement into the N3 mirror's default graph (skipping
+ *  malformed terms), the shared inner step of buildN3Store + ensureN3Cache. */
+function addStatementToN3(n3Store: N3.Store, st: $rdf.Statement, df: typeof N3.DataFactory): void {
+  try {
+    const subject = convertTerm(st.subject, df);
+    const predicate = convertTerm(st.predicate, df) as N3.NamedNode | null;
+    const object = convertTerm(st.object, df);
+    if (subject && predicate && object) {
+      // n3.addQuad's overloads insist on (Quad_Subject, Quad_Predicate,
+      // Quad_Object, ...) but our convertTerm produces N3.Term —
+      // structurally compatible for the runtime check it does.
+      n3Store.addQuad(subject as N3.Quad_Subject, predicate, object as N3.Quad_Object, df.defaultGraph());
+    }
+  } catch { /* skip malformed triples */ }
+}
+
+/** Build an N3.Store from rdflib's IndexedFormula for Comunica to query,
+ *  SYNCHRONOUSLY (atomic — no yield). O(n) in `s.statements.length`; see
+ *  `N3_REBUILD_WARN_MS`. `ensureN3Cache` is the yielding front door that falls
+ *  back to this on a concurrent write. */
 export function buildN3Store(s: $rdf.IndexedFormula): N3.Store {
   const started = performance.now();
   const n3Store = new N3.Store();
   const df = N3.DataFactory;
 
-  for (const st of s.statements) {
-    try {
-      const subject = convertTerm(st.subject, df);
-      const predicate = convertTerm(st.predicate, df) as N3.NamedNode;
-      const object = convertTerm(st.object, df);
-      if (subject && predicate && object) {
-        // n3.addQuad's overloads insist on (Quad_Subject, Quad_Predicate,
-        // Quad_Object, ...) but our convertTerm produces N3.Term —
-        // structurally compatible for the runtime check it does.
-        n3Store.addQuad(subject as N3.Quad_Subject, predicate, object as N3.Quad_Object, df.defaultGraph());
-      }
-    } catch { /* skip malformed triples */ }
-  }
+  for (const st of s.statements) addStatementToN3(n3Store, st, df);
 
   const elapsedMs = performance.now() - started;
   if (elapsedMs > N3_REBUILD_WARN_MS && process.env.NODE_ENV !== 'production') {
@@ -74,6 +80,48 @@ export function buildN3Store(s: $rdf.IndexedFormula): N3.Store {
   }
 
   return n3Store;
+}
+
+/** Each synchronous burst of the yielding cold rebuild is kept under this long
+ *  (ms) so file I/O, git, and IPC stay responsive while a large mirror builds
+ *  (#1115). */
+const N3_YIELD_SLICE_MS = 8;
+
+/**
+ * Return the live N3 mirror, building it if cold — but YIELDING so a large cold
+ * rebuild (project open, post-`indexAllNotes`, periodic) can't jank the main
+ * thread (#1115). Builds from a synchronous snapshot of `store.statements`, so a
+ * write that interleaves during a yield can't corrupt the iteration; if such a
+ * write (or another query's build) lands, the snapshot is stale and we fall back
+ * to the atomic synchronous `buildN3Store`. All post-yield checks + the cache
+ * assignment run synchronously, so the reconcile decision can't itself race.
+ * Warm queries (cache already live) return immediately with no yield.
+ */
+export async function ensureN3Cache(state: GraphState): Promise<N3.Store> {
+  if (state.n3Cache) return state.n3Cache;
+  const marker = state.store as unknown as MirrorMarker;
+  const startMutations = marker.__minervaMutations ?? 0;
+  const df = N3.DataFactory;
+  // Atomic snapshot (synchronous, no yield) — the async loop iterates this copy,
+  // immune to concurrent rdflib mutation splicing `store.statements`.
+  const stmts = state.store.statements.slice();
+  const n3 = new N3.Store();
+  let sliceStart = performance.now();
+  for (let i = 0; i < stmts.length; i++) {
+    addStatementToN3(n3, stmts[i]!, df);
+    // Cheap clock check every 1024 statements; yield when a slice runs long.
+    if ((i & 1023) === 0 && performance.now() - sliceStart > N3_YIELD_SLICE_MS) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      sliceStart = performance.now();
+    }
+  }
+  // Another query may have built the cache during our yields — use it.
+  if (state.n3Cache) return state.n3Cache;
+  // A write raced our build: the snapshot is stale, so rebuild atomically.
+  if ((marker.__minervaMutations ?? 0) !== startMutations) {
+    return (state.n3Cache = buildN3Store(state.store));
+  }
+  return (state.n3Cache = n3);
 }
 
 // rdflib's term shape isn't fully typed at this boundary — accept anything
@@ -252,6 +300,10 @@ interface MirrorMarker {
   __minervaMirrored?: boolean;
   /** Incremental mutations applied since the last full build (periodic reset). */
   __minervaN3Writes?: number;
+  /** Monotonic mutation count (every add/removeMatches, never reset). The
+   *  yielding cold rebuild (`ensureN3Cache`) snapshots this before its yields
+   *  and re-checks after, to detect a write that raced its async build. */
+  __minervaMutations?: number;
 }
 
 /** The two rdflib mutation methods + the read used to snapshot removals, viewed
@@ -341,6 +393,7 @@ export function instrumentStoreMirror(state: GraphState): void {
   }
 
   m.add = function (s: RdflibTermLike, p: RdflibTermLike, o: RdflibTermLike, g?: unknown) {
+    marker.__minervaMutations = (marker.__minervaMutations ?? 0) + 1;
     const ret = origAdd(s, p, o, g);
     mirrorAdd(state, s, p, o);
     bumpAndMaybeRebuild();
@@ -348,6 +401,7 @@ export function instrumentStoreMirror(state: GraphState): void {
   };
 
   m.removeMatches = function (s?: unknown, p?: unknown, o?: unknown, g?: unknown) {
+    marker.__minervaMutations = (marker.__minervaMutations ?? 0) + 1;
     if (!state.n3Cache) return origRemoveMatches(s, p, o, g);
     // Snapshot (.slice) the statements about to be removed BEFORE the rdflib
     // removal: rdflib's statementsMatching can return a live reference to its

--- a/tests/main/graph/n3-cache-yielding.test.ts
+++ b/tests/main/graph/n3-cache-yielding.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Yielding cold N3 rebuild (#1115 down-payment).
+ *
+ * `ensureN3Cache` builds the mirror from a synchronous snapshot, time-slicing
+ * with `setImmediate` yields so a large cold rebuild doesn't block the main
+ * thread. The safety property is concurrency: a write that interleaves during a
+ * yield must NOT corrupt the result — the build detects the raced mutation and
+ * falls back to the atomic synchronous rebuild, so the mirror still equals a
+ * from-scratch `buildN3Store` of the final rdflib state.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type * as N3 from 'n3';
+import * as $rdf from 'rdflib';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { buildN3Store, ensureN3Cache, getState, resetN3Mirror, RDF, MINERVA } from '../../../src/main/graph/state';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function tripleSet(store: N3.Store): Set<string> {
+  const keys = new Set<string>();
+  for (const q of store.getQuads(null, null, null, null)) {
+    const o = q.object;
+    const oKey = o.termType === 'Literal'
+      ? `L${o.value}${o.datatype?.value ?? ''}`
+      : `${o.termType}${o.value}`;
+    keys.add(`${q.subject.value}${q.predicate.value}${oKey}`);
+  }
+  return keys;
+}
+
+describe('ensureN3Cache — yielding cold rebuild (#1115)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-n3yield-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  it('builds a mirror equal to the synchronous buildN3Store', async () => {
+    await indexNote(ctx, 'a.md', '---\ntitle: A\ntags: [x]\n---\n# A\n\n[[b]]\n');
+    await indexNote(ctx, 'b.md', '---\ntitle: B\n---\n# B\n');
+    const state = getState(ctx)!;
+    const mirror = await ensureN3Cache(state);
+    expect([...tripleSet(mirror)].sort()).toEqual([...tripleSet(buildN3Store(state.store))].sort());
+  });
+
+  it('returns the same live instance on a warm call (no rebuild)', async () => {
+    await indexNote(ctx, 'a.md', '---\ntitle: A\n---\n# A\n');
+    const state = getState(ctx)!;
+    const first = await ensureN3Cache(state);
+    const second = await ensureN3Cache(state);
+    expect(second).toBe(first);
+  });
+
+  it('a write that races the async build is reflected (falls back to the atomic rebuild)', async () => {
+    // Seed enough triples that the build spans several yields, so a write
+    // injected via setImmediate lands *mid-build*.
+    const state = getState(ctx)!;
+    const g = $rdf.sym('urn:seed');
+    for (let i = 0; i < 60000; i++) {
+      state.store.add($rdf.sym(`urn:s${i}`), RDF('type'), MINERVA('Seed'), g);
+    }
+    resetN3Mirror(state); // ensure cold (n3Cache null) so ensureN3Cache rebuilds
+
+    const racedSubject = $rdf.sym('urn:raced-in');
+    const p = ensureN3Cache(state); // runs slice 1 synchronously, then yields
+    // Scheduled after the build's first-slice setImmediate → runs during a yield.
+    await new Promise<void>((resolve) => setImmediate(() => {
+      state.store.add(racedSubject, RDF('type'), MINERVA('Raced'), g);
+      resolve();
+    }));
+    const mirror = await p;
+
+    // The raced write must be present, and the mirror must equal a fresh rebuild
+    // of the final rdflib state (i.e. the fallback produced a consistent result).
+    const key = `urn:raced-in${RDF('type').value}NamedNode${MINERVA('Raced').value}`;
+    expect(tripleSet(mirror).has(key)).toBe(true);
+    expect([...tripleSet(mirror)].sort()).toEqual([...tripleSet(buildN3Store(state.store))].sort());
+  });
+});


### PR DESCRIPTION
A scoped down-payment on #1115 (move heavy graph work off the main thread / yield it). #1115 itself — a `utilityProcess`/worker relocation — stays deferred to telemetry; this handles only the one residual synchronous blip.

## Why just this slice

After #1110 made the N3 mirror incremental, the O(triples) `buildN3Store` runs only on a **cold** build (project open, post-`indexAllNotes`, periodic self-heal) — no longer on every save. But that residual rebuild is still a single synchronous main-thread block (~100 ms at 5k notes, growing with the vault). This yields it so it can't jank the UI at large scale.

## The change

`ensureN3Cache` is the new front door for `queryGraph`: build the mirror if cold, **time-sliced with `setImmediate` yields** (~8 ms bursts) so file I/O, git, and IPC stay responsive during a large rebuild. Warm queries return the live mirror with **no yield**.

## The concurrency hazard (the whole reason this needs care)

`state.ts` is lock-free *only because* graph work is fully synchronous today — nothing can interleave a rebuild. The moment the build `await`s, a write (a save→`indexNote`) could run during the yield and mutate `store.statements` mid-iteration → corruption + a mirror inconsistent with rdflib. Guarded three ways:

1. **Build from a synchronous `store.statements.slice()` snapshot** — the async loop iterates an immutable copy, immune to a concurrent write splicing the live array.
2. **Monotonic mutation counter**, snapshotted before the yields. After building, if it changed (a write raced) — or another query already built the cache — **discard the async result and fall back to the atomic synchronous `buildN3Store`** (correct by construction, from the final rdflib state).
3. All post-yield checks + the cache assignment run **synchronously**, so the reconcile decision itself can't race.

Net: any race → the atomic path. The async path only wins when nothing raced (the common project-open case).

## Success criteria (of #1115, partial)
- [x] Heavy graph op no longer blocks the main thread — the cold rebuild is yielded (chunked)
- [x] File I/O + git remain responsive during a rebuild — ≤8 ms synchronous bursts
- [x] Query correctness preserved — snapshot + race-fallback keeps the mirror == `buildN3Store`
- [x] `pnpm lint` and `pnpm test` pass
- [ ] Off-process/worker relocation — *out of scope, still deferred to #1115*

## Verification
- New `n3-cache-yielding.test.ts`: the yielding build equals a synchronous `buildN3Store`; a warm call reuses the live instance; and — the key one — **a write injected via `setImmediate` mid-build is reflected in the result** (exercises the race → sync-fallback path).
- Full `pnpm test` → **4966 pass** (every query in the suite now flows through `ensureN3Cache`). `tsc` / `eslint` clean.
- `pnpm build:e2e && npx playwright test happy-paths smoke journeys` → **8 pass**, incl. the real write→reindex→SPARQL flow.

Based on `main` (has #1110). Touches only `state.ts` + `queries.ts`, so it's independent of the open #1473 (`indexers.ts`) PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)