### PR TITLE
refactor(publish): move target credentials to a gitignored .minerva/secrets.json

### DIFF
--- a/src/main/project-config.ts
+++ b/src/main/project-config.ts
@@ -41,10 +41,12 @@ export interface ProjectConfigShape {
 }
 
 /**
- * A configured "Publish → git remote" destination (#254): an exporter
- * paired with a git remote/branch to push its output to (e.g. a static
- * site → GitHub Pages). Stored in `.minerva/config.json`, which is
- * gitignored, so a remote URL never rides along in the thoughtbase repo.
+ * A configured publish destination (#254; multi-transport #1444). Non-secret
+ * fields (remote URL, bucket, endpoint, region, prefix, access-key id) live in
+ * `.minerva/config.json`, which travels with the thoughtbase. Credentials do
+ * NOT: they're encrypted in the gitignored `.minerva/secrets.json` so they never
+ * ride along in a git-backed / shared thoughtbase — same reasoning that moved
+ * compute trust out of the config (#1412).
  */
 interface PublishTargetBase {
   /** Stable id — names the publish-cache workspace and the config entry. */
@@ -100,10 +102,14 @@ export interface S3PublishTarget extends PublishTargetBase {
 
 export type PublishTarget = GitPublishTarget | S3PublishTarget;
 
-/** On-disk targets: the encrypted secret replaces the plaintext write field. */
-type StoredGitTarget = Omit<GitPublishTarget, 'githubToken' | 'hasToken'> & { githubTokenEnc?: string };
-type StoredS3Target = Omit<S3PublishTarget, 'secretAccessKey' | 'hasSecret'> & { secretAccessKeyEnc?: string };
+/** On-disk (config.json) target: non-secret fields only. The encrypted secret
+ *  lives in the gitignored `.minerva/secrets.json`. */
+type StoredGitTarget = Omit<GitPublishTarget, 'githubToken' | 'hasToken'>;
+type StoredS3Target = Omit<S3PublishTarget, 'secretAccessKey' | 'hasSecret'>;
 type StoredTarget = StoredGitTarget | StoredS3Target;
+
+/** Encrypted per-target credentials, stored in `.minerva/secrets.json`. */
+interface TargetSecret { s3Secret?: string; githubToken?: string }
 
 function configPath(rootPath: string): string {
   return path.join(rootPath, '.minerva', 'config.json');
@@ -171,24 +177,80 @@ export function setExcerptNoteFolder(rootPath: string, folder: string): void {
   patchProjectConfig(rootPath, { excerpt: { ...existing, noteFolder: cleaned } });
 }
 
-function readStoredTargets(rootPath: string): StoredTarget[] {
-  return (readProjectConfig(rootPath).publish?.targets as StoredTarget[] | undefined) ?? [];
+function secretsPath(rootPath: string): string {
+  return path.join(rootPath, '.minerva', 'secrets.json');
 }
 
-/** Map an on-disk target to its wire form — for S3, replace the encrypted
- *  secret with a `hasSecret` flag so the plaintext never reaches the renderer. */
-function toWireTarget(t: StoredTarget): PublishTarget {
-  if (t.kind === 's3') {
-    const { secretAccessKeyEnc, ...rest } = t;
-    return { ...rest, hasSecret: !!secretAccessKeyEnc };
+function readSecrets(rootPath: string): Record<string, TargetSecret> {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(secretsPath(rootPath), 'utf-8')) as { publishTargets?: Record<string, TargetSecret> };
+    return parsed.publishTargets ?? {};
+  } catch {
+    return {};
   }
-  const { githubTokenEnc, ...rest } = t;
-  return { ...rest, hasToken: !!githubTokenEnc };
+}
+
+/** Ensure a rule is present in the Minerva-owned `.minerva/.gitignore`. */
+function ensureMinervaGitignored(rootPath: string, rule: string): void {
+  const dir = path.join(rootPath, '.minerva');
+  const file = path.join(dir, '.gitignore');
+  let current = '';
+  try { current = fs.readFileSync(file, 'utf-8'); } catch { /* none yet */ }
+  if (current.split(/\r?\n/).some((l) => l.trim() === rule)) return;
+  fs.mkdirSync(dir, { recursive: true });
+  const next = current && !current.endsWith('\n') ? `${current}\n` : current;
+  fs.writeFileSync(file, `${next}${rule}\n`, 'utf-8');
+}
+
+function writeSecrets(rootPath: string, secrets: Record<string, TargetSecret>): void {
+  const file = secretsPath(rootPath);
+  if (Object.keys(secrets).length === 0) {
+    try { fs.unlinkSync(file); } catch { /* already absent */ }
+    return;
+  }
+  ensureMinervaGitignored(rootPath, 'secrets.json');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify({ publishTargets: secrets }, null, 2), 'utf-8');
+}
+
+/**
+ * Config targets (non-secret) + the per-target secret map, migrating any legacy
+ * inline `*Enc` (pre-split, when secrets lived in config.json) out into
+ * `secrets.json` on first access — so a git-backed thoughtbase never commits them.
+ */
+function loadPublishState(rootPath: string): { targets: StoredTarget[]; secrets: Record<string, TargetSecret> } {
+  const raw = (readProjectConfig(rootPath).publish?.targets ?? []) as (StoredTarget & { secretAccessKeyEnc?: string; githubTokenEnc?: string })[];
+  const secrets = readSecrets(rootPath);
+  let migrated = false;
+  const targets: StoredTarget[] = raw.map((t) => {
+    const { secretAccessKeyEnc, githubTokenEnc, ...rest } = t;
+    if (secretAccessKeyEnc || githubTokenEnc) {
+      migrated = true;
+      const cur = { ...(secrets[t.id] ?? {}) };
+      if (secretAccessKeyEnc && !cur.s3Secret) cur.s3Secret = secretAccessKeyEnc;
+      if (githubTokenEnc && !cur.githubToken) cur.githubToken = githubTokenEnc;
+      secrets[t.id] = cur;
+    }
+    return rest;
+  });
+  if (migrated) {
+    patchProjectConfig(rootPath, { publish: { targets } });
+    writeSecrets(rootPath, secrets);
+  }
+  return { targets, secrets };
+}
+
+/** Map an on-disk target + its secret entry to the wire form: presence flags
+ *  only, never the encrypted credential. */
+function toWireTarget(t: StoredTarget, secret: TargetSecret | undefined): PublishTarget {
+  if (t.kind === 's3') return { ...t, hasSecret: !!secret?.s3Secret };
+  return { ...t, hasToken: !!secret?.githubToken };
 }
 
 /** All configured publish targets (#254, #1444), secrets stripped. Empty when unset. */
 export function getPublishTargets(rootPath: string): PublishTarget[] {
-  return readStoredTargets(rootPath).map(toWireTarget);
+  const { targets, secrets } = loadPublishState(rootPath);
+  return targets.map((t) => toWireTarget(t, secrets[t.id]));
 }
 
 export function getPublishTarget(rootPath: string, id: string): PublishTarget | null {
@@ -200,11 +262,13 @@ export function getPublishTarget(rootPath: string, id: string): PublishTarget | 
  * at publish time. Never crosses to the renderer. Empty for non-S3 / unknown ids.
  */
 export function getS3Credentials(rootPath: string, id: string): { accessKeyId?: string; secretAccessKey?: string } {
-  const t = readStoredTargets(rootPath).find((x) => x.id === id);
+  const { targets, secrets } = loadPublishState(rootPath);
+  const t = targets.find((x) => x.id === id);
   if (!t || t.kind !== 's3') return {};
+  const enc = secrets[id]?.s3Secret;
   return {
     ...(t.accessKeyId ? { accessKeyId: t.accessKeyId } : {}),
-    ...(t.secretAccessKeyEnc ? { secretAccessKey: decryptSecret(t.secretAccessKeyEnc) } : {}),
+    ...(enc ? { secretAccessKey: decryptSecret(enc) } : {}),
   };
 }
 
@@ -214,42 +278,54 @@ export function getS3Credentials(rootPath: string, id: string): { accessKeyId?: 
  * `gh` CLI / env fallback then applies).
  */
 export function getGitCredentials(rootPath: string, id: string): { token?: string } {
-  const t = readStoredTargets(rootPath).find((x) => x.id === id);
+  const { targets, secrets } = loadPublishState(rootPath);
+  const t = targets.find((x) => x.id === id);
   if (!t || t.kind === 's3') return {};
-  return t.githubTokenEnc ? { token: decryptSecret(t.githubTokenEnc) } : {};
+  const enc = secrets[id]?.githubToken;
+  return enc ? { token: decryptSecret(enc) } : {};
 }
 
-/** Wire → on-disk: for S3, apply the tri-state secret (string sets/encrypts,
- *  '' clears, omitted keeps the existing encrypted value) and drop the plaintext. */
-function toStoredTarget(target: PublishTarget, existing: StoredTarget | undefined): StoredTarget {
+/** Wire → on-disk config form: drop the write-only secret + its presence flag. */
+function toStoredTarget(target: PublishTarget): StoredTarget {
   if (target.kind === 's3') {
-    const { secretAccessKey, hasSecret: _hasSecret, ...rest } = target;
-    const prevEnc = existing && existing.kind === 's3' ? existing.secretAccessKeyEnc : undefined;
-    const enc = secretAccessKey === undefined ? prevEnc
-      : secretAccessKey === '' ? undefined
-      : encryptSecret(secretAccessKey);
-    return { ...rest, ...(enc ? { secretAccessKeyEnc: enc } : {}) };
+    const { secretAccessKey: _s, hasSecret: _h, ...rest } = target;
+    return rest;
   }
-  const { githubToken, hasToken: _hasToken, ...rest } = target;
-  const prevEnc = existing && existing.kind !== 's3' ? existing.githubTokenEnc : undefined;
-  const enc = githubToken === undefined ? prevEnc
-    : githubToken === '' ? undefined
-    : encryptSecret(githubToken);
-  return { ...rest, ...(enc ? { githubTokenEnc: enc } : {}) };
+  const { githubToken: _t, hasToken: _ht, ...rest } = target;
+  return rest;
 }
 
-/** Insert or replace a target by id, preserving the rest of the list (and other
- *  targets' encrypted secrets — CRUD operates on the STORED shape). */
+/** Apply a wire target's tri-state secret onto its secret entry: a string sets
+ *  (encrypted), '' clears, omitted keeps the stored value. Returns undefined
+ *  when nothing remains, so the entry can be dropped. */
+function applySecret(prev: TargetSecret | undefined, target: PublishTarget): TargetSecret | undefined {
+  const cur: TargetSecret = { ...(prev ?? {}) };
+  const field: keyof TargetSecret = target.kind === 's3' ? 's3Secret' : 'githubToken';
+  const value = target.kind === 's3' ? target.secretAccessKey : target.githubToken;
+  if (value === '') delete cur[field];
+  else if (value !== undefined) cur[field] = encryptSecret(value);
+  return Object.keys(cur).length > 0 ? cur : undefined;
+}
+
+/** Insert or replace a target by id, preserving the rest of the list and other
+ *  targets' secrets. Non-secret fields → config.json; the credential → secrets.json. */
 export function upsertPublishTarget(rootPath: string, target: PublishTarget): void {
-  const targets = readStoredTargets(rootPath);
+  const { targets, secrets } = loadPublishState(rootPath);
+  const stored = toStoredTarget(target);
   const idx = targets.findIndex((t) => t.id === target.id);
-  const stored = toStoredTarget(target, idx >= 0 ? targets[idx] : undefined);
   if (idx >= 0) targets[idx] = stored;
   else targets.push(stored);
+  const secret = applySecret(secrets[target.id], target);
+  if (secret) secrets[target.id] = secret;
+  else delete secrets[target.id];
   patchProjectConfig(rootPath, { publish: { targets } });
+  writeSecrets(rootPath, secrets);
 }
 
 export function removePublishTarget(rootPath: string, id: string): void {
-  const targets = readStoredTargets(rootPath).filter((t) => t.id !== id);
-  patchProjectConfig(rootPath, { publish: { targets } });
+  const { targets, secrets } = loadPublishState(rootPath);
+  const next = targets.filter((t) => t.id !== id);
+  delete secrets[id];
+  patchProjectConfig(rootPath, { publish: { targets: next } });
+  writeSecrets(rootPath, secrets);
 }

--- a/tests/main/project-config-s3.test.ts
+++ b/tests/main/project-config-s3.test.ts
@@ -31,7 +31,10 @@ import {
 
 let root: string;
 const configFile = () => path.join(root, '.minerva', 'config.json');
+const secretsFile = () => path.join(root, '.minerva', 'secrets.json');
+const gitignoreFile = () => path.join(root, '.minerva', '.gitignore');
 const rawTargets = () => JSON.parse(fs.readFileSync(configFile(), 'utf-8')).publish.targets;
+const rawSecrets = () => JSON.parse(fs.readFileSync(secretsFile(), 'utf-8')).publishTargets;
 
 const s3: S3PublishTarget = {
   id: 's3a', kind: 's3', label: 'Site', exporter: 'static-site', bucket: 'b', region: 'auto',
@@ -42,17 +45,22 @@ beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-pcfg-')
 afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
 
 describe('S3 target credentials', () => {
-  it('encrypts the secret at rest and never returns it from the read path', () => {
+  it('keeps the secret out of config.json — encrypted in the gitignored secrets.json', () => {
     upsertPublishTarget(root, s3);
     const onDisk = rawTargets()[0];
-    expect(onDisk.secretAccessKey).toBeUndefined();            // no plaintext field
-    expect(onDisk.secretAccessKeyEnc.startsWith('enc:v1:')).toBe(true);
-    expect(JSON.stringify(onDisk)).not.toContain('super-secret');
+    expect(onDisk.secretAccessKey).toBeUndefined();            // no plaintext
+    expect(onDisk.secretAccessKeyEnc).toBeUndefined();         // no ciphertext in config either
+    expect(fs.readFileSync(configFile(), 'utf-8')).not.toContain('super-secret');
+    expect(onDisk.accessKeyId).toBe('AKIA');                   // non-secret fields stay in config
+
+    // The secret lives, encrypted, in secrets.json — which is gitignored.
+    expect(rawSecrets().s3a.s3Secret.startsWith('enc:v1:')).toBe(true);
+    expect(fs.readFileSync(secretsFile(), 'utf-8')).not.toContain('super-secret');
+    expect(fs.readFileSync(gitignoreFile(), 'utf-8')).toMatch(/^secrets\.json$/m);
 
     const wire = getPublishTargets(root)[0] as S3PublishTarget;
-    expect(wire.secretAccessKey).toBeUndefined();              // stripped from read
+    expect(wire.secretAccessKey).toBeUndefined();
     expect(wire.hasSecret).toBe(true);
-    expect(wire.accessKeyId).toBe('AKIA');                     // non-secret fields kept
   });
 
   it('decrypts the secret only for the transport', () => {
@@ -95,12 +103,15 @@ describe('Git target token (#1508)', () => {
     githubToken: 'ghp_secret',
   };
 
-  it('encrypts the token at rest and never returns it from the read path', () => {
+  it('keeps the token out of config.json — encrypted in the gitignored secrets.json', () => {
     upsertPublishTarget(root, git);
     const onDisk = rawTargets()[0];
     expect(onDisk.githubToken).toBeUndefined();
-    expect(onDisk.githubTokenEnc.startsWith('enc:v1:')).toBe(true);
-    expect(JSON.stringify(onDisk)).not.toContain('ghp_secret');
+    expect(onDisk.githubTokenEnc).toBeUndefined();
+    expect(fs.readFileSync(configFile(), 'utf-8')).not.toContain('ghp_secret');
+
+    expect(rawSecrets().g.githubToken.startsWith('enc:v1:')).toBe(true);
+    expect(fs.readFileSync(gitignoreFile(), 'utf-8')).toMatch(/^secrets\.json$/m);
 
     const wire = getPublishTargets(root)[0] as GitPublishTarget;
     expect(wire.githubToken).toBeUndefined();
@@ -121,5 +132,34 @@ describe('Git target token (#1508)', () => {
     upsertPublishTarget(root, { ...git, githubToken: '' });
     expect(getGitCredentials(root, 'g').token).toBeUndefined();
     expect((getPublishTargets(root)[0] as GitPublishTarget).hasToken).toBe(false);
+  });
+});
+
+describe('migration: legacy inline secrets in config.json move to secrets.json', () => {
+  it('relocates *Enc out of config.json on first read', () => {
+    // Simulate a pre-split config.json with the secret inline (as the S3/GitHub
+    // PRs originally wrote it).
+    fs.mkdirSync(path.join(root, '.minerva'), { recursive: true });
+    fs.writeFileSync(configFile(), JSON.stringify({
+      publish: { targets: [
+        { id: 's3a', kind: 's3', label: 'S', exporter: 'static-site', bucket: 'b', accessKeyId: 'AKIA', secretAccessKeyEnc: 'enc:v1:legacy-s3' },
+        { id: 'g', label: 'G', exporter: 'static-site', gitRemote: 'https://x', gitBranch: 'gh-pages', githubTokenEnc: 'enc:v1:legacy-gh' },
+      ] },
+    }));
+
+    // Any read triggers the one-time migration.
+    getPublishTargets(root);
+
+    // config.json no longer carries the ciphertext…
+    const cfg = fs.readFileSync(configFile(), 'utf-8');
+    expect(cfg).not.toContain('secretAccessKeyEnc');
+    expect(cfg).not.toContain('githubTokenEnc');
+    // …it's in the gitignored secrets.json instead.
+    expect(rawSecrets().s3a.s3Secret).toBe('enc:v1:legacy-s3');
+    expect(rawSecrets().g.githubToken).toBe('enc:v1:legacy-gh');
+    expect(fs.readFileSync(gitignoreFile(), 'utf-8')).toMatch(/^secrets\.json$/m);
+    // Non-secret fields survive; hasSecret/hasToken reflect the relocated secrets.
+    expect((getPublishTargets(root)[0] as S3PublishTarget).hasSecret).toBe(true);
+    expect((getPublishTargets(root)[1] as GitPublishTarget).hasToken).toBe(true);
   });
 });


### PR DESCRIPTION
First of two for the config-storage concern raised on #1443. Fixes the credential-placement issue introduced by the S3 (#1444) and GitHub-token (#1508) work.

## Problem
Publish-target secrets were stored — encrypted — **inline in `.minerva/config.json`**. But config.json **travels with the thoughtbase** and is **committable** if the user `git init`s it. The code even *claimed* config.json was gitignored (`project-config.ts` comment) — it isn't; only `publish-cache/` is. That's the same trust-transfer hole that moved **compute trust** out of the config (#1412, cited in-code).

## Change
Split storage by sensitivity:
- **Non-secret fields** (remote URL, bucket, endpoint, region, prefix, access-key **id**) stay in `config.json` — travels with the thoughtbase, safe to commit.
- **The encrypted credential** moves to **`.minerva/secrets.json`**, which Minerva adds to `.minerva/.gitignore`.

The wire + credential API is **unchanged** — `getPublishTargets` still strips secrets and reports `hasSecret`/`hasToken`, `getS3Credentials`/`getGitCredentials` still decrypt, `upsert` stays tri-state. Only the ciphertext's *location* moves.

- `secrets.json` shape: `{ publishTargets: { [id]: { s3Secret?, githubToken? } } }` (encrypted values); the file is deleted when empty.
- **One-time migration**: any legacy inline `*Enc` in config.json is relocated to secrets.json on first read (`loadPublishState`), so existing configs self-heal and stop committing secrets.
- Fixed the stale "config.json is gitignored" comment.

## Notes
`secrets.json` is still `safeStorage`/machine-scoped (won't decrypt if the project moves machines — the `gh`/env fallback covers git). The point isn't cross-machine portability; it's that credentials are **no longer committed or read as thoughtbase content**.

## Tests
Secret kept out of config.json + encrypted in the gitignored secrets.json (S3 + git); decrypt-for-transport, tri-state, cross-target isolation unchanged; new **migration** test (inline `*Enc` → secrets.json). `pnpm lint` clean; publish + config + ipc + preload + dialog suites green (396).

Next: #1443 (Thoughtbase Properties: rename + base IRI), which stores its name/base-IRI in the now-cleanly-committable config.json.