### PR TITLE
fix(security): DOMPurify the note preview + neutralize remote beacons (#1327, #1332)

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -9,6 +9,7 @@
     import {hydrateCardCallouts} from '../markdown/card-callout';
     import {slugify} from '../../../shared/slug';
     import {createPreviewMarkdown} from '../preview/markdown-config';
+    import {sanitizeNoteHtml} from '../preview/sanitize-note-html';
     import {api} from '../ipc/client';
     import {clampSubmenu} from '../utils/menuClamp';
     import {type ChartHandle} from '../charts';
@@ -252,6 +253,14 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     // synchronously so there's no FOUC, then coalesce subsequent
     // changes to one render per ~120ms idle window.
     function renderContent(c: string): string {
+        // DOMPurify pass before the result reaches `{@html rendered}` (#1327 /
+        // M2 + #1332 / L4). Single choke point so both the initial seed and the
+        // debounced re-render are sanitised; preserves the rich markup (KaTeX,
+        // mermaid/vega/query placeholders, wiki-links, task checkboxes) while
+        // stripping scripting vectors + remote privacy beacons.
+        return sanitizeNoteHtml(renderContentRaw(c));
+    }
+    function renderContentRaw(c: string): string {
         // Turtle files are indexable + previewable but they aren't
         // markdown — running them through markdown-it turns `@prefix`
         // lines into stray HTML and IRI angle-brackets into wrecked
@@ -948,8 +957,8 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         <aside class="csl-numeric-bibliography" aria-label="References">
             <h2>References</h2>
             {#each cslBibliographyEntries as entry, i (i)}
-                <!-- citeproc emits trusted HTML from project-controlled meta.ttl -->
-                <div class="csl-bibliography-entry">{@html entry}</div>
+                <!-- citeproc HTML from project-controlled meta.ttl — sanitised as defence-in-depth (#1327) -->
+                <div class="csl-bibliography-entry">{@html sanitizeNoteHtml(entry)}</div>
             {/each}
         </aside>
     {/if}
@@ -959,7 +968,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
             style={tooltipStyle}
             aria-hidden="true"
     >
-        {@html tooltipHtml}
+        {@html sanitizeNoteHtml(tooltipHtml)}
     </div>
 </div>
 

--- a/src/renderer/lib/preview/sanitize-note-html.ts
+++ b/src/renderer/lib/preview/sanitize-note-html.ts
@@ -1,0 +1,124 @@
+/**
+ * DOMPurify sanitiser for note-preview HTML (#1327 / M2 + #1332 / L4).
+ *
+ * The note preview renders untrusted markdown with `html: true` and injects
+ * the result with `{@html}` (Preview.svelte). Historically the ONLY defence
+ * was CSP (no `unsafe-inline` in `script-src`). This adds an explicit
+ * DOMPurify pass as defence-in-depth so a future CSP regression, a
+ * Chromium CSP bypass, or a subtle markup trick can't turn stored note HTML
+ * into renderer XSS — which in Electron borders on RCE via the IPC surface.
+ *
+ * FORBID-based config (mirrors `compute-output-sanitize.ts`): the default
+ * allowlist (HTML + SVG + MathML, keeping `class` / `style` / `data-*`)
+ * preserves the app's rich output untouched — KaTeX math (inline
+ * `style`-positioned spans + MathML), mermaid / vega / query placeholders,
+ * wiki / cite / quote links (`data-*`), callouts, footnotes, task-list
+ * checkboxes, tables — while `<script>` / `<iframe>` / `<object>` /
+ * `<embed>` / `<form>` and inline `on*` handlers are stripped. Using
+ * `FORBID_*` over an `USE_PROFILES` allowlist is deliberate: enumerating
+ * every tag/attr the rich pipeline emits (all of KaTeX's MathML, SVG, the
+ * custom `data-*` vocabulary) is brittle; forbidding the small dangerous set
+ * is not. (See the note in `compute-output-sanitize.ts` on why the two
+ * options don't combine cleanly.)
+ *
+ * L4 (privacy beacons): a raw-HTML `<img src="https://tracker">` or CSS
+ * `background:url(https://…)` embedded directly in note markup phones home
+ * on open, leaking "note opened" + IP/User-Agent to a third party. The
+ * `afterSanitizeAttributes` hook neutralises exactly those two remote-fetch
+ * vectors WITHOUT breaking the app's own image feature: markdown `![](url)`
+ * images are emitted by the preview's image rule with a recognisable marker
+ * (`class="remote-image"` + `data-remote-src`, `local-image`, or a
+ * `youtube-thumb`), so they're left intact — only *unmarked* raw `<img>`
+ * (which never came through the image rule) has its remote `src`/`srcset`
+ * dropped. The full opt-in "block ALL remote content" mode (including
+ * markdown remote images) is a separate policy feature, tracked apart.
+ */
+
+import DOMPurify from 'dompurify';
+
+const FORBID_TAGS = ['script', 'iframe', 'object', 'embed', 'form'];
+
+// KaTeX emits its accessibility MathML wrapped in `<semantics>` with the
+// original TeX in `<annotation encoding="application/x-tex">`. DOMPurify's
+// default MathML profile keeps `<math>/<mrow>/<msup>/…` but drops those two
+// (and their `encoding` attr), which would leak the TeX source as stray text
+// in the visually-hidden `.katex-mathml` node. Both are inert MathML markup —
+// re-allow them so the math accessibility tree survives whole.
+const ADD_TAGS = ['semantics', 'annotation'];
+const ADD_ATTR = ['encoding'];
+
+const FORBID_ATTR = [
+  'onerror',
+  'onload',
+  'onclick',
+  'onmouseover',
+  'onmouseout',
+  'onfocus',
+  'onblur',
+  'onkeydown',
+  'onkeyup',
+  'onkeypress',
+  'onsubmit',
+  'oninput',
+  'onchange',
+  'onanimationstart',
+  'onanimationend',
+  'onpointerover',
+];
+
+// App-generated `<img>` (from the preview image rule / youtube fence) carries
+// one of these markers; a raw-HTML `<img>` beacon carries none, so the
+// remote-content strip below keys on their absence.
+const APP_IMAGE_CLASS = /\b(?:remote-image|local-image|youtube-thumb)\b/;
+// Remote (http/https) or protocol-relative (`//host/…`). data:/blob:/local
+// srcs are untouched.
+const REMOTE_SRC = /^(?:https?:)?\/\//i;
+// A CSS `url(…)` whose target is remote/protocol-relative — quoted or not.
+// Leaves `url(data:…)`, `url(blob:…)`, `url(#localref)` alone.
+const REMOTE_CSS_URL = /url\(\s*['"]?\s*(?:https?:)?\/\/[^)]*\)/gi;
+
+/**
+ * Post-attribute hook (runs per element). Strips the two L4 beacon vectors:
+ * remote `url(…)` in inline styles (any element) and remote `src`/`srcset`
+ * on unmarked raw `<img>`.
+ */
+function neutraliseBeacons(node: Element): void {
+  const style = node.getAttribute?.('style');
+  if (style && REMOTE_CSS_URL.test(style)) {
+    // Global regex — reset lastIndex from the .test() above before replacing.
+    REMOTE_CSS_URL.lastIndex = 0;
+    const cleaned = style.replace(REMOTE_CSS_URL, '').trim();
+    if (cleaned) node.setAttribute('style', cleaned);
+    else node.removeAttribute('style');
+  }
+  REMOTE_CSS_URL.lastIndex = 0;
+
+  if (node.nodeName !== 'IMG') return;
+  const cls = node.getAttribute('class') ?? '';
+  const isAppImage =
+    node.hasAttribute('data-remote-src') ||
+    node.hasAttribute('data-rel') ||
+    APP_IMAGE_CLASS.test(cls);
+  if (isAppImage) return;
+  // Unmarked raw <img>: drop remote src + any srcset so it can't phone home.
+  if (REMOTE_SRC.test(node.getAttribute('src') ?? '')) node.removeAttribute('src');
+  if (node.hasAttribute('srcset')) node.removeAttribute('srcset');
+}
+
+/**
+ * Sanitise note-preview HTML for injection via `{@html}`. Preserves the full
+ * rich-markdown surface; strips scripting vectors + remote privacy beacons.
+ * Empty/falsy input is returned unchanged.
+ */
+export function sanitizeNoteHtml(html: string): string {
+  if (!html) return html;
+  // Hooks are process-global on the shared DOMPurify instance, so add and
+  // remove ours around the synchronous sanitise call (no `await` between —
+  // the renderer is single-threaded, so no other sanitise can interleave).
+  DOMPurify.addHook('afterSanitizeAttributes', neutraliseBeacons);
+  try {
+    return DOMPurify.sanitize(html, { FORBID_TAGS, FORBID_ATTR, ADD_TAGS, ADD_ATTR });
+  } finally {
+    DOMPurify.removeHook('afterSanitizeAttributes');
+  }
+}

--- a/tests/renderer/preview/sanitize-note-html.test.ts
+++ b/tests/renderer/preview/sanitize-note-html.test.ts
@@ -1,0 +1,218 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * jsdom (not happy-dom): DOMPurify v3's element-table detection skips a few
+ * tags under happy-dom's lighter DOM (iframe/embed/form survive FORBID_TAGS),
+ * matching the note in `compute-output-sanitize.test.ts`. The Electron
+ * renderer runs real Chromium, which jsdom approximates closely enough.
+ *
+ * Tests for `sanitizeNoteHtml` — the DOMPurify pass the note preview runs
+ * before injecting markdown output via `{@html}` (#1327 / M2 + #1332 / L4).
+ *
+ * Two guarantees, both load-bearing:
+ *  1. NEUTRALISE — scripting vectors (`<script>`, `on*` handlers, `<iframe>`/
+ *     `<form>`, `javascript:` hrefs) and remote privacy beacons (raw `<img>`
+ *     remote `src`, CSS `background:url(https://…)`) are stripped.
+ *  2. PRESERVE — the app's rich pipeline output is untouched: KaTeX math
+ *     (MathML + inline-`style` spans), mermaid/vega/query placeholders,
+ *     wiki/cite links (`data-*`), task-list checkboxes, tables, and the app's
+ *     OWN marked remote images (markdown `![](url)`, youtube thumbs).
+ *
+ * The end-to-end block renders real `createPreviewMarkdown` output through the
+ * sanitiser — the actual safety net that the allowlist doesn't silently break
+ * a preview feature.
+ */
+import { describe, it, expect } from 'vitest';
+import { sanitizeNoteHtml } from '../../../src/renderer/lib/preview/sanitize-note-html';
+import { createPreviewMarkdown, type PreviewMarkdownDeps } from '../../../src/renderer/lib/preview/markdown-config';
+
+function makeDeps(over: Partial<PreviewMarkdownDeps> = {}): PreviewMarkdownDeps {
+  return {
+    collapsedFences: new Set<number>(),
+    runningFences: new Set<number>(),
+    getRenderPathOverride: () => null,
+    getNotePath: () => null,
+    getCanRun: () => false,
+    ...over,
+  };
+}
+
+describe('sanitizeNoteHtml — neutralises scripting vectors', () => {
+  it('strips <script> entirely', () => {
+    expect(sanitizeNoteHtml('<p>hi</p><script>alert(1)</script>')).not.toContain('<script');
+  });
+
+  it('strips inline event handlers but keeps the element', () => {
+    const out = sanitizeNoteHtml('<img src="local.png" onerror="alert(1)" alt="x">');
+    expect(out).not.toContain('onerror');
+    expect(out).toContain('local.png'); // non-remote src preserved
+  });
+
+  it('drops <iframe>, <object>, <embed>, <form>', () => {
+    const out = sanitizeNoteHtml(
+      '<iframe src="https://evil"></iframe><object></object><embed><form><input></form>',
+    );
+    expect(out).not.toContain('<iframe');
+    expect(out).not.toContain('<object');
+    expect(out).not.toContain('<embed');
+    expect(out).not.toContain('<form');
+  });
+
+  it('neutralises javascript: hrefs', () => {
+    const out = sanitizeNoteHtml('<a href="javascript:alert(1)">x</a>');
+    expect(out).not.toContain('javascript:');
+  });
+});
+
+describe('sanitizeNoteHtml — neutralises L4 remote privacy beacons', () => {
+  it('strips remote src from an unmarked raw <img> beacon', () => {
+    const out = sanitizeNoteHtml('<img src="https://attacker.example/beacon.gif">');
+    expect(out).not.toContain('attacker.example');
+    expect(out).not.toMatch(/src="https?:/);
+  });
+
+  it('strips protocol-relative src from a raw <img>', () => {
+    const out = sanitizeNoteHtml('<img src="//attacker.example/beacon.gif">');
+    expect(out).not.toContain('attacker.example');
+  });
+
+  it('strips srcset from a raw <img>', () => {
+    const out = sanitizeNoteHtml('<img src="x" srcset="https://attacker.example/b.gif 1x">');
+    expect(out).not.toContain('srcset');
+    expect(out).not.toContain('attacker.example');
+  });
+
+  it('strips a remote CSS background url() from inline style', () => {
+    const out = sanitizeNoteHtml('<div style="background:url(https://attacker.example/b.png)">x</div>');
+    expect(out).not.toContain('attacker.example');
+  });
+
+  it('leaves a local data: background url() intact', () => {
+    const out = sanitizeNoteHtml('<div style="background:url(data:image/gif;base64,AAA)">x</div>');
+    expect(out).toContain('data:image/gif');
+  });
+});
+
+describe('sanitizeNoteHtml — preserves the app image feature (marked images)', () => {
+  it('keeps a marked remote-image src (markdown ![](https://…))', () => {
+    const out = sanitizeNoteHtml(
+      '<img class="remote-image" data-remote-src="https://ex.com/a.png" src="https://ex.com/a.png" alt="a" loading="lazy">',
+    );
+    expect(out).toContain('src="https://ex.com/a.png"');
+    expect(out).toContain('data-remote-src');
+  });
+
+  it('keeps a youtube-thumb remote src', () => {
+    const out = sanitizeNoteHtml(
+      '<img class="youtube-thumb" data-youtube-id="abc" src="https://img.youtube.com/vi/abc/0.jpg" alt="v">',
+    );
+    expect(out).toContain('img.youtube.com');
+  });
+
+  it('keeps a local-image placeholder (data-rel, no src)', () => {
+    const out = sanitizeNoteHtml('<img class="local-image" data-rel="notes/a.png" alt="a">');
+    expect(out).toContain('data-rel="notes/a.png"');
+    expect(out).toContain('local-image');
+  });
+});
+
+describe('sanitizeNoteHtml — preserves rich markup', () => {
+  it('keeps KaTeX MathML + inline-style spans', () => {
+    const katex =
+      '<span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML">' +
+      '<semantics><mrow><msup><mi>x</mi><mn>2</mn></msup></mrow>' +
+      '<annotation encoding="application/x-tex">x^2</annotation></semantics></math></span>' +
+      '<span class="katex-html" aria-hidden="true" style="height:0.8141em;vertical-align:0em;">x2</span></span>';
+    const out = sanitizeNoteHtml(katex);
+    expect(out).toContain('<math');
+    expect(out).toContain('<msup');
+    expect(out).toContain('<annotation');
+    expect(out).toContain('aria-hidden="true"');
+    expect(out).toMatch(/style="height:0\.8141em/); // positioning style survives
+    expect(out).toContain('katex-mathml');
+  });
+
+  it('keeps wiki-link data-* attributes', () => {
+    const out = sanitizeNoteHtml('<a class="wiki-link" data-target="foo" data-tooltip-kind="note">foo</a>');
+    expect(out).toContain('data-target="foo"');
+    expect(out).toContain('class="wiki-link"');
+  });
+
+  it('keeps a task-list checkbox input', () => {
+    const out = sanitizeNoteHtml('<input type="checkbox" data-task-line="3" checked>');
+    expect(out).toContain('type="checkbox"');
+    expect(out).toContain('data-task-line="3"');
+    expect(out).toContain('checked');
+  });
+
+  it('keeps mermaid / vega / query placeholders', () => {
+    expect(sanitizeNoteHtml('<div class="mermaid-block" data-mermaid-pending="1">graph TD</div>'))
+      .toContain('data-mermaid-pending="1"');
+    expect(sanitizeNoteHtml('<div class="vega-block" data-vega-pending="1" data-vega-mode="lite">{}</div>'))
+      .toContain('data-vega-mode="lite"');
+    expect(sanitizeNoteHtml('<div class="query-block" data-type="list" data-query="SELECT ?s WHERE {}">x</div>'))
+      .toContain('data-query="SELECT ?s WHERE {}"');
+  });
+
+  it('keeps tables and footnote anchors', () => {
+    const out = sanitizeNoteHtml(
+      '<table><thead><tr><th>a</th></tr></thead><tbody><tr><td>b</td></tr></tbody></table>' +
+      '<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>',
+    );
+    expect(out).toContain('<table');
+    expect(out).toContain('<th>a</th>');
+    expect(out).toContain('href="#fn1"');
+  });
+
+  it('returns falsy input unchanged', () => {
+    expect(sanitizeNoteHtml('')).toBe('');
+  });
+});
+
+describe('sanitizeNoteHtml — end-to-end over real preview output', () => {
+  const md = createPreviewMarkdown(makeDeps());
+
+  it('leaves a kitchen-sink note intact through render + sanitise', () => {
+    const src = [
+      '# Heading',
+      '',
+      'Inline math $x^2$ and a [[foo]] wiki-link.',
+      '',
+      '![diagram](https://ex.com/a.png)',
+      '',
+      '- [x] done',
+      '- [ ] todo',
+      '',
+      '| a | b |',
+      '| - | - |',
+      '| 1 | 2 |',
+      '',
+      '> [!note] A callout',
+      '> body',
+      '',
+      'A footnote.[^1]',
+      '',
+      '[^1]: the note',
+    ].join('\n');
+    const out = sanitizeNoteHtml(md.render(src, {}));
+
+    expect(out).toContain('<h1 id="heading">');
+    expect(out).toContain('katex'); // math rendered + survived
+    expect(out).toContain('wiki-link');
+    expect(out).toContain('src="https://ex.com/a.png"'); // marked remote image survives
+    expect(out).toContain('remote-image');
+    expect(out).toContain('type="checkbox"');
+    expect(out).toContain('<table');
+    expect(out).toContain('footnote'); // footnote machinery survives
+    expect(out).not.toContain('<script');
+  });
+
+  it('scrubs an embedded raw <script> + beacon while keeping the prose', () => {
+    const src = 'Hello **world**.\n\n<script>fetch("https://evil")</script>\n\n<img src="https://tracker.example/b.gif">';
+    const out = sanitizeNoteHtml(md.render(src, {}));
+    expect(out).toContain('<strong>world</strong>');
+    expect(out).not.toContain('<script');
+    expect(out).not.toContain('evil');
+    expect(out).not.toContain('tracker.example');
+  });
+});


### PR DESCRIPTION
Closes #1327 (M2). Addresses the defense-in-depth half of #1332 (L4).

## Problem
The note preview built markdown-it with `html: true` and injected the result via `{@html}` — the note body, the CSL bibliography entries, and the hover tooltips — with **no DOMPurify**. CSP (`script-src` without `'unsafe-inline'`) was the *only* layer preventing script execution. A future CSP regression, a Chromium CSP bypass, or a subtle markup trick would turn stored note HTML straight into renderer XSS — which in Electron borders on RCE via the IPC surface. Separately (#1332), a raw `<img src="https://tracker">` or CSS `background:url(https://…)` in a note phones home on open, leaking "note opened" + IP/UA.

## Change
New `sanitizeNoteHtml` (`src/renderer/lib/preview/sanitize-note-html.ts`), wired into all three `{@html}` sites in `Preview.svelte`.

- **FORBID-based config** (mirrors `compute-output-sanitize.ts`): the default allowlist (HTML + SVG + MathML, keeping `class`/`style`/`data-*`) preserves the rich pipeline untouched — KaTeX math (MathML + inline-`style`-positioned spans; `<semantics>`/`<annotation>` re-allowed so the accessibility tree + TeX source survive), mermaid/vega/query placeholders, wiki/cite/quote links, task-list checkboxes, tables, footnotes — while `<script>`/`<iframe>`/`<object>`/`<embed>`/`<form>` and inline `on*` handlers are stripped.
- **L4 beacon neutralization** (same pass, `afterSanitizeAttributes` hook): drops remote `src`/`srcset` on *unmarked* raw `<img>` and remote `url(…)` in inline styles. The app's own images (markdown `![](url)` → `remote-image`/`data-remote-src`, `local-image`, youtube thumbs) carry a marker and are left intact, so the image feature is unaffected. `data:`/`blob:`/local URLs pass through. The full opt-in *block-all-remote-content* mode remains a separate policy feature.

## Sibling audit (requested in #1327)
- **SourceDetail** — renders via `renderInlineWithMath` (`html:false`) → safe.
- **ComputeDraftCard** — output paths already use `sanitizeComputeOutputHtml`; `f.message` is an app constant (built from the hardcoded `FLAGGED_IMPORT_MODULES` + static rule table, not user-captured text) → safe.
- **MessageList** — `html:false` → safe.

Preview was the only genuinely-exposed site.

## Tests
20-case suite (`tests/renderer/preview/sanitize-note-html.test.ts`, jsdom — DOMPurify's element table needs it, per the compute sanitizer's note): scripting-vector neutralization, L4 beacon stripping, rich-markup preservation (KaTeX/wiki-links/checkboxes/placeholders/tables), and an **end-to-end pass over real `createPreviewMarkdown` output** as the regression net that the allowlist doesn't silently break a preview feature. `pnpm lint` clean; the 35-file preview+components suite (377 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)