### PR TITLE
feat(llm): local / OpenAI-compatible endpoints + custom models (#1497)

### DIFF
--- a/src/main/llm/provider/index.ts
+++ b/src/main/llm/provider/index.ts
@@ -37,11 +37,14 @@ function missingKeyError(id: ProviderId): Error {
 
 /**
  * Which provider a model belongs to. Built-in models carry it in the catalog;
- * an unknown id falls back to Anthropic (user-defined local models get their own
- * resolution in BYOM #1497).
+ * a user-defined custom model (settings.customModels) routes to `local`; an
+ * otherwise-unknown id falls back to Anthropic.
  */
-function resolveProviderId(model: string): ProviderId {
-  return providerForModel(model) ?? 'anthropic';
+function resolveProviderId(model: string, settings: LLMSettings): ProviderId {
+  const builtIn = providerForModel(model);
+  if (builtIn) return builtIn;
+  if (settings.customModels?.some((m) => m.id === model)) return 'local';
+  return 'anthropic';
 }
 
 /** Construct the provider for `id`, reading its credentials from settings.
@@ -63,8 +66,18 @@ function buildProvider(id: ProviderId, settings: LLMSettings): LLMProvider {
       if (!c?.apiKey) throw missingKeyError('google');
       return new GoogleProvider(c.apiKey);
     }
-    case 'local':
-      throw new Error(`Local / OpenAI-compatible models aren't wired up yet (BYOM #1497).`);
+    case 'local': {
+      // OpenAI-compatible endpoint (Ollama/LM Studio/vLLM/…). Reuses the OpenAI
+      // implementation with a custom base URL; the key is optional (keyless
+      // local servers). Reports id 'local' for provenance.
+      const c = settings.providers.local;
+      if (!c?.baseURL) {
+        throw new Error(
+          `${MISSING_API_KEY_MARKER}. Set a base URL for the ${PROVIDERS.local.label} endpoint in the LLM settings.`,
+        );
+      }
+      return new OpenAIProvider(c.apiKey ?? '', c.baseURL, undefined, 'local');
+    }
   }
 }
 
@@ -77,7 +90,7 @@ function buildProvider(id: ProviderId, settings: LLMSettings): LLMProvider {
 export async function getProvider(modelOverride?: string): Promise<ResolvedProvider> {
   const settings = await getSettings();
   const model = modelOverride ?? settings.model;
-  const provider = buildProvider(resolveProviderId(model), settings);
+  const provider = buildProvider(resolveProviderId(model, settings), settings);
   return {
     provider,
     model,
@@ -95,12 +108,12 @@ export function createProviderForKey(providerId: ProviderId, apiKey: string, bas
   switch (providerId) {
     case 'openai':
       return new OpenAIProvider(apiKey, baseURL);
+    case 'local':
+      return new OpenAIProvider(apiKey, baseURL, undefined, 'local');
     case 'google':
       return new GoogleProvider(apiKey);
     case 'anthropic':
     default:
-      // local reuses an OpenAI-shaped check once wired (#1497); until then only
-      // anthropic/openai/google reach here from the settings UI.
       return new AnthropicProvider(apiKey);
   }
 }

--- a/src/main/llm/provider/openai.ts
+++ b/src/main/llm/provider/openai.ts
@@ -103,13 +103,15 @@ export function parseToolArgs(args: string): unknown {
 }
 
 export class OpenAIProvider implements LLMProvider {
-  readonly id = 'openai';
+  readonly id: string;
   private readonly client: OpenAI;
 
   /** `client` is injectable for tests; production passes only key + baseURL.
    *  An empty key (keyless local endpoints, #1497) is replaced with a dummy the
-   *  SDK accepts — those servers ignore it. */
-  constructor(apiKey: string, baseURL?: string, client?: OpenAI) {
+   *  SDK accepts — those servers ignore it. `id` lets a local OpenAI-compatible
+   *  endpoint report `'local'` for provenance while reusing this implementation. */
+  constructor(apiKey: string, baseURL?: string, client?: OpenAI, id = 'openai') {
+    this.id = id;
     this.client = client ?? new OpenAI({ apiKey: apiKey || 'no-key', ...(baseURL ? { baseURL } : {}) });
   }
 

--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -10,6 +10,7 @@ import type {
   ProviderCredentials,
   ProviderCredentialsUpdate,
   ProviderConfigView,
+  CustomModel,
 } from '../../shared/tools/types';
 import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { isEffort, type Effort } from '../../shared/tools/effort';
@@ -47,6 +48,25 @@ function resolveEffortSetting(stored: unknown): Effort | undefined {
 }
 
 /**
+ * Validate the persisted user-defined local models (BYOM #1497). Keeps only
+ * entries with a non-empty string id, dedupes by id (first wins), and returns
+ * undefined when none remain so the field stays omitted.
+ */
+function resolveCustomModels(stored: unknown): CustomModel[] | undefined {
+  if (!Array.isArray(stored)) return undefined;
+  const out: CustomModel[] = [];
+  const seen = new Set<string>();
+  for (const entry of stored) {
+    if (!entry || typeof entry !== 'object') continue;
+    const { id, label } = entry as Record<string, unknown>;
+    if (typeof id !== 'string' || !id.trim() || seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, ...(typeof label === 'string' && label.trim() ? { label } : {}) });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
  * Validate the persisted per-skill model override map (skill id → model id).
  * Returns undefined when absent/empty so the field stays omitted, matching the
  * optional shape. Without this, a saved override is written to disk but never
@@ -76,6 +96,7 @@ type StoredCreds = { apiKey?: string; baseURL?: string };
 interface StoredSettings {
   apiKey?: unknown;
   providers?: unknown;
+  customModels?: unknown;
   model?: unknown;
   web?: unknown;
   effort?: unknown;
@@ -159,12 +180,14 @@ export async function getSettings(): Promise<LLMSettings> {
   const parsed = await readParsed();
   const effort = resolveEffortSetting(parsed.effort);
   const toolModelOverrides = resolveToolModelOverrides(parsed.toolModelOverrides);
+  const customModels = resolveCustomModels(parsed.customModels);
   return {
     providers: decryptProviders(storedProviders(parsed)),
     model: resolveModel(parsed.model),
     web: resolveWeb(parsed.web),
     ...(effort ? { effort } : {}),
     ...(toolModelOverrides ? { toolModelOverrides } : {}),
+    ...(customModels ? { customModels } : {}),
   };
 }
 
@@ -182,6 +205,7 @@ export async function getSettingsForDisplay(): Promise<LLMSettingsView> {
   const toolModelOverrides = resolveToolModelOverrides(parsed.toolModelOverrides);
   const model = resolveModel(parsed.model);
   const providers = providerViews(storedProviders(parsed));
+  const customModels = resolveCustomModels(parsed.customModels);
   const activeProvider = providerForModel(model) ?? 'anthropic';
   const hasApiKey = providers[activeProvider]?.hasApiKey ?? false;
   return {
@@ -191,6 +215,7 @@ export async function getSettingsForDisplay(): Promise<LLMSettingsView> {
     ...(toolModelOverrides ? { toolModelOverrides } : {}),
     hasApiKey,
     providers,
+    ...(customModels ? { customModels } : {}),
   };
 }
 
@@ -210,8 +235,9 @@ function applyCredsUpdate(existing: StoredCreds | undefined, u: ProviderCredenti
 }
 
 export async function saveSettings(update: LLMSettingsUpdate): Promise<void> {
-  const { apiKey: legacyKey, providers: providerUpdates, ...rest } = update;
-  const existing = storedProviders(await readParsed());
+  const { apiKey: legacyKey, providers: providerUpdates, customModels: customModelsUpdate, ...rest } = update;
+  const parsed = await readParsed();
+  const existing = storedProviders(parsed);
   const next: Partial<Record<ProviderId, StoredCreds>> = { ...existing };
 
   if (providerUpdates) {
@@ -231,7 +257,13 @@ export async function saveSettings(update: LLMSettingsUpdate): Promise<void> {
     if (c && Object.keys(c).length > 0) providers[id] = c;
   }
 
-  const onDisk = { ...rest, providers };
+  // customModels is a full-replacement tri-state: omitted ⇒ preserve the stored
+  // list; provided (incl. []) ⇒ validate + replace.
+  const customModels = customModelsUpdate === undefined
+    ? resolveCustomModels(parsed.customModels)
+    : resolveCustomModels(customModelsUpdate);
+
+  const onDisk = { ...rest, providers, ...(customModels ? { customModels } : {}) };
   await fs.writeFile(settingsPath(), JSON.stringify(onDisk, null, 2), 'utf-8');
 }
 

--- a/src/shared/tools/models.ts
+++ b/src/shared/tools/models.ts
@@ -46,6 +46,22 @@ export const MODEL_OPTIONS: ModelOption[] = [
   { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', provider: 'google' },
 ];
 
+/**
+ * User-defined local models (BYOM #1497) as `ModelOption`s tagged `local`.
+ * `customModels` is the persisted list from settings; each entry's `label`
+ * falls back to its id.
+ */
+export function customModelOptions(customModels: { id: string; label?: string }[] | undefined): ModelOption[] {
+  return (customModels ?? [])
+    .filter((m) => m.id)
+    .map((m) => ({ value: m.id, label: m.label || m.id, provider: 'local' as const }));
+}
+
+/** The full picker catalog: built-in models + the user's local models. */
+export function allModelOptions(customModels?: { id: string; label?: string }[]): ModelOption[] {
+  return [...MODEL_OPTIONS, ...customModelOptions(customModels)];
+}
+
 export function modelLabel(value: string): string {
   return MODEL_OPTIONS.find((m) => m.value === value)?.label ?? value;
 }

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -287,6 +287,19 @@ export interface ProviderConfigView {
   baseURL?: string;
 }
 
+/**
+ * A user-defined model served by an OpenAI-compatible / local endpoint (BYOM
+ * #1497). Its `id` is the model name the endpoint expects (e.g. `llama3.1`,
+ * `qwen2.5-coder`); all custom models route to the `local` provider. Unpriced
+ * and effort-less by default — the pricing/effort tables tolerate ids they
+ * don't know.
+ */
+export interface CustomModel {
+  id: string;
+  /** Optional display label; falls back to `id`. */
+  label?: string;
+}
+
 export interface LLMSettings {
   /**
    * Per-provider credentials (BYOM #1492), keyed by provider id. Replaces the
@@ -294,6 +307,8 @@ export interface LLMSettings {
    * `providers.anthropic` on read/save.
    */
   providers: Partial<Record<ProviderId, ProviderCredentials>>;
+  /** User-defined local / OpenAI-compatible models (BYOM #1497). */
+  customModels?: CustomModel[];
   model: string;
   web?: WebSettings;
   /**
@@ -331,6 +346,8 @@ export interface LLMSettingsView {
   hasApiKey: boolean;
   /** Per-provider configuration status (BYOM #1492), for the multi-provider UI. */
   providers: Partial<Record<ProviderId, ProviderConfigView>>;
+  /** User-defined local models (BYOM #1497), echoed back for the picker/UI. */
+  customModels?: CustomModel[];
 }
 
 /**
@@ -348,6 +365,9 @@ export interface LLMSettingsUpdate {
   apiKey?: string;
   /** Per-provider credential updates (BYOM #1492), tri-state per field. */
   providers?: Partial<Record<ProviderId, ProviderCredentialsUpdate>>;
+  /** Full replacement of the user-defined local models list (BYOM #1497).
+   *  Omitted ⇒ unchanged; an empty array clears them. */
+  customModels?: CustomModel[];
   model: string;
   web?: WebSettings;
   effort?: import('./effort').Effort;

--- a/tests/main/llm/provider-factory.test.ts
+++ b/tests/main/llm/provider-factory.test.ts
@@ -53,6 +53,31 @@ describe('getProvider — provider resolution from the effective model', () => {
   });
 });
 
+describe('getProvider — local / custom models (#1497)', () => {
+  it('routes a custom model to the local provider with the configured base URL', async () => {
+    h.getSettings.mockResolvedValue({
+      providers: { local: { baseURL: 'http://localhost:11434/v1' } },
+      customModels: [{ id: 'llama3.1' }],
+      model: 'claude-opus-5',
+    });
+    const r = await getProvider('llama3.1');
+    expect(r.provider.id).toBe('local');
+    expect(r.model).toBe('llama3.1');
+  });
+
+  it('throws asking for a base URL when a custom model is selected but local has none', async () => {
+    h.getSettings.mockResolvedValue({ providers: {}, customModels: [{ id: 'llama3.1' }], model: 'claude-opus-5' });
+    await expect(getProvider('llama3.1')).rejects.toThrow(MISSING_API_KEY_MARKER);
+    await expect(getProvider('llama3.1')).rejects.toThrow(/base URL/i);
+  });
+
+  it('an unknown id that is NOT a custom model still falls back to Anthropic', async () => {
+    h.getSettings.mockResolvedValue({ providers: { anthropic: { apiKey: 'sk-ant' } }, model: 'claude-opus-5' });
+    const r = await getProvider('totally-unknown');
+    expect(r.provider.id).toBe('anthropic');
+  });
+});
+
 describe('getProvider — missing credentials', () => {
   it('throws the marker error naming OpenAI when its key is absent', async () => {
     h.getSettings.mockResolvedValue({ providers: { anthropic: { apiKey: 'sk-ant' } }, model: 'claude-opus-5' });

--- a/tests/main/llm/settings.test.ts
+++ b/tests/main/llm/settings.test.ts
@@ -192,6 +192,26 @@ describe('llm settings — API key at-rest encryption (#1326)', () => {
     });
   });
 
+  describe('custom local models (BYOM #1497)', () => {
+    it('round-trips, dedupes by id, and drops invalid/blank entries', async () => {
+      await saveSettings({
+        model: base.model,
+        customModels: [{ id: 'llama3.1', label: 'Llama' }, { id: 'llama3.1' }, { id: '  ' }, { id: 'qwen' }],
+      });
+      const expected = [{ id: 'llama3.1', label: 'Llama' }, { id: 'qwen' }];
+      expect((await getSettings()).customModels).toEqual(expected);
+      expect((await getSettingsForDisplay()).customModels).toEqual(expected);
+    });
+
+    it('omitting customModels preserves the stored list; [] clears it', async () => {
+      await saveSettings({ model: base.model, customModels: [{ id: 'llama3.1' }] });
+      await saveSettings({ model: base.model }); // omitted → preserved
+      expect((await getSettings()).customModels).toEqual([{ id: 'llama3.1' }]);
+      await saveSettings({ model: base.model, customModels: [] }); // explicit clear
+      expect((await getSettings()).customModels).toBeUndefined();
+    });
+  });
+
   describe('per-skill model overrides round-trip (#...)', () => {
     it('reads back the saved override map — the API path and the settings view', async () => {
       await saveSettings({ ...base, toolModelOverrides: { 'extract-key-claims': 'claude-opus-4-8' } });

--- a/tests/shared/model-registry-parity.test.ts
+++ b/tests/shared/model-registry-parity.test.ts
@@ -17,7 +17,7 @@
  * still render.
  */
 import { describe, it, expect } from 'vitest';
-import { MODEL_OPTIONS, MODEL_PRICING } from '../../src/shared/tools/models';
+import { MODEL_OPTIONS, MODEL_PRICING, customModelOptions, allModelOptions } from '../../src/shared/tools/models';
 import { EFFORT_ENTRY_MODEL_IDS } from '../../src/shared/tools/effort';
 import { isProviderId } from '../../src/shared/tools/providers';
 
@@ -47,5 +47,22 @@ describe('model-registry parity', () => {
     for (const m of MODEL_OPTIONS) {
       expect(isProviderId(m.provider), `${m.value} has unknown provider "${m.provider}"`).toBe(true);
     }
+  });
+});
+
+describe('custom (local) model options (#1497)', () => {
+  it('tags each custom model local, label falls back to id, blanks dropped', () => {
+    expect(customModelOptions([{ id: 'llama3.1', label: 'Llama' }, { id: 'qwen' }, { id: '' }])).toEqual([
+      { value: 'llama3.1', label: 'Llama', provider: 'local' },
+      { value: 'qwen', label: 'qwen', provider: 'local' },
+    ]);
+    expect(customModelOptions(undefined)).toEqual([]);
+  });
+
+  it('allModelOptions appends custom models after the built-in catalog', () => {
+    expect(allModelOptions([{ id: 'llama3.1' }])).toEqual([
+      ...MODEL_OPTIONS,
+      { value: 'llama3.1', label: 'llama3.1', provider: 'local' },
+    ]);
   });
 });


### PR DESCRIPTION
BYOM epic #1492 — child 5/6. The open-source payoff, reusing the OpenAI implementation. Stacks on #1502.

## What
- **Factory `local` case:** builds `OpenAIProvider` with the user's `baseURL` (`settings.providers.local.baseURL` — default Ollama `http://localhost:11434/v1`, also LM Studio / vLLM / llama.cpp / OpenRouter / Together), an **optional** key (keyless local servers), reporting id `'local'` for provenance (`OpenAIProvider` gained a trailing `id` ctor param). No base URL → a clear "set a base URL" marker error so the settings affordance fires.
- **Custom model resolution:** `resolveProviderId` now consults `settings.customModels` — a user-defined model id routes to `local`; a truly-unknown id still falls back to Anthropic.
- **Settings:** `LLMSettings`/`View`/`Update` gain `customModels` (`CustomModel { id, label? }`). `resolveCustomModels` validates (non-empty id, dedupe by id, drop blanks). Save is full-replacement tri-state: **omitted preserves** the stored list, **`[]` clears** it.
- **Shared helpers:** `customModelOptions()` tags each `local` (label ← id); `allModelOptions(custom)` = built-in catalog + custom, ready for the pickers (#1498).
- `createProviderForKey` handles `local` (for the #1498 connection check).

Custom models are unpriced + effort-less, which the pricing/effort tables already tolerate, so the parity guardrail is unaffected — no fake entries needed.

## Tests
Factory routes a custom model → `local` (with base URL; without → base-URL error; unknown-non-custom → Anthropic). Settings `customModels` round-trip (dedupe, blanks, omit-preserves, `[]`-clears). Shared `customModelOptions`/`allModelOptions`. `pnpm lint` clean; llm + shared green (1305).

## Reachable today
A local model works end-to-end once `providers.local.baseURL` + a `customModels` entry are set (settings JSON for now; the UI to manage them is #1498).

Part of #1492.