### PR TITLE
refactor(publish): introduce PublishTransport seam + dispatcher (#1444)

### DIFF
--- a/src/main/ipc/register-publish.ts
+++ b/src/main/ipc/register-publish.ts
@@ -125,7 +125,10 @@ export function registerPublish(): void {
     Channels.PUBLISH_TO_GIT,
     withRootPath(async (rootPath, targetId: string, opts?: { dryRun?: boolean }) => {
       try {
-        const result = await publish.publishToGit(rootPath, targetId, {
+        // Dispatch by target kind (#1444). Git is the only transport today; S3
+        // slots in behind the same seam. The channel stays PUBLISH_TO_GIT until
+        // the S3 transport PR generalizes it.
+        const result = await publish.publishTarget(rootPath, targetId, {
           dryRun: opts?.dryRun ?? false,
           version: app.getVersion(),
         });

--- a/src/main/project-config.ts
+++ b/src/main/project-config.ts
@@ -50,6 +50,11 @@ export interface PublishTarget {
   id: string;
   /** Human label shown in the Publish menu/dialog. */
   label: string;
+  /**
+   * Transport kind (#1444). Absent on pre-existing targets ⇒ treated as 'git'.
+   * The S3 variant's fields land alongside the git ones in the S3 transport PR.
+   */
+  kind?: 'git' | 's3';
   /** Exporter id whose directory-tree output gets pushed (e.g. 'static-site'). */
   exporter: string;
   /** Remote URL. SSH forms are normalized to HTTPS at push time (#254 auth). */

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -40,3 +40,4 @@ export { resolvePlan, runExporter } from './pipeline';
 export { listExporters, exportersFor, getExporter, listExportGroups, type ExportGroupListing } from './registry';
 export { runExport, type RunExportInput, type RunExportResult } from './run-export';
 export { publishToGit, type PublishResult, type PublishOptions } from './publish-to-git';
+export { publishTarget, getTransport, registerTransport, type PublishTransport, type PublishTargetKind } from './transport';

--- a/src/main/publish/transport/git.ts
+++ b/src/main/publish/transport/git.ts
@@ -1,0 +1,12 @@
+/**
+ * The git publish transport (#1444) — the first `PublishTransport`. A thin
+ * adapter over the existing `publishToGit` orchestration, which keeps its own
+ * signature/tests unchanged; the transport just registers it behind the seam.
+ */
+import { publishToGit } from '../publish-to-git';
+import type { PublishTransport } from './types';
+
+export const gitTransport: PublishTransport = {
+  kind: 'git',
+  publish: (rootPath, target, opts) => publishToGit(rootPath, target.id, opts),
+};

--- a/src/main/publish/transport/index.ts
+++ b/src/main/publish/transport/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Publish-transport dispatcher (#1444). Resolves a configured target and hands
+ * it to the transport for its `kind` — the single branch point a new transport
+ * slots into (mirrors the `LLMProvider` factory). Existing targets predate the
+ * `kind` field and default to git.
+ */
+import { getPublishTarget } from '../../project-config';
+import type { PublishOptions, PublishResult } from '../publish-to-git';
+import { getTransport } from './registry';
+
+export async function publishTarget(
+  rootPath: string,
+  targetId: string,
+  opts: PublishOptions = {},
+): Promise<PublishResult> {
+  const target = getPublishTarget(rootPath, targetId);
+  if (!target) throw new Error(`No publish target "${targetId}" is configured for this thoughtbase.`);
+  const kind = target.kind ?? 'git';
+  const transport = getTransport(kind);
+  if (!transport) throw new Error(`No publish transport is registered for kind "${kind}".`);
+  return transport.publish(rootPath, target, opts);
+}
+
+export { getTransport, registerTransport } from './registry';
+export type { PublishTransport, PublishTargetKind } from './types';

--- a/src/main/publish/transport/registry.ts
+++ b/src/main/publish/transport/registry.ts
@@ -1,0 +1,19 @@
+/**
+ * Publish-transport registry (#1444). Built-in transports register at module
+ * load — they're internal (git, and S3 next), not user-pluggable, so there's no
+ * explicit `registerBuiltin…()` step to wire into startup.
+ */
+import type { PublishTransport, PublishTargetKind } from './types';
+import { gitTransport } from './git';
+
+const transports = new Map<PublishTargetKind, PublishTransport>();
+
+export function registerTransport(transport: PublishTransport): void {
+  transports.set(transport.kind, transport);
+}
+
+export function getTransport(kind: PublishTargetKind): PublishTransport | undefined {
+  return transports.get(kind);
+}
+
+registerTransport(gitTransport);

--- a/src/main/publish/transport/types.ts
+++ b/src/main/publish/transport/types.ts
@@ -1,0 +1,28 @@
+/**
+ * The publish-transport seam (#1444).
+ *
+ * Rendering (the exporter registry) turns notes into a file tree; a *transport*
+ * ships that tree somewhere. Git was the only transport and was hardwired into
+ * `publishToGit`; this interface makes "ship the artifact" pluggable so a second
+ * transport (S3 / S3-compatible) is a new implementation, not a fork of the
+ * publish flow — the same shape the exporter registry and the `LLMProvider`
+ * seam already use.
+ *
+ * Stated direction: `docs/vision/publication.md` → publication should be
+ * output-neutral: produce the artifact, let the user host it wherever.
+ */
+import type { PublishTarget } from '../../project-config';
+import type { PublishOptions, PublishResult } from '../publish-to-git';
+
+export type PublishTargetKind = 'git' | 's3';
+
+export interface PublishTransport {
+  /** The target kind this transport handles. */
+  readonly kind: PublishTargetKind;
+  /**
+   * Ship a configured target's exported artifact. Resolves the exporter output
+   * itself (via `runExport`) so the caller stays transport-neutral. `dryRun`
+   * previews without shipping where the transport can.
+   */
+  publish(rootPath: string, target: PublishTarget, opts: PublishOptions): Promise<PublishResult>;
+}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -321,10 +321,12 @@ export interface PublishApi {
   toGit(targetId: string, opts?: { dryRun?: boolean }): Promise<PublishGitResponse>;
 }
 
-/** A configured "Publish → git remote" destination (#254). */
+/** A configured publish destination (#254; multi-transport #1444). */
 export interface PublishTarget {
   id: string;
   label: string;
+  /** Transport kind (#1444); absent ⇒ 'git'. */
+  kind?: 'git' | 's3';
   exporter: string;
   gitRemote: string;
   gitBranch: string;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -481,11 +481,13 @@ export interface ChannelMap {
   'conversation:fileNoteBodyDraft': (draft: ConversationNoteBodyDraft) => FileNoteBodyDraftResult;
 }
 
-/** A configured "Publish → git remote" destination (#254). Mirror of the
+/** A configured publish destination (#254; multi-transport #1444). Mirror of the
  *  main-side `PublishTarget` (project-config) + renderer `PublishTarget`. */
 export interface PublishTarget {
   id: string;
   label: string;
+  /** Transport kind (#1444); absent ⇒ 'git'. */
+  kind?: 'git' | 's3';
   exporter: string;
   gitRemote: string;
   gitBranch: string;

--- a/tests/main/publish/publish-transport.test.ts
+++ b/tests/main/publish/publish-transport.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Publish-transport seam + dispatcher (#1444).
+ *
+ * The dispatcher resolves a configured target and routes it to the transport
+ * registered for its `kind` (defaulting absent → git). Git is registered by
+ * default; a fake transport exercises dispatch + the target/kind guards without
+ * touching the network.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({ getPublishTarget: vi.fn() }));
+vi.mock('../../../src/main/project-config', () => ({ getPublishTarget: h.getPublishTarget }));
+
+import { publishTarget, getTransport, registerTransport } from '../../../src/main/publish/transport';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('transport registry', () => {
+  it('registers the git transport by default', () => {
+    expect(getTransport('git')?.kind).toBe('git');
+  });
+});
+
+describe('publishTarget dispatch', () => {
+  it('routes a target to the transport for its kind', async () => {
+    const publishFn = vi.fn(async () => ({
+      targetId: 'x', dryRun: false, branch: '', branchCreated: false, changes: [], committed: false, pushed: false,
+    }));
+    registerTransport({ kind: 's3', publish: publishFn });
+    const target = { id: 'x', label: 'X', kind: 's3', exporter: 'static-site' };
+    h.getPublishTarget.mockReturnValue(target);
+
+    await publishTarget('/root', 'x', { dryRun: true });
+    expect(publishFn).toHaveBeenCalledWith('/root', target, { dryRun: true });
+  });
+
+  it('throws when the target does not exist', async () => {
+    h.getPublishTarget.mockReturnValue(null);
+    await expect(publishTarget('/root', 'missing')).rejects.toThrow(/No publish target "missing"/);
+  });
+
+  it('throws when no transport is registered for the target kind', async () => {
+    h.getPublishTarget.mockReturnValue({ id: 'x', label: 'X', kind: 'nope', exporter: 'static-site' });
+    await expect(publishTarget('/root', 'x')).rejects.toThrow(/No publish transport is registered for kind "nope"/);
+  });
+});


### PR DESCRIPTION
First of ~3 PRs for #1444 (object-storage publishing). **Foundation — no behavior change, git stays the only transport.**

## Why
Publishing is split into **rendering** (the pluggable `Exporter` registry) and **transport** (git, hardwired in `publishToGit`). #1444 adds S3 as a second transport; the issue recommends extracting the transport seam first so the second (and third) target isn't a copy-paste fork. This is that seam — the same interface + factory shape the exporter registry and the `LLMProvider` seam (BYOM) already use.

## What
- **`src/main/publish/transport/`** — `PublishTransport` interface + a registry (git registered by default) + a `publishTarget(rootPath, targetId, opts)` **dispatcher** that resolves a target and routes it to the transport for its `kind`.
- **`git.ts`** adapts the existing `publishToGit` **unchanged** (its signature and tests are untouched); `register-publish`'s `PUBLISH_TO_GIT` handler now calls the dispatcher instead of `publishToGit` directly.
- **`PublishTarget` gains an optional `kind?: 'git' | 's3'`** (absent ⇒ git, so existing `.minerva/config.json` targets need no migration), threaded through all three parallel decls (`project-config`, `ipc-contract`, `client`) as the issue calls for. The S3 variant's concrete fields (endpoint/bucket/region/creds) land with the S3 transport PR.

## Deliberately deferred to the S3 PR
The channel stays `PUBLISH_TO_GIT` and `PublishResult` keeps its git shape (`branch`/`sha`/…) for now — generalizing the channel name and neutralizing the result belong with the transport that needs them, not this no-op refactor.

## Tests
Registry has git; dispatch routes by `kind`; missing-target and unknown-kind guards. `pnpm lint` clean; publish + ipc/preload suites green (existing `publish-to-git` behavior unchanged).

Part of #1444. Next: S3 transport (`@aws-sdk/client-s3`, configurable endpoint) + `safeStorage`-encrypted credentials — the part BYOM's secrets work gives us a leg up on.