### PR TITLE
feat(llm): provider-aware model registry + parity guardrail (#1493)

### DIFF
--- a/src/shared/tools/effort.ts
+++ b/src/shared/tools/effort.ts
@@ -49,6 +49,14 @@ const SUPPORT: Record<string, Effort[]> = {
   'claude-haiku-4-5': [],
 };
 
+/**
+ * Model ids with an explicit effort-support entry above. Exported so the model-
+ * registry parity test (BYOM #1493) can assert every catalog model is declared
+ * here — a model added without an entry silently loses effort control (`[]`),
+ * which this guardrail turns into a CI failure.
+ */
+export const EFFORT_ENTRY_MODEL_IDS: readonly string[] = Object.keys(SUPPORT);
+
 export function supportedEfforts(model: string): Effort[] {
   return SUPPORT[model] ?? [];
 }

--- a/src/shared/tools/models.ts
+++ b/src/shared/tools/models.ts
@@ -1,15 +1,23 @@
 /**
- * Canonical list of Anthropic models surfaced in the UI.
+ * Canonical list of built-in models surfaced in the UI, grouped by provider
+ * (BYOM, epic #1492). Each entry declares its `provider` (see `providers.ts`)
+ * so the settings/picker UI can group models and route each to the right
+ * `LLMProvider` implementation.
  *
  * Kept in `shared/` so both the Settings dialog and the per-conversation
  * picker read from the same source of truth. Callers that need the
- * current default read it from LLMSettings.model, which is validated
- * against this list.
+ * current default read it from LLMSettings.model. Note ids are NOT validated
+ * against this list at call time — user-defined local models (BYOM #1497) are
+ * legitimate ids absent here — so treat this as the built-in catalog, not an
+ * allowlist.
  */
+
+import type { ProviderId } from './providers';
 
 export interface ModelOption {
   value: string;
   label: string;
+  provider: ProviderId;
 }
 
 export const MODEL_OPTIONS: ModelOption[] = [
@@ -20,16 +28,25 @@ export const MODEL_OPTIONS: ModelOption[] = [
   // DEFAULT_MODEL in main/llm/settings.ts). Opus 4.8 is kept (still active) so
   // a user who explicitly selected it isn't reset to the default. Sonnet 4.6 is
   // likewise kept; Sonnet 5 is its successor tier.
-  { value: 'claude-opus-5', label: 'Claude Opus 5' },
-  { value: 'claude-fable-5', label: 'Claude Fable 5' },
-  { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
-  { value: 'claude-sonnet-5', label: 'Claude Sonnet 5' },
-  { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
-  { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+  { value: 'claude-opus-5', label: 'Claude Opus 5', provider: 'anthropic' },
+  { value: 'claude-fable-5', label: 'Claude Fable 5', provider: 'anthropic' },
+  { value: 'claude-opus-4-8', label: 'Claude Opus 4.8', provider: 'anthropic' },
+  { value: 'claude-sonnet-5', label: 'Claude Sonnet 5', provider: 'anthropic' },
+  { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', provider: 'anthropic' },
+  { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', provider: 'anthropic' },
 ];
 
 export function modelLabel(value: string): string {
   return MODEL_OPTIONS.find((m) => m.value === value)?.label ?? value;
+}
+
+/**
+ * The provider a built-in model belongs to, or `undefined` for an id not in the
+ * catalog (e.g. a user-defined local model). Callers that need a concrete
+ * provider for an unknown id resolve it from settings, not from here.
+ */
+export function providerForModel(value: string): ProviderId | undefined {
+  return MODEL_OPTIONS.find((m) => m.value === value)?.provider;
 }
 
 // ── Pricing (#821) ───────────────────────────────────────────────────────────

--- a/src/shared/tools/providers.ts
+++ b/src/shared/tools/providers.ts
@@ -1,0 +1,77 @@
+/**
+ * LLM provider registry (BYOM, epic #1492 — child #1493).
+ *
+ * The provider *implementations* live behind the `LLMProvider` seam in
+ * `src/main/llm/provider/` (#1148); this is the shared, renderer-safe metadata
+ * that names the providers, drives per-provider credential storage + settings
+ * UI, and lets the model registry (`models.ts`) tag each model with its
+ * provider. Kept in `shared/` so main and renderer read one source of truth.
+ *
+ * Adding a provider means: one entry here, one model-catalog block in
+ * `models.ts`, and one `LLMProvider` implementation wired into the factory.
+ */
+
+/**
+ * The set of known providers. `local` is the OpenAI-compatible escape hatch —
+ * a user-configured base URL (Ollama, LM Studio, vLLM, llama.cpp, OpenRouter,
+ * Together, …) served by the OpenAI implementation, so the whole open-source
+ * long tail needs no bespoke code.
+ */
+export type ProviderId = 'anthropic' | 'openai' | 'google' | 'local';
+
+export interface ProviderMeta {
+  id: ProviderId;
+  /** Human label for settings / picker group headers. */
+  label: string;
+  /** Env var consulted as a fallback when no key is stored; null when keyless. */
+  envVar: string | null;
+  /** Whether a request needs an API key (local endpoints often don't). */
+  requiresKey: boolean;
+  /** Whether the user configures a custom base URL (surfaced in settings). */
+  usesBaseURL: boolean;
+  /** Suggested base URL when `usesBaseURL` (Ollama's default). */
+  defaultBaseURL?: string;
+}
+
+export const PROVIDERS: Record<ProviderId, ProviderMeta> = {
+  anthropic: {
+    id: 'anthropic',
+    label: 'Anthropic',
+    envVar: 'ANTHROPIC_API_KEY',
+    requiresKey: true,
+    usesBaseURL: false,
+  },
+  openai: {
+    id: 'openai',
+    label: 'OpenAI',
+    envVar: 'OPENAI_API_KEY',
+    requiresKey: true,
+    usesBaseURL: false,
+  },
+  google: {
+    id: 'google',
+    label: 'Google Gemini',
+    envVar: 'GEMINI_API_KEY',
+    requiresKey: true,
+    usesBaseURL: false,
+  },
+  local: {
+    id: 'local',
+    label: 'Local / OpenAI-compatible',
+    envVar: null,
+    requiresKey: false,
+    usesBaseURL: true,
+    defaultBaseURL: 'http://localhost:11434/v1',
+  },
+};
+
+/** All provider ids, in a stable display order (catalog / settings order). */
+export const PROVIDER_IDS: ProviderId[] = ['anthropic', 'openai', 'google', 'local'];
+
+export function isProviderId(value: string): value is ProviderId {
+  return Object.prototype.hasOwnProperty.call(PROVIDERS, value);
+}
+
+export function providerLabel(id: ProviderId): string {
+  return PROVIDERS[id]?.label ?? id;
+}

--- a/tests/shared/model-registry-parity.test.ts
+++ b/tests/shared/model-registry-parity.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Model-registry parity guardrail (BYOM epic #1492, child #1493).
+ *
+ * The model catalog is split across three co-located-but-separate tables:
+ *   - `MODEL_OPTIONS`  (models.ts)  — the models + their provider
+ *   - `MODEL_PRICING`  (models.ts)  — $/MTok per model
+ *   - `SUPPORT`        (effort.ts)  — supported reasoning-effort levels per model
+ *
+ * Before this test the only thing keeping them in sync was hand-written
+ * per-model cases, so adding a model but forgetting its pricing/effort entry
+ * degraded SILENTLY (unpriced cost, no effort control) rather than failing CI.
+ * These assertions make the forward coupling — every catalog model is fully
+ * described — a hard gate, and check each model names a real provider.
+ *
+ * Orphans (a pricing/effort entry with no catalog model) are intentionally NOT
+ * failed: a deprecated id may keep its price so historical conversation costs
+ * still render.
+ */
+import { describe, it, expect } from 'vitest';
+import { MODEL_OPTIONS, MODEL_PRICING } from '../../src/shared/tools/models';
+import { EFFORT_ENTRY_MODEL_IDS } from '../../src/shared/tools/effort';
+import { isProviderId } from '../../src/shared/tools/providers';
+
+const ids = MODEL_OPTIONS.map((m) => m.value);
+
+describe('model-registry parity', () => {
+  it('has no duplicate model ids', () => {
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every catalog model has an effort-support entry', () => {
+    for (const id of ids) {
+      expect(EFFORT_ENTRY_MODEL_IDS, `${id} missing from SUPPORT (effort.ts)`).toContain(id);
+    }
+  });
+
+  it('every catalog model has a pricing entry', () => {
+    for (const id of ids) {
+      expect(
+        Object.prototype.hasOwnProperty.call(MODEL_PRICING, id),
+        `${id} missing from MODEL_PRICING`,
+      ).toBe(true);
+    }
+  });
+
+  it('every catalog model names a known provider', () => {
+    for (const m of MODEL_OPTIONS) {
+      expect(isProviderId(m.provider), `${m.value} has unknown provider "${m.provider}"`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
BYOM epic #1492 — child 1/6. Foundation PR: no behavior change, no new provider wired yet.

## What
- **`src/shared/tools/providers.ts`** (new) — the `ProviderId` union (`anthropic` / `openai` / `google` / `local`) + a `PROVIDERS` metadata table (label, env var, `requiresKey`, `usesBaseURL`, `defaultBaseURL`). This is the shared, renderer-safe registry the later PRs build on: per-provider credential storage (#1494), provider-grouped pickers (#1498), and the factory branch (#1495). `local` is the OpenAI-compatible escape hatch (Ollama default `http://localhost:11434/v1`, LM Studio, vLLM, llama.cpp, …) so the open-source long tail needs no bespoke provider code.
- **`models.ts`** — `ModelOption` gains a required `provider` field; all six Claude models tagged `anthropic`; new `providerForModel()` helper. Header reframed from "Anthropic models" to a provider-grouped built-in catalog.
- **`effort.ts`** — export `EFFORT_ENTRY_MODEL_IDS` (the `SUPPORT` keys) for the guardrail.

## The guardrail (the point of this PR)
`tests/shared/model-registry-parity.test.ts`. The catalog is spread across three co-located tables — `MODEL_OPTIONS`, `MODEL_PRICING` (models.ts), and `SUPPORT` (effort.ts). Recon found **no test enforced they stay in sync**: adding a model but forgetting its pricing/effort entry degraded *silently* (unpriced cost, no effort control). This makes the forward coupling a hard gate — every catalog model must have an effort entry, a pricing entry, and a known provider — so the mistake fails CI instead. Orphan pricing/effort entries are intentionally allowed (a deprecated id may keep its price for historical cost display).

## Scope / safety
Purely additive shared metadata. Model ids are still not validated against the catalog at call time (user-defined local models, #1497, are legitimate ids absent from it). `pnpm lint` clean; parity + effort + conversation-cost suites green.

Part of #1492.