### PR TITLE
feat(llm): Google/Gemini provider implementation (#1496)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@fontsource-variable/ibm-plex-sans": "^5.3.0",
     "@fontsource/ibm-plex-mono": "^5.3.0",
     "@fontsource/ibm-plex-serif": "^5.3.0",
+    "@google/genai": "^2.14.0",
     "@huggingface/transformers": "^4.2.0",
     "@mozilla/readability": "^0.6.0",
     "@retorquere/bibtex-parser": "^9.0.29",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       '@fontsource/ibm-plex-serif':
         specifier: ^5.3.0
         version: 5.3.0
+      '@google/genai':
+        specifier: ^2.14.0
+        version: 2.14.0
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@26.1.2)
@@ -1695,6 +1698,15 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
+  '@google/genai@2.14.0':
+    resolution: {integrity: sha512-pRsFFPYhDARkVlzC4iSAb7Oj83HZJCjM5cVabvAl3Su/6464ULo6JOAqJiZqbD+H2d7DfT78zvXbtxJa1+KYdg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@huggingface/jinja@0.5.9':
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
     engines: {node: '>=18'}
@@ -2609,6 +2621,9 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
@@ -2871,6 +2886,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -3014,6 +3033,9 @@ packages:
   bignumber.js@11.1.5:
     resolution: {integrity: sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -3055,6 +3077,9 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -3489,6 +3514,10 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -3625,6 +3654,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-installer-dmg@5.0.1:
     resolution: {integrity: sha512-qOa1aAQdX57C+vzhDk3549dd/PRlNL4F8y736MTD1a43qptD+PvHY97Bo9gSf+OZ8iUWE7BrYSpk/FgLUe40EA==}
@@ -3901,6 +3933,10 @@ packages:
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fetch-sparql-endpoint@7.1.1:
     resolution: {integrity: sha512-OslECjEPhhTg2uXJpuKqucOFLkIaK2TkbUjW+fWgHKLsH4kTZ/J7UKid2w6f3dF0MOEqF0gEO5kiUh3pq3uhfA==}
     hasBin: true
@@ -3953,6 +3989,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -4003,6 +4043,14 @@ packages:
   galactus@1.0.0:
     resolution: {integrity: sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==}
     engines: {node: '>= 12'}
+
+  gaxios@7.3.0:
+    resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -4092,6 +4140,14 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -4192,6 +4248,10 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -4431,6 +4491,9 @@ packages:
       canvas:
         optional: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -4493,6 +4556,12 @@ packages:
 
   just-permutations@2.2.1:
     resolution: {integrity: sha512-J2W9djsAsl346A9H41H/S8VXfnPjxZSFfBbAsZRbtFUQTpfmGBGJLWNeZgoDtzBw+ZaN7WF/DOsAJ+V/e6P5cQ==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
@@ -4920,6 +4989,11 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -4928,6 +5002,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
@@ -5081,6 +5159,10 @@ packages:
   p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
 
   p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
@@ -5511,6 +5593,10 @@ packages:
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
   reusify@1.1.0:
@@ -6393,6 +6479,10 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -10205,6 +10295,17 @@ snapshots:
 
   '@gar/promisify@1.1.3': {}
 
+  '@google/genai@2.14.0':
+    dependencies:
+      google-auth-library: 10.9.1
+      p-retry: 4.6.2
+      protobufjs: 7.6.4
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@huggingface/jinja@0.5.9': {}
 
   '@huggingface/tokenizers@0.1.3': {}
@@ -11149,6 +11250,8 @@ snapshots:
     dependencies:
       '@types/node': 26.1.2
 
+  '@types/retry@0.12.0': {}
+
   '@types/semver@7.7.1': {}
 
   '@types/spark-md5@3.0.5': {}
@@ -11493,6 +11596,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
@@ -11626,6 +11731,8 @@ snapshots:
 
   bignumber.js@11.1.5: {}
 
+  bignumber.js@9.3.1: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -11671,6 +11778,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -12153,6 +12262,8 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -12287,6 +12398,10 @@ snapshots:
       readable-stream: 2.3.8
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-installer-dmg@5.0.1:
     dependencies:
@@ -12600,6 +12715,11 @@ snapshots:
 
   fecha@4.2.3: {}
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fetch-sparql-endpoint@7.1.1:
     dependencies:
       '@traqula/parser-sparql-1-2': 1.1.8
@@ -12667,6 +12787,10 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -12723,6 +12847,22 @@ snapshots:
       debug: 4.4.3
       flora-colossus: 2.0.0
       fs-extra: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  gaxios@7.3.0:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.3.0
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12852,6 +12992,19 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+
+  google-auth-library@10.9.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.0
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -12996,6 +13149,13 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -13207,6 +13367,10 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -13294,6 +13458,17 @@ snapshots:
   junk@3.1.0: {}
 
   just-permutations@2.2.1: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   katex@0.16.47:
     dependencies:
@@ -13719,11 +13894,19 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
+  node-domexception@1.0.0: {}
+
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-releases@2.0.36: {}
 
@@ -13870,6 +14053,11 @@ snapshots:
   p-map@4.0.0:
     dependencies:
       aggregate-error: 3.1.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   p-try@1.0.0: {}
 
@@ -14350,6 +14538,8 @@ snapshots:
   ret@0.1.15: {}
 
   retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -15418,6 +15608,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/main/llm/provider/google.ts
+++ b/src/main/llm/provider/google.ts
@@ -1,0 +1,226 @@
+/**
+ * The Google (Gemini) implementation of the provider seam (BYOM #1496).
+ *
+ * The third `LLMProvider`, and the ONLY importer of `@google/genai`. Everything
+ * Gemini-specific — `Content`/`Part` message shapes, `functionCall` /
+ * `functionResponse` parts, `thinkingConfig` budgets, streamed
+ * `GenerateContentResponse` getters, and `usageMetadata` field names — is
+ * translated to and from the neutral types in `./types` here. The agentic loop
+ * in `../index.ts` sees none of it.
+ *
+ * NOT ported (no cross-provider equivalent): prompt-cache breakpoints,
+ * server-side web search + citations, and the code-execution container.
+ * `web`/`containerId` on the request are ignored; `citations` comes back empty.
+ *
+ * Function-call correlation: Gemini matches a `functionResponse` to its call by
+ * NAME (with an optional `id`), unlike OpenAI/Anthropic's required call id. The
+ * loop only hands `toolResultMessage` a `toolUseId` + content, so the call name
+ * is encoded INTO the neutral id (`id::name`, or just `name`) and decoded back
+ * when building the response part — keeping the provider stateless.
+ */
+import { GoogleGenAI } from '@google/genai';
+import type {
+  Content,
+  FunctionDeclaration,
+  GenerateContentConfig,
+  GenerateContentResponseUsageMetadata,
+  Part,
+} from '@google/genai';
+import type { TurnUsage } from '../../../shared/types';
+import type { ConnectionCheckResult } from '../../../shared/tools/types';
+import { toConnectionResult } from '../connection-error';
+import type { Effort } from '../../../shared/tools/effort';
+import type {
+  ChatMessage,
+  CompletionRequest,
+  CompletionResult,
+  LLMProvider,
+  ProviderMessage,
+  ProviderToolCall,
+  ProviderToolResult,
+  ToolSpec,
+  TurnHooks,
+  TurnRequest,
+  TurnResult,
+} from './types';
+
+/** Conservative output-token ceiling — see the note in `openai.ts`. Gemini
+ *  counts thinking tokens separately from `maxOutputTokens`, but keep parity. */
+const MAX_OUTPUT_TOKENS = 32_000;
+
+function emptyUsage(): TurnUsage {
+  return { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
+}
+
+/** Map neutral effort → a Gemini `thinkingBudget` (tokens). The caller has
+ *  already clamped to the model's supported set (effort.ts SUPPORT), so a
+ *  non-thinking model never reaches here with an effort. */
+export function thinkingBudgetFor(effort: Effort | undefined): number | undefined {
+  if (!effort) return undefined;
+  if (effort === 'low') return 2048;
+  if (effort === 'medium') return 8192;
+  return 16384; // high / xhigh / max
+}
+
+export function foldGeminiUsage(u: GenerateContentResponseUsageMetadata | undefined): TurnUsage {
+  if (!u) return emptyUsage();
+  return {
+    inputTokens: u.promptTokenCount ?? 0,
+    outputTokens: u.candidatesTokenCount ?? 0,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+  };
+}
+
+/** Encode a call's name into the neutral id so `toolResultMessage` can recover
+ *  it (Gemini responses key on name). */
+export function encodeToolId(name: string, id: string | undefined): string {
+  return id ? `${id}::${name}` : name;
+}
+
+/** Recover `{ id?, name }` from an encoded neutral tool id. */
+export function decodeToolId(toolUseId: string): { id?: string; name: string } {
+  const sep = toolUseId.indexOf('::');
+  if (sep < 0) return { name: toolUseId };
+  return { id: toolUseId.slice(0, sep), name: toolUseId.slice(sep + 2) };
+}
+
+export class GoogleProvider implements LLMProvider {
+  readonly id = 'google';
+  private readonly ai: GoogleGenAI;
+
+  /** `ai` is injectable for tests; production passes only the key. */
+  constructor(apiKey: string, ai?: GoogleGenAI) {
+    this.ai = ai ?? new GoogleGenAI({ apiKey });
+  }
+
+  // A ProviderMessage is a single Gemini `Content`. The loop holds them opaquely.
+  ingestHistory(messages: ChatMessage[]): ProviderMessage[] {
+    return messages.map(
+      (m) =>
+        ({ role: m.role === 'assistant' ? 'model' : 'user', parts: [{ text: m.content }] }) as Content as unknown as ProviderMessage,
+    );
+  }
+
+  toolResultMessage(results: ProviderToolResult[]): ProviderMessage {
+    const parts: Part[] = results.map((r) => {
+      const { id, name } = decodeToolId(r.toolUseId);
+      return {
+        functionResponse: {
+          ...(id ? { id } : {}),
+          name,
+          response: r.isError ? { error: r.content } : { result: r.content },
+        },
+      };
+    });
+    return { role: 'user', parts } as Content as unknown as ProviderMessage;
+  }
+
+  private buildConfig(system: string | undefined, tools: ToolSpec[], effort: Effort | undefined, signal: AbortSignal | undefined): GenerateContentConfig {
+    const budget = thinkingBudgetFor(effort);
+    return {
+      ...(system ? { systemInstruction: system } : {}),
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      ...(tools.length > 0
+        ? {
+            tools: [
+              {
+                functionDeclarations: tools.map((s): FunctionDeclaration => ({
+                  name: s.name,
+                  ...(s.description ? { description: s.description } : {}),
+                  // Neutral JSON-Schema → Gemini's Schema. Structurally close; a
+                  // schema with Gemini-incompatible fields is the skill-validation
+                  // initiative's concern, not this plumbing's.
+                  parameters: s.input_schema as unknown as NonNullable<FunctionDeclaration['parameters']>,
+                })),
+              },
+            ],
+          }
+        : {}),
+      ...(budget !== undefined ? { thinkingConfig: { thinkingBudget: budget } } : {}),
+      ...(signal ? { abortSignal: signal } : {}),
+    };
+  }
+
+  async runTurn(req: TurnRequest, hooks: TurnHooks): Promise<TurnResult> {
+    const contents = req.history as unknown as Content[];
+    const stream = await this.ai.models.generateContentStream({
+      model: req.model,
+      contents,
+      config: this.buildConfig(req.system, req.tools, req.effort, req.signal),
+    });
+
+    let text = '';
+    const calls: { id?: string; name: string; args: Record<string, unknown> }[] = [];
+    let usage: GenerateContentResponseUsageMetadata | undefined;
+
+    for await (const chunk of stream) {
+      const t = chunk.text;
+      if (t) {
+        text += t;
+        hooks.onTextDelta?.(t);
+      }
+      // Gemini emits each function call complete in one part (no partial args),
+      // so fire the indicator + record it as it arrives.
+      for (const fc of chunk.functionCalls ?? []) {
+        const name = fc.name ?? '';
+        const args = fc.args ?? {};
+        hooks.onToolCallStart?.(name, args);
+        calls.push({ ...(fc.id ? { id: fc.id } : {}), name, args });
+      }
+      if (chunk.usageMetadata) usage = chunk.usageMetadata;
+    }
+
+    const toolCalls: ProviderToolCall[] = calls.map((c) => ({
+      id: encodeToolId(c.name, c.id),
+      name: c.name,
+      input: c.args,
+    }));
+
+    const parts: Part[] = [
+      ...(text ? [{ text }] : []),
+      ...calls.map((c) => ({ functionCall: { ...(c.id ? { id: c.id } : {}), name: c.name, args: c.args } })),
+    ];
+    const assistant: Content = { role: 'model', parts };
+
+    return {
+      assistantMessage: assistant as unknown as ProviderMessage,
+      text,
+      toolCalls,
+      citations: [],
+      usage: foldGeminiUsage(usage),
+      stopReason: calls.length > 0 ? 'tool_use' : 'end',
+    };
+  }
+
+  async complete(req: CompletionRequest, onDelta?: (delta: string) => void): Promise<CompletionResult> {
+    const contents: Content[] = req.messages.map((m) => ({
+      role: m.role === 'assistant' ? 'model' : 'user',
+      parts: [{ text: m.content }],
+    }));
+    const config = this.buildConfig(req.system, [], req.effort, req.signal);
+
+    if (!onDelta) {
+      const res = await this.ai.models.generateContent({ model: req.model, contents, config });
+      return { text: res.text ?? '', usage: foldGeminiUsage(res.usageMetadata) };
+    }
+
+    const stream = await this.ai.models.generateContentStream({ model: req.model, contents, config });
+    let text = '';
+    let usage: GenerateContentResponseUsageMetadata | undefined;
+    for await (const chunk of stream) {
+      const t = chunk.text;
+      if (t) {
+        text += t;
+        onDelta(t);
+      }
+      if (chunk.usageMetadata) usage = chunk.usageMetadata;
+    }
+    return { text, usage: foldGeminiUsage(usage) };
+  }
+
+  async checkConnection(): Promise<ConnectionCheckResult> {
+    // A minimal authenticated listing: no generation, so token-free.
+    return toConnectionResult(() => this.ai.models.list());
+  }
+}

--- a/src/main/llm/provider/index.ts
+++ b/src/main/llm/provider/index.ts
@@ -13,6 +13,7 @@ import { providerForModel } from '../../../shared/tools/models';
 import { PROVIDERS, type ProviderId } from '../../../shared/tools/providers';
 import { AnthropicProvider } from './anthropic';
 import { OpenAIProvider } from './openai';
+import { GoogleProvider } from './google';
 import type { LLMProvider, WebToolSettings } from './types';
 
 export type { LLMProvider } from './types';
@@ -57,8 +58,11 @@ function buildProvider(id: ProviderId, settings: LLMSettings): LLMProvider {
       if (!c?.apiKey) throw missingKeyError('openai');
       return new OpenAIProvider(c.apiKey, c.baseURL);
     }
-    case 'google':
-      throw new Error(`${PROVIDERS.google.label} models aren't wired up yet (BYOM #1496).`);
+    case 'google': {
+      const c = settings.providers.google;
+      if (!c?.apiKey) throw missingKeyError('google');
+      return new GoogleProvider(c.apiKey);
+    }
     case 'local':
       throw new Error(`Local / OpenAI-compatible models aren't wired up yet (BYOM #1497).`);
   }
@@ -91,10 +95,12 @@ export function createProviderForKey(providerId: ProviderId, apiKey: string, bas
   switch (providerId) {
     case 'openai':
       return new OpenAIProvider(apiKey, baseURL);
+    case 'google':
+      return new GoogleProvider(apiKey);
     case 'anthropic':
     default:
-      // google/local reuse an OpenAI-shaped check once wired (#1496/#1497);
-      // until then only anthropic + openai reach here from the settings UI.
+      // local reuses an OpenAI-shaped check once wired (#1497); until then only
+      // anthropic/openai/google reach here from the settings UI.
       return new AnthropicProvider(apiKey);
   }
 }

--- a/src/shared/tools/effort.ts
+++ b/src/shared/tools/effort.ts
@@ -54,6 +54,10 @@ const SUPPORT: Record<string, Effort[]> = {
   'gpt-5-mini': ['low', 'medium', 'high'],
   'o3': ['low', 'medium', 'high'],
   'o4-mini': ['low', 'medium', 'high'],
+  // Gemini 2.5 maps neutral effort → thinkingBudget (google.ts). xhigh/max snap
+  // to high via clampEffort since they're not listed.
+  'gemini-2.5-pro': ['low', 'medium', 'high'],
+  'gemini-2.5-flash': ['low', 'medium', 'high'],
 };
 
 /**

--- a/src/shared/tools/models.ts
+++ b/src/shared/tools/models.ts
@@ -41,6 +41,9 @@ export const MODEL_OPTIONS: ModelOption[] = [
   { value: 'gpt-5-mini', label: 'GPT-5 mini', provider: 'openai' },
   { value: 'o3', label: 'OpenAI o3', provider: 'openai' },
   { value: 'o4-mini', label: 'OpenAI o4-mini', provider: 'openai' },
+  // Google Gemini (BYOM #1496). Thinking-capable 2.5 models.
+  { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', provider: 'google' },
+  { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', provider: 'google' },
 ];
 
 export function modelLabel(value: string): string {
@@ -93,6 +96,10 @@ export const MODEL_PRICING: Record<string, ModelPrice> = {
   'gpt-5-mini': { input: 0.25, output: 2 },
   'o3': { input: 2, output: 8 },
   'o4-mini': { input: 1.1, output: 4.4 },
+  // Google Gemini — representative published $/MTok at authoring time (Pro's
+  // higher >200k-context tier isn't modelled); verify before relying on cost.
+  'gemini-2.5-pro': { input: 1.25, output: 10 },
+  'gemini-2.5-flash': { input: 0.3, output: 2.5 },
 };
 
 /**

--- a/tests/main/llm/gemini-provider.test.ts
+++ b/tests/main/llm/gemini-provider.test.ts
@@ -1,0 +1,144 @@
+/**
+ * GoogleProvider — Gemini wire-format translation behind the provider seam
+ * (BYOM #1496). Pure mappers are tested directly; `runTurn` / `complete` run
+ * through an INJECTED fake GoogleGenAI client so streaming accumulation,
+ * function-call handling, the name-encoded tool id round-trip, and usage
+ * mapping are exercised without a network call.
+ */
+import { describe, it, expect } from 'vitest';
+import type { GoogleGenAI } from '@google/genai';
+import {
+  GoogleProvider,
+  thinkingBudgetFor,
+  foldGeminiUsage,
+  encodeToolId,
+  decodeToolId,
+} from '../../../src/main/llm/provider/google';
+
+/** A fake GoogleGenAI: streaming yields `streamChunks`, non-streaming returns
+ *  `response`. */
+function fakeAi(opts: { streamChunks?: unknown[]; response?: unknown }): GoogleGenAI {
+  return {
+    models: {
+      generateContentStream: async () =>
+        (async function* () {
+          for (const c of opts.streamChunks ?? []) yield c;
+        })(),
+      generateContent: async () => opts.response,
+      list: async () => ({ page: [] }),
+    },
+  } as unknown as GoogleGenAI;
+}
+
+describe('GoogleProvider — pure mappers', () => {
+  it('thinkingBudgetFor maps neutral effort to a token budget', () => {
+    expect(thinkingBudgetFor(undefined)).toBeUndefined();
+    expect(thinkingBudgetFor('low')).toBe(2048);
+    expect(thinkingBudgetFor('medium')).toBe(8192);
+    expect(thinkingBudgetFor('high')).toBe(16384);
+    expect(thinkingBudgetFor('xhigh')).toBe(16384);
+    expect(thinkingBudgetFor('max')).toBe(16384);
+  });
+
+  it('foldGeminiUsage maps prompt/candidate token counts', () => {
+    expect(foldGeminiUsage({ promptTokenCount: 9, candidatesTokenCount: 4 }))
+      .toEqual({ inputTokens: 9, outputTokens: 4, cacheCreationTokens: 0, cacheReadTokens: 0 });
+    expect(foldGeminiUsage(undefined)).toEqual({ inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 });
+  });
+
+  it('encode/decode tool id round-trips name (with and without a call id)', () => {
+    expect(encodeToolId('search', undefined)).toBe('search');
+    expect(decodeToolId('search')).toEqual({ name: 'search' });
+    expect(encodeToolId('search', 'fc1')).toBe('fc1::search');
+    expect(decodeToolId('fc1::search')).toEqual({ id: 'fc1', name: 'search' });
+  });
+});
+
+describe('GoogleProvider — history shaping', () => {
+  const provider = new GoogleProvider('key', fakeAi({}));
+
+  it('ingestHistory maps assistant → model role with a text part', () => {
+    const h = provider.ingestHistory([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'yo' },
+    ]);
+    expect(h).toEqual([
+      { role: 'user', parts: [{ text: 'hi' }] },
+      { role: 'model', parts: [{ text: 'yo' }] },
+    ]);
+  });
+
+  it('toolResultMessage builds functionResponse parts, decoding the id::name', () => {
+    const msg = provider.toolResultMessage([
+      { toolUseId: 'fc1::search', content: 'ok', isError: false },
+      { toolUseId: 'lookup', content: 'boom', isError: true },
+    ]);
+    expect(msg).toEqual({
+      role: 'user',
+      parts: [
+        { functionResponse: { id: 'fc1', name: 'search', response: { result: 'ok' } } },
+        { functionResponse: { name: 'lookup', response: { error: 'boom' } } },
+      ],
+    });
+  });
+});
+
+describe('GoogleProvider — runTurn (injected stream)', () => {
+  it('accumulates text + a function call, and maps stop/usage', async () => {
+    const provider = new GoogleProvider('key', fakeAi({
+      streamChunks: [
+        { text: 'Hel' },
+        { text: 'lo' },
+        { functionCalls: [{ id: 'fc1', name: 'search', args: { q: 'hi' } }] },
+        { usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 } },
+      ],
+    }));
+
+    const deltas: string[] = [];
+    const toolStarts: string[] = [];
+    const res = await provider.runTurn(
+      {
+        model: 'gemini-2.5-pro',
+        system: 'sys',
+        history: provider.ingestHistory([{ role: 'user', content: 'hi' }]),
+        tools: [],
+        web: { enabled: false },
+        maxTokens: 1000,
+      },
+      { onTextDelta: (d) => deltas.push(d), onToolCallStart: (n) => toolStarts.push(n) },
+    );
+
+    expect(res.text).toBe('Hello');
+    expect(deltas.join('')).toBe('Hello');
+    expect(res.toolCalls).toEqual([{ id: 'fc1::search', name: 'search', input: { q: 'hi' } }]);
+    expect(toolStarts).toEqual(['search']);
+    expect(res.stopReason).toBe('tool_use');
+    expect(res.usage).toEqual({ inputTokens: 10, outputTokens: 5, cacheCreationTokens: 0, cacheReadTokens: 0 });
+    expect(res.citations).toEqual([]);
+  });
+
+  it('a plain text turn stops with "end"', async () => {
+    const provider = new GoogleProvider('key', fakeAi({
+      streamChunks: [{ text: 'done' }, { usageMetadata: { promptTokenCount: 3, candidatesTokenCount: 1 } }],
+    }));
+    const res = await provider.runTurn(
+      { model: 'gemini-2.5-flash', system: 's', history: [], tools: [], web: { enabled: false }, maxTokens: 100 },
+      {},
+    );
+    expect(res.text).toBe('done');
+    expect(res.toolCalls).toEqual([]);
+    expect(res.stopReason).toBe('end');
+  });
+});
+
+describe('GoogleProvider — complete (non-streaming)', () => {
+  it('returns text + usage', async () => {
+    const provider = new GoogleProvider('key', fakeAi({
+      response: { text: 'the answer', usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 2 } },
+    }));
+    const res = await provider.complete({ model: 'gemini-2.5-pro', messages: [{ role: 'user', content: 'q' }], maxTokens: 100 });
+    expect(res.text).toBe('the answer');
+    expect(res.usage.inputTokens).toBe(4);
+    expect(res.usage.outputTokens).toBe(2);
+  });
+});

--- a/tests/main/llm/provider-factory.test.ts
+++ b/tests/main/llm/provider-factory.test.ts
@@ -18,7 +18,7 @@ import { MISSING_API_KEY_MARKER } from '../../../src/shared/llm-errors';
 beforeEach(() => {
   vi.clearAllMocks();
   h.getSettings.mockResolvedValue({
-    providers: { anthropic: { apiKey: 'sk-ant' }, openai: { apiKey: 'sk-openai' } },
+    providers: { anthropic: { apiKey: 'sk-ant' }, openai: { apiKey: 'sk-openai' }, google: { apiKey: 'sk-gemini' } },
     model: 'claude-opus-5',
   });
 });
@@ -41,6 +41,12 @@ describe('getProvider — provider resolution from the effective model', () => {
     expect(r.provider.id).toBe('anthropic');
   });
 
+  it('routes a Gemini model override to the Google provider', async () => {
+    const r = await getProvider('gemini-2.5-pro');
+    expect(r.provider.id).toBe('google');
+    expect(r.model).toBe('gemini-2.5-pro');
+  });
+
   it('falls back to Anthropic for an unknown model id', async () => {
     const r = await getProvider('some-unlisted-model');
     expect(r.provider.id).toBe('anthropic');
@@ -52,6 +58,12 @@ describe('getProvider — missing credentials', () => {
     h.getSettings.mockResolvedValue({ providers: { anthropic: { apiKey: 'sk-ant' } }, model: 'claude-opus-5' });
     await expect(getProvider('gpt-5')).rejects.toThrow(MISSING_API_KEY_MARKER);
     await expect(getProvider('gpt-5')).rejects.toThrow(/OpenAI/);
+  });
+
+  it('throws the marker error naming Gemini when its key is absent', async () => {
+    h.getSettings.mockResolvedValue({ providers: { anthropic: { apiKey: 'sk-ant' } }, model: 'claude-opus-5' });
+    await expect(getProvider('gemini-2.5-pro')).rejects.toThrow(MISSING_API_KEY_MARKER);
+    await expect(getProvider('gemini-2.5-pro')).rejects.toThrow(/Gemini/);
   });
 
   it('throws the marker error naming Anthropic when its key is absent', async () => {

--- a/tests/main/llm/provider-seam.test.ts
+++ b/tests/main/llm/provider-seam.test.ts
@@ -44,6 +44,11 @@ const SDKS: { name: string; importRe: RegExp; sanctioned: string }[] = [
     importRe: /(?:from|require\()\s*['"]openai(?:\/[^'"]*)?['"]/,
     sanctioned: path.join('src', 'main', 'llm', 'provider', 'openai.ts'),
   },
+  {
+    name: '@google/genai',
+    importRe: /(?:from|require\()\s*['"]@google\/genai['"]/,
+    sanctioned: path.join('src', 'main', 'llm', 'provider', 'google.ts'),
+  },
 ];
 
 const NON_PROVIDER_FILES = [


### PR DESCRIPTION
BYOM epic #1492 — child 4/6. The third `LLMProvider`. Stacks on #1501.

## Gemini provider (`provider/google.ts`) — only importer of `@google/genai`
Full `LLMProvider` over `generateContent`/`generateContentStream`:
- Neutral `ToolSpec` → `functionDeclarations`, `Content`/`Part` message shapes, streamed function-call handling, text/usage accumulation, `effort` → `thinkingConfig.thinkingBudget` (low/medium/high → 2k/8k/16k tokens), `usageMetadata` mapping. History is one Gemini `Content` per `ProviderMessage`.
- **Function-call correlation:** Gemini matches a `functionResponse` to its call by **name** (id optional), unlike OpenAI/Anthropic's required call id. The loop only hands `toolResultMessage` a `toolUseId` + content, so the call name is encoded **into** the neutral id (`id::name`, or just `name`) and decoded when building the response part — keeping the provider stateless. Round-trip tested.
- Anthropic-only capabilities (prompt cache, server web search + citations, code-exec container) have no equivalent and are absent; `citations` empty.

## Factory + registry
`buildProvider` + `createProviderForKey` handle `google`. `gemini-2.5-pro` / `gemini-2.5-flash` added to the catalog (representative pricing, flagged verify-before-relying; effort `SUPPORT` low/medium/high). Seam test extended to confine `@google/genai` to `google.ts`.

## Tests
`gemini-provider.test.ts` drives `runTurn`/`complete` through an **injected fake `GoogleGenAI`** (function-call handling, the id encode/decode round-trip, stop/usage mapping) plus the pure mappers; `provider-factory.test.ts` gains Gemini routing + a missing-key case. `pnpm lint` clean; full llm suite green (285).

## Scope
Wiring only — validating skills against Gemini's function-calling / schema strictness is the separate initiative (the JSON-Schema → Gemini `Schema` pass is intentionally minimal). A Gemini model is reachable end-to-end today via `GEMINI_API_KEY` (env fallback from #1494); key-entry UI is #1498.

Part of #1492.