### PR TITLE
feat(llm): provider factory branch + OpenAI implementation (#1495)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "minisearch": "^7.2.0",
     "n3": "^2.1.1",
     "onnxruntime-web": "^1.27.0",
+    "openai": "^7.1.0",
     "pdfjs-dist": "^6.1.200",
     "rdflib": "^2.4.0",
     "sql-formatter": "^15.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       onnxruntime-web:
         specifier: ^1.27.0
         version: 1.27.0
+      openai:
+        specifier: ^7.1.0
+        version: 7.1.0(ws@8.21.1)
       pdfjs-dist:
         specifier: ^6.1.200
         version: 6.1.200
@@ -5009,6 +5012,27 @@ packages:
 
   onnxruntime-web@1.27.0:
     resolution: {integrity: sha512-ogDLsqIozHZwifPuN37OproAo0byX6t43/bP8GzeZWBWD6MOGExswFAx3up4NS/vvWBOg2u2PXomDt3rMmdQSg==}
+
+  openai@7.1.0:
+    resolution: {integrity: sha512-7xWJ9iO5z5u1dnIUGwoUmZHkSyrUYXX2cUxo2E/26iKFrSC8IdEak7z94d5UntU7z+S/Cid33hYymwMSab2fZQ==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   opencollective-postinstall@2.0.3:
     resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
@@ -13791,6 +13815,10 @@ snapshots:
       onnxruntime-common: 1.27.0
       platform: 1.3.6
       protobufjs: 7.6.4
+
+  openai@7.1.0(ws@8.21.1):
+    optionalDependencies:
+      ws: 8.21.1
 
   opencollective-postinstall@2.0.3: {}
 

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -228,8 +228,7 @@ export async function complete(
     messages = [{ role: 'user', content: prompt }];
   }
 
-  const { provider, model: defaultModel, effort: defaultEffort } = await getProvider();
-  const model = modelOverride ?? defaultModel;
+  const { provider, model, effort: defaultEffort } = await getProvider(modelOverride);
   const effort = resolveEffort(model, effortOverride, defaultEffort);
 
   // `const` (not the outer `let`) so TS keeps the narrowing inside the closure.
@@ -262,8 +261,7 @@ export async function complete(
 export async function completeWithTools(
   options: CompleteWithToolsOptions,
 ): Promise<CompleteWithToolsResult> {
-  const { provider, model: defaultModel, web, effort: defaultEffort } = await getProvider();
-  const model = options.model ?? defaultModel;
+  const { provider, model, web, effort: defaultEffort } = await getProvider(options.model);
   const effort = resolveEffort(model, options.effort, defaultEffort);
   const { toolContext, callbacks, maxIterations = 10 } = options;
 

--- a/src/main/llm/provider/index.ts
+++ b/src/main/llm/provider/index.ts
@@ -1,46 +1,82 @@
 /**
  * Provider factory — the single place the conversation layer resolves *which*
- * model provider to use (#1148). Today there is one; when a second ships, it
- * branches here on a settings field and nothing above this line changes.
+ * model provider to use (#1148). The provider is chosen from the EFFECTIVE
+ * model (per-conversation override beats the global default), because a
+ * per-conversation model can belong to a different provider than the default
+ * (BYOM #1495) — so the caller passes its resolved model in.
  */
 import { getSettings } from '../settings';
 import { MISSING_API_KEY_MARKER } from '../../../shared/llm-errors';
-import { DEFAULT_WEB_SETTINGS } from '../../../shared/tools/types';
+import { DEFAULT_WEB_SETTINGS, type LLMSettings } from '../../../shared/tools/types';
 import type { Effort } from '../../../shared/tools/effort';
+import { providerForModel } from '../../../shared/tools/models';
+import { PROVIDERS, type ProviderId } from '../../../shared/tools/providers';
 import { AnthropicProvider } from './anthropic';
+import { OpenAIProvider } from './openai';
 import type { LLMProvider, WebToolSettings } from './types';
 
 export type { LLMProvider } from './types';
 
 export interface ResolvedProvider {
   provider: LLMProvider;
-  /** The default model for this provider, from settings. */
+  /** The effective model this provider will run (override ?? default). */
   model: string;
   web: WebToolSettings;
   /** Global default reasoning effort, before per-call override/clamping. */
   effort: Effort | undefined;
 }
 
+/** The marker error the renderer detects to show the "Open Settings"
+ *  affordance, named per provider so the message is honest. */
+function missingKeyError(id: ProviderId): Error {
+  const meta = PROVIDERS[id];
+  const env = meta.envVar ? ` or the ${meta.envVar} environment variable` : '';
+  return new Error(`${MISSING_API_KEY_MARKER}. Set the ${meta.label} API key in the LLM settings${env}.`);
+}
+
 /**
- * Build the configured provider plus the settings the caller threads into each
- * request (model, web tools, default effort). Throws the marker error the
- * renderer detects when no API key is set, so the "Open Settings" affordance
- * still fires exactly as before.
+ * Which provider a model belongs to. Built-in models carry it in the catalog;
+ * an unknown id falls back to Anthropic (user-defined local models get their own
+ * resolution in BYOM #1497).
  */
-export async function getProvider(): Promise<ResolvedProvider> {
-  const settings = await getSettings();
-  // Anthropic is still the only wired implementation (BYOM #1495 branches this
-  // on the selected model's provider). Read its per-provider credentials.
-  const apiKey = settings.providers.anthropic?.apiKey;
-  if (!apiKey) {
-    throw new Error(
-      `${MISSING_API_KEY_MARKER}. Set it in the LLM settings or ANTHROPIC_API_KEY environment variable.`,
-    );
+function resolveProviderId(model: string): ProviderId {
+  return providerForModel(model) ?? 'anthropic';
+}
+
+/** Construct the provider for `id`, reading its credentials from settings.
+ *  Throws the missing-key marker when the required key is absent. */
+function buildProvider(id: ProviderId, settings: LLMSettings): LLMProvider {
+  switch (id) {
+    case 'anthropic': {
+      const key = settings.providers.anthropic?.apiKey;
+      if (!key) throw missingKeyError('anthropic');
+      return new AnthropicProvider(key);
+    }
+    case 'openai': {
+      const c = settings.providers.openai;
+      if (!c?.apiKey) throw missingKeyError('openai');
+      return new OpenAIProvider(c.apiKey, c.baseURL);
+    }
+    case 'google':
+      throw new Error(`${PROVIDERS.google.label} models aren't wired up yet (BYOM #1496).`);
+    case 'local':
+      throw new Error(`Local / OpenAI-compatible models aren't wired up yet (BYOM #1497).`);
   }
-  const provider = new AnthropicProvider(apiKey);
+}
+
+/**
+ * Build the provider for the given model (or the global default when omitted)
+ * plus the settings the caller threads into each request (resolved model, web
+ * tools, default effort). Throws the marker error the renderer detects when the
+ * chosen provider has no API key, so the "Open Settings" affordance fires.
+ */
+export async function getProvider(modelOverride?: string): Promise<ResolvedProvider> {
+  const settings = await getSettings();
+  const model = modelOverride ?? settings.model;
+  const provider = buildProvider(resolveProviderId(model), settings);
   return {
     provider,
-    model: settings.model,
+    model,
     web: settings.web ?? { ...DEFAULT_WEB_SETTINGS },
     effort: settings.effort,
   };
@@ -49,8 +85,16 @@ export async function getProvider(): Promise<ResolvedProvider> {
 /**
  * Build a provider bound to an explicit key, bypassing stored settings — used
  * by the "Check connection" validator to test an unsaved typed key. Keeps
- * provider construction (and the SDK) behind the seam.
+ * provider construction (and the SDKs) behind the seam.
  */
-export function createProviderForKey(apiKey: string): LLMProvider {
-  return new AnthropicProvider(apiKey);
+export function createProviderForKey(providerId: ProviderId, apiKey: string, baseURL?: string): LLMProvider {
+  switch (providerId) {
+    case 'openai':
+      return new OpenAIProvider(apiKey, baseURL);
+    case 'anthropic':
+    default:
+      // google/local reuse an OpenAI-shaped check once wired (#1496/#1497);
+      // until then only anthropic + openai reach here from the settings UI.
+      return new AnthropicProvider(apiKey);
+  }
 }

--- a/src/main/llm/provider/openai.ts
+++ b/src/main/llm/provider/openai.ts
@@ -1,0 +1,255 @@
+/**
+ * The OpenAI implementation of the provider seam (BYOM #1495).
+ *
+ * The second `LLMProvider`. Like `anthropic.ts` it is the ONLY place the
+ * `openai` SDK is imported; everything OpenAI-specific — Chat Completions
+ * message/tool shapes, streamed tool-call fragment reassembly, `reasoning_effort`,
+ * `max_completion_tokens`, and usage field names — is translated to and from the
+ * neutral types in `./types` here. The agentic loop in `../index.ts` sees none
+ * of it.
+ *
+ * The same implementation serves OpenAI-compatible local endpoints (Ollama, LM
+ * Studio, vLLM, …) via a custom `baseURL` — that's BYOM #1497; the constructor
+ * already takes one.
+ *
+ * NOT ported from Anthropic (no cross-provider equivalent, so intentionally
+ * absent): prompt-cache breakpoints, server-side web search/fetch + citations,
+ * and the code-execution container. `web`/`containerId` on the request are
+ * ignored here; `citations` comes back empty.
+ */
+import OpenAI from 'openai';
+import type { TurnUsage } from '../../../shared/types';
+import type { ConnectionCheckResult } from '../../../shared/tools/types';
+import { toConnectionResult } from '../connection-error';
+import type { Effort } from '../../../shared/tools/effort';
+import type {
+  ChatMessage,
+  CompletionRequest,
+  CompletionResult,
+  LLMProvider,
+  ProviderMessage,
+  ProviderToolCall,
+  ProviderToolResult,
+  StopReason,
+  ToolSpec,
+  TurnHooks,
+  TurnRequest,
+  TurnResult,
+} from './types';
+
+type ChatMsg = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+
+/**
+ * A conservative output-token ceiling. The loop hands us Anthropic's 64k budget
+ * (`../index.ts`), which exceeds some OpenAI models' `max_completion_tokens`
+ * limit and would 400. Reasoning tokens also count toward this, so it must be
+ * comfortably large; 32k clears typical turns for every model we ship. Per-model
+ * caps are a refinement for the skill-validation initiative.
+ */
+const MAX_OUTPUT_TOKENS = 32_000;
+
+function emptyUsage(): TurnUsage {
+  return { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
+}
+
+/** Map neutral effort → OpenAI `reasoning_effort`. Levels above `high` (xhigh/
+ *  max) clamp to `high` — the caller has already clamped to the model's
+ *  supported set (effort.ts SUPPORT), so a non-reasoning model never reaches
+ *  here with an effort. */
+export function reasoningEffortFor(effort: Effort | undefined): 'low' | 'medium' | 'high' | undefined {
+  if (!effort) return undefined;
+  return effort === 'low' || effort === 'medium' ? effort : 'high';
+}
+
+/** ToolSpec (`{name, description, input_schema}`) → OpenAI function tool. */
+export function toChatTools(specs: ToolSpec[]): OpenAI.Chat.Completions.ChatCompletionTool[] {
+  return specs.map((s) => ({
+    type: 'function',
+    function: {
+      name: s.name,
+      ...(s.description ? { description: s.description } : {}),
+      parameters: s.input_schema,
+    },
+  }));
+}
+
+export function mapFinishReason(reason: string | null | undefined): StopReason {
+  if (reason === 'tool_calls') return 'tool_use';
+  return 'end';
+}
+
+/** OpenAI usage → neutral TurnUsage. Cached prompt tokens are counted as full
+ *  input (a slight over-estimate) rather than mapped onto Anthropic's cache-read
+ *  price multiplier, which doesn't match OpenAI's cached-input rate. */
+export function foldOpenAIUsage(usage: OpenAI.Completions.CompletionUsage | undefined): TurnUsage {
+  if (!usage) return emptyUsage();
+  return {
+    inputTokens: usage.prompt_tokens ?? 0,
+    outputTokens: usage.completion_tokens ?? 0,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+  };
+}
+
+/** Parse a streamed tool-call's accumulated JSON `arguments`, tolerating a
+ *  malformed/empty string (→ `{}`) rather than throwing mid-loop. */
+export function parseToolArgs(args: string): unknown {
+  if (!args) return {};
+  try {
+    return JSON.parse(args);
+  } catch {
+    return {};
+  }
+}
+
+export class OpenAIProvider implements LLMProvider {
+  readonly id = 'openai';
+  private readonly client: OpenAI;
+
+  /** `client` is injectable for tests; production passes only key + baseURL.
+   *  An empty key (keyless local endpoints, #1497) is replaced with a dummy the
+   *  SDK accepts — those servers ignore it. */
+  constructor(apiKey: string, baseURL?: string, client?: OpenAI) {
+    this.client = client ?? new OpenAI({ apiKey: apiKey || 'no-key', ...(baseURL ? { baseURL } : {}) });
+  }
+
+  // A ProviderMessage is a CHUNK of native messages (an array). A seed turn and
+  // an assistant turn are one-element chunks; a batch of tool results is a
+  // multi-element chunk — OpenAI needs one `role:'tool'` message per call. The
+  // loop only ever holds these opaquely; `runTurn` flattens them.
+  ingestHistory(messages: ChatMessage[]): ProviderMessage[] {
+    return messages.map((m) => [{ role: m.role, content: m.content }] as ChatMsg[] as unknown as ProviderMessage);
+  }
+
+  toolResultMessage(results: ProviderToolResult[]): ProviderMessage {
+    const msgs: ChatMsg[] = results.map((r) => ({
+      role: 'tool',
+      tool_call_id: r.toolUseId,
+      content: r.content,
+    }));
+    return msgs as unknown as ProviderMessage;
+  }
+
+  async runTurn(req: TurnRequest, hooks: TurnHooks): Promise<TurnResult> {
+    const messages: ChatMsg[] = [
+      { role: 'system', content: req.system },
+      ...(req.history as unknown as ChatMsg[][]).flat(),
+    ];
+
+    const reasoning = reasoningEffortFor(req.effort);
+    const stream = await this.client.chat.completions.create(
+      {
+        model: req.model,
+        messages,
+        stream: true,
+        stream_options: { include_usage: true },
+        max_completion_tokens: Math.min(req.maxTokens, MAX_OUTPUT_TOKENS),
+        ...(req.tools.length > 0 ? { tools: toChatTools(req.tools) } : {}),
+        ...(reasoning ? { reasoning_effort: reasoning } : {}),
+      },
+      { signal: req.signal },
+    );
+
+    let text = '';
+    // Streamed tool calls arrive as fragments keyed by `index`; reassemble id +
+    // name + argument text across chunks.
+    const toolAcc = new Map<number, { id: string; name: string; args: string }>();
+    const emitted = new Set<number>();
+    let finishReason: string | null | undefined;
+    let usage: OpenAI.Completions.CompletionUsage | undefined;
+
+    for await (const chunk of stream) {
+      const choice = chunk.choices[0];
+      const delta = choice?.delta;
+      if (delta?.content) {
+        text += delta.content;
+        hooks.onTextDelta?.(delta.content);
+      }
+      for (const tc of delta?.tool_calls ?? []) {
+        const cur = toolAcc.get(tc.index) ?? { id: '', name: '', args: '' };
+        if (tc.id) cur.id = tc.id;
+        if (tc.function?.name) cur.name = tc.function.name;
+        if (tc.function?.arguments) cur.args += tc.function.arguments;
+        toolAcc.set(tc.index, cur);
+        // Fire the indicator as soon as the name is known (args still streaming).
+        if (cur.name && !emitted.has(tc.index)) {
+          emitted.add(tc.index);
+          hooks.onToolCallStart?.(cur.name, {});
+        }
+      }
+      if (choice?.finish_reason) finishReason = choice.finish_reason;
+      if (chunk.usage) usage = chunk.usage;
+    }
+
+    const calls = [...toolAcc.values()];
+    const toolCalls: ProviderToolCall[] = calls.map((t) => ({
+      id: t.id,
+      name: t.name,
+      input: parseToolArgs(t.args),
+    }));
+
+    const assistant: ChatMsg = {
+      role: 'assistant',
+      content: text || null,
+      ...(calls.length > 0
+        ? {
+            tool_calls: calls.map((t) => ({
+              id: t.id,
+              type: 'function' as const,
+              function: { name: t.name, arguments: t.args },
+            })),
+          }
+        : {}),
+    };
+
+    return {
+      assistantMessage: [assistant] as ChatMsg[] as unknown as ProviderMessage,
+      text,
+      toolCalls,
+      citations: [],
+      usage: foldOpenAIUsage(usage),
+      stopReason: mapFinishReason(finishReason),
+    };
+  }
+
+  async complete(req: CompletionRequest, onDelta?: (delta: string) => void): Promise<CompletionResult> {
+    const messages: ChatMsg[] = [
+      ...(req.system ? [{ role: 'system' as const, content: req.system }] : []),
+      ...req.messages.map((m) => ({ role: m.role, content: m.content })),
+    ];
+    const reasoning = reasoningEffortFor(req.effort);
+    const base = {
+      model: req.model,
+      messages,
+      max_completion_tokens: Math.min(req.maxTokens, MAX_OUTPUT_TOKENS),
+      ...(reasoning ? { reasoning_effort: reasoning } : {}),
+    };
+
+    if (!onDelta) {
+      const res = await this.client.chat.completions.create(base, { signal: req.signal });
+      return { text: res.choices[0]?.message?.content ?? '', usage: foldOpenAIUsage(res.usage) };
+    }
+
+    const stream = await this.client.chat.completions.create(
+      { ...base, stream: true, stream_options: { include_usage: true } },
+      { signal: req.signal },
+    );
+    let text = '';
+    let usage: OpenAI.Completions.CompletionUsage | undefined;
+    for await (const chunk of stream) {
+      const d = chunk.choices[0]?.delta?.content;
+      if (d) {
+        text += d;
+        onDelta(d);
+      }
+      if (chunk.usage) usage = chunk.usage;
+    }
+    return { text, usage: foldOpenAIUsage(usage) };
+  }
+
+  async checkConnection(): Promise<ConnectionCheckResult> {
+    // A minimal authenticated GET: no tokens spent. Any success means the key +
+    // endpoint are accepted.
+    return toConnectionResult(() => this.client.models.list());
+  }
+}

--- a/src/main/llm/validate.ts
+++ b/src/main/llm/validate.ts
@@ -25,5 +25,5 @@ export async function checkConnection(candidateKey?: string): Promise<Connection
   if (!key) {
     return { ok: false, error: 'No API key to check — enter one above or save it first.' };
   }
-  return createProviderForKey(key).checkConnection();
+  return createProviderForKey('anthropic', key).checkConnection();
 }

--- a/src/shared/tools/effort.ts
+++ b/src/shared/tools/effort.ts
@@ -47,6 +47,13 @@ const SUPPORT: Record<string, Effort[]> = {
   'claude-sonnet-5': ['low', 'medium', 'high', 'max'],
   'claude-sonnet-4-6': ['low', 'medium', 'high', 'max'],
   'claude-haiku-4-5': [],
+  // OpenAI reasoning models take `reasoning_effort` (low/medium/high). The
+  // provider maps neutral xhigh/max → high, and clampEffort snaps a picked
+  // xhigh/max down to high since it's not listed here.
+  'gpt-5': ['low', 'medium', 'high'],
+  'gpt-5-mini': ['low', 'medium', 'high'],
+  'o3': ['low', 'medium', 'high'],
+  'o4-mini': ['low', 'medium', 'high'],
 };
 
 /**

--- a/src/shared/tools/models.ts
+++ b/src/shared/tools/models.ts
@@ -34,6 +34,13 @@ export const MODEL_OPTIONS: ModelOption[] = [
   { value: 'claude-sonnet-5', label: 'Claude Sonnet 5', provider: 'anthropic' },
   { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', provider: 'anthropic' },
   { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5', provider: 'anthropic' },
+  // OpenAI (BYOM #1495). Reasoning-capable models with large output caps, so
+  // they clear the provider's max_completion_tokens clamp. gpt-4o / non-reasoning
+  // tiers are intentionally omitted for now (lower output caps + no reasoning).
+  { value: 'gpt-5', label: 'GPT-5', provider: 'openai' },
+  { value: 'gpt-5-mini', label: 'GPT-5 mini', provider: 'openai' },
+  { value: 'o3', label: 'OpenAI o3', provider: 'openai' },
+  { value: 'o4-mini', label: 'OpenAI o4-mini', provider: 'openai' },
 ];
 
 export function modelLabel(value: string): string {
@@ -77,6 +84,15 @@ export const MODEL_PRICING: Record<string, ModelPrice> = {
   'claude-sonnet-5': { input: 3, output: 15 },
   'claude-sonnet-4-6': { input: 3, output: 15 },
   'claude-haiku-4-5': { input: 1, output: 5 },
+  // OpenAI (BYOM #1495). Representative published $/MTok at authoring time —
+  // verify before relying on the cost figure; like the Sonnet note above, an
+  // out-of-date rate over- or under-estimates rather than failing. OpenAI's
+  // cached-input discount isn't modelled (usage counts cached tokens as full
+  // input — see foldOpenAIUsage), so real cost trends slightly below these.
+  'gpt-5': { input: 1.25, output: 10 },
+  'gpt-5-mini': { input: 0.25, output: 2 },
+  'o3': { input: 2, output: 8 },
+  'o4-mini': { input: 1.1, output: 4.4 },
 };
 
 /**

--- a/tests/main/llm/openai-provider.test.ts
+++ b/tests/main/llm/openai-provider.test.ts
@@ -1,0 +1,173 @@
+/**
+ * OpenAIProvider — wire-format translation behind the provider seam (BYOM #1495).
+ *
+ * The pure mappers (tools, reasoning effort, finish reason, usage, tool-arg
+ * parsing) are unit-tested directly; `runTurn` / `complete` are driven through
+ * an INJECTED fake OpenAI client (the constructor's test-only 3rd arg) so the
+ * streamed-tool-call reassembly, text accumulation, stop-reason, and usage
+ * mapping are exercised without a network call.
+ */
+import { describe, it, expect } from 'vitest';
+import type OpenAI from 'openai';
+import {
+  OpenAIProvider,
+  reasoningEffortFor,
+  toChatTools,
+  mapFinishReason,
+  foldOpenAIUsage,
+  parseToolArgs,
+} from '../../../src/main/llm/provider/openai';
+import type { ToolSpec } from '../../../src/main/llm/provider/types';
+
+/** A fake OpenAI client: streaming `create` yields `streamChunks`, non-streaming
+ *  returns `response`. */
+function fakeClient(opts: { streamChunks?: unknown[]; response?: unknown }): OpenAI {
+  return {
+    chat: {
+      completions: {
+        create: async (params: { stream?: boolean }) => {
+          if (params.stream) {
+            return (async function* () {
+              for (const c of opts.streamChunks ?? []) yield c;
+            })();
+          }
+          return opts.response;
+        },
+      },
+    },
+    models: { list: async () => ({ data: [] }) },
+  } as unknown as OpenAI;
+}
+
+describe('OpenAIProvider — pure mappers', () => {
+  it('reasoningEffortFor maps neutral effort, clamping xhigh/max → high', () => {
+    expect(reasoningEffortFor(undefined)).toBeUndefined();
+    expect(reasoningEffortFor('low')).toBe('low');
+    expect(reasoningEffortFor('medium')).toBe('medium');
+    expect(reasoningEffortFor('high')).toBe('high');
+    expect(reasoningEffortFor('xhigh')).toBe('high');
+    expect(reasoningEffortFor('max')).toBe('high');
+  });
+
+  it('toChatTools translates a ToolSpec to an OpenAI function tool', () => {
+    const spec: ToolSpec = {
+      name: 'search',
+      description: 'find things',
+      input_schema: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+    };
+    expect(toChatTools([spec])).toEqual([
+      {
+        type: 'function',
+        function: {
+          name: 'search',
+          description: 'find things',
+          parameters: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+        },
+      },
+    ]);
+  });
+
+  it('mapFinishReason: tool_calls → tool_use, everything else → end', () => {
+    expect(mapFinishReason('tool_calls')).toBe('tool_use');
+    expect(mapFinishReason('stop')).toBe('end');
+    expect(mapFinishReason('length')).toBe('end');
+    expect(mapFinishReason(null)).toBe('end');
+  });
+
+  it('foldOpenAIUsage maps prompt/completion tokens (cache fields zeroed)', () => {
+    expect(foldOpenAIUsage({ prompt_tokens: 12, completion_tokens: 7, total_tokens: 19 }))
+      .toEqual({ inputTokens: 12, outputTokens: 7, cacheCreationTokens: 0, cacheReadTokens: 0 });
+    expect(foldOpenAIUsage(undefined)).toEqual({ inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 });
+  });
+
+  it('parseToolArgs parses JSON and tolerates malformed/empty', () => {
+    expect(parseToolArgs('{"q":"hi"}')).toEqual({ q: 'hi' });
+    expect(parseToolArgs('')).toEqual({});
+    expect(parseToolArgs('{not json')).toEqual({});
+  });
+});
+
+describe('OpenAIProvider — history shaping', () => {
+  const provider = new OpenAIProvider('sk-test', undefined, fakeClient({}));
+
+  it('ingestHistory wraps each seed turn as a one-message chunk', () => {
+    const h = provider.ingestHistory([{ role: 'user', content: 'hi' }]);
+    expect(h).toHaveLength(1);
+    expect(h[0]).toEqual([{ role: 'user', content: 'hi' }]);
+  });
+
+  it('toolResultMessage emits one role:tool message per result', () => {
+    const msg = provider.toolResultMessage([
+      { toolUseId: 'call_1', content: 'ok', isError: false },
+      { toolUseId: 'call_2', content: 'bad', isError: true },
+    ]);
+    expect(msg).toEqual([
+      { role: 'tool', tool_call_id: 'call_1', content: 'ok' },
+      { role: 'tool', tool_call_id: 'call_2', content: 'bad' },
+    ]);
+  });
+});
+
+// Chunk builders keep the deeply-nested OpenAI stream shape readable.
+const chunk = (delta: unknown, finish: string | null = null) => ({ choices: [{ delta, finish_reason: finish }] });
+const usageChunk = (usage: unknown) => ({ choices: [], usage });
+
+describe('OpenAIProvider — runTurn (injected stream)', () => {
+  it('accumulates text + a fragmented tool call, and maps stop/usage', async () => {
+    const streamChunks = [
+      chunk({ content: 'Hel' }),
+      chunk({ content: 'lo' }),
+      chunk({ tool_calls: [{ index: 0, id: 'call_1', function: { name: 'search', arguments: '{"q":' } }] }),
+      chunk({ tool_calls: [{ index: 0, function: { arguments: '"hi"}' } }] }, 'tool_calls'),
+      usageChunk({ prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }),
+    ];
+    const provider = new OpenAIProvider('sk-test', undefined, fakeClient({ streamChunks }));
+
+    const deltas: string[] = [];
+    const toolStarts: string[] = [];
+    const res = await provider.runTurn(
+      {
+        model: 'gpt-5',
+        system: 'sys',
+        history: provider.ingestHistory([{ role: 'user', content: 'hi' }]),
+        tools: [],
+        web: { enabled: false },
+        maxTokens: 1000,
+      },
+      { onTextDelta: (d) => deltas.push(d), onToolCallStart: (n) => toolStarts.push(n) },
+    );
+
+    expect(res.text).toBe('Hello');
+    expect(deltas.join('')).toBe('Hello');
+    expect(res.toolCalls).toEqual([{ id: 'call_1', name: 'search', input: { q: 'hi' } }]);
+    expect(toolStarts).toEqual(['search']); // indicator fired once, when the name arrived
+    expect(res.stopReason).toBe('tool_use');
+    expect(res.usage).toEqual({ inputTokens: 10, outputTokens: 5, cacheCreationTokens: 0, cacheReadTokens: 0 });
+    expect(res.citations).toEqual([]);
+  });
+
+  it('a plain text turn stops with "end"', async () => {
+    const provider = new OpenAIProvider('sk-test', undefined, fakeClient({
+      streamChunks: [chunk({ content: 'done' }, 'stop'), usageChunk({ prompt_tokens: 3, completion_tokens: 1 })],
+    }));
+    const res = await provider.runTurn(
+      { model: 'gpt-5', system: 's', history: [], tools: [], web: { enabled: false }, maxTokens: 100 },
+      {},
+    );
+    expect(res.text).toBe('done');
+    expect(res.toolCalls).toEqual([]);
+    expect(res.stopReason).toBe('end');
+  });
+});
+
+describe('OpenAIProvider — complete (non-streaming)', () => {
+  it('returns the message content + usage', async () => {
+    const provider = new OpenAIProvider('sk-test', undefined, fakeClient({
+      response: { choices: [{ message: { content: 'the answer' } }], usage: { prompt_tokens: 4, completion_tokens: 2 } },
+    }));
+    const res = await provider.complete({ model: 'gpt-5', messages: [{ role: 'user', content: 'q' }], maxTokens: 100 });
+    expect(res.text).toBe('the answer');
+    expect(res.usage.inputTokens).toBe(4);
+    expect(res.usage.outputTokens).toBe(2);
+  });
+});

--- a/tests/main/llm/provider-factory.test.ts
+++ b/tests/main/llm/provider-factory.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Provider factory branch (BYOM #1495).
+ *
+ * `getProvider(modelOverride?)` resolves the provider from the EFFECTIVE model —
+ * the per-conversation override, not just the global default — so a conversation
+ * pinned to an OpenAI model routes to the OpenAI implementation even when the
+ * default is Claude. Missing credentials throw the marker error the renderer
+ * detects to show "Open Settings".
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({ getSettings: vi.fn() }));
+vi.mock('../../../src/main/llm/settings', () => ({ getSettings: h.getSettings }));
+
+import { getProvider } from '../../../src/main/llm/provider';
+import { MISSING_API_KEY_MARKER } from '../../../src/shared/llm-errors';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getSettings.mockResolvedValue({
+    providers: { anthropic: { apiKey: 'sk-ant' }, openai: { apiKey: 'sk-openai' } },
+    model: 'claude-opus-5',
+  });
+});
+
+describe('getProvider — provider resolution from the effective model', () => {
+  it('uses the default model when no override is given', async () => {
+    const r = await getProvider();
+    expect(r.provider.id).toBe('anthropic');
+    expect(r.model).toBe('claude-opus-5');
+  });
+
+  it('routes an OpenAI model override to the OpenAI provider', async () => {
+    const r = await getProvider('gpt-5');
+    expect(r.provider.id).toBe('openai');
+    expect(r.model).toBe('gpt-5');
+  });
+
+  it('routes a Claude model override to the Anthropic provider', async () => {
+    const r = await getProvider('claude-haiku-4-5');
+    expect(r.provider.id).toBe('anthropic');
+  });
+
+  it('falls back to Anthropic for an unknown model id', async () => {
+    const r = await getProvider('some-unlisted-model');
+    expect(r.provider.id).toBe('anthropic');
+  });
+});
+
+describe('getProvider — missing credentials', () => {
+  it('throws the marker error naming OpenAI when its key is absent', async () => {
+    h.getSettings.mockResolvedValue({ providers: { anthropic: { apiKey: 'sk-ant' } }, model: 'claude-opus-5' });
+    await expect(getProvider('gpt-5')).rejects.toThrow(MISSING_API_KEY_MARKER);
+    await expect(getProvider('gpt-5')).rejects.toThrow(/OpenAI/);
+  });
+
+  it('throws the marker error naming Anthropic when its key is absent', async () => {
+    h.getSettings.mockResolvedValue({ providers: {}, model: 'claude-opus-5' });
+    await expect(getProvider()).rejects.toThrow(MISSING_API_KEY_MARKER);
+    await expect(getProvider()).rejects.toThrow(/Anthropic/);
+  });
+});

--- a/tests/main/llm/provider-seam.test.ts
+++ b/tests/main/llm/provider-seam.test.ts
@@ -29,27 +29,49 @@ function collectTsFiles(dir: string): string[] {
   return out;
 }
 
-// Match a real import/require of the SDK, not a passing mention in a comment
-// (types.ts, for instance, names it in prose while importing nothing from it).
-const SDK_IMPORT = /(?:from|require\()\s*['"]@anthropic-ai\/sdk['"]/;
-// The single sanctioned home of the SDK. Everything Claude-specific lives here.
-const SANCTIONED = path.join('src', 'main', 'llm', 'provider', 'anthropic.ts');
+// Each provider SDK is confined to its own implementation file. A real
+// import/require (not a passing mention in a comment — types.ts names Anthropic
+// in prose while importing nothing) anywhere else breaks the seam. As providers
+// are added (BYOM #1492) each SDK gets a row here.
+const SDKS: { name: string; importRe: RegExp; sanctioned: string }[] = [
+  {
+    name: '@anthropic-ai/sdk',
+    importRe: /(?:from|require\()\s*['"]@anthropic-ai\/sdk['"]/,
+    sanctioned: path.join('src', 'main', 'llm', 'provider', 'anthropic.ts'),
+  },
+  {
+    name: 'openai',
+    importRe: /(?:from|require\()\s*['"]openai(?:\/[^'"]*)?['"]/,
+    sanctioned: path.join('src', 'main', 'llm', 'provider', 'openai.ts'),
+  },
+];
 
-describe('provider seam (#1148)', () => {
-  const importers = collectTsFiles(srcRoot)
-    .filter((f) => SDK_IMPORT.test(fs.readFileSync(f, 'utf-8')))
-    .map((f) => path.relative(repoRoot, f))
-    .sort();
+const NON_PROVIDER_FILES = [
+  path.join('src', 'main', 'llm', 'index.ts'),
+  path.join('src', 'main', 'llm', 'tools', 'registry.ts'),
+  path.join('src', 'main', 'llm', 'tools', 'types.ts'),
+];
 
-  it('confines the Anthropic SDK to the single provider implementation', () => {
-    expect(importers).toEqual([SANCTIONED]);
-  });
+describe('provider seam (#1148, BYOM #1492)', () => {
+  const files = collectTsFiles(srcRoot);
+  const importersOf = (re: RegExp) =>
+    files
+      .filter((f) => re.test(fs.readFileSync(f, 'utf-8')))
+      .map((f) => path.relative(repoRoot, f))
+      .sort();
 
-  it('does not let the SDK leak into tool definitions or the agentic loop', () => {
-    // Belt-and-braces: name the two files that used to import the SDK, so a
-    // reader of a failure sees *where* the seam broke, not just a count.
-    expect(importers).not.toContain(path.join('src', 'main', 'llm', 'index.ts'));
-    expect(importers).not.toContain(path.join('src', 'main', 'llm', 'tools', 'registry.ts'));
-    expect(importers).not.toContain(path.join('src', 'main', 'llm', 'tools', 'types.ts'));
+  for (const sdk of SDKS) {
+    it(`confines ${sdk.name} to its single provider implementation`, () => {
+      expect(importersOf(sdk.importRe)).toEqual([sdk.sanctioned]);
+    });
+  }
+
+  it('does not let any provider SDK leak into tool definitions or the agentic loop', () => {
+    // Belt-and-braces: name the files that must never import a provider SDK, so
+    // a reader of a failure sees *where* the seam broke, not just a count.
+    for (const sdk of SDKS) {
+      const importers = importersOf(sdk.importRe);
+      for (const f of NON_PROVIDER_FILES) expect(importers).not.toContain(f);
+    }
   });
 });

--- a/tests/main/llm/validate.test.ts
+++ b/tests/main/llm/validate.test.ts
@@ -30,13 +30,13 @@ describe('checkConnection — key resolution', () => {
     const res = await checkConnection('  sk-typed  ');
     expect(res).toEqual({ ok: true });
     expect(h.getSettings).not.toHaveBeenCalled();
-    expect(h.createProviderForKey).toHaveBeenCalledWith('sk-typed');
+    expect(h.createProviderForKey).toHaveBeenCalledWith('anthropic', 'sk-typed');
   });
 
   it('falls back to the stored key when no candidate is given', async () => {
     await checkConnection('');
     expect(h.getSettings).toHaveBeenCalled();
-    expect(h.createProviderForKey).toHaveBeenCalledWith('sk-stored');
+    expect(h.createProviderForKey).toHaveBeenCalledWith('anthropic', 'sk-stored');
   });
 
   it('short-circuits with no provider call when there is no key at all', async () => {


### PR DESCRIPTION
BYOM epic #1492 — child 3/6. The first real second provider. Stacks on #1500 (merged).

## Factory (`provider/index.ts`)
- `getProvider(modelOverride?)` resolves the provider from the **effective** model (per-conversation override, not just the global default). This fixes a latent cross-provider bug: the provider used to be built from the default model *before* the override was applied, so a conversation pinned to an OpenAI model would have been sent to the Anthropic client. Both `index.ts` call sites now pass their resolved model in.
- `buildProvider()` branches on the model's provider. Missing credentials throw the `MISSING_API_KEY` marker **named per provider**, so the "Open Settings" affordance stays honest. `google`/`local` throw an explicit "not wired yet" (#1496/#1497).
- `createProviderForKey(providerId, apiKey, baseURL?)` generalized.

## OpenAI provider (`provider/openai.ts`) — only importer of the `openai` SDK
Full `LLMProvider` over Chat Completions:
- Neutral `ToolSpec` → function tools; **streamed tool-call fragment reassembly** (id/name/arguments arrive in pieces across chunks) → `ProviderToolCall`; text + usage accumulation; `effort` → `reasoning_effort` (xhigh/max clamp to high); `finish_reason` → `StopReason`.
- History is carried as native message **chunks** (arrays) so a batch of tool results becomes N `role:'tool'` messages — the seam's opaque `ProviderMessage` makes this internal.
- `max_completion_tokens` clamped to 32k (the loop hands over Claude's 64k budget, which exceeds some OpenAI caps and must also cover reasoning tokens). Constructor takes an optional `baseURL` (reused for local, #1497) and an **injectable client** for tests.
- Anthropic-only capabilities (prompt-cache breakpoints, server-side web search + citations, code-execution container) have no cross-provider equivalent and are intentionally absent; `citations` comes back empty.

## Registry
`gpt-5`, `gpt-5-mini`, `o3`, `o4-mini` added — reasoning models with large output caps (clear the token clamp), each with representative pricing (flagged verify-before-relying) + effort `SUPPORT` low/medium/high. Non-reasoning / low-cap OpenAI tiers deferred.

## Seam test
Generalized to confine **each** provider SDK to its own file (`openai` → `openai.ts`) and to keep any provider SDK out of the loop/tools.

## Tests
`openai-provider.test.ts` drives `runTurn`/`complete` through an **injected fake client** (fragmented tool-call reassembly, stop/usage mapping) plus the pure mappers; `provider-factory.test.ts` covers effective-model routing (OpenAI override → OpenAI provider) and per-provider missing-key errors. `pnpm lint` clean; full llm suite green (274).

## Scope
Wiring only — validating skills/gate against OpenAI's tool-calling behavior is the separate initiative. UI to enter an OpenAI key lands in #1498; until then an OpenAI model is reachable via `OPENAI_API_KEY` (env fallback from #1494).

Part of #1492.