### PR TITLE
feat(llm): multi-provider settings UI + provider-grouped pickers (#1498)

### DIFF
--- a/src/main/ipc/register-tools.ts
+++ b/src/main/ipc/register-tools.ts
@@ -11,6 +11,7 @@ import type { MenuConfig } from '../../shared/skills/menu-config';
 import { getSettingsForDisplay, saveSettings, getApiKeyStorage } from '../llm/settings';
 import { checkConnection } from '../llm/validate';
 import type { ToolExecutionRequest, LLMSettingsUpdate } from '../../shared/tools/types';
+import type { ProviderId } from '../../shared/tools/providers';
 import { winFromEvent } from './helpers';
 
 export function registerTools(): void {
@@ -98,8 +99,9 @@ export function registerTools(): void {
   handle(Channels.TOOL_GET_KEY_STORAGE, () => getApiKeyStorage());
 
   // Active key validation for the settings "Check connection" button — an
-  // unsaved typed key (if any) takes precedence over the stored one.
-  handle(Channels.TOOL_CHECK_CONNECTION, (_e, candidateKey?: string) =>
-    checkConnection(candidateKey),
+  // unsaved typed key (if any) takes precedence over the stored one. Per
+  // provider (BYOM #1498); baseURL lets a local endpoint be tested unsaved.
+  handle(Channels.TOOL_CHECK_CONNECTION, (_e, providerId: ProviderId, candidateKey?: string, baseURL?: string) =>
+    checkConnection(providerId, candidateKey, baseURL),
   );
 }

--- a/src/main/llm/settings.ts
+++ b/src/main/llm/settings.ts
@@ -15,10 +15,8 @@ import type {
 import { DEFAULT_WEB_SETTINGS } from '../../shared/tools/types';
 import { isEffort, type Effort } from '../../shared/tools/effort';
 import { PROVIDERS, PROVIDER_IDS, type ProviderId } from '../../shared/tools/providers';
-import { providerForModel } from '../../shared/tools/models';
+import { providerForModel, DEFAULT_MODEL } from '../../shared/tools/models';
 import { encryptSecret, decryptSecret, isEncrypted, secretEncryptionAvailable } from '../secret-storage';
-
-const DEFAULT_MODEL = 'claude-opus-5';
 
 const DEPRECATED_MODELS = new Set<string>([
   'claude-sonnet-4-20250514',

--- a/src/main/llm/validate.ts
+++ b/src/main/llm/validate.ts
@@ -2,28 +2,41 @@
  * Active API-key validation for the settings "Check connection" button (#...).
  *
  * The `hasApiKey` flag is a presence check — it says something is stored, not
- * that Anthropic will accept it. This makes a real, *free* request
- * (`models.list`, a GET that spends no tokens) via the provider so an expired /
- * revoked / mistyped key surfaces immediately instead of on the next message.
+ * that the provider will accept it. This makes a real, *free* request via the
+ * provider so an expired / revoked / mistyped key (or an unreachable local
+ * endpoint) surfaces immediately instead of on the next message.
  *
- * Validates the *effective* key: a non-empty `candidateKey` (an unsaved value
- * still in the settings input) takes precedence, so the user can test a key
- * before committing it; otherwise the stored key (or `ANTHROPIC_API_KEY`) is
- * used via `getSettings()`.
+ * Validates the *effective* credentials for the chosen provider (BYOM #1498): a
+ * non-empty `candidateKey` (an unsaved value still in the settings input) takes
+ * precedence; otherwise the stored key for that provider is used via
+ * `getSettings()`. `baseURL` lets a local / OpenAI-compatible endpoint be tested
+ * before it's saved.
  *
- * The actual request lives in the provider (the only place the Anthropic SDK is
- * imported, per the #1148 seam); this module owns key resolution and the pure
- * error → reason mapping.
+ * The actual request lives in the provider (the only place a provider SDK is
+ * imported, per the #1148 seam); this module owns credential resolution.
  */
 import { createProviderForKey } from './provider';
 import { getSettings } from './settings';
+import { PROVIDERS, type ProviderId } from '../../shared/tools/providers';
 import type { ConnectionCheckResult } from '../../shared/tools/types';
 
-export async function checkConnection(candidateKey?: string): Promise<ConnectionCheckResult> {
+export async function checkConnection(
+  providerId: ProviderId,
+  candidateKey?: string,
+  baseURL?: string,
+): Promise<ConnectionCheckResult> {
+  const settings = await getSettings();
+  const stored = settings.providers[providerId];
   const typed = candidateKey?.trim();
-  const key = typed && typed.length > 0 ? typed : (await getSettings()).providers.anthropic?.apiKey;
-  if (!key) {
+  const key = typed && typed.length > 0 ? typed : (stored?.apiKey ?? '');
+  const effectiveBaseURL = baseURL?.trim() || stored?.baseURL;
+
+  // Keyless providers (local) just need an endpoint; keyed providers need a key.
+  if (PROVIDERS[providerId].requiresKey && !key) {
     return { ok: false, error: 'No API key to check — enter one above or save it first.' };
   }
-  return createProviderForKey('anthropic', key).checkConnection();
+  if (PROVIDERS[providerId].usesBaseURL && !effectiveBaseURL) {
+    return { ok: false, error: 'No base URL to check — enter the endpoint above first.' };
+  }
+  return createProviderForKey(providerId, key, effectiveBaseURL).checkConnection();
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -437,8 +437,8 @@ contextBridge.exposeInMainWorld('api', {
     getSettings: () => invoke(Channels.TOOL_GET_SETTINGS),
     setSettings: (settings: Parameters<ChannelMap['tool:setSettings']>[0]) => invoke(Channels.TOOL_SET_SETTINGS, settings),
     getKeyStorage: () => invoke(Channels.TOOL_GET_KEY_STORAGE),
-    checkConnection: (candidateKey?: string) =>
-      invoke(Channels.TOOL_CHECK_CONNECTION, candidateKey),
+    checkConnection: (providerId: Parameters<ChannelMap['tool:checkConnection']>[0], candidateKey?: string, baseURL?: string) =>
+      invoke(Channels.TOOL_CHECK_CONNECTION, providerId, candidateKey, baseURL),
     onInvoke: (cb: (toolId: string) => void) => subscribeIpc(Channels.TOOL_INVOKE, cb),
   },
   skills: {

--- a/src/renderer/lib/components/AiSettings.svelte
+++ b/src/renderer/lib/components/AiSettings.svelte
@@ -1,86 +1,138 @@
 <script lang="ts">
   /**
-   * AI settings panel (default model + Anthropic API key, extracted from
-   * SettingsDialog for #672). Per-skill model overrides now live inline in
-   * the Skills panel.
+   * AI settings panel (BYOM #1498). Multi-provider: a default-model picker
+   * grouped by provider, a default reasoning-effort picker, one credential
+   * section per provider (API key and/or base URL + a connection check), and a
+   * manager for user-defined local models.
    *
-   * Unlike the other settings panels, the AI settings are persisted by the
-   * dialog's Done handler (so the key + model apply together), not on each
-   * edit. So this panel is presentational: the dialog owns the state and the
-   * save, and binds it here via `$bindable` props. `apiKeyStatus` is
-   * read-only (reflects what's already stored).
+   * Presentational: SettingsDialog owns the state (so keys + model apply
+   * together on Done) and binds it here. `providerViews` is the read-only
+   * loaded status (never carries a plaintext key).
    */
-  import { MODEL_OPTIONS } from '../../../shared/tools/models';
+  import { groupedModelOptions } from '../../../shared/tools/models';
   import { EFFORT_LEVELS, type Effort } from '../../../shared/tools/effort';
-  import type { ApiKeyStorage, ConnectionCheckResult } from '../../../shared/tools/types';
+  import { PROVIDERS, PROVIDER_IDS, type ProviderId } from '../../../shared/tools/providers';
+  import type { ProviderConfigView, CustomModel, ConnectionCheckResult } from '../../../shared/tools/types';
   import { voiceSettings, VOICE_MODEL_OPTIONS } from '../voice/voice-settings.svelte';
+
+  /** Per-provider input state (structurally shared with SettingsDialog, which
+   *  owns it — kept in sync by shape, not import, to avoid cross-component type
+   *  exports). */
+  interface ProviderInput {
+    /** Unsaved typed key (blank ⇒ keep the stored one). */
+    key: string;
+    /** Endpoint for providers that use one (local). */
+    baseURL: string;
+    /** Clear the stored key on save. */
+    clear: boolean;
+  }
 
   interface Props {
     model: string;
     effort: Effort | undefined;
-    apiKeyInput: string;
-    clearApiKey: boolean;
-    apiKeyStatus: 'unknown' | 'set' | 'unset';
-    /** At-rest storage status of the saved key (#1326). Null while loading. */
-    keyStorage: ApiKeyStorage | null;
-    /** Actively validate a key against Anthropic — the typed value if present,
-     *  else the stored one. */
-    onCheckConnection: (candidateKey: string) => Promise<ConnectionCheckResult>;
+    /** Per-provider input state, keyed by provider id. */
+    providerInputs: Record<ProviderId, ProviderInput>;
+    /** Loaded per-provider status (no plaintext keys). */
+    providerViews: Partial<Record<ProviderId, ProviderConfigView>>;
+    /** Whether OS secure storage is available (machine-wide) — drives the
+     *  "encrypted at rest" claim honestly. */
+    secureStorageAvailable: boolean;
+    /** User-defined local models. */
+    customModels: CustomModel[];
+    onCheckConnection: (providerId: ProviderId, candidateKey: string, baseURL: string) => Promise<ConnectionCheckResult>;
   }
 
   let {
     model = $bindable(),
     effort = $bindable(),
-    apiKeyInput = $bindable(),
-    clearApiKey = $bindable(),
-    apiKeyStatus,
-    keyStorage,
+    providerInputs = $bindable(),
+    providerViews,
+    secureStorageAvailable,
+    customModels = $bindable(),
     onCheckConnection,
   }: Props = $props();
 
-  // The saved key is protected at rest only when it's actually encrypted on
-  // disk — reflect that literally, don't claim security we don't have.
-  const keyEncrypted = $derived(apiKeyStatus === 'set' && !clearApiKey && keyStorage?.encrypted === true);
+  const groups = $derived(groupedModelOptions(customModels));
 
-  // "Check connection" — a presence check (✓ API key saved) doesn't prove
-  // Anthropic will accept the key; this fires a real request on demand.
-  let checking = $state(false);
-  let checkResult = $state<ConnectionCheckResult | null>(null);
-  // A stale result must not linger after the key text changes.
-  $effect(() => { void apiKeyInput; checkResult = null; });
-  // Nothing to check when clearing, or when there's neither a stored key nor a
-  // typed one.
-  const canCheck = $derived(!clearApiKey && (apiKeyStatus === 'set' || apiKeyInput.trim().length > 0));
-
-  async function runCheck() {
-    if (checking) return;
-    checking = true;
-    checkResult = null;
-    try {
-      checkResult = await onCheckConnection(apiKeyInput);
-    } catch (e) {
-      checkResult = { ok: false, error: e instanceof Error ? e.message : String(e) };
-    } finally {
-      checking = false;
-    }
-  }
-
-  // '' in the <select> means "no override → built-in default"; map to/from
-  // the optional `effort` prop.
   function onEffortChange(e: Event) {
     const v = (e.currentTarget as HTMLSelectElement).value;
     effort = v ? (v as Effort) : undefined;
+  }
+
+  // Per-provider "check connection" state.
+  const checkState = $state<Record<string, { checking: boolean; result: ConnectionCheckResult | null }>>(
+    Object.fromEntries(PROVIDER_IDS.map((id) => [id, { checking: false, result: null }])),
+  );
+
+  /** Reassign a provider's input (rather than mutate in place) so the change is
+   *  reactive whether the parent bound a `$state` proxy or a plain object. */
+  function setInput(id: ProviderId, patch: Partial<{ key: string; baseURL: string; clear: boolean }>) {
+    providerInputs = { ...providerInputs, [id]: { ...providerInputs[id], ...patch } };
+  }
+
+  function canCheck(id: ProviderId): boolean {
+    const meta = PROVIDERS[id];
+    const inp = providerInputs[id];
+    const view = providerViews[id];
+    if (inp.clear) return false;
+    if (meta.requiresKey && !(view?.hasApiKey || inp.key.trim())) return false;
+    if (meta.usesBaseURL && !(inp.baseURL.trim() || view?.baseURL)) return false;
+    return true;
+  }
+
+  async function runCheck(id: ProviderId) {
+    const st = checkState[id]!;
+    if (st.checking) return;
+    st.checking = true;
+    st.result = null;
+    try {
+      st.result = await onCheckConnection(id, providerInputs[id].key, providerInputs[id].baseURL);
+    } catch (e) {
+      st.result = { ok: false, error: e instanceof Error ? e.message : String(e) };
+    } finally {
+      st.checking = false;
+    }
+  }
+
+  // A stale check result must not linger after its key/base-URL is edited.
+  $effect(() => {
+    for (const id of PROVIDER_IDS) {
+      void providerInputs[id].key;
+      void providerInputs[id].baseURL;
+    }
+    for (const id of PROVIDER_IDS) checkState[id]!.result = null;
+  });
+
+  // Custom (local) model management.
+  let newModelId = $state('');
+  let newModelLabel = $state('');
+  function addCustomModel() {
+    const id = newModelId.trim();
+    if (!id || customModels.some((m) => m.id === id)) return;
+    const label = newModelLabel.trim();
+    customModels = [...customModels, { id, ...(label ? { label } : {}) }];
+    newModelId = '';
+    newModelLabel = '';
+  }
+  function removeCustomModel(id: string) {
+    customModels = customModels.filter((m) => m.id !== id);
   }
 </script>
 
 <div class="field">
   <label for="model">Default model</label>
   <select id="model" bind:value={model}>
-    {#each MODEL_OPTIONS as m}
-      <option value={m.value}>{m.label}</option>
+    {#each groups as g (g.provider)}
+      <optgroup label={g.label}>
+        {#each g.models as m (m.value)}
+          <option value={m.value}>{m.label}</option>
+        {/each}
+      </optgroup>
     {/each}
   </select>
+  <p class="hint">Per-conversation and per-skill pickers can override this.</p>
 </div>
+
 <div class="field">
   <label for="effort">Default reasoning effort</label>
   <select id="effort" value={effort ?? ''} onchange={onEffortChange}>
@@ -91,79 +143,142 @@
   </select>
   <p class="hint">
     Higher effort lets the model think longer. Leave on “Model default” to send
-    no preference. Per-conversation overrides take precedence. Not all models
-    support every level — the per-conversation picker only offers what the chosen
-    model accepts (Haiku has no effort control), and “Extra” is Opus-only.
+    no preference. Not all models support every level — each provider maps this
+    to its own control, and unsupported levels are clamped.
   </p>
-</div>
-<div class="field">
-  <div class="api-key-status" class:saved={apiKeyStatus === 'set' && !clearApiKey}>
-    {#if apiKeyStatus === 'unknown'}
-      Loading…
-    {:else if clearApiKey}
-      API key will be cleared on save
-    {:else if keyEncrypted}
-      🔒 API key saved — encrypted at rest
-    {:else if apiKeyStatus === 'set'}
-      ✓ API key saved
-    {:else}
-      No API key set
-    {/if}
-  </div>
-  <label for="api-key">
-    Anthropic API key
-  </label>
-  <input
-    id="api-key"
-    type="password"
-    bind:value={apiKeyInput}
-    placeholder={apiKeyStatus === 'set' ? 'Type to replace existing key' : 'Enter Anthropic API key'}
-    autocomplete="off"
-    spellcheck="false"
-    autocapitalize="off"
-    oncopy={(e) => e.preventDefault()}
-    oncut={(e) => e.preventDefault()}
-    oncontextmenu={(e) => e.preventDefault()}
-    disabled={clearApiKey}
-  />
-  <p class="hint">
-    {#if keyStorage?.available}
-      Your key is encrypted at rest with your operating system's secure storage
-      (Keychain on macOS, Credential Manager on Windows, libsecret on Linux).
-    {:else if keyStorage}
-      No system secure store is available here, so the key is saved as plain text
-      in your user data directory.
-    {:else}
-      The key is stored in your user data directory.
-    {/if}
-    The saved value is never displayed back. You can also set
-    <code>ANTHROPIC_API_KEY</code> as an environment variable.
-  </p>
-  <div class="check-conn">
-    <button class="btn-check" onclick={runCheck} disabled={!canCheck || checking}>
-      {checking ? 'Checking…' : 'Check connection'}
-    </button>
-    {#if checkResult}
-      <span class="check-result" class:ok={checkResult.ok} class:bad={!checkResult.ok}>
-        {#if checkResult.ok}✓ Connected — Anthropic accepted the key.{:else}✗ {checkResult.error}{/if}
-      </span>
-    {/if}
-  </div>
-  {#if apiKeyStatus === 'set' && !clearApiKey}
-    <button class="link-btn" onclick={() => { clearApiKey = true; apiKeyInput = ''; }}>
-      Clear saved key
-    </button>
-  {:else if clearApiKey}
-    <button class="link-btn" onclick={() => { clearApiKey = false; }}>
-      Cancel clear
-    </button>
-  {/if}
 </div>
 
-<!-- Voice/dictation (#voice). Unlike the model/key above (saved by the dialog
-     on Done), these are renderer-local prefs persisted immediately to
-     localStorage by the voiceSettings store — the transcriber runs entirely in
-     the renderer, so main never needs them. -->
+<!-- One credential section per provider. -->
+{#each PROVIDER_IDS as id (id)}
+  {@const meta = PROVIDERS[id]}
+  {@const view = providerViews[id]}
+  {@const inp = providerInputs[id]}
+  {@const check = checkState[id]}
+  <div class="provider-section">
+    <div class="provider-head">{meta.label}</div>
+
+    {#if meta.requiresKey}
+      <div class="field">
+        <div class="api-key-status" class:saved={view?.hasApiKey && !inp.clear}>
+          {#if inp.clear}
+            API key will be cleared on save
+          {:else if view?.hasApiKey && secureStorageAvailable}
+            🔒 API key saved — encrypted at rest
+          {:else if view?.hasApiKey}
+            ✓ API key saved
+          {:else}
+            No API key set
+          {/if}
+        </div>
+        <input
+          type="password"
+          bind:value={inp.key}
+          placeholder={view?.hasApiKey ? 'Type to replace existing key' : `Enter ${meta.label} API key`}
+          autocomplete="off"
+          spellcheck="false"
+          autocapitalize="off"
+          oncopy={(e) => e.preventDefault()}
+          oncut={(e) => e.preventDefault()}
+          oncontextmenu={(e) => e.preventDefault()}
+          disabled={inp.clear}
+        />
+        {#if view?.hasApiKey && !inp.clear}
+          <button class="link-btn" onclick={() => setInput(id, { clear: true, key: '' })}>Clear saved key</button>
+        {:else if inp.clear}
+          <button class="link-btn" onclick={() => setInput(id, { clear: false })}>Cancel clear</button>
+        {/if}
+      </div>
+    {/if}
+
+    {#if meta.usesBaseURL}
+      <div class="field">
+        <label for="baseurl-{id}">Base URL</label>
+        <input
+          id="baseurl-{id}"
+          type="text"
+          bind:value={inp.baseURL}
+          placeholder={meta.defaultBaseURL ?? 'https://…/v1'}
+          autocomplete="off"
+          spellcheck="false"
+          autocapitalize="off"
+        />
+        <p class="hint">
+          Any OpenAI-compatible endpoint — Ollama, LM Studio, vLLM, llama.cpp,
+          OpenRouter, Together. Add the models it serves below.
+        </p>
+      </div>
+    {/if}
+
+    <div class="check-conn">
+      <button class="btn-check" onclick={() => runCheck(id)} disabled={!canCheck(id) || check?.checking}>
+        {check?.checking ? 'Checking…' : 'Check connection'}
+      </button>
+      {#if check?.result}
+        <span class="check-result" class:ok={check.result.ok} class:bad={!check.result.ok}>
+          {#if check.result.ok}✓ Connected — {meta.label} accepted it.{:else}✗ {check.result.error}{/if}
+        </span>
+      {/if}
+    </div>
+
+    {#if meta.envVar}
+      <p class="hint">You can also set <code>{meta.envVar}</code> as an environment variable.</p>
+    {/if}
+
+    {#if id === 'local'}
+      <div class="field">
+        <span class="pseudo-label">Local models</span>
+        {#if customModels.length > 0}
+          <ul class="custom-model-list">
+            {#each customModels as m (m.id)}
+              <li>
+                <span class="custom-model-name">{m.label ? `${m.label} · ${m.id}` : m.id}</span>
+                <button class="link-btn" onclick={() => removeCustomModel(m.id)}>Remove</button>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="hint">No local models added yet.</p>
+        {/if}
+        <div class="add-model-row">
+          <input
+            type="text"
+            bind:value={newModelId}
+            placeholder="Model id (e.g. llama3.1)"
+            autocomplete="off"
+            spellcheck="false"
+            onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCustomModel(); } }}
+          />
+          <input
+            type="text"
+            bind:value={newModelLabel}
+            placeholder="Label (optional)"
+            autocomplete="off"
+            spellcheck="false"
+            onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCustomModel(); } }}
+          />
+          <button class="btn-check" onclick={addCustomModel} disabled={!newModelId.trim()}>Add</button>
+        </div>
+      </div>
+    {/if}
+  </div>
+{/each}
+
+<div class="field">
+  <p class="hint">
+    {#if secureStorageAvailable}
+      Keys are encrypted at rest with your operating system's secure storage
+      (Keychain on macOS, Credential Manager on Windows, libsecret on Linux).
+    {:else}
+      No system secure store is available here, so keys are saved as plain text
+      in your user data directory.
+    {/if}
+    Saved keys are never displayed back.
+  </p>
+</div>
+
+<!-- Voice/dictation (#voice). Renderer-local prefs persisted immediately to
+     localStorage by the voiceSettings store — the transcriber runs in the
+     renderer, so main never needs them. -->
 <div class="field">
   <label class="checkbox-row">
     <input type="checkbox" bind:checked={voiceSettings.enabled} />
@@ -193,7 +308,8 @@
     color: var(--text);
     font-size: 12px;
   }
-  .field label { color: var(--text); }
+  .field label,
+  .pseudo-label { color: var(--text); font-size: 12px; }
   .field.disabled { opacity: 0.5; }
   .checkbox-row {
     flex-direction: row;
@@ -203,6 +319,7 @@
   }
   .checkbox-row input { cursor: pointer; }
   .field input[type="password"],
+  .field input[type="text"],
   .field select {
     padding: 5px 8px;
     background: var(--bg);
@@ -212,7 +329,7 @@
     font-size: 12px;
     font-family: inherit;
   }
-  .field input[type="password"]:focus,
+  .field input:focus,
   .field select:focus {
     outline: none;
     border-color: var(--accent);
@@ -242,15 +359,48 @@
   }
   .link-btn:hover { color: var(--text); }
 
-  /* AI panel — API key status. */
+  /* Per-provider credential section. */
+  .provider-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 0;
+    border-top: 1px solid var(--border);
+  }
+  .provider-head {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text);
+  }
+
   .api-key-status {
     font-size: 11px;
     color: var(--text-muted);
-    margin-bottom: 4px;
   }
-  .api-key-status.saved {
-    color: var(--accent);
+  .api-key-status.saved { color: var(--accent); }
+
+  .custom-model-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
   }
+  .custom-model-list li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .custom-model-list .link-btn { margin-top: 0; }
+  .custom-model-name { font-size: 12px; }
+  .add-model-row {
+    display: flex;
+    gap: 6px;
+    margin-top: 4px;
+  }
+  .add-model-row input { flex: 1; min-width: 0; }
 
   /* Check-connection row: a small button + an inline result. Success uses
      --sage, failure --rust (signal colors, not red — per CLAUDE.md). */
@@ -259,7 +409,6 @@
     align-items: center;
     gap: 10px;
     flex-wrap: wrap;
-    margin-top: 8px;
   }
   .btn-check {
     padding: 4px 12px;
@@ -269,12 +418,11 @@
     color: var(--text);
     font-size: 11px;
     cursor: pointer;
+    white-space: nowrap;
   }
   .btn-check:hover:not(:disabled) { border-color: var(--accent); }
   .btn-check:disabled { opacity: 0.5; cursor: default; }
-  .check-result {
-    font-size: 11px;
-  }
+  .check-result { font-size: 11px; }
   .check-result.ok { color: var(--sage); }
   .check-result.bad { color: var(--rust); }
 </style>

--- a/src/renderer/lib/components/ConversationsPanel.svelte
+++ b/src/renderer/lib/components/ConversationsPanel.svelte
@@ -5,7 +5,8 @@
   import { getDialogStore } from '../stores/dialogs.svelte';
   import { CONFIRM_KEYS } from '../confirm-keys';
   import { api } from '../ipc/client';
-  import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
+  import { groupedModelOptions, modelLabel, DEFAULT_MODEL } from '../../../shared/tools/models';
+  import type { CustomModel } from '../../../shared/tools/types';
   import {
     EFFORT_LEVELS,
     supportedEfforts,
@@ -52,6 +53,8 @@
   // user can see which concrete model "default" resolves to.
   let defaultModel = $state<string | null>(null);
   let defaultEffort = $state<Effort | undefined>(undefined);
+  // User-defined local models, merged into the picker (BYOM #1498).
+  let customModels = $state<CustomModel[]>([]);
   // Width-of-tab-bar overflow handling deferred to polish (#505).
 
   onMount(async () => {
@@ -63,6 +66,7 @@
       const s = await api.tools.getSettings();
       defaultModel = s.model ?? null;
       defaultEffort = s.effort;
+      customModels = s.customModels ? [...s.customModels] : [];
     } catch { /* settings unavailable; picker still works without the label */ }
   });
 
@@ -106,7 +110,7 @@
   /** Resolve the model a conversation actually runs on (override → global
    *  default → built-in fallback), for gating the effort picker. */
   function effectiveModel(model: string | undefined): string {
-    return model ?? defaultModel ?? 'claude-opus-5';
+    return model ?? defaultModel ?? DEFAULT_MODEL;
   }
 
   async function handleModelChange(tabId: string, e: Event) {
@@ -242,8 +246,12 @@
             title="Model used for this conversation"
           >
             <option value="">{defaultModel ? `Default (${modelLabel(defaultModel)})` : 'Default'}</option>
-            {#each MODEL_OPTIONS.filter((m) => m.value !== defaultModel) as m}
-              <option value={m.value}>{m.label}</option>
+            {#each groupedModelOptions(customModels) as g (g.provider)}
+              <optgroup label={g.label}>
+                {#each g.models as m (m.value)}
+                  <option value={m.value}>{m.label}</option>
+                {/each}
+              </optgroup>
             {/each}
           </select>
           {#if modelSupportsEffort(effectiveModel(tab.conversation.model))}

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -53,6 +53,19 @@
   import SkillsSettings from './SkillsSettings.svelte';
   import BibliographySettings from './BibliographySettings.svelte';
   import AiSettings from './AiSettings.svelte';
+  import { DEFAULT_MODEL } from '../../../shared/tools/models';
+  import { PROVIDERS, PROVIDER_IDS, type ProviderId } from '../../../shared/tools/providers';
+  import type { ProviderConfigView, ProviderCredentialsUpdate, CustomModel } from '../../../shared/tools/types';
+
+  /** Per-provider input state; matches AiSettings's structural shape. */
+  interface ProviderInput { key: string; baseURL: string; clear: boolean }
+
+  /** Fresh, empty per-provider input state (BYOM #1498). */
+  function emptyProviderInputs(): Record<ProviderId, ProviderInput> {
+    return Object.fromEntries(
+      PROVIDER_IDS.map((id) => [id, { key: '', baseURL: '', clear: false }]),
+    ) as Record<ProviderId, ProviderInput>;
+  }
 
   interface Props {
     onApplyEditor: (s: EditorSettings) => void;
@@ -290,12 +303,13 @@
   let clipper = $state<import('../../../shared/clipper-pairing').ClipperState | null>(null);
   let clipperRevealed = $state(false);
   let clipperCopied = $state(false);
-  let model = $state('claude-opus-5');
+  let model = $state(DEFAULT_MODEL);
   let effort = $state<import('../../../shared/tools/effort').Effort | undefined>(undefined);
-  let apiKeyInput = $state('');
-  let apiKeyStatus = $state<'unknown' | 'set' | 'unset'>('unknown');
-  let clearApiKey = $state(false);
-  let keyStorage = $state<import('../../../shared/tools/types').ApiKeyStorage | null>(null);
+  // Per-provider credential inputs + loaded status (BYOM #1498).
+  let providerInputs = $state<Record<ProviderId, ProviderInput>>(emptyProviderInputs());
+  let providerViews = $state<Partial<Record<ProviderId, ProviderConfigView>>>({});
+  let secureStorageAvailable = $state(false);
+  let customModels = $state<CustomModel[]>([]);
 
   let toolModelOverrides = $state<Record<string, string>>({});
 
@@ -310,9 +324,14 @@
       const s = await api.tools.getSettings();
       model = s.model;
       effort = s.effort;
-      apiKeyStatus = s.hasApiKey ? 'set' : 'unset';
+      providerViews = s.providers ?? {};
+      customModels = s.customModels ? [...s.customModels] : [];
+      // Prefill base-URL inputs from stored config so the user sees/edits them.
+      for (const id of PROVIDER_IDS) {
+        providerInputs[id].baseURL = s.providers?.[id]?.baseURL ?? '';
+      }
       try {
-        keyStorage = await api.tools.getKeyStorage();
+        secureStorageAvailable = (await api.tools.getKeyStorage()).available;
       } catch (e) {
         console.error('[settings] failed to load key storage status:', e);
       }
@@ -389,9 +408,22 @@
     setFontFamily(fontFamily);
     onThemeChanged();
 
-    // Web + AI — build the settings update and save. The apiKey is tri-state:
-    // clear → '', a typed value → that key, otherwise OMIT it so main preserves
-    // the stored key without decrypting (the dialog never held the plaintext).
+    // Web + AI — build the settings update and save. Per-provider keys are
+    // tri-state (BYOM #1498): clear → '', a typed value → that key, otherwise
+    // OMIT so main preserves the stored key without decrypting; base URLs send
+    // their current value (trimmed; '' clears).
+    const providerUpdates: Partial<Record<ProviderId, ProviderCredentialsUpdate>> = {};
+    for (const id of PROVIDER_IDS) {
+      const meta = PROVIDERS[id];
+      const inp = providerInputs[id];
+      const upd: ProviderCredentialsUpdate = {};
+      if (meta.requiresKey) {
+        if (inp.clear) upd.apiKey = '';
+        else if (inp.key) upd.apiKey = inp.key;
+      }
+      if (meta.usesBaseURL) upd.baseURL = inp.baseURL.trim();
+      if (Object.keys(upd).length > 0) providerUpdates[id] = upd;
+    }
     const next: LLMSettingsUpdate = {
       model,
       web: {
@@ -401,7 +433,8 @@
       },
       ...(effort ? { effort } : {}),
       ...(Object.keys(toolModelOverrides).length > 0 ? { toolModelOverrides } : {}),
-      ...(clearApiKey ? { apiKey: '' } : apiKeyInput ? { apiKey: apiKeyInput } : {}),
+      ...(Object.keys(providerUpdates).length > 0 ? { providers: providerUpdates } : {}),
+      customModels,
     };
     try {
       await settings.setToolSettings(next);
@@ -963,7 +996,7 @@
           <BibliographySettings />
 
         {:else if activeTab === 'skills'}
-          <SkillsSettings bind:toolModelOverrides defaultModel={model} />
+          <SkillsSettings bind:toolModelOverrides defaultModel={model} {customModels} />
 
         {:else if activeTab === 'compute'}
           <ComputeSettings />
@@ -972,11 +1005,11 @@
           <AiSettings
             bind:model
             bind:effort
-            bind:apiKeyInput
-            bind:clearApiKey
-            {apiKeyStatus}
-            {keyStorage}
-            onCheckConnection={(candidateKey) => api.tools.checkConnection(candidateKey)}
+            bind:providerInputs
+            bind:customModels
+            {providerViews}
+            {secureStorageAvailable}
+            onCheckConnection={(providerId, candidateKey, baseURL) => api.tools.checkConnection(providerId, candidateKey, baseURL)}
           />
         {/if}
       </section>

--- a/src/renderer/lib/components/SkillsSettings.svelte
+++ b/src/renderer/lib/components/SkillsSettings.svelte
@@ -23,7 +23,8 @@
   } from '../../../shared/skills/menu-config';
   import { registerSkillInfos } from '../tools/tool-registry';
   import { getSettingsStore } from '../stores/settings.svelte';
-  import { MODEL_OPTIONS, modelLabel } from '../../../shared/tools/models';
+  import { groupedModelOptions, modelLabel } from '../../../shared/tools/models';
+  import type { CustomModel } from '../../../shared/tools/types';
 
   const settings = getSettingsStore();
 
@@ -36,8 +37,10 @@
      *  preference resolves to this, so the empty option names it instead of
      *  saying a bare "Default model". */
     defaultModel?: string;
+    /** User-defined local models, merged into each skill's picker (BYOM #1498). */
+    customModels?: CustomModel[];
   }
-  let { toolModelOverrides = $bindable({}), defaultModel }: Props = $props();
+  let { toolModelOverrides = $bindable({}), defaultModel, customModels }: Props = $props();
 
   /** Label for a skill row's empty ("use the default") model option. The
    *  resolution order at run time is: this skill's `model:` preference, then
@@ -275,8 +278,12 @@
                   onchange={(e) => setToolOverride(s.id, e.currentTarget.value)}
                 >
                   <option value="">{defaultOptionLabel(s.model)}</option>
-                  {#each MODEL_OPTIONS as m (m.value)}
-                    <option value={m.value}>{m.label}</option>
+                  {#each groupedModelOptions(customModels) as g (g.provider)}
+                    <optgroup label={g.label}>
+                      {#each g.models as m (m.value)}
+                        <option value={m.value}>{m.label}</option>
+                      {/each}
+                    </optgroup>
                   {/each}
                 </select>
                 {#if s.source === 'user'}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -692,9 +692,14 @@ export interface ToolsApi {
   getSettings(): Promise<import('../../../shared/tools/types').LLMSettingsView>;
   setSettings(update: import('../../../shared/tools/types').LLMSettingsUpdate): Promise<void>;
   getKeyStorage(): Promise<import('../../../shared/tools/types').ApiKeyStorage>;
-  /** Actively validate an API key against Anthropic. Pass the unsaved typed key
-   *  to test it before saving; omit/empty to test the stored key. */
-  checkConnection(candidateKey?: string): Promise<import('../../../shared/tools/types').ConnectionCheckResult>;
+  /** Actively validate a provider's credentials. Pass the unsaved typed key
+   *  (and baseURL, for local) to test before saving; omit/empty to test the
+   *  stored values (BYOM #1498). */
+  checkConnection(
+    providerId: import('../../../shared/tools/providers').ProviderId,
+    candidateKey?: string,
+    baseURL?: string,
+  ): Promise<import('../../../shared/tools/types').ConnectionCheckResult>;
   onInvoke(cb: (toolId: string) => void): void;
 }
 

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -55,6 +55,7 @@ import type {
   ConnectionCheckResult,
 } from './tools/types';
 import type { SkillCatalogInfo } from './skills/types';
+import type { ProviderId } from './tools/providers';
 import type { MenuConfig } from './skills/menu-config';
 import type {
   SourceMetadata,
@@ -358,7 +359,7 @@ export interface ChannelMap {
   'tool:getSettings': () => LLMSettingsView;
   'tool:setSettings': (update: LLMSettingsUpdate) => void;
   'tool:getKeyStorage': () => ApiKeyStorage;
-  'tool:checkConnection': (candidateKey?: string) => ConnectionCheckResult;
+  'tool:checkConnection': (providerId: ProviderId, candidateKey?: string, baseURL?: string) => ConnectionCheckResult;
 
   // Skills (markdown skill files — #622)
   'skills:list': () => SkillCatalogInfo;

--- a/src/shared/tools/models.ts
+++ b/src/shared/tools/models.ts
@@ -12,7 +12,11 @@
  * allowlist.
  */
 
-import type { ProviderId } from './providers';
+import { PROVIDERS, PROVIDER_IDS, type ProviderId } from './providers';
+
+/** The default model for fresh installs / unset configs. Single source of
+ *  truth shared by main (settings.ts) and the renderer's picker fallbacks. */
+export const DEFAULT_MODEL = 'claude-opus-5';
 
 export interface ModelOption {
   value: string;
@@ -60,6 +64,24 @@ export function customModelOptions(customModels: { id: string; label?: string }[
 /** The full picker catalog: built-in models + the user's local models. */
 export function allModelOptions(customModels?: { id: string; label?: string }[]): ModelOption[] {
   return [...MODEL_OPTIONS, ...customModelOptions(customModels)];
+}
+
+export interface ModelGroup {
+  provider: ProviderId;
+  label: string;
+  models: ModelOption[];
+}
+
+/**
+ * The picker catalog grouped by provider (for `<optgroup>`s), in provider
+ * display order. Empty groups (a provider with no configured/built-in models)
+ * are omitted. `customModels` adds the user's local models to the `local` group.
+ */
+export function groupedModelOptions(customModels?: { id: string; label?: string }[]): ModelGroup[] {
+  const all = allModelOptions(customModels);
+  return PROVIDER_IDS
+    .map((provider) => ({ provider, label: PROVIDERS[provider].label, models: all.filter((m) => m.provider === provider) }))
+    .filter((g) => g.models.length > 0);
 }
 
 export function modelLabel(value: string): string {

--- a/tests/main/llm/validate.test.ts
+++ b/tests/main/llm/validate.test.ts
@@ -25,32 +25,51 @@ beforeEach(() => {
   h.createProviderForKey.mockReturnValue({ checkConnection: h.providerCheck });
 });
 
-describe('checkConnection — key resolution', () => {
-  it('validates a typed key (trimmed) without touching stored settings', async () => {
-    const res = await checkConnection('  sk-typed  ');
+describe('checkConnection — credential resolution', () => {
+  it('validates a typed key (trimmed), preferring it over the stored one', async () => {
+    const res = await checkConnection('anthropic', '  sk-typed  ');
     expect(res).toEqual({ ok: true });
-    expect(h.getSettings).not.toHaveBeenCalled();
-    expect(h.createProviderForKey).toHaveBeenCalledWith('anthropic', 'sk-typed');
+    expect(h.createProviderForKey).toHaveBeenCalledWith('anthropic', 'sk-typed', undefined);
   });
 
-  it('falls back to the stored key when no candidate is given', async () => {
-    await checkConnection('');
+  it('falls back to the stored key for the provider when no candidate is given', async () => {
+    await checkConnection('anthropic', '');
     expect(h.getSettings).toHaveBeenCalled();
-    expect(h.createProviderForKey).toHaveBeenCalledWith('anthropic', 'sk-stored');
+    expect(h.createProviderForKey).toHaveBeenCalledWith('anthropic', 'sk-stored', undefined);
   });
 
-  it('short-circuits with no provider call when there is no key at all', async () => {
+  it('short-circuits with no provider call when a keyed provider has no key', async () => {
     h.getSettings.mockResolvedValue({ providers: { anthropic: { apiKey: '' } } });
-    const res = await checkConnection(undefined);
+    const res = await checkConnection('anthropic', undefined);
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/No API key/i);
     expect(h.createProviderForKey).not.toHaveBeenCalled();
   });
 
+  it('resolves the requested provider (openai) from settings', async () => {
+    h.getSettings.mockResolvedValue({ providers: { openai: { apiKey: 'sk-openai' } } });
+    await checkConnection('openai');
+    expect(h.createProviderForKey).toHaveBeenCalledWith('openai', 'sk-openai', undefined);
+  });
+
+  it('checks a keyless local endpoint by base URL (typed beats stored)', async () => {
+    h.getSettings.mockResolvedValue({ providers: { local: { baseURL: 'http://stored/v1' } } });
+    await checkConnection('local', '', 'http://typed:11434/v1');
+    expect(h.createProviderForKey).toHaveBeenCalledWith('local', '', 'http://typed:11434/v1');
+  });
+
+  it('errors when a local endpoint has no base URL', async () => {
+    h.getSettings.mockResolvedValue({ providers: {} });
+    const res = await checkConnection('local');
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/base URL/i);
+    expect(h.createProviderForKey).not.toHaveBeenCalled();
+  });
+
   it('passes the provider result straight through', async () => {
-    h.providerCheck.mockResolvedValue({ ok: false, error: 'Anthropic rejected this key' });
-    const res = await checkConnection('sk-bad');
-    expect(res).toEqual({ ok: false, error: 'Anthropic rejected this key' });
+    h.providerCheck.mockResolvedValue({ ok: false, error: 'provider rejected this key' });
+    const res = await checkConnection('anthropic', 'sk-bad');
+    expect(res).toEqual({ ok: false, error: 'provider rejected this key' });
   });
 });
 

--- a/tests/renderer/components/AiSettings.test.ts
+++ b/tests/renderer/components/AiSettings.test.ts
@@ -1,96 +1,98 @@
 /**
  * @vitest-environment happy-dom
  *
- * Render coverage for AiSettings (#672) — the model / API-key panel extracted
- * from SettingsDialog. The dialog owns persistence (save-on-Done) and binds the
- * state in; this pins the presentational behavior: the API-key status states +
- * the clear/cancel toggle, and the default-model select. (Per-skill model
- * overrides moved to SkillsSettings — see SkillsSettings.test.ts.)
+ * Render coverage for AiSettings (BYOM #1498) — the multi-provider model / key
+ * panel. SettingsDialog owns persistence (save-on-Done) and binds state in;
+ * this pins the presentational behavior: per-provider key status + clear toggle,
+ * the provider-grouped default-model select, the per-provider connection check,
+ * and the local custom-model manager.
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
-import type { ConnectionCheckResult } from '../../../src/shared/tools/types';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import type { ConnectionCheckResult, ProviderConfigView, CustomModel } from '../../../src/shared/tools/types';
+import type { ProviderId } from '../../../src/shared/tools/providers';
 
 import AiSettings from '../../../src/renderer/lib/components/AiSettings.svelte';
 
-function props(over: Partial<{
-  model: string; apiKeyInput: string; clearApiKey: boolean;
-  apiKeyStatus: 'unknown' | 'set' | 'unset';
-  onCheckConnection: (candidateKey: string) => Promise<ConnectionCheckResult>;
-}> = {}) {
+type Inputs = Record<ProviderId, { key: string; baseURL: string; clear: boolean }>;
+function inputs(over: Partial<Inputs> = {}): Inputs {
   return {
-    model: 'claude-sonnet-4-6',
-    apiKeyInput: '',
-    clearApiKey: false,
-    apiKeyStatus: 'set' as const,
-    onCheckConnection: vi.fn(async () => ({ ok: true })),
+    anthropic: { key: '', baseURL: '', clear: false },
+    openai: { key: '', baseURL: '', clear: false },
+    google: { key: '', baseURL: '', clear: false },
+    local: { key: '', baseURL: '', clear: false },
     ...over,
   };
 }
 
-afterEach(() => {
-  cleanup();
-});
+function props(over: Record<string, unknown> = {}) {
+  return {
+    model: 'claude-sonnet-4-6',
+    effort: undefined,
+    providerInputs: inputs(),
+    providerViews: { anthropic: { hasApiKey: true } } as Partial<Record<ProviderId, ProviderConfigView>>,
+    secureStorageAvailable: true,
+    customModels: [] as CustomModel[],
+    onCheckConnection: vi.fn(async (): Promise<ConnectionCheckResult> => ({ ok: true })),
+    ...over,
+  };
+}
 
-describe('AiSettings (#672)', () => {
-  it('renders the API-key status for each state', () => {
-    expect(render(AiSettings, props({ apiKeyStatus: 'set' })).getByText('✓ API key saved')).toBeTruthy();
-    cleanup();
-    expect(render(AiSettings, props({ apiKeyStatus: 'unset' })).getByText('No API key set')).toBeTruthy();
-    cleanup();
-    expect(render(AiSettings, props({ apiKeyStatus: 'unknown' })).getByText('Loading…')).toBeTruthy();
+afterEach(() => cleanup());
+
+describe('AiSettings (BYOM #1498)', () => {
+  it('shows per-provider key status: encrypted for the configured one, unset for the rest', () => {
+    const { getByText, getAllByText } = render(AiSettings, props());
+    expect(getByText('🔒 API key saved — encrypted at rest')).toBeTruthy(); // anthropic (secure store on)
+    expect(getAllByText('No API key set').length).toBe(2); // openai + google unconfigured
   });
 
-  it('Clear saved key flips to the cleared state and disables the input; Cancel clear restores it', async () => {
-    const { getByText, getByLabelText, queryByText } = render(AiSettings, props({ apiKeyStatus: 'set' }));
-
-    await fireEvent.click(getByText('Clear saved key'));
-    expect(getByText('API key will be cleared on save')).toBeTruthy();
-    expect((getByLabelText('Anthropic API key') as HTMLInputElement).disabled).toBe(true);
-    expect(queryByText('✓ API key saved')).toBeNull();
-
-    await fireEvent.click(getByText('Cancel clear'));
+  it('drops the "encrypted" claim when secure storage is unavailable', () => {
+    const { getByText } = render(AiSettings, props({ secureStorageAvailable: false }));
     expect(getByText('✓ API key saved')).toBeTruthy();
   });
 
-  it('renders the default-model select with the bound value', () => {
+  it('Clear saved key flips to the cleared state; Cancel clear restores it', async () => {
+    const { getByText } = render(AiSettings, props());
+    await fireEvent.click(getByText('Clear saved key'));
+    expect(getByText('API key will be cleared on save')).toBeTruthy();
+    await fireEvent.click(getByText('Cancel clear'));
+    expect(getByText('🔒 API key saved — encrypted at rest')).toBeTruthy();
+  });
+
+  it('renders a provider-grouped default-model select with the bound value', () => {
     const { getByLabelText } = render(AiSettings, props());
-    expect((getByLabelText('Default model') as HTMLSelectElement).value).toBe('claude-sonnet-4-6');
+    const select = getByLabelText('Default model') as HTMLSelectElement;
+    expect(select.value).toBe('claude-sonnet-4-6');
+    const groups = [...select.querySelectorAll('optgroup')].map((g) => g.label);
+    expect(groups).toContain('Anthropic');
+    expect(groups).toContain('OpenAI');
+    expect(groups).toContain('Google Gemini');
   });
 
-  it('Check connection calls back with the typed key and shows success', async () => {
-    const onCheckConnection = vi.fn(async () => ({ ok: true }));
-    const { getByText, findByText } = render(
+  it('the first (Anthropic) Check connection calls back with the provider id + typed key', async () => {
+    const onCheckConnection = vi.fn(async (): Promise<ConnectionCheckResult> => ({ ok: true }));
+    const { getAllByText, findByText } = render(
       AiSettings,
-      props({ apiKeyInput: 'sk-typed', apiKeyStatus: 'unset', onCheckConnection }),
+      props({ providerInputs: inputs({ anthropic: { key: 'sk-typed', baseURL: '', clear: false } }), onCheckConnection }),
     );
-    await fireEvent.click(getByText('Check connection'));
-    expect(onCheckConnection).toHaveBeenCalledWith('sk-typed');
+    await fireEvent.click(getAllByText('Check connection')[0]!);
+    expect(onCheckConnection).toHaveBeenCalledWith('anthropic', 'sk-typed', '');
     await findByText(/Connected/);
   });
 
-  it('shows the failure reason returned by the check', async () => {
-    const onCheckConnection = vi.fn(
-      async (): Promise<ConnectionCheckResult> => ({ ok: false, error: 'Anthropic rejected this key' }),
-    );
-    const { getByText, findByText } = render(AiSettings, props({ apiKeyStatus: 'set', onCheckConnection }));
-    await fireEvent.click(getByText('Check connection'));
-    await findByText(/rejected this key/);
-  });
-
-  it('disables Check connection when there is neither a stored nor a typed key', () => {
-    const { getByText } = render(AiSettings, props({ apiKeyStatus: 'unset', apiKeyInput: '' }));
-    expect((getByText('Check connection') as HTMLButtonElement).disabled).toBe(true);
-  });
-
-  it('clears a stale result when the key text changes', async () => {
-    const { getByText, getByLabelText, findByText, queryByText } = render(
-      AiSettings, props({ apiKeyStatus: 'set' }),
-    );
-    await fireEvent.click(getByText('Check connection'));
-    await findByText(/Connected/);
-    await fireEvent.input(getByLabelText('Anthropic API key'), { target: { value: 'x' } });
-    await waitFor(() => expect(queryByText(/Connected/)).toBeNull());
+  it('adds and removes a local custom model, and surfaces it in the picker', async () => {
+    const { getByPlaceholderText, getByText, getByLabelText, container } = render(AiSettings, props());
+    await fireEvent.input(getByPlaceholderText('Model id (e.g. llama3.1)'), { target: { value: 'llama3.1' } });
+    await fireEvent.click(getByText('Add'));
+    // Shows in the managed list.
+    expect(container.querySelector('.custom-model-name')?.textContent).toContain('llama3.1');
+    // And under the local group in the default-model select.
+    const select = getByLabelText('Default model') as HTMLSelectElement;
+    expect([...select.querySelectorAll('option')].map((o) => o.value)).toContain('llama3.1');
+    // Remove it.
+    await fireEvent.click(getByText('Remove'));
+    expect(container.querySelector('.custom-model-name')).toBeNull();
   });
 });

--- a/tests/shared/model-registry-parity.test.ts
+++ b/tests/shared/model-registry-parity.test.ts
@@ -17,7 +17,7 @@
  * still render.
  */
 import { describe, it, expect } from 'vitest';
-import { MODEL_OPTIONS, MODEL_PRICING, customModelOptions, allModelOptions } from '../../src/shared/tools/models';
+import { MODEL_OPTIONS, MODEL_PRICING, customModelOptions, allModelOptions, groupedModelOptions } from '../../src/shared/tools/models';
 import { EFFORT_ENTRY_MODEL_IDS } from '../../src/shared/tools/effort';
 import { isProviderId } from '../../src/shared/tools/providers';
 
@@ -64,5 +64,15 @@ describe('custom (local) model options (#1497)', () => {
       ...MODEL_OPTIONS,
       { value: 'llama3.1', label: 'llama3.1', provider: 'local' },
     ]);
+  });
+
+  it('groupedModelOptions groups by provider, custom models under local, empty groups dropped', () => {
+    const groups = groupedModelOptions([{ id: 'llama3.1' }]);
+    const byProvider = Object.fromEntries(groups.map((g) => [g.provider, g]));
+    expect(byProvider.anthropic.label).toBe('Anthropic');
+    expect(byProvider.anthropic.models.every((m) => m.provider === 'anthropic')).toBe(true);
+    expect(byProvider.local.models.map((m) => m.value)).toEqual(['llama3.1']);
+    // Without custom models the local group is absent (no built-in local models).
+    expect(groupedModelOptions().some((g) => g.provider === 'local')).toBe(false);
   });
 });


### PR DESCRIPTION
BYOM epic #1492 — child 6/6, the finale. The UI that makes BYOM usable without editing JSON. Stacks on #1503.

## AiSettings.svelte (rewritten, multi-provider)
- **A credential section per provider:** API key entry with an honest status ("🔒 API key saved — encrypted at rest" when OS secure storage is available, else "✓ saved"), a **base-URL** field for the local / OpenAI-compatible endpoint, and a per-provider **Check connection**.
- **Local model manager:** add a custom model (id + optional label), remove.
- The **default-model picker is grouped by provider** (`<optgroup>`) and includes the custom local models, via `groupedModelOptions()`.
- Clear/cancel + custom-model edits **reassign** the bindable props (not in-place nested mutation) so they're reactive whether the parent binds a `$state` proxy or (in tests) a plain object.

## SettingsDialog.svelte
Per-provider input state (`providerInputs`) + loaded `providerViews` + `secureStorageAvailable` + `customModels`; loads from `getSettings().providers`/`customModels`; save builds a per-provider `providers` update + `customModels`, dropping the legacy single-`apiKey` path. Threads `customModels` to SkillsSettings.

## Pickers grouped + custom models threaded
- **ConversationsPanel** (per-conversation) and **SkillsSettings** (per-skill) render `<optgroup>`s via `groupedModelOptions(customModels)`; ConversationsPanel loads `customModels` from `getSettings`.
- The two hardcoded `'claude-opus-5'` fallbacks now use a shared **`DEFAULT_MODEL`**, newly exported from `shared/tools/models.ts` and deduped with main `settings.ts`.

## Provider-aware connection check
`checkConnection(providerId, candidateKey?, baseURL?)` through the ipc-contract → `validate.ts` (resolves per-provider stored creds; keyed providers require a key, local requires a base URL) → register-tools → preload → client.

## Tests
AiSettings re-covered for the multi-provider panel (per-provider status, encrypted claim, grouped select, connection-check callback, custom-model add/remove); `validate` for provider-aware resolution incl. OpenAI + keyless local + missing base URL; `groupedModelOptions`. `pnpm lint` clean; llm + shared + renderer + preload/ipc green (1509). Preload/IPC snapshots unchanged (arity change doesn't alter the bridge shape).

Closes the epic (#1492): Anthropic / OpenAI / Gemini / local all configurable and selectable from the UI.

Part of #1492.