### PR TITLE
feat(publish): PublishDialog S3 target UI + test-connection (#1444)

### DIFF
--- a/src/main/ipc/register-publish.ts
+++ b/src/main/ipc/register-publish.ts
@@ -138,4 +138,22 @@ export function registerPublish(): void {
       }
     }),
   );
+
+  // Validate S3 credentials/endpoint before saving a target (#1444). No rootPath
+  // needed — HeadBucket only depends on the bucket + endpoint + credentials.
+  handle(Channels.PUBLISH_CHECK_S3, (_e, config: {
+    bucket: string; endpoint?: string; region?: string; accessKeyId?: string; secretAccessKey?: string;
+  }) =>
+    publish.checkS3Connection(
+      {
+        id: 'check', label: 'check', exporter: '', kind: 's3', bucket: config.bucket,
+        ...(config.endpoint ? { endpoint: config.endpoint } : {}),
+        ...(config.region ? { region: config.region } : {}),
+      },
+      {
+        ...(config.accessKeyId ? { accessKeyId: config.accessKeyId } : {}),
+        ...(config.secretAccessKey ? { secretAccessKey: config.secretAccessKey } : {}),
+      },
+    ),
+  );
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -201,6 +201,8 @@ contextBridge.exposeInMainWorld('api', {
     removeTarget: (id: string) => invoke(Channels.PUBLISH_REMOVE_TARGET, id),
     toGit: (targetId: string, opts?: Parameters<ChannelMap['publish:toGit']>[1]) =>
       invoke(Channels.PUBLISH_TO_GIT, targetId, opts),
+    checkS3: (config: Parameters<ChannelMap['publish:checkS3']>[0]) =>
+      invoke(Channels.PUBLISH_CHECK_S3, config),
   },
   app: {
     getInfo: () => invoke(Channels.APP_GET_INFO),

--- a/src/renderer/lib/components/PublishDialog.svelte
+++ b/src/renderer/lib/components/PublishDialog.svelte
@@ -22,12 +22,46 @@
   let outcome = $state<{ targetId: string; dryRun: boolean; res: PublishGitResponse } | null>(null);
 
   // ── Add-target form ─────────────────────────────────────────────────────
+  let fKind = $state<'git' | 's3'>('git');
   let fLabel = $state('');
-  let fRemote = $state('');
-  let fBranch = $state('gh-pages');
   let fExporter = $state('static-site');
   let fSubdir = $state('.');
+  // git
+  let fRemote = $state('');
+  let fBranch = $state('gh-pages');
   let fTemplate = $state('Publish {{date}} from Minerva');
+  // s3
+  let fBucket = $state('');
+  let fEndpoint = $state('');
+  let fRegion = $state('');
+  let fAccessKeyId = $state('');
+  let fSecret = $state('');
+
+  // S3 "test connection" state (#1444).
+  let s3Checking = $state(false);
+  let s3CheckResult = $state<import('../../../shared/tools/types').ConnectionCheckResult | null>(null);
+  // Any edit to the S3 credentials invalidates a prior check result.
+  $effect(() => { void fBucket; void fEndpoint; void fRegion; void fAccessKeyId; void fSecret; s3CheckResult = null; });
+  const canCheckS3 = $derived(fBucket.trim() !== '');
+
+  async function runS3Check(): Promise<void> {
+    if (s3Checking || !canCheckS3) return;
+    s3Checking = true;
+    s3CheckResult = null;
+    try {
+      s3CheckResult = await api.publish.checkS3({
+        bucket: fBucket.trim(),
+        ...(fEndpoint.trim() ? { endpoint: fEndpoint.trim() } : {}),
+        ...(fRegion.trim() ? { region: fRegion.trim() } : {}),
+        ...(fAccessKeyId.trim() ? { accessKeyId: fAccessKeyId.trim() } : {}),
+        ...(fSecret ? { secretAccessKey: fSecret } : {}),
+      });
+    } catch (e) {
+      s3CheckResult = { ok: false, error: e instanceof Error ? e.message : String(e) };
+    } finally {
+      s3Checking = false;
+    }
+  }
 
   onMount(async () => {
     await refresh();
@@ -57,23 +91,43 @@
     return id;
   }
 
-  const canSave = $derived(fLabel.trim() !== '' && fRemote.trim() !== '' && fBranch.trim() !== '');
+  const canSave = $derived(
+    fLabel.trim() !== '' &&
+      (fKind === 's3'
+        ? fBucket.trim() !== ''
+        : fRemote.trim() !== '' && fBranch.trim() !== ''),
+  );
 
   async function saveTarget(): Promise<void> {
     if (!canSave) return;
-    const target: PublishTarget = {
-      id: uniqueId(slug(fLabel)),
-      label: fLabel.trim(),
-      exporter: fExporter,
-      gitRemote: fRemote.trim(),
-      gitBranch: fBranch.trim(),
-      subdir: fSubdir.trim() || '.',
-      commitMessageTemplate: fTemplate.trim() || 'Publish {{date}} from Minerva',
-    };
+    const common = { id: uniqueId(slug(fLabel)), label: fLabel.trim(), exporter: fExporter, subdir: fSubdir.trim() || '.' };
+    const target: PublishTarget = fKind === 's3'
+      ? {
+          ...common,
+          kind: 's3',
+          bucket: fBucket.trim(),
+          ...(fEndpoint.trim() ? { endpoint: fEndpoint.trim() } : {}),
+          ...(fRegion.trim() ? { region: fRegion.trim() } : {}),
+          ...(fAccessKeyId.trim() ? { accessKeyId: fAccessKeyId.trim() } : {}),
+          // Write-only + tri-state: send only when the user typed one.
+          ...(fSecret ? { secretAccessKey: fSecret } : {}),
+        }
+      : {
+          ...common,
+          gitRemote: fRemote.trim(),
+          gitBranch: fBranch.trim(),
+          commitMessageTemplate: fTemplate.trim() || 'Publish {{date}} from Minerva',
+        };
     targets = await publish.upsertTarget(target);
     showForm = false;
     fLabel = '';
     fRemote = '';
+    fBucket = '';
+    fEndpoint = '';
+    fRegion = '';
+    fAccessKeyId = '';
+    fSecret = '';
+    s3CheckResult = null;
   }
 
   async function removeTarget(id: string): Promise<void> {
@@ -119,8 +173,8 @@
 <div class="publish-backdrop" onmousedown={onBackdrop} onkeydown={onKeydown}>
   <div class="publish-dialog" role="dialog" aria-labelledby="publish-title">
     <h2 id="publish-title">Publish to Web</h2>
-    <p class="sub">Push an export to a git remote — e.g. a static site to GitHub Pages.
-      Authentication uses your GitHub CLI login or a <code>GH_TOKEN</code>.</p>
+    <p class="sub">Push an export to a git remote (e.g. a static site to GitHub Pages) or upload it
+      to an S3 / S3-compatible bucket (Amazon S3, Cloudflare R2, Backblaze B2, MinIO, …).</p>
 
     {#if !loaded}
       <p class="muted">Loading…</p>
@@ -142,10 +196,14 @@
                 {/if}
               </div>
               <div class="target-actions">
-                <button onclick={() => run(t, true)} disabled={busyId === t.id}>
-                  {busyId === t.id ? 'Working…' : 'Preview'}
+                {#if t.kind !== 's3'}
+                  <button onclick={() => run(t, true)} disabled={busyId === t.id}>
+                    {busyId === t.id ? 'Working…' : 'Preview'}
+                  </button>
+                {/if}
+                <button class="primary" onclick={() => run(t, false)} disabled={busyId === t.id}>
+                  {busyId === t.id && t.kind === 's3' ? 'Uploading…' : 'Publish'}
                 </button>
-                <button class="primary" onclick={() => run(t, false)} disabled={busyId === t.id}>Publish</button>
                 <button class="ghost" onclick={() => removeTarget(t.id)} disabled={busyId === t.id} title="Remove target">✕</button>
               </div>
             </div>
@@ -174,7 +232,11 @@
                   {/if}
                 {:else if res.result.committed}
                   <div class="outcome-head">Published — {counts(res)}</div>
-                  <div class="muted">Pushed to <code>{res.result.branch}</code>{res.result.branchCreated ? ' (created)' : ''} · {res.result.sha?.slice(0, 7)} · {res.result.commitMessage}</div>
+                  {#if t.kind === 's3'}
+                    <div class="muted">Uploaded to <code>s3://{t.bucket}{t.subdir && t.subdir !== '.' ? `/${t.subdir}` : ''}</code>.</div>
+                  {:else}
+                    <div class="muted">Pushed to <code>{res.result.branch}</code>{res.result.branchCreated ? ' (created)' : ''} · {res.result.sha?.slice(0, 7)} · {res.result.commitMessage}</div>
+                  {/if}
                 {:else}
                   <div class="outcome-head">Up to date</div>
                   <div class="muted">Nothing has changed since the last publish.</div>
@@ -187,18 +249,49 @@
 
       {#if showForm}
         <div class="form">
-          <label>Label<input bind:value={fLabel} placeholder="My Garden" /></label>
-          <label>Remote URL<input bind:value={fRemote} placeholder="git@github.com:you/garden.git" /></label>
-          <div class="row">
-            <label>Branch<input bind:value={fBranch} /></label>
-            <label>Subdirectory<input bind:value={fSubdir} /></label>
+          <div class="kind-switch" role="radiogroup" aria-label="Transport">
+            <button class:selected={fKind === 'git'} role="radio" aria-checked={fKind === 'git'} onclick={() => { fKind = 'git'; }}>Git remote</button>
+            <button class:selected={fKind === 's3'} role="radio" aria-checked={fKind === 's3'} onclick={() => { fKind = 's3'; }}>S3 bucket</button>
           </div>
+
+          <label>Label<input bind:value={fLabel} placeholder="My Garden" /></label>
+
+          {#if fKind === 's3'}
+            <label>Bucket<input bind:value={fBucket} placeholder="my-site-bucket" /></label>
+            <div class="row">
+              <label>Endpoint (S3-compatible; blank for AWS)<input bind:value={fEndpoint} placeholder="https://<account>.r2.cloudflarestorage.com" /></label>
+              <label>Region<input bind:value={fRegion} placeholder="auto" /></label>
+            </div>
+            <label>Key prefix<input bind:value={fSubdir} placeholder="." /></label>
+            <div class="row">
+              <label>Access key ID<input bind:value={fAccessKeyId} autocomplete="off" spellcheck="false" /></label>
+              <label>Secret access key<input type="password" bind:value={fSecret} autocomplete="off" spellcheck="false"
+                oncopy={(e) => e.preventDefault()} oncut={(e) => e.preventDefault()} placeholder="stored encrypted" /></label>
+            </div>
+            <p class="muted">Leave the keys blank to use the AWS default credential chain (<code>~/.aws</code>, env vars). Preview isn't available for S3 yet — Publish uploads changed files and removes ones no longer exported.</p>
+            <div class="check-conn">
+              <button onclick={runS3Check} disabled={!canCheckS3 || s3Checking}>{s3Checking ? 'Checking…' : 'Test connection'}</button>
+              {#if s3CheckResult}
+                <span class="check-result" class:ok={s3CheckResult.ok} class:bad={!s3CheckResult.ok}>
+                  {#if s3CheckResult.ok}✓ Reached the bucket.{:else}✗ {s3CheckResult.error}{/if}
+                </span>
+              {/if}
+            </div>
+          {:else}
+            <label>Remote URL<input bind:value={fRemote} placeholder="git@github.com:you/garden.git" /></label>
+            <div class="row">
+              <label>Branch<input bind:value={fBranch} /></label>
+              <label>Subdirectory<input bind:value={fSubdir} /></label>
+            </div>
+            <label>Commit message<input bind:value={fTemplate} /></label>
+            <p class="muted">Authentication uses your GitHub CLI login or a <code>GH_TOKEN</code>.</p>
+          {/if}
+
           <label>Exporter
             <select bind:value={fExporter}>
               {#each exporters as e (e.id)}<option value={e.id}>{e.label}</option>{/each}
             </select>
           </label>
-          <label>Commit message<input bind:value={fTemplate} /></label>
           <div class="form-actions">
             <button class="ghost" onclick={() => { showForm = false; }}>Cancel</button>
             <button class="primary" onclick={saveTarget} disabled={!canSave}>Save target</button>
@@ -268,6 +361,14 @@
   .form .row label { flex: 1; }
   .form input, .form select { background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 6px 8px; font-size: 0.88rem; }
   .form-actions { display: flex; justify-content: flex-end; gap: 8px; }
+
+  .kind-switch { display: flex; gap: 6px; }
+  .kind-switch button { flex: 1; }
+  .kind-switch button.selected { background: var(--accent); color: var(--accent-ink, #1a1a1a); border-color: transparent; }
+  .check-conn { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .check-result { font-size: 0.82rem; }
+  .check-result.ok { color: var(--sage, #6a9); }
+  .check-result.bad { color: var(--rust, #c66); }
 
   .footer { display: flex; justify-content: space-between; gap: 8px; margin-top: 18px; }
 </style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -319,6 +319,14 @@ export interface PublishApi {
   removeTarget(id: string): Promise<PublishTarget[]>;
   /** Export + commit + push (or, with `dryRun`, preview the diff only). */
   toGit(targetId: string, opts?: { dryRun?: boolean }): Promise<PublishGitResponse>;
+  /** Validate S3 credentials + endpoint against the bucket, before saving (#1444). */
+  checkS3(config: {
+    bucket: string;
+    endpoint?: string;
+    region?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+  }): Promise<import('../../../shared/tools/types').ConnectionCheckResult>;
 }
 
 /** A configured publish destination (#254; multi-transport #1444). */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -573,6 +573,8 @@ export const Channels = {
   PUBLISH_REMOVE_TARGET: 'publish:removeTarget',
   /** Publication: export + commit + push to a target (dryRun previews the diff) (#254). */
   PUBLISH_TO_GIT: 'publish:toGit',
+  /** Validate S3 credentials/endpoint against the bucket (HeadBucket) — settings "Check connection" (#1444). */
+  PUBLISH_CHECK_S3: 'publish:checkS3',
   /** Menu → "Export…" — opens the preview dialog for a specific exporter id (payload). */
   MENU_EXPORT: 'menu:export',
   /** Menu → "Publish to Web…" — opens the git-publish dialog (#254). */

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -289,6 +289,14 @@ export interface ChannelMap {
         commitMessage?: string;
       } }
     | { ok: false; error: string };
+  /** Validate S3 credentials + endpoint against the bucket, before saving (#1444). */
+  'publish:checkS3': (config: {
+    bucket: string;
+    endpoint?: string;
+    region?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+  }) => ConnectionCheckResult;
 
   // Compute (notebook cells)
   'compute:runCell': (language: string, code: string, notePath?: string) => CellResult;

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -139,6 +139,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "proposal:expire",
   "proposal:list",
   "proposal:reject",
+  "publish:checkS3",
   "publish:listExporters",
   "publish:listTargets",
   "publish:removeTarget",

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -261,6 +261,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "reject",
   ],
   "publish": [
+    "checkS3",
     "listExporters",
     "listTargets",
     "removeTarget",

--- a/tests/renderer/components/PublishDialog.test.ts
+++ b/tests/renderer/components/PublishDialog.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * PublishDialog S3 target flow (#1444). The store is a thin passthrough to
+ * `api.publish`, so mocking the client covers both. Verifies the kind switch
+ * reveals S3 fields, "Test connection" calls `checkS3`, and Save builds an S3
+ * target carrying the write-only secret. (Git path is unchanged.)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+
+const api = vi.hoisted(() => ({
+  publish: {
+    listTargets: vi.fn(async () => []),
+    listExporters: vi.fn(async () => [{ id: 'static-site', label: 'Static Site', acceptedKinds: ['project'] }]),
+    upsertTarget: vi.fn(async (t: unknown) => [t]),
+    removeTarget: vi.fn(async () => []),
+    toGit: vi.fn(),
+    checkS3: vi.fn(async () => ({ ok: true })),
+  },
+}));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api }));
+
+import PublishDialog from '../../../src/renderer/lib/components/PublishDialog.svelte';
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => cleanup());
+
+async function openS3Form() {
+  const view = render(PublishDialog, { onClose: vi.fn() });
+  await view.findByText('Add target…');
+  await fireEvent.click(view.getByText('Add target…'));
+  await fireEvent.click(view.getByText('S3 bucket'));
+  return view;
+}
+
+describe('PublishDialog — S3 target', () => {
+  it('the kind switch reveals S3 fields (bucket), hides the git remote field', async () => {
+    const { getByLabelText, queryByLabelText } = await openS3Form();
+    expect(getByLabelText('Bucket')).toBeTruthy();
+    expect(queryByLabelText('Remote URL')).toBeNull();
+  });
+
+  it('Test connection calls checkS3 with the entered config and shows the result', async () => {
+    const { getByLabelText, getByText, findByText } = await openS3Form();
+    await fireEvent.input(getByLabelText('Bucket'), { target: { value: 'my-bucket' } });
+    await fireEvent.click(getByText('Test connection'));
+    expect(api.publish.checkS3).toHaveBeenCalledWith(expect.objectContaining({ bucket: 'my-bucket' }));
+    await findByText(/Reached the bucket/);
+  });
+
+  it('Save builds an S3 target with the write-only secret', async () => {
+    const { getByLabelText, getByText } = await openS3Form();
+    await fireEvent.input(getByLabelText('Label'), { target: { value: 'My Site' } });
+    await fireEvent.input(getByLabelText('Bucket'), { target: { value: 'my-bucket' } });
+    await fireEvent.input(getByLabelText('Secret access key'), { target: { value: 'sk-secret' } });
+    await fireEvent.click(getByText('Save target'));
+
+    expect(api.publish.upsertTarget).toHaveBeenCalledTimes(1);
+    const saved = api.publish.upsertTarget.mock.calls[0]![0] as Record<string, unknown>;
+    expect(saved).toMatchObject({ kind: 's3', label: 'My Site', bucket: 'my-bucket', secretAccessKey: 'sk-secret' });
+    expect(saved.gitRemote).toBeUndefined();
+  });
+
+  it('Save omits the secret when none was typed (tri-state keep)', async () => {
+    const { getByLabelText, getByText } = await openS3Form();
+    await fireEvent.input(getByLabelText('Label'), { target: { value: 'My Site' } });
+    await fireEvent.input(getByLabelText('Bucket'), { target: { value: 'my-bucket' } });
+    await fireEvent.click(getByText('Save target'));
+    const saved = api.publish.upsertTarget.mock.calls[0]![0] as Record<string, unknown>;
+    expect('secretAccessKey' in saved).toBe(false);
+  });
+});


### PR DESCRIPTION
Final PR for #1444 — makes S3 publishing configurable from the UI. The transport + encrypted credential storage already landed (#1505 / #1506); this is pure renderer + a small IPC method. Stacks on #1506.

## PublishDialog
- **Kind switch** (Git | S3) in the add-target form. S3 shows bucket / endpoint (blank = AWS) / region / key-prefix / access-key-id / secret-access-key; git keeps remote / branch / commit-message. `saveTarget` builds the matching union variant; the **secret is write-only and only sent when typed** (tri-state keep — matches the storage contract).
- **Test connection** for S3 → `HeadBucket` via a new `publish:checkS3` IPC, with an inline ✓/✗ result that clears on any credential edit.
- **Deferred-preview decision honored**: S3 targets **hide the Preview button** — the existence-based dry run would mark every *unchanged* file as "modified", which is exactly why content-diff preview was deferred — and the form notes preview isn't available yet, plus that blank keys fall back to the AWS default credential chain. The published outcome is kind-aware (`s3://bucket/prefix`, no branch/sha). Subtitle + git-only auth note de-hardcoded.

## IPC
`publish:checkS3` — channel + contract + handler (builds a throwaway target + creds; no rootPath needed) + preload + client type. Preload + IPC-registration snapshots updated.

## Test
`PublishDialog.test.ts` (happy-dom, mocking `api.publish`): the kind switch reveals S3 fields, Test connection calls `checkS3`, and Save builds an S3 target carrying the write-only secret (and omits it when untyped). `pnpm lint` clean; publish + config + ipc + preload + dialog suites green (383).

**Closes #1444.** S3 / S3-compatible object storage is now a first-class publish transport end-to-end — configurable, credentialed (encrypted at rest), and testable from the dialog, alongside GitHub Pages.