### PR TITLE
fix(security): hash-pin the embedding model download (#1489)

### DIFF
--- a/scripts/fetch-embedding-model.mjs
+++ b/scripts/fetch-embedding-model.mjs
@@ -5,47 +5,71 @@
  * fully offline at RUNTIME — but the ~23 MB weights shouldn't bloat the git repo
  * (no LFS here). So we fetch them at dev/build time into a gitignored dir that
  * forge ships via `extraResource: ['resources']`. Idempotent: files already
- * present at the right size are skipped, so this is a no-op on warm trees and
- * adds no network cost to a normal `pnpm dev`.
+ * present with the right SHA-256 are skipped, so this is a no-op on warm trees
+ * and adds no network cost to a normal `pnpm dev`.
  *
  * Build-time network is fine — the *app* is offline, not the build. CI fetches
  * once; the packaged app carries the weights and never phones home.
+ *
+ * Integrity (#1489 / A08). Two pins, both load-bearing:
+ *   1. `REVISION` — an immutable HF commit SHA, NOT the moving `main` branch, so
+ *      a future upstream force-push / retag can't change what we fetch.
+ *   2. `sha256` per file — the exact bytes are verified on every path (already
+ *      present, copied from the transformers.js cache, or freshly downloaded).
+ *      A mismatch on a fresh download THROWS, failing the build rather than
+ *      shipping (or silently trusting) tampered/MITM'd weights. A stale/corrupt
+ *      already-present or cached file simply fails the check and is re-fetched.
+ *
+ * To bump the model: pick the new HF commit SHA, download each file at that
+ * revision, and update `REVISION` + every `sha256` below in the same commit.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import crypto from 'node:crypto';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const MODEL_ID = 'Xenova/all-MiniLM-L6-v2';
 const DEST = path.join(ROOT, 'resources', 'models', 'all-MiniLM-L6-v2');
 
+// Immutable pin — the HF commit these hashes were taken from. Never `main`.
+export const REVISION = '751bff37182d3f1213fa05d7196b954e230abad9';
+
 // The exact files the WASM embedder loads: the quantized ONNX graph + the
-// tokenizer trio. Sizes are the known-good byte counts so a truncated/partial
-// download is re-fetched rather than trusted.
-const FILES = [
-  { rel: 'onnx/model_quantized.onnx', minBytes: 22_000_000 },
-  { rel: 'tokenizer.json', minBytes: 600_000 },
-  { rel: 'tokenizer_config.json', minBytes: 100 },
-  { rel: 'config.json', minBytes: 100 },
+// tokenizer trio, each pinned to its known-good SHA-256. The hash subsumes the
+// old byte-count check — a truncated or altered file can't match it.
+export const FILES = [
+  { rel: 'onnx/model_quantized.onnx', sha256: 'afdb6f1a0e45b715d0bb9b11772f032c399babd23bfc31fed1c170afc848bdb1' },
+  { rel: 'tokenizer.json', sha256: 'da0e79933b9ed51798a3ae27893d3c5fa4a201126cef75586296df9b4d2c62a0' },
+  { rel: 'tokenizer_config.json', sha256: '9261e7d79b44c8195c1cada2b453e55b00aeb81e907a6664974b4d7776172ab3' },
+  { rel: 'config.json', sha256: '7135149f7cffa1a573466c6e4d8423ed73b62fd2332c575bf738a0d033f70df7' },
 ];
 
-const BASE = `https://huggingface.co/${MODEL_ID}/resolve/main`;
+const BASE = `https://huggingface.co/${MODEL_ID}/resolve/${REVISION}`;
 
 // Prefer the copy transformers.js may have already cached during install/use —
-// no network needed when it's there.
+// no network needed when it's there (and it's hash-verified all the same).
 const NPM_CACHE = path.join(
   ROOT, 'node_modules', '@huggingface', 'transformers', '.cache', MODEL_ID,
 );
 
-async function ensureFile(rel, minBytes) {
+export const sha256 = (buf) => crypto.createHash('sha256').update(buf).digest('hex');
+
+/** True iff `p` exists and its bytes hash to `expectedSha`. */
+export function fileHasSha(p, expectedSha) {
+  if (!fs.existsSync(p)) return false;
+  return sha256(fs.readFileSync(p)) === expectedSha;
+}
+
+async function ensureFile(rel, expectedSha) {
   const dest = path.join(DEST, rel);
-  if (fs.existsSync(dest) && fs.statSync(dest).size >= minBytes) return 'present';
+  if (fileHasSha(dest, expectedSha)) return 'present';
 
   fs.mkdirSync(path.dirname(dest), { recursive: true });
 
   const cached = path.join(NPM_CACHE, rel);
-  if (fs.existsSync(cached) && fs.statSync(cached).size >= minBytes) {
+  if (fileHasSha(cached, expectedSha)) {
     fs.copyFileSync(cached, dest);
     return 'copied';
   }
@@ -54,17 +78,32 @@ async function ensureFile(rel, minBytes) {
   const res = await fetch(url);
   if (!res.ok) throw new Error(`fetch ${url} → ${res.status} ${res.statusText}`);
   const buf = Buffer.from(await res.arrayBuffer());
-  if (buf.length < minBytes) throw new Error(`${rel} truncated: ${buf.length} < ${minBytes}`);
+  const got = sha256(buf);
+  if (got !== expectedSha) {
+    throw new Error(
+      `${rel} integrity check failed: sha256 ${got} != pinned ${expectedSha} ` +
+      `(revision ${REVISION}). Refusing to write — upstream bytes changed or the download was tampered.`,
+    );
+  }
   fs.writeFileSync(dest, buf);
   return 'downloaded';
 }
 
-let downloaded = 0;
-for (const f of FILES) {
-  const how = await ensureFile(f.rel, f.minBytes);
-  if (how !== 'present') downloaded++;
-  console.log(`  ${how.padEnd(10)} ${f.rel}`);
+export async function fetchEmbeddingModel() {
+  let downloaded = 0;
+  for (const f of FILES) {
+    const how = await ensureFile(f.rel, f.sha256);
+    if (how !== 'present') downloaded++;
+    console.log(`  ${how.padEnd(10)} ${f.rel}`);
+  }
+  console.log(downloaded === 0
+    ? 'embedding model already present — nothing to do'
+    : `embedding model ready in resources/models/all-MiniLM-L6-v2 (${downloaded} file(s) fetched)`);
+  return downloaded;
 }
-console.log(downloaded === 0
-  ? 'embedding model already present — nothing to do'
-  : `embedding model ready in resources/models/all-MiniLM-L6-v2 (${downloaded} file(s) fetched)`);
+
+// Run only when invoked as a script (`node scripts/fetch-embedding-model.mjs`),
+// not when imported by a test.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  await fetchEmbeddingModel();
+}

--- a/tests/scripts/fetch-embedding-model.test.ts
+++ b/tests/scripts/fetch-embedding-model.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Integrity-pin tests for the embedding-model fetch script (#1489 / A08).
+ *
+ * The script's real enforcement is at build time — a fetched file whose bytes
+ * don't match the pinned SHA-256 throws, failing CI rather than shipping
+ * tampered weights. These tests lock the pieces that make that enforcement
+ * sound: the hash helper is correct, `fileHasSha` accepts only exact-byte
+ * matches, and the pins themselves are well-formed and immutable (an actual
+ * commit SHA, never the moving `main` branch — a regression that reverts the
+ * pin to `main` would silently reopen the integrity hole).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+// @ts-expect-error -- plain JS build-time module, no .d.ts
+import { sha256, fileHasSha, FILES, REVISION } from '../../scripts/fetch-embedding-model.mjs';
+
+const hash = sha256 as (buf: Buffer) => string;
+const hasSha = fileHasSha as (p: string, expected: string) => boolean;
+const files = FILES as { rel: string; sha256: string }[];
+const revision = REVISION as string;
+
+describe('sha256', () => {
+  it('computes the standard SHA-256 of the input bytes', () => {
+    // Known vector: sha256("abc").
+    expect(hash(Buffer.from('abc'))).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+    );
+  });
+});
+
+describe('fileHasSha', () => {
+  it('accepts a file whose bytes match, rejects a mismatch or a missing file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-hashpin-'));
+    try {
+      const p = path.join(dir, 'f.bin');
+      fs.writeFileSync(p, Buffer.from('abc'));
+      const good = hash(Buffer.from('abc'));
+      expect(hasSha(p, good)).toBe(true);
+      expect(hasSha(p, 'deadbeef'.repeat(8))).toBe(false); // wrong (tampered) bytes
+      expect(hasSha(path.join(dir, 'missing.bin'), good)).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('pinned integrity metadata', () => {
+  it('pins an immutable 40-hex commit SHA, not a moving ref', () => {
+    expect(revision).toMatch(/^[0-9a-f]{40}$/);
+    expect(revision).not.toBe('main');
+  });
+
+  it('pins a well-formed SHA-256 for each of the four required files', () => {
+    const rels = files.map((f) => f.rel).sort();
+    expect(rels).toEqual([
+      'config.json',
+      'onnx/model_quantized.onnx',
+      'tokenizer.json',
+      'tokenizer_config.json',
+    ]);
+    for (const f of files) {
+      expect(f.sha256, `${f.rel} sha256`).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+});


### PR DESCRIPTION
Closes #1489 (integrity half split from L6 / #1334).

## Problem
`scripts/fetch-embedding-model.mjs` fetched the ~23 MB all-MiniLM-L6-v2 weights + tokenizer at build time with **no integrity check on the bytes** — only a `minBytes` truncation guard — and pulled from the moving `resolve/main` branch. A MITM'd download, a compromised mirror, or an upstream force-push would be written and shipped as-is (A08 — software/data integrity).

## Change
Two pins, both verified on every path:

1. **`REVISION`** — an immutable HF commit SHA (`751bff37…`) replaces `resolve/main`, so upstream can't change what a fresh fetch pulls.
2. **`sha256` per file** — the ONNX graph + tokenizer trio each carry their known-good hash. Verified whether the file is already present, copied from the transformers.js npm cache, or freshly downloaded. A mismatch on a fresh download **throws** (fails the build); a stale/corrupt present-or-cached file just fails the check and is re-fetched. The hash subsumes the old `minBytes` check.

The pinned hashes were computed from the bytes the app **already ships** and cross-checked against HF's copy at the pinned revision — all four match — so existing installs and warm trees are unaffected (still a no-op, now hash-verified).

## Testability
Refactored to `export { REVISION, FILES, sha256, fileHasSha, fetchEmbeddingModel }` with the top-level run guarded by an `import.meta.url === argv[1]` check, so importing it in a test doesn't trigger a real fetch.

`tests/scripts/fetch-embedding-model.test.ts`: `sha256` known-vector, `fileHasSha` exact-match / mismatch / missing, and that the pin is a 40-hex commit SHA (never `main`) with a well-formed sha256 for each required file — so a regression that reverts the pin to a moving ref fails CI. Full `pnpm lint` clean; the script still reports all-present locally.

## Out of scope
The runtime Whisper model is fetched **inside** transformers.js from the HF hub, so integrity-pinning it means intercepting that fetch or vendoring the weights — a larger, separate task. Noted on #1489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)