### PR TITLE
feat(publish): S3 / S3-compatible transport + encrypted credentials (#1444)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.115.0",
+    "@aws-sdk/client-s3": "^3.1098.0",
     "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/lang-sql": "^6.10.0",
     "@codemirror/legacy-modes": "^6.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.115.0
         version: 0.115.0
+      '@aws-sdk/client-s3':
+        specifier: ^3.1098.0
+        version: 3.1098.0
       '@codemirror/autocomplete':
         specifier: ^6.20.3
         version: 6.20.3
@@ -111,7 +114,7 @@ importers:
         version: 1.27.0
       openai:
         specifier: ^7.1.0
-        version: 7.1.0(ws@8.21.1)
+        version: 7.1.0(@aws-sdk/credential-provider-node@3.972.75)(@smithy/signature-v4@5.6.12)(ws@8.21.1)
       pdfjs-dist:
         specifier: ^6.1.200
         version: 6.1.200
@@ -270,6 +273,78 @@ packages:
   '@asamuzakjp/dom-selector@8.3.0':
     resolution: {integrity: sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==}
     engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@aws-sdk/checksums@3.1000.23':
+    resolution: {integrity: sha512-Hv4VX5+IdDYmAbOdiwZguz8fLh3WnE4VtyJwVNEHLulA+OYy7Z5L0ETGUlX2T4g8DLO8XxCV8CyWrtVL4uwqkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1098.0':
+    resolution: {integrity: sha512-6Z53QG2jdujsCt3eHO2cjCpdfvz2Pgs+hP/NINuGONZUJmdrHLLDvWM9F114Yq0NPIGtk+yA/GCjG3XiUhw+gA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.3':
+    resolution: {integrity: sha512-6YZTpF5Zzl0KdSrztM0l6ErKdnXrnnodIDYfayHE9SFfZU8Ubxls7H2XnfWT121jgwiG+WP1z5kyfVDsH5V4qA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.64':
+    resolution: {integrity: sha512-14kkR5aj1c7D+cYCrEcG2W3xw87wMYAEUeB/tMiQ2j0RVKzzdewd4mJw1+Q0JVLr4IFU1JHGDCyj0WqLrtIixg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.66':
+    resolution: {integrity: sha512-BrZxoXScBZ+nTOYy388zHkz1n5cS8C+uGFMozD4w9OKEWMq39Cu/9l/k385Hb54dtv0VIeh12f8h67o3xDNH9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.9':
+    resolution: {integrity: sha512-d/mMvS+sQjSWNA6+JCldK1YB/jQmtoWM8Izj10mrOZdRCeWNVb8IYQuuyHHKKKXcpGo5Pd0LIK6onHbLvlhuVQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.71':
+    resolution: {integrity: sha512-l93922lXnTs5RjM3QrMCXSmXiEgLFLaQ0Lco9F3tJ08o0mzGdAj6m2nAXDuTMHoUuL0u7RKmrhm+Z8/7GCilyg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.75':
+    resolution: {integrity: sha512-sdFhR4E3HWZefGL6OsBhxqXdqtFvxGOh8VLfiu9yttPgVNcpEozEDPmrTYmXA3CIf6npUETVLveQPGQ7GBzVhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.64':
+    resolution: {integrity: sha512-Q5noG5vfFo++bUaLGcjj8OHX5tmwa1O/5nDVMeaSSZgjzgvWbW6tgu/gSa+aENwcJXjoXDQh+8TRZR2zHds/aw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.8':
+    resolution: {integrity: sha512-37okeZyRdVkGrU6nyKBPGqQvyl/7CEiMpUVOb0+BCNCIR0VAuBxNgjMb0mnsR1EXm8dqQFfQZOJ5YW/0sBfa1w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.70':
+    resolution: {integrity: sha512-Ps/f9USafScb6CSQTRPNMzdKL5x5XRwDIRgFvnuFWfClGZe7/fI7iCFqXdxKjc9LBxP28E7iUgNloGgfgw406w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.69':
+    resolution: {integrity: sha512-ziSQA8AkB+u4K/5t/SStFbeoiNTG04reUeddCLNCAgmdRJGQ3+MJcpZOXXLdD6uyfCqSK1/R6004gRdXvHbYQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.38':
+    resolution: {integrity: sha512-jQDs+nxnmgo4+WPOmY373HIC8jx4KyYYMYDI74FWrzX3Ba9fYsV0dSA+7PNYNkhRbbRCRLre83tQ31F1ACCHkA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1098.0':
+    resolution: {integrity: sha512-6cFAviffeqYGjrXn4FqGbWcTxB3nbpBpQXUm6MvnrWZThJaVBTHHnespHgSUh4yVLfzhipSh9H/XjzkHQd9P4g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -2323,6 +2398,30 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
@@ -3052,6 +3151,9 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   bplist-creator@0.0.8:
     resolution: {integrity: sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==}
@@ -6682,6 +6784,171 @@ snapshots:
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
+
+  '@aws-sdk/checksums@3.1000.23':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1098.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.23
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/credential-provider-node': 3.972.75
+      '@aws-sdk/middleware-sdk-s3': 3.972.69
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.3':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.64':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.66':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.9':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/credential-provider-env': 3.972.64
+      '@aws-sdk/credential-provider-http': 3.972.66
+      '@aws-sdk/credential-provider-login': 3.972.71
+      '@aws-sdk/credential-provider-process': 3.972.64
+      '@aws-sdk/credential-provider-sso': 3.973.8
+      '@aws-sdk/credential-provider-web-identity': 3.972.70
+      '@aws-sdk/nested-clients': 3.997.38
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/nested-clients': 3.997.38
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.75':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.64
+      '@aws-sdk/credential-provider-http': 3.972.66
+      '@aws-sdk/credential-provider-ini': 3.973.9
+      '@aws-sdk/credential-provider-process': 3.972.64
+      '@aws-sdk/credential-provider-sso': 3.973.8
+      '@aws-sdk/credential-provider-web-identity': 3.972.70
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.64':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.8':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/nested-clients': 3.997.38
+      '@aws-sdk/token-providers': 3.1098.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/nested-clients': 3.997.38
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.38':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1098.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.3
+      '@aws-sdk/nested-clients': 3.997.38
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -10884,6 +11151,39 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@so-ric/colorspace@1.1.6':
     dependencies:
       color: 5.0.3
@@ -11746,6 +12046,8 @@ snapshots:
   boolbase@2.0.0: {}
 
   boolean@3.2.0: {}
+
+  bowser@2.14.1: {}
 
   bplist-creator@0.0.8:
     dependencies:
@@ -13999,8 +14301,10 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.6.4
 
-  openai@7.1.0(ws@8.21.1):
+  openai@7.1.0(@aws-sdk/credential-provider-node@3.972.75)(@smithy/signature-v4@5.6.12)(ws@8.21.1):
     optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.75
+      '@smithy/signature-v4': 5.6.12
       ws: 8.21.1
 
   opencollective-postinstall@2.0.3: {}

--- a/src/main/project-config.ts
+++ b/src/main/project-config.ts
@@ -9,6 +9,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { encryptSecret, decryptSecret } from './secret-storage';
 
 export interface ProjectConfigShape {
   baseUri?: string;
@@ -45,27 +46,54 @@ export interface ProjectConfigShape {
  * site → GitHub Pages). Stored in `.minerva/config.json`, which is
  * gitignored, so a remote URL never rides along in the thoughtbase repo.
  */
-export interface PublishTarget {
+interface PublishTargetBase {
   /** Stable id — names the publish-cache workspace and the config entry. */
   id: string;
   /** Human label shown in the Publish menu/dialog. */
   label: string;
-  /**
-   * Transport kind (#1444). Absent on pre-existing targets ⇒ treated as 'git'.
-   * The S3 variant's fields land alongside the git ones in the S3 transport PR.
-   */
-  kind?: 'git' | 's3';
   /** Exporter id whose directory-tree output gets pushed (e.g. 'static-site'). */
   exporter: string;
+  /** Output subdirectory / key prefix. '' / '.' = root. */
+  subdir?: string;
+}
+
+/** Publish → git remote (#254). `kind` absent ⇒ git (pre-#1444 targets). */
+export interface GitPublishTarget extends PublishTargetBase {
+  kind?: 'git';
   /** Remote URL. SSH forms are normalized to HTTPS at push time (#254 auth). */
   gitRemote: string;
   /** Branch to publish to, e.g. 'gh-pages'. */
   gitBranch: string;
-  /** Repo-relative subdirectory the output lands in. '' / '.' = repo root. */
-  subdir?: string;
   /** Commit message, with `{{date}}` / `{{version}}` placeholders. */
   commitMessageTemplate?: string;
 }
+
+/**
+ * Publish → S3 / S3-compatible object storage (#1444). One shape covers Amazon
+ * S3 and R2/B2/Spaces/MinIO via a custom `endpoint`. The secret access key is
+ * NEVER carried on this (wire) shape: it's stored encrypted on disk and only
+ * `hasSecret` crosses to the renderer; `secretAccessKey` is a WRITE-ONLY,
+ * tri-state field accepted on upsert (string sets, '' clears, omitted keeps) —
+ * mirroring the BYOM per-provider key handling.
+ */
+export interface S3PublishTarget extends PublishTargetBase {
+  kind: 's3';
+  bucket: string;
+  /** Custom endpoint for S3-compatible providers; omit for Amazon S3. */
+  endpoint?: string;
+  region?: string;
+  accessKeyId?: string;
+  /** Write-only on upsert; never returned by the read path. */
+  secretAccessKey?: string;
+  /** Read-only: a secret is stored. */
+  hasSecret?: boolean;
+}
+
+export type PublishTarget = GitPublishTarget | S3PublishTarget;
+
+/** On-disk S3 target: the encrypted secret replaces the plaintext write field. */
+type StoredS3Target = Omit<S3PublishTarget, 'secretAccessKey' | 'hasSecret'> & { secretAccessKeyEnc?: string };
+type StoredTarget = GitPublishTarget | StoredS3Target;
 
 function configPath(rootPath: string): string {
   return path.join(rootPath, '.minerva', 'config.json');
@@ -133,25 +161,66 @@ export function setExcerptNoteFolder(rootPath: string, folder: string): void {
   patchProjectConfig(rootPath, { excerpt: { ...existing, noteFolder: cleaned } });
 }
 
-/** All configured git-push publish targets (#254). Empty when unset. */
+function readStoredTargets(rootPath: string): StoredTarget[] {
+  return (readProjectConfig(rootPath).publish?.targets as StoredTarget[] | undefined) ?? [];
+}
+
+/** Map an on-disk target to its wire form — for S3, replace the encrypted
+ *  secret with a `hasSecret` flag so the plaintext never reaches the renderer. */
+function toWireTarget(t: StoredTarget): PublishTarget {
+  if (t.kind === 's3') {
+    const { secretAccessKeyEnc, ...rest } = t;
+    return { ...rest, hasSecret: !!secretAccessKeyEnc };
+  }
+  return t;
+}
+
+/** All configured publish targets (#254, #1444), secrets stripped. Empty when unset. */
 export function getPublishTargets(rootPath: string): PublishTarget[] {
-  return readProjectConfig(rootPath).publish?.targets ?? [];
+  return readStoredTargets(rootPath).map(toWireTarget);
 }
 
 export function getPublishTarget(rootPath: string, id: string): PublishTarget | null {
   return getPublishTargets(rootPath).find((t) => t.id === id) ?? null;
 }
 
-/** Insert or replace a target by id, preserving the rest of the list. */
+/**
+ * Decrypted S3 credentials for a target (#1444) — main-only, for the transport
+ * at publish time. Never crosses to the renderer. Empty for non-S3 / unknown ids.
+ */
+export function getS3Credentials(rootPath: string, id: string): { accessKeyId?: string; secretAccessKey?: string } {
+  const t = readStoredTargets(rootPath).find((x) => x.id === id);
+  if (!t || t.kind !== 's3') return {};
+  return {
+    ...(t.accessKeyId ? { accessKeyId: t.accessKeyId } : {}),
+    ...(t.secretAccessKeyEnc ? { secretAccessKey: decryptSecret(t.secretAccessKeyEnc) } : {}),
+  };
+}
+
+/** Wire → on-disk: for S3, apply the tri-state secret (string sets/encrypts,
+ *  '' clears, omitted keeps the existing encrypted value) and drop the plaintext. */
+function toStoredTarget(target: PublishTarget, existing: StoredTarget | undefined): StoredTarget {
+  if (target.kind !== 's3') return target;
+  const { secretAccessKey, hasSecret: _hasSecret, ...rest } = target;
+  const prevEnc = existing && existing.kind === 's3' ? existing.secretAccessKeyEnc : undefined;
+  const enc = secretAccessKey === undefined ? prevEnc
+    : secretAccessKey === '' ? undefined
+    : encryptSecret(secretAccessKey);
+  return { ...rest, ...(enc ? { secretAccessKeyEnc: enc } : {}) };
+}
+
+/** Insert or replace a target by id, preserving the rest of the list (and other
+ *  targets' encrypted secrets — CRUD operates on the STORED shape). */
 export function upsertPublishTarget(rootPath: string, target: PublishTarget): void {
-  const targets = getPublishTargets(rootPath);
+  const targets = readStoredTargets(rootPath);
   const idx = targets.findIndex((t) => t.id === target.id);
-  if (idx >= 0) targets[idx] = target;
-  else targets.push(target);
+  const stored = toStoredTarget(target, idx >= 0 ? targets[idx] : undefined);
+  if (idx >= 0) targets[idx] = stored;
+  else targets.push(stored);
   patchProjectConfig(rootPath, { publish: { targets } });
 }
 
 export function removePublishTarget(rootPath: string, id: string): void {
-  const targets = getPublishTargets(rootPath).filter((t) => t.id !== id);
+  const targets = readStoredTargets(rootPath).filter((t) => t.id !== id);
   patchProjectConfig(rootPath, { publish: { targets } });
 }

--- a/src/main/publish/index.ts
+++ b/src/main/publish/index.ts
@@ -41,3 +41,4 @@ export { listExporters, exportersFor, getExporter, listExportGroups, type Export
 export { runExport, type RunExportInput, type RunExportResult } from './run-export';
 export { publishToGit, type PublishResult, type PublishOptions } from './publish-to-git';
 export { publishTarget, getTransport, registerTransport, type PublishTransport, type PublishTargetKind } from './transport';
+export { publishToS3, checkS3Connection, type S3Credentials } from './publish-to-s3';

--- a/src/main/publish/publish-to-git.ts
+++ b/src/main/publish/publish-to-git.ts
@@ -45,6 +45,8 @@ export async function publishToGit(
 ): Promise<PublishResult> {
   const target = getPublishTarget(rootPath, targetId);
   if (!target) throw new Error(`No publish target "${targetId}" is configured for this thoughtbase.`);
+  // The dispatcher routes by kind; a non-git target reaching here is a bug.
+  if (target.kind === 's3') throw new Error(`Publish target "${targetId}" is not a git target.`);
 
   const dryRun = opts.dryRun ?? false;
   // Fail fast with a clear message before doing any work if creds are missing.

--- a/src/main/publish/publish-to-s3.ts
+++ b/src/main/publish/publish-to-s3.ts
@@ -1,0 +1,197 @@
+/**
+ * "Publish → S3 / S3-compatible object storage" transport (#1444).
+ *
+ * Mirror of `publish-to-git.ts`: run the configured exporter into a temp dir,
+ * then upload the tree. One build serves Amazon S3 and every S3-compatible
+ * provider (Cloudflare R2, Backblaze B2, DigitalOcean Spaces, Wasabi, MinIO) via
+ * a custom `endpoint`. Credentials are optional — when absent the AWS SDK's
+ * default chain (`~/.aws`, env) applies, which real-AWS users may prefer.
+ *
+ * Mirroring semantics match git's `clearWorkTree`: objects under the prefix that
+ * the new export doesn't produce are deleted (delete-orphans), so the published
+ * site never accumulates stale files. Preview is coarse (which files, by
+ * existence — no content diff; the etag/hash manifest compare is a follow-up,
+ * per #1444 decision #2): a dry run reports what *would* upload/delete without
+ * touching the bucket.
+ *
+ * `@aws-sdk/client-s3` is a Node/main dependency — no renderer bundling concern.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+// Type-only: the SDK values are dynamically imported inside the functions below
+// so that merely importing this module (via the publish barrel / transport
+// registry) never loads @aws-sdk — it's a heavy node-only dep that mis-resolves
+// under the test runner's browser condition, and lazy-loading keeps it out of
+// unrelated import graphs. It loads when an S3 publish actually runs.
+import type { S3Client } from '@aws-sdk/client-s3';
+import type { S3PublishTarget } from '../project-config';
+import type { ConnectionCheckResult } from '../../shared/tools/types';
+import { toConnectionResult } from '../llm/connection-error';
+import { runExport } from './run-export';
+import type { PublishOptions, PublishResult } from './publish-to-git';
+import type { PublishChange } from '../git/publish-git';
+
+export interface S3Credentials {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+}
+
+/** Content type by file extension; unknown → application/octet-stream. */
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.pdf': 'application/pdf',
+  '.txt': 'text/plain; charset=utf-8',
+  '.md': 'text/markdown; charset=utf-8',
+  '.xml': 'application/xml',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+};
+
+export function contentTypeFor(key: string): string {
+  return CONTENT_TYPES[path.extname(key).toLowerCase()] ?? 'application/octet-stream';
+}
+
+/** Normalise a prefix: strip surrounding slashes, collapse `\`. '' = bucket root. */
+export function normalizePrefix(prefix: string | undefined): string {
+  return (prefix ?? '').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+}
+
+/** Object key for a POSIX-relative export path under the target's prefix. */
+export function objectKey(prefix: string, relPath: string): string {
+  const rel = relPath.split(path.sep).join('/');
+  return prefix ? `${prefix}/${rel}` : rel;
+}
+
+/** Recursively collect files under `dir` as `{ relPath, absPath }`. */
+function walkFiles(dir: string): { relPath: string; absPath: string }[] {
+  const out: { relPath: string; absPath: string }[] = [];
+  const walk = (cur: string) => {
+    for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
+      const abs = path.join(cur, entry.name);
+      if (entry.isDirectory()) walk(abs);
+      else if (entry.isFile()) out.push({ relPath: path.relative(dir, abs), absPath: abs });
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+export async function buildS3Client(target: S3PublishTarget, creds: S3Credentials): Promise<S3Client> {
+  const { S3Client } = await import('@aws-sdk/client-s3');
+  const hasCreds = !!(creds.accessKeyId && creds.secretAccessKey);
+  return new S3Client({
+    region: target.region || 'us-east-1',
+    // A custom endpoint means an S3-compatible provider; path-style addressing
+    // is the portable choice (MinIO, and buckets with dots).
+    ...(target.endpoint ? { endpoint: target.endpoint, forcePathStyle: true } : {}),
+    // Omit `credentials` to fall back to the SDK's default chain (real AWS).
+    ...(hasCreds ? { credentials: { accessKeyId: creds.accessKeyId!, secretAccessKey: creds.secretAccessKey! } } : {}),
+  });
+}
+
+/** List every object key currently under `prefix`. */
+async function listExistingKeys(client: S3Client, bucket: string, prefix: string): Promise<Set<string>> {
+  const { ListObjectsV2Command } = await import('@aws-sdk/client-s3');
+  const keys = new Set<string>();
+  let token: string | undefined;
+  do {
+    const res = await client.send(new ListObjectsV2Command({
+      Bucket: bucket,
+      ...(prefix ? { Prefix: `${prefix}/` } : {}),
+      ...(token ? { ContinuationToken: token } : {}),
+    }));
+    for (const o of res.Contents ?? []) if (o.Key) keys.add(o.Key);
+    token = res.IsTruncated ? res.NextContinuationToken : undefined;
+  } while (token);
+  return keys;
+}
+
+export interface PublishToS3Deps {
+  /** Injectable client for tests; production builds one from the target + creds. */
+  client?: S3Client;
+}
+
+export async function publishToS3(
+  rootPath: string,
+  target: S3PublishTarget,
+  creds: S3Credentials,
+  opts: PublishOptions = {},
+  deps: PublishToS3Deps = {},
+): Promise<PublishResult> {
+  const dryRun = opts.dryRun ?? false;
+  const prefix = normalizePrefix(target.subdir);
+  const { PutObjectCommand, DeleteObjectsCommand } = await import('@aws-sdk/client-s3');
+  const client = deps.client ?? (await buildS3Client(target, creds));
+
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-s3-publish-'));
+  try {
+    await runExport(rootPath, { exporterId: target.exporter, input: { kind: 'project' }, outputDir: workspace });
+    const files = walkFiles(workspace);
+    const newKeys = new Map(files.map((f) => [objectKey(prefix, f.relPath), f.absPath]));
+
+    const existing = await listExistingKeys(client, target.bucket, prefix);
+    const orphans = [...existing].filter((k) => !newKeys.has(k));
+
+    const changes: PublishChange[] = [
+      ...[...newKeys.keys()].map((key): PublishChange => ({ path: key, status: existing.has(key) ? 'modified' : 'added' })),
+      ...orphans.map((key): PublishChange => ({ path: key, status: 'deleted' })),
+    ];
+
+    const base: PublishResult = {
+      targetId: target.id,
+      dryRun,
+      branch: '',
+      branchCreated: false,
+      changes,
+      committed: false,
+      pushed: false,
+    };
+    if (dryRun) return base;
+
+    for (const [key, absPath] of newKeys) {
+      await client.send(new PutObjectCommand({
+        Bucket: target.bucket,
+        Key: key,
+        Body: fs.readFileSync(absPath),
+        ContentType: contentTypeFor(key),
+      }));
+    }
+    // Delete orphans in batches of 1000 (the API limit).
+    for (let i = 0; i < orphans.length; i += 1000) {
+      await client.send(new DeleteObjectsCommand({
+        Bucket: target.bucket,
+        Delete: { Objects: orphans.slice(i, i + 1000).map((Key) => ({ Key })) },
+      }));
+    }
+
+    const shipped = changes.length > 0;
+    return { ...base, committed: shipped, pushed: shipped };
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+}
+
+/** Validate S3 credentials + endpoint against the bucket with a token-free
+ *  HeadBucket — powers the settings "Check connection" button (#1444). */
+export async function checkS3Connection(
+  target: S3PublishTarget,
+  creds: S3Credentials,
+  deps: PublishToS3Deps = {},
+): Promise<ConnectionCheckResult> {
+  const { HeadBucketCommand } = await import('@aws-sdk/client-s3');
+  const client = deps.client ?? (await buildS3Client(target, creds));
+  return toConnectionResult(() => client.send(new HeadBucketCommand({ Bucket: target.bucket })));
+}

--- a/src/main/publish/transport/registry.ts
+++ b/src/main/publish/transport/registry.ts
@@ -5,6 +5,7 @@
  */
 import type { PublishTransport, PublishTargetKind } from './types';
 import { gitTransport } from './git';
+import { s3Transport } from './s3';
 
 const transports = new Map<PublishTargetKind, PublishTransport>();
 
@@ -17,3 +18,4 @@ export function getTransport(kind: PublishTargetKind): PublishTransport | undefi
 }
 
 registerTransport(gitTransport);
+registerTransport(s3Transport);

--- a/src/main/publish/transport/s3.ts
+++ b/src/main/publish/transport/s3.ts
@@ -1,0 +1,15 @@
+/**
+ * The S3 publish transport (#1444) — second `PublishTransport`. Fetches the
+ * target's decrypted credentials (main-only) and delegates to `publishToS3`.
+ */
+import { getS3Credentials } from '../../project-config';
+import { publishToS3 } from '../publish-to-s3';
+import type { PublishTransport } from './types';
+
+export const s3Transport: PublishTransport = {
+  kind: 's3',
+  publish: (rootPath, target, opts) => {
+    if (target.kind !== 's3') throw new Error('s3Transport received a non-s3 target.');
+    return publishToS3(rootPath, target, getS3Credentials(rootPath, target.id), opts);
+  },
+};

--- a/src/renderer/lib/components/PublishDialog.svelte
+++ b/src/renderer/lib/components/PublishDialog.svelte
@@ -135,7 +135,11 @@
             <div class="target-head">
               <div class="target-meta">
                 <div class="target-label">{t.label}</div>
-                <div class="target-detail">{t.exporter} → {t.gitRemote} <span class="branch">({t.gitBranch})</span></div>
+                {#if t.kind === 's3'}
+                  <div class="target-detail">{t.exporter} → s3://{t.bucket}{t.subdir && t.subdir !== '.' ? `/${t.subdir}` : ''}</div>
+                {:else}
+                  <div class="target-detail">{t.exporter} → {t.gitRemote} <span class="branch">({t.gitBranch})</span></div>
+                {/if}
               </div>
               <div class="target-actions">
                 <button onclick={() => run(t, true)} disabled={busyId === t.id}>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -322,17 +322,30 @@ export interface PublishApi {
 }
 
 /** A configured publish destination (#254; multi-transport #1444). */
-export interface PublishTarget {
+interface PublishTargetBase {
   id: string;
   label: string;
-  /** Transport kind (#1444); absent ⇒ 'git'. */
-  kind?: 'git' | 's3';
   exporter: string;
+  subdir?: string;
+}
+export interface GitPublishTarget extends PublishTargetBase {
+  kind?: 'git';
   gitRemote: string;
   gitBranch: string;
-  subdir?: string;
   commitMessageTemplate?: string;
 }
+export interface S3PublishTarget extends PublishTargetBase {
+  kind: 's3';
+  bucket: string;
+  endpoint?: string;
+  region?: string;
+  accessKeyId?: string;
+  /** Write-only on upsert (tri-state); never returned by the read path. */
+  secretAccessKey?: string;
+  /** Read-only: a secret is stored. */
+  hasSecret?: boolean;
+}
+export type PublishTarget = GitPublishTarget | S3PublishTarget;
 
 export interface PublishChange {
   path: string;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -483,14 +483,27 @@ export interface ChannelMap {
 
 /** A configured publish destination (#254; multi-transport #1444). Mirror of the
  *  main-side `PublishTarget` (project-config) + renderer `PublishTarget`. */
-export interface PublishTarget {
+interface PublishTargetBase {
   id: string;
   label: string;
-  /** Transport kind (#1444); absent ⇒ 'git'. */
-  kind?: 'git' | 's3';
   exporter: string;
+  subdir?: string;
+}
+export interface GitPublishTarget extends PublishTargetBase {
+  kind?: 'git';
   gitRemote: string;
   gitBranch: string;
-  subdir?: string;
   commitMessageTemplate?: string;
 }
+export interface S3PublishTarget extends PublishTargetBase {
+  kind: 's3';
+  bucket: string;
+  endpoint?: string;
+  region?: string;
+  accessKeyId?: string;
+  /** Write-only on upsert (tri-state); never returned by the read path. */
+  secretAccessKey?: string;
+  /** Read-only: a secret is stored. */
+  hasSecret?: boolean;
+}
+export type PublishTarget = GitPublishTarget | S3PublishTarget;

--- a/tests/main/project-config-s3.test.ts
+++ b/tests/main/project-config-s3.test.ts
@@ -1,0 +1,88 @@
+/**
+ * S3 publish-target credential handling in project-config (#1444).
+ *
+ * The secret access key is encrypted at rest (secret-storage / safeStorage),
+ * stripped from the read path (only `hasSecret` crosses to the renderer),
+ * decrypted on demand for the transport, and tri-state on upsert — the same
+ * contract BYOM established for LLM keys. safeStorage is mocked reversibly.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: vi.fn((s: string) => Buffer.from('FAKEENC:' + s, 'utf-8')),
+    decryptString: vi.fn((buf: Buffer) => buf.toString('utf-8').replace(/^FAKEENC:/, '')),
+  },
+}));
+
+import {
+  getPublishTargets,
+  getS3Credentials,
+  upsertPublishTarget,
+  removePublishTarget,
+  type S3PublishTarget,
+  type GitPublishTarget,
+} from '../../src/main/project-config';
+
+let root: string;
+const configFile = () => path.join(root, '.minerva', 'config.json');
+const rawTargets = () => JSON.parse(fs.readFileSync(configFile(), 'utf-8')).publish.targets;
+
+const s3: S3PublishTarget = {
+  id: 's3a', kind: 's3', label: 'Site', exporter: 'static-site', bucket: 'b', region: 'auto',
+  endpoint: 'https://x.r2.cloudflarestorage.com', accessKeyId: 'AKIA', secretAccessKey: 'super-secret',
+};
+
+beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-pcfg-')); });
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+describe('S3 target credentials', () => {
+  it('encrypts the secret at rest and never returns it from the read path', () => {
+    upsertPublishTarget(root, s3);
+    const onDisk = rawTargets()[0];
+    expect(onDisk.secretAccessKey).toBeUndefined();            // no plaintext field
+    expect(onDisk.secretAccessKeyEnc.startsWith('enc:v1:')).toBe(true);
+    expect(JSON.stringify(onDisk)).not.toContain('super-secret');
+
+    const wire = getPublishTargets(root)[0] as S3PublishTarget;
+    expect(wire.secretAccessKey).toBeUndefined();              // stripped from read
+    expect(wire.hasSecret).toBe(true);
+    expect(wire.accessKeyId).toBe('AKIA');                     // non-secret fields kept
+  });
+
+  it('decrypts the secret only for the transport', () => {
+    upsertPublishTarget(root, s3);
+    expect(getS3Credentials(root, 's3a')).toEqual({ accessKeyId: 'AKIA', secretAccessKey: 'super-secret' });
+  });
+
+  it('upsert secret is tri-state: omitted keeps, "" clears', () => {
+    upsertPublishTarget(root, s3);
+    // Re-save WITHOUT a secret (e.g. edited the region) → existing secret preserved.
+    upsertPublishTarget(root, { ...s3, secretAccessKey: undefined, region: 'us-east-1' });
+    expect(getS3Credentials(root, 's3a').secretAccessKey).toBe('super-secret');
+    expect((getPublishTargets(root)[0] as S3PublishTarget).region).toBe('us-east-1');
+    // Explicit '' clears it.
+    upsertPublishTarget(root, { ...s3, secretAccessKey: '' });
+    expect(getS3Credentials(root, 's3a').secretAccessKey).toBeUndefined();
+    expect((getPublishTargets(root)[0] as S3PublishTarget).hasSecret).toBe(false);
+  });
+
+  it('removing one target preserves another target\'s encrypted secret', () => {
+    const git: GitPublishTarget = { id: 'g', label: 'G', exporter: 'static-site', gitRemote: 'https://x', gitBranch: 'gh-pages' };
+    upsertPublishTarget(root, s3);
+    upsertPublishTarget(root, git);
+    removePublishTarget(root, 'g');
+    expect(getS3Credentials(root, 's3a').secretAccessKey).toBe('super-secret'); // survived
+  });
+
+  it('leaves git targets unchanged (no secret handling)', () => {
+    const git: GitPublishTarget = { id: 'g', label: 'G', exporter: 'static-site', gitRemote: 'https://x', gitBranch: 'gh-pages' };
+    upsertPublishTarget(root, git);
+    expect(getPublishTargets(root)[0]).toEqual(git);
+    expect(getS3Credentials(root, 'g')).toEqual({});
+  });
+});

--- a/tests/main/publish/publish-to-s3.test.ts
+++ b/tests/main/publish/publish-to-s3.test.ts
@@ -1,0 +1,112 @@
+/**
+ * S3 publish transport (#1444).
+ *
+ * Pure helpers (content type, prefix, key) are tested directly. `publishToS3`
+ * runs through a mocked `runExport` (writes a small tree into the temp
+ * workspace) + an INJECTED fake S3Client, so upload → key mapping, content
+ * types, orphan deletion, the added/modified/deleted change list, and dry-run
+ * (no writes) are exercised without a bucket or a real project.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { S3Client } from '@aws-sdk/client-s3';
+
+const h = vi.hoisted(() => ({ runExport: vi.fn() }));
+vi.mock('../../../src/main/publish/run-export', () => ({ runExport: h.runExport }));
+
+// The real @aws-sdk/client-s3 mis-resolves to a broken browser build under the
+// runner's browser condition. We inject a fake client anyway, so a lightweight
+// mock (command classes whose names the fake dispatches on) is all we need.
+vi.mock('@aws-sdk/client-s3', () => {
+  class Cmd { input: Record<string, unknown>; constructor(input: Record<string, unknown>) { this.input = input; } }
+  return {
+    S3Client: class { send = vi.fn(); },
+    PutObjectCommand: class extends Cmd {},
+    ListObjectsV2Command: class extends Cmd {},
+    DeleteObjectsCommand: class extends Cmd {},
+    HeadBucketCommand: class extends Cmd {},
+  };
+});
+
+import {
+  publishToS3,
+  contentTypeFor,
+  normalizePrefix,
+  objectKey,
+} from '../../../src/main/publish/publish-to-s3';
+import type { S3PublishTarget } from '../../../src/main/project-config';
+
+function fakeClient(existingKeys: string[]) {
+  const puts: { Key: string; ContentType: string }[] = [];
+  const deletes: string[] = [];
+  const send = vi.fn(async (cmd: { constructor: { name: string }; input: Record<string, unknown> }) => {
+    switch (cmd.constructor.name) {
+      case 'ListObjectsV2Command':
+        return { Contents: existingKeys.map((Key) => ({ Key })), IsTruncated: false };
+      case 'PutObjectCommand':
+        puts.push({ Key: cmd.input.Key as string, ContentType: cmd.input.ContentType as string });
+        return {};
+      case 'DeleteObjectsCommand':
+        for (const o of (cmd.input.Delete as { Objects: { Key: string }[] }).Objects) deletes.push(o.Key);
+        return {};
+      default:
+        return {};
+    }
+  });
+  return { client: { send } as unknown as S3Client, puts, deletes };
+}
+
+const target: S3PublishTarget = { id: 't', kind: 's3', label: 'T', exporter: 'static-site', bucket: 'my-bucket', subdir: 'site' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.runExport.mockImplementation(async (_root: string, args: { outputDir: string }) => {
+    fs.mkdirSync(path.join(args.outputDir, 'css'), { recursive: true });
+    fs.writeFileSync(path.join(args.outputDir, 'index.html'), '<html>');
+    fs.writeFileSync(path.join(args.outputDir, 'css', 'style.css'), 'body{}');
+    return { filesWritten: 2, summary: '', outputDir: args.outputDir, writtenPaths: [] };
+  });
+});
+
+describe('pure helpers', () => {
+  it('contentTypeFor maps by extension, defaulting to octet-stream', () => {
+    expect(contentTypeFor('a/b.html')).toMatch(/text\/html/);
+    expect(contentTypeFor('x.css')).toMatch(/text\/css/);
+    expect(contentTypeFor('img.png')).toBe('image/png');
+    expect(contentTypeFor('data.bin')).toBe('application/octet-stream');
+  });
+  it('normalizePrefix strips slashes; objectKey joins under the prefix', () => {
+    expect(normalizePrefix('/site/')).toBe('site');
+    expect(normalizePrefix(undefined)).toBe('');
+    expect(objectKey('site', 'a/b.html')).toBe('site/a/b.html');
+    expect(objectKey('', 'x.html')).toBe('x.html');
+  });
+});
+
+describe('publishToS3', () => {
+  it('uploads the tree under the prefix with content types, deletes orphans', async () => {
+    const { client, puts, deletes } = fakeClient(['site/index.html', 'site/old.html']);
+    const res = await publishToS3('/root', target, {}, {}, { client });
+
+    expect(new Set(puts.map((p) => p.Key))).toEqual(new Set(['site/index.html', 'site/css/style.css']));
+    expect(puts.find((p) => p.Key === 'site/index.html')!.ContentType).toMatch(/text\/html/);
+    expect(deletes).toEqual(['site/old.html']); // orphan removed (mirror semantics)
+
+    const byPath = Object.fromEntries(res.changes.map((c) => [c.path, c.status]));
+    expect(byPath['site/index.html']).toBe('modified'); // existed
+    expect(byPath['site/css/style.css']).toBe('added'); // new
+    expect(byPath['site/old.html']).toBe('deleted');
+    expect(res.committed && res.pushed).toBe(true);
+  });
+
+  it('dry run reports changes but writes nothing', async () => {
+    const { client, puts, deletes } = fakeClient(['site/old.html']);
+    const res = await publishToS3('/root', target, {}, { dryRun: true }, { client });
+    expect(puts).toEqual([]);
+    expect(deletes).toEqual([]);
+    expect(res.dryRun).toBe(true);
+    expect(res.changes.some((c) => c.status === 'deleted' && c.path === 'site/old.html')).toBe(true);
+    expect(res.committed).toBe(false);
+  });
+});

--- a/tests/main/publish/publish-transport.test.ts
+++ b/tests/main/publish/publish-transport.test.ts
@@ -16,8 +16,9 @@ import { publishTarget, getTransport, registerTransport } from '../../../src/mai
 beforeEach(() => vi.clearAllMocks());
 
 describe('transport registry', () => {
-  it('registers the git transport by default', () => {
+  it('registers the git + s3 transports by default', () => {
     expect(getTransport('git')?.kind).toBe('git');
+    expect(getTransport('s3')?.kind).toBe('s3');
   });
 });
 


### PR DESCRIPTION
Second of ~3 PRs for #1444. The S3 transport behind the `PublishTransport` seam (#1505), with credentials stored via the BYOM secret-at-rest pattern — the leg-up that motivated tackling this now. Stacks on #1505.

## Transport — `src/main/publish/publish-to-s3.ts` (only `@aws-sdk/client-s3` site)
- Mirrors `publish-to-git`: `runExport` into a temp dir, then upload the tree. One build serves Amazon S3 **and** R2/B2/Spaces/MinIO via a custom `endpoint` (path-style for compatibles). Content-type by extension.
- **Mirror semantics**: orphan objects under the prefix (absent from the new export) are deleted, matching git's `clearWorkTree`. **Dry run** reports would-add/modify/delete (existence-based) without touching the bucket — the etag/hash *content-diff* preview stays a documented follow-up per #1444 decision #2.
- `@aws-sdk` is **dynamically imported** inside the functions (type-only static import) so importing the publish barrel / transport registry never loads it: it mis-resolves to a broken browser build under the test runner's `browser` condition, and lazy-loading keeps it out of unrelated import graphs. Client injectable for tests.
- `checkS3Connection`: token-free `HeadBucket` for the settings "test connection" button (wired in the UI PR).

## Credentials — `project-config.ts`, reusing `secret-storage.ts` (its **3rd** consumer)
- `PublishTarget` is now a **discriminated union** (`GitPublishTarget | S3PublishTarget`) threaded through all three parallel decls. S3's `secretAccessKey` is **write-only + tri-state** on upsert (string sets / `''` clears / omitted keeps), stored **encrypted** (`secretAccessKeyEnc`) and **stripped from the read path** — only `hasSecret` crosses to the renderer. `getS3Credentials` decrypts main-side for the transport. CRUD operates on the stored shape, so removing one target can't strip another's secret.

The registry registers `s3Transport`; the dispatcher routes s3 targets to it. `publishToGit` narrows the union (throws on a non-git target). PublishDialog's target list shows `s3://bucket` for S3 targets — the full create/edit form is PR3.

## Tests
S3 transport upload / orphan-delete / dry-run / content-type + pure helpers (mocked `runExport` + injected fake client); project-config S3 credential encrypt / strip / tri-state / cross-target isolation + git-path-unaffected; registry has s3. `pnpm lint` clean; publish + project-config + ipc + preload suites green (370).

Part of #1444. Next (PR3): PublishDialog S3 create/edit form (kind switch, endpoint/bucket/region/prefix + credential fields, test-connection, "no preview for S3" note) + de-hardcoded GitHub copy.