### PR TITLE
feat(publish): store GitHub token in secret storage (#1508)

### DIFF
--- a/src/main/git/publish-git.ts
+++ b/src/main/git/publish-git.ts
@@ -23,6 +23,7 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
+import type { ConnectionCheckResult } from '../../shared/tools/types';
 
 const AUTHOR = { name: 'Minerva', email: 'user@minerva.local' };
 
@@ -48,26 +49,58 @@ export function normalizeRemoteToHttps(url: string): string {
 }
 
 /**
- * Resolve an HTTPS token, preferring the GitHub CLI (per the issue) and
- * falling back to env. Throws a user-facing message when nothing works —
- * this is the "GitHub isn't configured" surface.
+ * Resolve an HTTPS token. Precedence (#1508): a `preferred` token (the target's
+ * safeStorage-encrypted token, so the `gh` CLI need not be installed) → the
+ * GitHub CLI (`gh auth token`) → a `GH_TOKEN`/`GITHUB_TOKEN` env var. Throws a
+ * user-facing message when nothing works — the "GitHub isn't configured" surface.
  */
-export function resolveGitHubToken(): string {
-  try {
-    const t = execFileSync('gh', ['auth', 'token'], {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-    if (t) return t;
-  } catch {
-    // gh not installed or not signed in — fall through to env.
-  }
+export function resolveGitHubToken(preferred?: string): string {
+  const stored = preferred?.trim();
+  if (stored) return stored;
+  const cli = ghCliToken();
+  if (cli) return cli;
   const env = (process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '').trim();
   if (env) return env;
   throw new Error(
-    "Git credentials aren't configured for this remote. Sign in with the GitHub CLI " +
-      '(`gh auth login`) or set a GH_TOKEN environment variable, then try again.',
+    "Git credentials aren't configured for this remote. Add a GitHub token in the publish " +
+      'target, sign in with the GitHub CLI (`gh auth login`), or set a GH_TOKEN environment variable, then try again.',
   );
+}
+
+/** The `gh auth token`, or '' when the CLI is absent / not signed in. */
+function ghCliToken(): string {
+  try {
+    return execFileSync('gh', ['auth', 'token'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Validate a GitHub token with a token-free `GET /user` — powers the publish
+ * dialog's "Test connection" (#1508). Resolves the effective token
+ * (candidate → gh CLI → env) so a blank field tests whatever the push would
+ * use. Never throws: failures come back as `{ ok: false, error }`.
+ */
+export async function checkGitHubToken(candidate?: string): Promise<ConnectionCheckResult> {
+  const token = (candidate?.trim() || ghCliToken() || process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '').trim();
+  if (!token) {
+    return { ok: false, error: 'No token to check — enter one, sign in with `gh`, or set GH_TOKEN.' };
+  }
+  try {
+    const res = await fetch('https://api.github.com/user', {
+      headers: { Authorization: `Bearer ${token}`, 'User-Agent': 'Minerva', Accept: 'application/vnd.github+json' },
+    });
+    if (res.ok) return { ok: true };
+    if (res.status === 401) return { ok: false, error: 'GitHub rejected the token (invalid or expired).' };
+    if (res.status === 403) return { ok: false, error: 'Token accepted but lacks permission (403).' };
+    return { ok: false, error: `GitHub returned ${res.status} ${res.statusText}.` };
+  } catch (e) {
+    return { ok: false, error: `Couldn't reach GitHub: ${e instanceof Error ? e.message : String(e)}` };
+  }
 }
 
 /** Render a commit template, filling `{{date}}` / `{{version}}`. */

--- a/src/main/ipc/register-publish.ts
+++ b/src/main/ipc/register-publish.ts
@@ -11,6 +11,7 @@ import {
   removePublishTarget,
   type PublishTarget,
 } from '../project-config';
+import { checkGitHubToken } from '../git/publish-git';
 import { withRootPath, withRootPathWin } from './helpers';
 
 export function registerPublish(): void {
@@ -155,5 +156,11 @@ export function registerPublish(): void {
         ...(config.secretAccessKey ? { secretAccessKey: config.secretAccessKey } : {}),
       },
     ),
+  );
+
+  // Validate a GitHub token (#1508) — a blank token tests the gh CLI / env
+  // fallback, matching what the push would resolve.
+  handle(Channels.PUBLISH_CHECK_GITHUB, (_e, config: { token?: string }) =>
+    checkGitHubToken(config.token),
   );
 }

--- a/src/main/project-config.ts
+++ b/src/main/project-config.ts
@@ -66,6 +66,15 @@ export interface GitPublishTarget extends PublishTargetBase {
   gitBranch: string;
   /** Commit message, with `{{date}}` / `{{version}}` placeholders. */
   commitMessageTemplate?: string;
+  /**
+   * GitHub token (#1508). Same secret contract as S3's key: WRITE-ONLY +
+   * tri-state on upsert (string sets, '' clears, omitted keeps), stored
+   * encrypted, never returned by the read path. Preferred over the `gh` CLI /
+   * `GH_TOKEN` env at push time.
+   */
+  githubToken?: string;
+  /** Read-only: a token is stored. */
+  hasToken?: boolean;
 }
 
 /**
@@ -91,9 +100,10 @@ export interface S3PublishTarget extends PublishTargetBase {
 
 export type PublishTarget = GitPublishTarget | S3PublishTarget;
 
-/** On-disk S3 target: the encrypted secret replaces the plaintext write field. */
+/** On-disk targets: the encrypted secret replaces the plaintext write field. */
+type StoredGitTarget = Omit<GitPublishTarget, 'githubToken' | 'hasToken'> & { githubTokenEnc?: string };
 type StoredS3Target = Omit<S3PublishTarget, 'secretAccessKey' | 'hasSecret'> & { secretAccessKeyEnc?: string };
-type StoredTarget = GitPublishTarget | StoredS3Target;
+type StoredTarget = StoredGitTarget | StoredS3Target;
 
 function configPath(rootPath: string): string {
   return path.join(rootPath, '.minerva', 'config.json');
@@ -172,7 +182,8 @@ function toWireTarget(t: StoredTarget): PublishTarget {
     const { secretAccessKeyEnc, ...rest } = t;
     return { ...rest, hasSecret: !!secretAccessKeyEnc };
   }
-  return t;
+  const { githubTokenEnc, ...rest } = t;
+  return { ...rest, hasToken: !!githubTokenEnc };
 }
 
 /** All configured publish targets (#254, #1444), secrets stripped. Empty when unset. */
@@ -197,16 +208,34 @@ export function getS3Credentials(rootPath: string, id: string): { accessKeyId?: 
   };
 }
 
+/**
+ * The decrypted GitHub token for a git target (#1508) — main-only, for the
+ * push. Empty for non-git / unknown ids or when no token is stored (the
+ * `gh` CLI / env fallback then applies).
+ */
+export function getGitCredentials(rootPath: string, id: string): { token?: string } {
+  const t = readStoredTargets(rootPath).find((x) => x.id === id);
+  if (!t || t.kind === 's3') return {};
+  return t.githubTokenEnc ? { token: decryptSecret(t.githubTokenEnc) } : {};
+}
+
 /** Wire → on-disk: for S3, apply the tri-state secret (string sets/encrypts,
  *  '' clears, omitted keeps the existing encrypted value) and drop the plaintext. */
 function toStoredTarget(target: PublishTarget, existing: StoredTarget | undefined): StoredTarget {
-  if (target.kind !== 's3') return target;
-  const { secretAccessKey, hasSecret: _hasSecret, ...rest } = target;
-  const prevEnc = existing && existing.kind === 's3' ? existing.secretAccessKeyEnc : undefined;
-  const enc = secretAccessKey === undefined ? prevEnc
-    : secretAccessKey === '' ? undefined
-    : encryptSecret(secretAccessKey);
-  return { ...rest, ...(enc ? { secretAccessKeyEnc: enc } : {}) };
+  if (target.kind === 's3') {
+    const { secretAccessKey, hasSecret: _hasSecret, ...rest } = target;
+    const prevEnc = existing && existing.kind === 's3' ? existing.secretAccessKeyEnc : undefined;
+    const enc = secretAccessKey === undefined ? prevEnc
+      : secretAccessKey === '' ? undefined
+      : encryptSecret(secretAccessKey);
+    return { ...rest, ...(enc ? { secretAccessKeyEnc: enc } : {}) };
+  }
+  const { githubToken, hasToken: _hasToken, ...rest } = target;
+  const prevEnc = existing && existing.kind !== 's3' ? existing.githubTokenEnc : undefined;
+  const enc = githubToken === undefined ? prevEnc
+    : githubToken === '' ? undefined
+    : encryptSecret(githubToken);
+  return { ...rest, ...(enc ? { githubTokenEnc: enc } : {}) };
 }
 
 /** Insert or replace a target by id, preserving the rest of the list (and other

--- a/src/main/publish/publish-to-git.ts
+++ b/src/main/publish/publish-to-git.ts
@@ -12,7 +12,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getPublishTarget } from '../project-config';
+import { getPublishTarget, getGitCredentials } from '../project-config';
 import { runExport } from './run-export';
 import * as pg from '../git/publish-git';
 import type { PublishChange } from '../git/publish-git';
@@ -50,7 +50,8 @@ export async function publishToGit(
 
   const dryRun = opts.dryRun ?? false;
   // Fail fast with a clear message before doing any work if creds are missing.
-  const token = pg.resolveGitHubToken();
+  // Prefer the target's stored token (#1508), else the gh CLI / env.
+  const token = pg.resolveGitHubToken(getGitCredentials(rootPath, targetId).token);
 
   ensurePublishCacheIgnored(rootPath);
   const workspace = path.join(rootPath, '.minerva', 'publish-cache', target.id);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -203,6 +203,8 @@ contextBridge.exposeInMainWorld('api', {
       invoke(Channels.PUBLISH_TO_GIT, targetId, opts),
     checkS3: (config: Parameters<ChannelMap['publish:checkS3']>[0]) =>
       invoke(Channels.PUBLISH_CHECK_S3, config),
+    checkGitHub: (config: Parameters<ChannelMap['publish:checkGitHub']>[0]) =>
+      invoke(Channels.PUBLISH_CHECK_GITHUB, config),
   },
   app: {
     getInfo: () => invoke(Channels.APP_GET_INFO),

--- a/src/renderer/lib/components/PublishDialog.svelte
+++ b/src/renderer/lib/components/PublishDialog.svelte
@@ -30,6 +30,7 @@
   let fRemote = $state('');
   let fBranch = $state('gh-pages');
   let fTemplate = $state('Publish {{date}} from Minerva');
+  let fToken = $state('');
   // s3
   let fBucket = $state('');
   let fEndpoint = $state('');
@@ -43,6 +44,24 @@
   // Any edit to the S3 credentials invalidates a prior check result.
   $effect(() => { void fBucket; void fEndpoint; void fRegion; void fAccessKeyId; void fSecret; s3CheckResult = null; });
   const canCheckS3 = $derived(fBucket.trim() !== '');
+
+  // GitHub "test connection" (#1508). A blank token tests the gh CLI / env fallback.
+  let gitChecking = $state(false);
+  let gitCheckResult = $state<import('../../../shared/tools/types').ConnectionCheckResult | null>(null);
+  $effect(() => { void fToken; gitCheckResult = null; });
+
+  async function runGitHubCheck(): Promise<void> {
+    if (gitChecking) return;
+    gitChecking = true;
+    gitCheckResult = null;
+    try {
+      gitCheckResult = await api.publish.checkGitHub({ ...(fToken.trim() ? { token: fToken.trim() } : {}) });
+    } catch (e) {
+      gitCheckResult = { ok: false, error: e instanceof Error ? e.message : String(e) };
+    } finally {
+      gitChecking = false;
+    }
+  }
 
   async function runS3Check(): Promise<void> {
     if (s3Checking || !canCheckS3) return;
@@ -117,17 +136,21 @@
           gitRemote: fRemote.trim(),
           gitBranch: fBranch.trim(),
           commitMessageTemplate: fTemplate.trim() || 'Publish {{date}} from Minerva',
+          // Write-only + tri-state: send only when the user typed one.
+          ...(fToken ? { githubToken: fToken } : {}),
         };
     targets = await publish.upsertTarget(target);
     showForm = false;
     fLabel = '';
     fRemote = '';
+    fToken = '';
     fBucket = '';
     fEndpoint = '';
     fRegion = '';
     fAccessKeyId = '';
     fSecret = '';
     s3CheckResult = null;
+    gitCheckResult = null;
   }
 
   async function removeTarget(id: string): Promise<void> {
@@ -284,7 +307,17 @@
               <label>Subdirectory<input bind:value={fSubdir} /></label>
             </div>
             <label>Commit message<input bind:value={fTemplate} /></label>
-            <p class="muted">Authentication uses your GitHub CLI login or a <code>GH_TOKEN</code>.</p>
+            <label>GitHub token (optional)<input type="password" bind:value={fToken} autocomplete="off" spellcheck="false"
+              oncopy={(e) => e.preventDefault()} oncut={(e) => e.preventDefault()} placeholder="stored encrypted" /></label>
+            <p class="muted">Leave blank to use your GitHub CLI login (<code>gh</code>) or a <code>GH_TOKEN</code> environment variable.</p>
+            <div class="check-conn">
+              <button onclick={runGitHubCheck} disabled={gitChecking}>{gitChecking ? 'Checking…' : 'Test connection'}</button>
+              {#if gitCheckResult}
+                <span class="check-result" class:ok={gitCheckResult.ok} class:bad={!gitCheckResult.ok}>
+                  {#if gitCheckResult.ok}✓ GitHub accepted the token.{:else}✗ {gitCheckResult.error}{/if}
+                </span>
+              {/if}
+            </div>
           {/if}
 
           <label>Exporter

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -327,6 +327,8 @@ export interface PublishApi {
     accessKeyId?: string;
     secretAccessKey?: string;
   }): Promise<import('../../../shared/tools/types').ConnectionCheckResult>;
+  /** Validate a GitHub token; blank tests the gh CLI / env fallback (#1508). */
+  checkGitHub(config: { token?: string }): Promise<import('../../../shared/tools/types').ConnectionCheckResult>;
 }
 
 /** A configured publish destination (#254; multi-transport #1444). */

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -575,6 +575,8 @@ export const Channels = {
   PUBLISH_TO_GIT: 'publish:toGit',
   /** Validate S3 credentials/endpoint against the bucket (HeadBucket) — settings "Check connection" (#1444). */
   PUBLISH_CHECK_S3: 'publish:checkS3',
+  /** Validate a GitHub token (GET /user) — publish dialog "Test connection" (#1508). */
+  PUBLISH_CHECK_GITHUB: 'publish:checkGitHub',
   /** Menu → "Export…" — opens the preview dialog for a specific exporter id (payload). */
   MENU_EXPORT: 'menu:export',
   /** Menu → "Publish to Web…" — opens the git-publish dialog (#254). */

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -297,6 +297,8 @@ export interface ChannelMap {
     accessKeyId?: string;
     secretAccessKey?: string;
   }) => ConnectionCheckResult;
+  /** Validate a GitHub token (GET /user); blank tests the gh CLI / env fallback (#1508). */
+  'publish:checkGitHub': (config: { token?: string }) => ConnectionCheckResult;
 
   // Compute (notebook cells)
   'compute:runCell': (language: string, code: string, notePath?: string) => CellResult;

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -139,6 +139,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "proposal:expire",
   "proposal:list",
   "proposal:reject",
+  "publish:checkGitHub",
   "publish:checkS3",
   "publish:listExporters",
   "publish:listTargets",

--- a/tests/main/project-config-s3.test.ts
+++ b/tests/main/project-config-s3.test.ts
@@ -22,6 +22,7 @@ vi.mock('electron', () => ({
 import {
   getPublishTargets,
   getS3Credentials,
+  getGitCredentials,
   upsertPublishTarget,
   removePublishTarget,
   type S3PublishTarget,
@@ -79,10 +80,46 @@ describe('S3 target credentials', () => {
     expect(getS3Credentials(root, 's3a').secretAccessKey).toBe('super-secret'); // survived
   });
 
-  it('leaves git targets unchanged (no secret handling)', () => {
+  it('leaves git targets without a token unchanged, hasToken false', () => {
     const git: GitPublishTarget = { id: 'g', label: 'G', exporter: 'static-site', gitRemote: 'https://x', gitBranch: 'gh-pages' };
     upsertPublishTarget(root, git);
-    expect(getPublishTargets(root)[0]).toEqual(git);
+    expect(getPublishTargets(root)[0]).toEqual({ ...git, hasToken: false });
     expect(getS3Credentials(root, 'g')).toEqual({});
+    expect(getGitCredentials(root, 'g')).toEqual({});
+  });
+});
+
+describe('Git target token (#1508)', () => {
+  const git: GitPublishTarget = {
+    id: 'g', label: 'G', exporter: 'static-site', gitRemote: 'https://github.com/me/site', gitBranch: 'gh-pages',
+    githubToken: 'ghp_secret',
+  };
+
+  it('encrypts the token at rest and never returns it from the read path', () => {
+    upsertPublishTarget(root, git);
+    const onDisk = rawTargets()[0];
+    expect(onDisk.githubToken).toBeUndefined();
+    expect(onDisk.githubTokenEnc.startsWith('enc:v1:')).toBe(true);
+    expect(JSON.stringify(onDisk)).not.toContain('ghp_secret');
+
+    const wire = getPublishTargets(root)[0] as GitPublishTarget;
+    expect(wire.githubToken).toBeUndefined();
+    expect(wire.hasToken).toBe(true);
+    expect(wire.gitRemote).toBe('https://github.com/me/site');
+  });
+
+  it('decrypts the token only for the push', () => {
+    upsertPublishTarget(root, git);
+    expect(getGitCredentials(root, 'g')).toEqual({ token: 'ghp_secret' });
+  });
+
+  it('token is tri-state: omitted keeps, "" clears', () => {
+    upsertPublishTarget(root, git);
+    upsertPublishTarget(root, { ...git, githubToken: undefined, gitBranch: 'main' });
+    expect(getGitCredentials(root, 'g').token).toBe('ghp_secret');
+    expect((getPublishTargets(root)[0] as GitPublishTarget).gitBranch).toBe('main');
+    upsertPublishTarget(root, { ...git, githubToken: '' });
+    expect(getGitCredentials(root, 'g').token).toBeUndefined();
+    expect((getPublishTargets(root)[0] as GitPublishTarget).hasToken).toBe(false);
   });
 });

--- a/tests/main/publish-git-auth.test.ts
+++ b/tests/main/publish-git-auth.test.ts
@@ -1,0 +1,80 @@
+/**
+ * GitHub auth resolution + token check (#1508).
+ *
+ * `resolveGitHubToken` precedence: a preferred (stored) token → `gh auth token`
+ * → GH_TOKEN/GITHUB_TOKEN env → throw. `checkGitHubToken` validates via
+ * GET /user, resolving the same fallback chain, and never throws.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => ({ execFileSync: vi.fn() }));
+vi.mock('node:child_process', () => ({ execFileSync: h.execFileSync }));
+
+import { resolveGitHubToken, checkGitHubToken } from '../../src/main/git/publish-git';
+
+const GH_ABSENT = () => { throw new Error('gh not found'); };
+
+// process.env is worker-global, so snapshot + restore to avoid leaking the
+// deletions into other test files that share the worker.
+const envSnapshot = { GH_TOKEN: process.env.GH_TOKEN, GITHUB_TOKEN: process.env.GITHUB_TOKEN };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.GH_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const [k, v] of Object.entries(envSnapshot)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe('resolveGitHubToken — precedence', () => {
+  it('prefers the passed (stored) token, without invoking gh', () => {
+    h.execFileSync.mockImplementation(() => 'gh-token');
+    expect(resolveGitHubToken('  stored-token  ')).toBe('stored-token');
+    expect(h.execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the gh CLI when no stored token', () => {
+    h.execFileSync.mockReturnValue('gh-token\n');
+    expect(resolveGitHubToken()).toBe('gh-token');
+  });
+
+  it('falls back to the env var when gh is unavailable', () => {
+    h.execFileSync.mockImplementation(GH_ABSENT);
+    process.env.GH_TOKEN = 'env-token';
+    expect(resolveGitHubToken()).toBe('env-token');
+  });
+
+  it('throws a configuration message when nothing is available', () => {
+    h.execFileSync.mockImplementation(GH_ABSENT);
+    expect(() => resolveGitHubToken()).toThrow(/aren't configured/i);
+  });
+});
+
+describe('checkGitHubToken', () => {
+  it('reports ok on a 200 from GET /user', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200 })));
+    expect(await checkGitHubToken('ghp_x')).toEqual({ ok: true });
+  });
+
+  it('maps 401 to an invalid-token message', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 401, statusText: 'Unauthorized' })));
+    const r = await checkGitHubToken('ghp_bad');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/invalid or expired/i);
+  });
+
+  it('short-circuits when there is no token to check', async () => {
+    h.execFileSync.mockImplementation(GH_ABSENT);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await checkGitHubToken();
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no token/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/main/publish/publish-to-git.test.ts
+++ b/tests/main/publish/publish-to-git.test.ts
@@ -38,7 +38,7 @@ const h = vi.hoisted(() => {
   };
 });
 
-vi.mock('../../../src/main/project-config', () => ({ getPublishTarget: () => h.target }));
+vi.mock('../../../src/main/project-config', () => ({ getPublishTarget: () => h.target, getGitCredentials: () => ({}) }));
 vi.mock('../../../src/main/publish/run-export', () => ({ runExport: h.runExport }));
 vi.mock('../../../src/main/git/publish-git', async (orig) => {
   const actual = await orig<typeof import('../../../src/main/git/publish-git')>();

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -261,6 +261,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "reject",
   ],
   "publish": [
+    "checkGitHub",
     "checkS3",
     "listExporters",
     "listTargets",

--- a/tests/renderer/components/PublishDialog.test.ts
+++ b/tests/renderer/components/PublishDialog.test.ts
@@ -17,6 +17,7 @@ const api = vi.hoisted(() => ({
     removeTarget: vi.fn(async () => []),
     toGit: vi.fn(),
     checkS3: vi.fn(async () => ({ ok: true })),
+    checkGitHub: vi.fn(async () => ({ ok: true })),
   },
 }));
 vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api }));
@@ -69,5 +70,42 @@ describe('PublishDialog — S3 target', () => {
     await fireEvent.click(getByText('Save target'));
     const saved = api.publish.upsertTarget.mock.calls[0]![0] as Record<string, unknown>;
     expect('secretAccessKey' in saved).toBe(false);
+  });
+});
+
+describe('PublishDialog — git target token (#1508)', () => {
+  async function openGitForm() {
+    const view = render(PublishDialog, { onClose: vi.fn() });
+    await view.findByText('Add target…');
+    await fireEvent.click(view.getByText('Add target…')); // git is the default kind
+    return view;
+  }
+
+  it('Save includes the write-only GitHub token when typed, omits it otherwise', async () => {
+    const view = await openGitForm();
+    await fireEvent.input(view.getByLabelText('Label'), { target: { value: 'Site' } });
+    await fireEvent.input(view.getByLabelText('Remote URL'), { target: { value: 'https://github.com/me/site' } });
+    await fireEvent.input(view.getByLabelText('GitHub token (optional)'), { target: { value: 'ghp_x' } });
+    await fireEvent.click(view.getByText('Save target'));
+    let saved = api.publish.upsertTarget.mock.calls[0]![0] as Record<string, unknown>;
+    expect(saved).toMatchObject({ gitRemote: 'https://github.com/me/site', githubToken: 'ghp_x' });
+    expect(saved.kind).toBeUndefined(); // git targets carry no explicit kind
+
+    cleanup();
+    vi.clearAllMocks();
+    const v2 = await openGitForm();
+    await fireEvent.input(v2.getByLabelText('Label'), { target: { value: 'Site' } });
+    await fireEvent.input(v2.getByLabelText('Remote URL'), { target: { value: 'https://github.com/me/site' } });
+    await fireEvent.click(v2.getByText('Save target'));
+    saved = api.publish.upsertTarget.mock.calls[0]![0] as Record<string, unknown>;
+    expect('githubToken' in saved).toBe(false);
+  });
+
+  it('Test connection calls checkGitHub with the typed token', async () => {
+    const view = await openGitForm();
+    await fireEvent.input(view.getByLabelText('GitHub token (optional)'), { target: { value: 'ghp_x' } });
+    await fireEvent.click(view.getByText('Test connection'));
+    expect(api.publish.checkGitHub).toHaveBeenCalledWith({ token: 'ghp_x' });
+    await view.findByText(/accepted the token/);
   });
 });


### PR DESCRIPTION
Closes #1508. Drops the **gh-CLI / GH_TOKEN-env prerequisite** for git publishing by letting a target carry its own GitHub token, encrypted at rest — reusing the S3/BYOM secret pattern.

**No GitHub API library needed** (the premise worth correcting up front): isomorphic-git already performs the authenticated HTTPS push; only the token *source* changes. A library would only buy API extras, and even the "test connection" is a one-line `fetch`.

## Change
- **`resolveGitHubToken(preferred?)`** precedence: **stored token → `gh` CLI → `GH_TOKEN`/`GITHUB_TOKEN` env** (was gh → env). Additive — the CLI/env stay as zero-config fallbacks. `publishToGit` passes the target's decrypted token via `getGitCredentials`.
- **`project-config`**: `GitPublishTarget` gains write-only `githubToken` (tri-state on upsert: set / `''` clears / omitted keeps) + read-only `hasToken`; stored encrypted (`githubTokenEnc`), **stripped from the read path**; `getGitCredentials` decrypts main-side. Same `toWireTarget`/`toStoredTarget` mappers that handle the S3 secret.
- **`checkGitHubToken(candidate?)`** — `GET /user`, resolving candidate → gh → env; powers a **Test connection** via a new `publish:checkGitHub` IPC.
- **PublishDialog** git form: optional "GitHub token" password field + a note that blank uses `gh`/`GH_TOKEN`, and a Test-connection button.

## Tests
Token encrypt/strip/tri-state in project-config; `resolveGitHubToken` precedence + `checkGitHubToken` status mapping (mocked `child_process` + `fetch`); dialog git-token save (write-only, omitted when untyped) + `checkGitHub`. Also fixed the pre-existing `publish-to-git` mock to export `getGitCredentials`, and made the new auth test restore `process.env` (worker-global, so a leak breaks sibling files). `pnpm lint` clean; publish + config + ipc + preload + dialog suites green (395). Preload + IPC snapshots updated.

## Notes
- **Additive, not a replacement** — removing gh/env would regress CLI users for no benefit.
- Like all `safeStorage` secrets, a stored token is machine-scoped (won't decrypt if the project moves machines; the gh/env fallback still applies).

Stacked on #1507 (merged).