### PR TITLE
feat(llm): multi-provider settings schema + secrets + migration (#1494)

### DIFF
--- a/src/main/llm/provider/index.ts
+++ b/src/main/llm/provider/index.ts
@@ -29,14 +29,15 @@ export interface ResolvedProvider {
  */
 export async function getProvider(): Promise<ResolvedProvider> {
   const settings = await getSettings();
-  if (!settings.apiKey) {
+  // Anthropic is still the only wired implementation (BYOM #1495 branches this
+  // on the selected model's provider). Read its per-provider credentials.
+  const apiKey = settings.providers.anthropic?.apiKey;
+  if (!apiKey) {
     throw new Error(
       `${MISSING_API_KEY_MARKER}. Set it in the LLM settings or ANTHROPIC_API_KEY environment variable.`,
     );
   }
-  // Single provider today. A second provider is a new `case` here keyed off a
-  // settings field — see docs/vision/substrate-mcp.md → Internal agnosticism.
-  const provider = new AnthropicProvider(settings.apiKey);
+  const provider = new AnthropicProvider(apiKey);
   return {
     provider,
     model: settings.model,

--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -1,9 +1,20 @@
 import { app } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import type { LLMSettings, LLMSettingsView, LLMSettingsUpdate, WebSettings, ApiKeyStorage } from '../../shared/tools/types';
+import type {
+  LLMSettings,
+  LLMSettingsView,
+  LLMSettingsUpdate,
+  WebSettings,
+  ApiKeyStorage,
+  ProviderCredentials,
+  ProviderCredentialsUpdate,
+  ProviderConfigView,
+} from '../../shared/tools/types';
 import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { isEffort, type Effort } from '../../shared/tools/effort';
+import { PROVIDERS, PROVIDER_IDS, type ProviderId } from '../../shared/tools/providers';
+import { providerForModel } from '../../shared/tools/models';
 import { encryptSecret, decryptSecret, isEncrypted, secretEncryptionAvailable } from '../secret-storage';
 
 const DEFAULT_MODEL = 'claude-opus-5';
@@ -54,105 +65,188 @@ function settingsPath(): string {
   return path.join(app.getPath('userData'), 'llm-settings.json');
 }
 
-export async function getSettings(): Promise<LLMSettings> {
+// ── Provider credentials (BYOM #1492) ────────────────────────────────────────
+
+/** Raw stored credentials — `apiKey` is the on-disk form (encrypted or legacy
+ *  plaintext), NOT decrypted. */
+type StoredCreds = { apiKey?: string; baseURL?: string };
+
+/** The on-disk settings shape, tolerant of both the legacy single-`apiKey`
+ *  layout and the new per-provider `providers` map. */
+interface StoredSettings {
+  apiKey?: unknown;
+  providers?: unknown;
+  model?: unknown;
+  web?: unknown;
+  effort?: unknown;
+  toolModelOverrides?: unknown;
+}
+
+async function readParsed(): Promise<StoredSettings> {
   try {
-    const raw = await fs.readFile(settingsPath(), 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<LLMSettings>;
-    const effort = resolveEffortSetting(parsed.effort);
-    // Decrypt the stored key (#1326). `decryptSecret` passes a legacy
-    // plaintext value through unchanged, so pre-encryption configs keep
-    // working. Only fall back to the env var when the field is absent —
-    // an explicitly-cleared ('') key stays cleared, matching the prior
-    // `?? env ?? ''` semantics.
-    const apiKey = typeof parsed.apiKey === 'string'
-      ? decryptSecret(parsed.apiKey)
-      : (process.env.ANTHROPIC_API_KEY ?? '');
-    const toolModelOverrides = resolveToolModelOverrides(parsed.toolModelOverrides);
-    return {
-      apiKey,
-      model: resolveModel(parsed.model),
-      web: resolveWeb(parsed.web),
-      ...(effort ? { effort } : {}),
-      ...(toolModelOverrides ? { toolModelOverrides } : {}),
-    };
+    return JSON.parse(await fs.readFile(settingsPath(), 'utf-8')) as StoredSettings;
   } catch {
-    return {
-      apiKey: process.env.ANTHROPIC_API_KEY ?? '',
-      model: DEFAULT_MODEL,
-      web: { ...DEFAULT_WEB_SETTINGS },
-    };
+    return {};
   }
+}
+
+/**
+ * The raw stored per-provider credentials, applying the legacy migration: a
+ * pre-BYOM top-level `apiKey` string is read as `providers.anthropic.apiKey`.
+ * Values are left in their on-disk (possibly-encrypted) form.
+ */
+function storedProviders(parsed: StoredSettings): Partial<Record<ProviderId, StoredCreds>> {
+  const out: Partial<Record<ProviderId, StoredCreds>> = {};
+  if (parsed.providers && typeof parsed.providers === 'object') {
+    const map = parsed.providers as Record<string, unknown>;
+    for (const id of PROVIDER_IDS) {
+      const c = map[id];
+      if (!c || typeof c !== 'object') continue;
+      const { apiKey, baseURL } = c as Record<string, unknown>;
+      const creds: StoredCreds = {};
+      if (typeof apiKey === 'string') creds.apiKey = apiKey;
+      if (typeof baseURL === 'string' && baseURL.trim()) creds.baseURL = baseURL.trim();
+      if (Object.keys(creds).length > 0) out[id] = creds;
+    }
+    return out;
+  }
+  // Legacy: a top-level string apiKey migrates to the Anthropic slot. Only when
+  // it's a string (even '') — an absent key leaves the slot empty so the env
+  // fallback still applies.
+  if (typeof parsed.apiKey === 'string') out.anthropic = { apiKey: parsed.apiKey };
+  return out;
+}
+
+function envKeyFor(id: ProviderId): string | undefined {
+  const name = PROVIDERS[id].envVar;
+  return name ? (process.env[name] || undefined) : undefined;
+}
+
+/** Decrypt every provider's key for the call path, folding in the env var as a
+ *  fallback only when no key field is stored (an explicitly-cleared '' stays
+ *  cleared, matching the pre-BYOM `?? env` semantics). */
+function decryptProviders(stored: Partial<Record<ProviderId, StoredCreds>>): Partial<Record<ProviderId, ProviderCredentials>> {
+  const out: Partial<Record<ProviderId, ProviderCredentials>> = {};
+  for (const id of PROVIDER_IDS) {
+    const s = stored[id];
+    const apiKey = s && typeof s.apiKey === 'string' ? decryptSecret(s.apiKey) : envKeyFor(id);
+    const creds: ProviderCredentials = {};
+    if (apiKey) creds.apiKey = apiKey;
+    if (s?.baseURL) creds.baseURL = s.baseURL;
+    if (Object.keys(creds).length > 0) out[id] = creds;
+  }
+  return out;
+}
+
+/** Display-only per-provider status (no decrypt). */
+function providerViews(stored: Partial<Record<ProviderId, StoredCreds>>): Partial<Record<ProviderId, ProviderConfigView>> {
+  const out: Partial<Record<ProviderId, ProviderConfigView>> = {};
+  for (const id of PROVIDER_IDS) {
+    const s = stored[id];
+    const hasStoredKey = !!(s && typeof s.apiKey === 'string' && s.apiKey.length > 0);
+    // Env fallback only counts when no key field is stored for this provider.
+    const hasEnvKey = s && typeof s.apiKey === 'string' ? false : !!envKeyFor(id);
+    const meta = PROVIDERS[id];
+    const hasApiKey = meta.requiresKey ? (hasStoredKey || hasEnvKey) : !!s?.baseURL;
+    const view: ProviderConfigView = { hasApiKey };
+    if (s?.baseURL) view.baseURL = s.baseURL;
+    out[id] = view;
+  }
+  return out;
+}
+
+export async function getSettings(): Promise<LLMSettings> {
+  const parsed = await readParsed();
+  const effort = resolveEffortSetting(parsed.effort);
+  const toolModelOverrides = resolveToolModelOverrides(parsed.toolModelOverrides);
+  return {
+    providers: decryptProviders(storedProviders(parsed)),
+    model: resolveModel(parsed.model),
+    web: resolveWeb(parsed.web),
+    ...(effort ? { effort } : {}),
+    ...(toolModelOverrides ? { toolModelOverrides } : {}),
+  };
 }
 
 /**
  * Display-only settings for the settings panel / model picker. Same as
- * `getSettings` but WITHOUT decrypting the API key — reading settings to show
+ * `getSettings` but WITHOUT decrypting any API key — reading settings to show
  * the model, effort, or a set/unset badge must never prompt the OS keychain.
  * The plaintext key is only ever materialized by the API-call path
- * (`getSettings`). `hasApiKey` reports whether a key is configured (stored, or
- * via the env var) using the raw stored value — no decrypt.
+ * (`getSettings`). `hasApiKey` reports whether the ACTIVE model's provider has a
+ * usable key; `providers` carries the per-provider detail for the BYOM UI.
  */
 export async function getSettingsForDisplay(): Promise<LLMSettingsView> {
-  try {
-    const raw = await fs.readFile(settingsPath(), 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<LLMSettings>;
-    const effort = resolveEffortSetting(parsed.effort);
-    const hasApiKey = typeof parsed.apiKey === 'string'
-      ? parsed.apiKey.length > 0
-      : !!process.env.ANTHROPIC_API_KEY;
-    const toolModelOverrides = resolveToolModelOverrides(parsed.toolModelOverrides);
-    return {
-      model: resolveModel(parsed.model),
-      web: resolveWeb(parsed.web),
-      ...(effort ? { effort } : {}),
-      ...(toolModelOverrides ? { toolModelOverrides } : {}),
-      hasApiKey,
-    };
-  } catch {
-    return {
-      model: DEFAULT_MODEL,
-      web: { ...DEFAULT_WEB_SETTINGS },
-      hasApiKey: !!process.env.ANTHROPIC_API_KEY,
-    };
-  }
+  const parsed = await readParsed();
+  const effort = resolveEffortSetting(parsed.effort);
+  const toolModelOverrides = resolveToolModelOverrides(parsed.toolModelOverrides);
+  const model = resolveModel(parsed.model);
+  const providers = providerViews(storedProviders(parsed));
+  const activeProvider = providerForModel(model) ?? 'anthropic';
+  const hasApiKey = providers[activeProvider]?.hasApiKey ?? false;
+  return {
+    model,
+    web: resolveWeb(parsed.web),
+    ...(effort ? { effort } : {}),
+    ...(toolModelOverrides ? { toolModelOverrides } : {}),
+    hasApiKey,
+    providers,
+  };
 }
 
-/** Read the raw stored apiKey string (encrypted or legacy plaintext) without
- *  decrypting, so a save that doesn't touch the key can preserve it verbatim. */
-async function readStoredApiKey(): Promise<string> {
-  try {
-    const raw = await fs.readFile(settingsPath(), 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<LLMSettings>;
-    return typeof parsed.apiKey === 'string' ? parsed.apiKey : '';
-  } catch {
-    return '';
+/** Apply a tri-state credential update to a provider's stored form: a string
+ *  sets the field (apiKey encrypted), `''` clears it (kept as an empty field so
+ *  it suppresses the env fallback, matching the legacy clear semantics), and an
+ *  omitted field preserves the stored value verbatim. */
+function applyCredsUpdate(existing: StoredCreds | undefined, u: ProviderCredentialsUpdate): StoredCreds {
+  const out: StoredCreds = { ...(existing ?? {}) };
+  if (u.apiKey !== undefined) out.apiKey = u.apiKey === '' ? '' : encryptSecret(u.apiKey);
+  if (u.baseURL !== undefined) {
+    const trimmed = u.baseURL.trim();
+    if (trimmed) out.baseURL = trimmed;
+    else delete out.baseURL;
   }
+  return out;
 }
 
 export async function saveSettings(update: LLMSettingsUpdate): Promise<void> {
-  // apiKey is tri-state (#1326): a provided string is encrypted at rest (''
-  // clears); an OMITTED apiKey preserves the stored value verbatim — no decrypt
-  // and no re-encrypt, so saving unrelated settings never touches the keychain.
-  const { apiKey: providedKey, ...rest } = update;
-  const apiKey = providedKey === undefined
-    ? await readStoredApiKey()
-    : encryptSecret(providedKey);
-  const onDisk = { ...rest, apiKey };
+  const { apiKey: legacyKey, providers: providerUpdates, ...rest } = update;
+  const existing = storedProviders(await readParsed());
+  const next: Partial<Record<ProviderId, StoredCreds>> = { ...existing };
+
+  if (providerUpdates) {
+    for (const id of PROVIDER_IDS) {
+      const u = providerUpdates[id];
+      if (u) next[id] = applyCredsUpdate(existing[id], u);
+    }
+  }
+  // Legacy single-key path (current single-provider UI) → Anthropic slot.
+  if (legacyKey !== undefined) {
+    next.anthropic = applyCredsUpdate(next.anthropic, { apiKey: legacyKey });
+  }
+
+  const providers: Partial<Record<ProviderId, StoredCreds>> = {};
+  for (const id of PROVIDER_IDS) {
+    const c = next[id];
+    if (c && Object.keys(c).length > 0) providers[id] = c;
+  }
+
+  const onDisk = { ...rest, providers };
   await fs.writeFile(settingsPath(), JSON.stringify(onDisk, null, 2), 'utf-8');
 }
 
 /**
- * Report how the stored API key is protected at rest, for the settings UI
- * (#1326). `available` reflects the machine's secure-storage capability;
- * `encrypted` reflects the actual on-disk form of the currently-stored key
- * (a legacy plaintext key reads back `encrypted: false` until it's re-saved).
+ * Report how a provider's stored API key is protected at rest, for the settings
+ * UI (#1326). Defaults to Anthropic so the existing single-key IPC caller is
+ * unchanged. `available` reflects the machine's secure-storage capability;
+ * `encrypted` reflects the actual on-disk form of that provider's stored key (a
+ * legacy plaintext key reads back `encrypted: false` until it's re-saved).
  */
-export async function getApiKeyStorage(): Promise<ApiKeyStorage> {
+export async function getApiKeyStorage(providerId: ProviderId = 'anthropic'): Promise<ApiKeyStorage> {
   let encrypted = false;
   try {
-    const raw = await fs.readFile(settingsPath(), 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<LLMSettings>;
-    encrypted = typeof parsed.apiKey === 'string' && parsed.apiKey.length > 0 && isEncrypted(parsed.apiKey);
+    const raw = storedProviders(await readParsed())[providerId]?.apiKey;
+    encrypted = typeof raw === 'string' && raw.length > 0 && isEncrypted(raw);
   } catch {
     // No settings file yet — nothing stored, so nothing encrypted.
   }

--- a/src/main/llm/validate.ts
+++ b/src/main/llm/validate.ts
@@ -21,7 +21,7 @@ import type { ConnectionCheckResult } from '../../shared/tools/types';
 
 export async function checkConnection(candidateKey?: string): Promise<ConnectionCheckResult> {
   const typed = candidateKey?.trim();
-  const key = typed && typed.length > 0 ? typed : (await getSettings()).apiKey;
+  const key = typed && typed.length > 0 ? typed : (await getSettings()).providers.anthropic?.apiKey;
   if (!key) {
     return { ok: false, error: 'No API key to check — enter one above or save it first.' };
   }

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -1,3 +1,5 @@
+import type { ProviderId } from './providers';
+
 export type ToolCategory = 'learning' | 'research' | 'analysis';
 
 export type ContextRequirement =
@@ -256,8 +258,42 @@ export interface ConnectionCheckResult {
   error?: string;
 }
 
+/**
+ * Per-provider credentials (BYOM, epic #1492). On the call path (`getSettings`)
+ * `apiKey` is the decrypted key — with the provider's env var folded in as a
+ * fallback — and `baseURL` is the configured endpoint (OpenAI-compatible /
+ * local). Absent/empty `apiKey` means "not configured" for that provider.
+ */
+export interface ProviderCredentials {
+  apiKey?: string;
+  baseURL?: string;
+}
+
+/** Tri-state save form of `ProviderCredentials`: a string sets the field
+ *  (apiKey is encrypted at rest), `''` clears it, and OMITTING it keeps the
+ *  stored value untouched — so a save that doesn't touch a key never decrypts
+ *  or re-encrypts it. */
+export interface ProviderCredentialsUpdate {
+  apiKey?: string;
+  baseURL?: string;
+}
+
+/** Display-only per-provider status (no plaintext key ever crosses to the
+ *  renderer). */
+export interface ProviderConfigView {
+  /** A usable key is configured (stored, or via the provider's env var), or the
+   *  provider is keyless (local). */
+  hasApiKey: boolean;
+  baseURL?: string;
+}
+
 export interface LLMSettings {
-  apiKey: string;
+  /**
+   * Per-provider credentials (BYOM #1492), keyed by provider id. Replaces the
+   * former single `apiKey`; the legacy top-level key migrates into
+   * `providers.anthropic` on read/save.
+   */
+  providers: Partial<Record<ProviderId, ProviderCredentials>>;
   model: string;
   web?: WebSettings;
   /**
@@ -287,8 +323,14 @@ export interface LLMSettingsView {
   web?: WebSettings;
   effort?: import('./effort').Effort;
   toolModelOverrides?: Record<string, string>;
-  /** Whether a usable key is configured (stored, or via ANTHROPIC_API_KEY). */
+  /**
+   * Whether the ACTIVE model's provider has a usable key — the convenience flag
+   * the current single-key settings UI + the "open settings" affordance read.
+   * Per-provider detail is in `providers`.
+   */
   hasApiKey: boolean;
+  /** Per-provider configuration status (BYOM #1492), for the multi-provider UI. */
+  providers: Partial<Record<ProviderId, ProviderConfigView>>;
 }
 
 /**
@@ -298,7 +340,14 @@ export interface LLMSettingsView {
  * doesn't touch the key neither decrypts nor re-encrypts it).
  */
 export interface LLMSettingsUpdate {
+  /**
+   * Legacy convenience: tri-state Anthropic key, applied to
+   * `providers.anthropic.apiKey`. The current single-key UI still sends this;
+   * the multi-provider UI (BYOM #1498) uses `providers` instead.
+   */
   apiKey?: string;
+  /** Per-provider credential updates (BYOM #1492), tri-state per field. */
+  providers?: Partial<Record<ProviderId, ProviderCredentialsUpdate>>;
   model: string;
   web?: WebSettings;
   effort?: import('./effort').Effort;

--- a/tests/main/llm/auto-link-integration.test.ts
+++ b/tests/main/llm/auto-link-integration.test.ts
@@ -44,7 +44,7 @@ describe('Auto-link integration (#342)', () => {
     await initGraph(ctx);
     completeMock.mockReset();
     getSettingsMock.mockReset();
-    getSettingsMock.mockResolvedValue({ model: 'claude-sonnet-4-6', apiKey: 'fake' });
+    getSettingsMock.mockResolvedValue({ model: 'claude-sonnet-4-6', providers: { anthropic: { apiKey: 'fake' } } });
   });
 
   afterEach(async () => {

--- a/tests/main/llm/auto-tag-integration.test.ts
+++ b/tests/main/llm/auto-tag-integration.test.ts
@@ -36,7 +36,7 @@ describe('runAutoTag() integration (#342)', () => {
     await initGraph(ctx);
     completeMock.mockReset();
     getSettingsMock.mockReset();
-    getSettingsMock.mockResolvedValue({ model: 'claude-sonnet-4-6', apiKey: 'fake' });
+    getSettingsMock.mockResolvedValue({ model: 'claude-sonnet-4-6', providers: { anthropic: { apiKey: 'fake' } } });
   });
 
   afterEach(async () => {

--- a/tests/main/llm/conversation-tool-dispatch.test.ts
+++ b/tests/main/llm/conversation-tool-dispatch.test.ts
@@ -112,7 +112,7 @@ describe('completeWithTools() dispatch loop (#342)', () => {
     streamMock.mockReset();
     getSettingsMock.mockReset();
     getSettingsMock.mockResolvedValue({
-      apiKey: 'fake',
+      providers: { anthropic: { apiKey: 'fake' } },
       model: 'claude-sonnet-4-6',
       web: { enabled: false, allowedDomains: [], blockedDomains: [] },
     });

--- a/tests/main/llm/settings.test.ts
+++ b/tests/main/llm/settings.test.ts
@@ -1,10 +1,12 @@
 /**
- * LLM settings — API key at-rest encryption + backward compatibility (#1326).
+ * LLM settings — per-provider credentials, at-rest encryption + backward
+ * compatibility (#1326, BYOM #1494).
  *
- * `saveSettings` encrypts the Anthropic key on disk; `getSettings` decrypts it
- * transparently and still reads pre-encryption (plaintext) configs. Stubs
- * `app.getPath('userData')` to a temp dir and mocks `safeStorage` with a
- * reversible fake (mirrors clipper-config.test).
+ * `saveSettings` encrypts each provider's key on disk under a `providers` map;
+ * `getSettings` decrypts transparently, folds in each provider's env var as a
+ * fallback, and still reads the pre-BYOM single-`apiKey` layout (migrated into
+ * `providers.anthropic`). Stubs `app.getPath('userData')` to a temp dir and
+ * mocks `safeStorage` with a reversible fake (mirrors clipper-config.test).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
@@ -33,18 +35,25 @@ vi.mock('electron', () => ({
 
 import { safeStorage } from 'electron';
 import { getSettings, getSettingsForDisplay, saveSettings, getApiKeyStorage } from '../../../src/main/llm/settings';
-import type { LLMSettings } from '../../../src/shared/tools/types';
+import type { LLMSettingsUpdate } from '../../../src/shared/tools/types';
 
 const settingsFile = () => path.join(tempDir, 'llm-settings.json');
-const base: LLMSettings = {
-  apiKey: '',
+const base: LLMSettingsUpdate = {
   model: 'claude-sonnet-5',
   web: { enabled: false, allowedDomains: [], blockedDomains: [] },
 };
 
+/** The decrypted Anthropic key on the call path. */
+const anthropicKey = async () => (await getSettings()).providers.anthropic?.apiKey;
+/** The raw on-disk Anthropic key (encrypted / plaintext), or undefined. */
+const onDiskAnthropic = (): string | undefined =>
+  JSON.parse(fs.readFileSync(settingsFile(), 'utf-8')).providers?.anthropic?.apiKey;
+
 beforeEach(() => {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-llm-settings-'));
   delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.GEMINI_API_KEY;
   vi.clearAllMocks();
 });
 afterEach(() => {
@@ -52,36 +61,37 @@ afterEach(() => {
 });
 
 describe('llm settings — API key at-rest encryption (#1326)', () => {
-  it('reads a legacy plaintext apiKey unchanged (backward compat)', async () => {
+  it('reads a legacy plaintext apiKey unchanged (backward compat → providers.anthropic)', async () => {
     fs.writeFileSync(settingsFile(), JSON.stringify({ apiKey: 'sk-ant-legacy', model: 'claude-sonnet-5' }));
-    expect((await getSettings()).apiKey).toBe('sk-ant-legacy');
+    expect(await anthropicKey()).toBe('sk-ant-legacy');
   });
 
   it('encrypts the apiKey on save and decrypts it on read', async () => {
     await saveSettings({ ...base, apiKey: 'sk-ant-secret' });
     const onDisk = fs.readFileSync(settingsFile(), 'utf-8');
     expect(onDisk).not.toContain('sk-ant-secret');
-    expect((JSON.parse(onDisk).apiKey as string).startsWith('enc:v1:')).toBe(true);
-    expect((await getSettings()).apiKey).toBe('sk-ant-secret');
+    expect(onDiskAnthropic()!.startsWith('enc:v1:')).toBe(true);
+    expect(await anthropicKey()).toBe('sk-ant-secret');
   });
 
-  it('migrates a legacy plaintext key to encrypted on the next save', async () => {
+  it('migrates a legacy plaintext key to the providers map, encrypted, on the next save', async () => {
     fs.writeFileSync(settingsFile(), JSON.stringify({ apiKey: 'sk-ant-old', model: 'claude-sonnet-5' }));
     const loaded = await getSettings();
-    expect(loaded.apiKey).toBe('sk-ant-old');
+    expect(loaded.providers.anthropic?.apiKey).toBe('sk-ant-old');
     await saveSettings(loaded);
     const onDisk = fs.readFileSync(settingsFile(), 'utf-8');
     expect(onDisk).not.toContain('sk-ant-old');
-    expect((JSON.parse(onDisk).apiKey as string).startsWith('enc:v1:')).toBe(true);
+    expect(JSON.parse(onDisk).apiKey).toBeUndefined();      // legacy top-level field gone
+    expect(onDiskAnthropic()!.startsWith('enc:v1:')).toBe(true);
   });
 
   it('falls back to the env var when apiKey is absent, but respects an explicit empty', async () => {
     process.env.ANTHROPIC_API_KEY = 'sk-ant-env';
     fs.writeFileSync(settingsFile(), JSON.stringify({ model: 'claude-sonnet-5' }));
-    expect((await getSettings()).apiKey).toBe('sk-ant-env');
+    expect(await anthropicKey()).toBe('sk-ant-env');
     // An explicitly-cleared key stays cleared (matches the pre-#1326 `??` chain).
     fs.writeFileSync(settingsFile(), JSON.stringify({ apiKey: '', model: 'claude-sonnet-5' }));
-    expect((await getSettings()).apiKey).toBe('');
+    expect(await anthropicKey()).toBeUndefined();
   });
 
   describe('display read + keep-on-save never touch the keychain', () => {
@@ -90,6 +100,7 @@ describe('llm settings — API key at-rest encryption (#1326)', () => {
       vi.clearAllMocks();
       const view = await getSettingsForDisplay();
       expect(view.hasApiKey).toBe(true);
+      expect(view.providers.anthropic?.hasApiKey).toBe(true);
       expect(view.model).toBe('claude-sonnet-5');
       expect((view as { apiKey?: string }).apiKey).toBeUndefined(); // no plaintext leaks out
       expect(safeStorage.decryptString).not.toHaveBeenCalled();
@@ -105,23 +116,23 @@ describe('llm settings — API key at-rest encryption (#1326)', () => {
 
     it('saving without an apiKey preserves the stored key verbatim, no decrypt/encrypt', async () => {
       await saveSettings({ ...base, apiKey: 'sk-ant-secret' });
-      const encrypted = JSON.parse(fs.readFileSync(settingsFile(), 'utf-8')).apiKey as string;
+      const encrypted = onDiskAnthropic();
       vi.clearAllMocks();
       // A settings save that doesn't touch the key omits apiKey entirely.
       await saveSettings({ model: 'claude-opus-4-8', web: base.web });
       const after = JSON.parse(fs.readFileSync(settingsFile(), 'utf-8'));
-      expect(after.apiKey).toBe(encrypted);       // byte-for-byte preserved
-      expect(after.model).toBe('claude-opus-4-8'); // the actual edit landed
+      expect(after.providers.anthropic.apiKey).toBe(encrypted); // byte-for-byte preserved
+      expect(after.model).toBe('claude-opus-4-8');              // the actual edit landed
       expect(safeStorage.decryptString).not.toHaveBeenCalled();
       expect(safeStorage.encryptString).not.toHaveBeenCalled();
       // And the key still decrypts for the API-call path.
-      expect((await getSettings()).apiKey).toBe('sk-ant-secret');
+      expect(await anthropicKey()).toBe('sk-ant-secret');
     });
 
     it('an explicit empty apiKey clears the stored key', async () => {
       await saveSettings({ ...base, apiKey: 'sk-ant-secret' });
       await saveSettings({ model: base.model, web: base.web, apiKey: '' });
-      expect(JSON.parse(fs.readFileSync(settingsFile(), 'utf-8')).apiKey).toBe('');
+      expect(onDiskAnthropic()).toBe('');
       expect((await getSettingsForDisplay()).hasApiKey).toBe(false);
     });
   });
@@ -142,6 +153,42 @@ describe('llm settings — API key at-rest encryption (#1326)', () => {
       // Re-saving migrates it to encrypted, which the indicator then reflects.
       await saveSettings(await getSettings());
       expect(await getApiKeyStorage()).toEqual({ available: true, encrypted: true });
+    });
+  });
+
+  describe('multi-provider credentials (BYOM #1494)', () => {
+    it('stores + reads a per-provider key without disturbing the others', async () => {
+      await saveSettings({ ...base, apiKey: 'sk-ant-secret' });
+      await saveSettings({ model: base.model, providers: { openai: { apiKey: 'sk-openai' } } });
+      const s = await getSettings();
+      expect(s.providers.anthropic?.apiKey).toBe('sk-ant-secret'); // untouched
+      expect(s.providers.openai?.apiKey).toBe('sk-openai');
+      // Each key is encrypted at rest independently.
+      const onDisk = JSON.parse(fs.readFileSync(settingsFile(), 'utf-8'));
+      expect(onDisk.providers.openai.apiKey.startsWith('enc:v1:')).toBe(true);
+    });
+
+    it('folds each provider env var in as a fallback', async () => {
+      process.env.OPENAI_API_KEY = 'sk-openai-env';
+      process.env.GEMINI_API_KEY = 'sk-gemini-env';
+      const s = await getSettings();
+      expect(s.providers.openai?.apiKey).toBe('sk-openai-env');
+      expect(s.providers.google?.apiKey).toBe('sk-gemini-env');
+      const view = await getSettingsForDisplay();
+      expect(view.providers.openai?.hasApiKey).toBe(true);
+      expect(view.providers.google?.hasApiKey).toBe(true);
+    });
+
+    it('persists a local baseURL and treats a keyless local endpoint as configured once it has one', async () => {
+      await saveSettings({ model: base.model, providers: { local: { baseURL: 'http://localhost:11434/v1' } } });
+      expect((await getSettings()).providers.local?.baseURL).toBe('http://localhost:11434/v1');
+      expect((await getSettingsForDisplay()).providers.local?.hasApiKey).toBe(true); // keyless, but has an endpoint
+    });
+
+    it('getApiKeyStorage targets the requested provider', async () => {
+      await saveSettings({ model: base.model, providers: { openai: { apiKey: 'sk-openai' } } });
+      expect(await getApiKeyStorage('openai')).toEqual({ available: true, encrypted: true });
+      expect(await getApiKeyStorage('anthropic')).toEqual({ available: true, encrypted: false });
     });
   });
 

--- a/tests/main/llm/validate.test.ts
+++ b/tests/main/llm/validate.test.ts
@@ -20,7 +20,7 @@ import { describeConnectionFailure } from '../../../src/main/llm/connection-erro
 
 beforeEach(() => {
   vi.clearAllMocks();
-  h.getSettings.mockResolvedValue({ apiKey: 'sk-stored' });
+  h.getSettings.mockResolvedValue({ providers: { anthropic: { apiKey: 'sk-stored' } } });
   h.providerCheck.mockResolvedValue({ ok: true });
   h.createProviderForKey.mockReturnValue({ checkConnection: h.providerCheck });
 });
@@ -40,7 +40,7 @@ describe('checkConnection — key resolution', () => {
   });
 
   it('short-circuits with no provider call when there is no key at all', async () => {
-    h.getSettings.mockResolvedValue({ apiKey: '' });
+    h.getSettings.mockResolvedValue({ providers: { anthropic: { apiKey: '' } } });
     const res = await checkConnection(undefined);
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/No API key/i);


### PR DESCRIPTION
BYOM epic #1492 — child 2/6. Widens LLM config to hold many providers. **Anthropic stays the only wired implementation, so the app behaves identically after migration** — the real second provider (OpenAI) lands in #1495.

## Schema (`shared/tools/types.ts`)
- `LLMSettings.apiKey: string` → `providers: Record<ProviderId, ProviderCredentials { apiKey?, baseURL? }>` (decrypted on the call path). `baseURL` is the OpenAI-compatible/local endpoint field, threaded but unused until #1497.
- `LLMSettingsView` gains a per-provider `providers` status map (no plaintext ever crosses to the renderer). `hasApiKey` is **kept** — redefined as "the active model's provider has a usable key" — so the current single-key UI + the open-settings affordance need no change.
- `LLMSettingsUpdate` keeps a legacy tri-state `apiKey?` (maps to `providers.anthropic`, which is exactly what the current UI sends) **and** adds a per-provider `providers?` update for the BYOM UI (#1498).

## `settings.ts`
- Per-provider encrypt-at-rest + decrypt, keyed by provider. Per-provider **env fallback** via `PROVIDERS[id].envVar` (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`), applied only when no key field is stored — an explicit `''` stays cleared, preserving the pre-BYOM semantics exactly.
- **Migration**: a legacy top-level `apiKey` string is read as `providers.anthropic.apiKey` and rewritten into the map on the next save (the legacy field is dropped).
- `getApiKeyStorage(providerId = 'anthropic')` — the default keeps the existing IPC caller unchanged, so **no preload/bridge change** (snapshots untouched); #1498 passes a providerId.
- A save that touches one provider preserves the others' keys byte-for-byte.
- `getProvider()` / `validate` now read `providers.anthropic.apiKey`.

`secret-storage.ts` was already key-agnostic — reused as-is for N keys.

## Tests
`settings.test.ts` rewritten to the `providers` shape (the legacy single-`apiKey` on-disk layout is precisely what the migration must still read, so those cases stay) + new multi-provider coverage: independent per-provider storage, per-provider env fallback, local `baseURL`, and targeted `getApiKeyStorage`. `validate` + three integration mocks updated. `pnpm lint` clean; full llm + settings-UI + preload/IPC snapshot suites green (284 tests).

Part of #1492. Stacks on #1499 (merged).