### PR TITLE
test(search): deflake debounced-persist timing test

### DIFF
--- a/tests/main/search/index.test.ts
+++ b/tests/main/search/index.test.ts
@@ -12,8 +12,11 @@
  * Uses `_setPersistDebounceMsForTests` to shrink the real debounce window
  * rather than mocking time — `schedulePersist`'s timer callback does real
  * `fs` I/O, which doesn't resolve on vitest's fake-timer clock (it settles
- * via libuv's real thread pool), so faking `setTimeout` here would just
- * trade a slow test for a flaky one.
+ * via libuv's real thread pool), so faking `setTimeout` here would just trade
+ * a slow test for a flaky one. To stay robust on a loaded CI runner (where a
+ * `setTimeout` slips and the async write flushes late), the "did write"
+ * assertions POLL for the file via `waitForIndex` rather than assuming a fixed
+ * sleep landed it.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
@@ -29,7 +32,7 @@ import {
 } from '../../../src/main/search/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
-const DEBOUNCE_MS = 50;
+const DEBOUNCE_MS = 200;
 
 function indexFilePath(root: string): string {
   return path.join(root, '.minerva', 'search-index.json');
@@ -37,6 +40,26 @@ function indexFilePath(root: string): string {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/**
+ * Poll until the debounced write has landed AND the file is fully written
+ * (non-empty + parseable) — waits out both the timer firing and the async fs
+ * flush, so a loaded runner can't race the assertion. Throws on timeout.
+ */
+async function waitForIndex(root: string, timeoutMs = 5000): Promise<unknown> {
+  const p = indexFilePath(root);
+  const start = Date.now();
+  for (;;) {
+    try {
+      const raw = fs.readFileSync(p, 'utf-8');
+      if (raw) return JSON.parse(raw);
+    } catch {
+      // Not written yet, or caught mid-write — keep polling.
+    }
+    if (Date.now() - start > timeoutMs) throw new Error(`search index not written within ${timeoutMs}ms`);
+    await sleep(10);
+  }
 }
 
 describe('search index persistence (perf #1107)', () => {
@@ -70,9 +93,7 @@ describe('search index persistence (perf #1107)', () => {
     await sleep(DEBOUNCE_MS / 2);
     expect(fs.existsSync(indexFilePath(root))).toBe(false);
 
-    await sleep(DEBOUNCE_MS);
-    expect(fs.existsSync(indexFilePath(root))).toBe(true);
-    const written = JSON.parse(fs.readFileSync(indexFilePath(root), 'utf-8'));
+    const written = await waitForIndex(root);
     expect(JSON.stringify(written)).toContain('a.md');
   });
 
@@ -87,9 +108,7 @@ describe('search index persistence (perf #1107)', () => {
     await sleep(DEBOUNCE_MS / 2);
     expect(fs.existsSync(indexFilePath(root))).toBe(false);
 
-    await sleep(DEBOUNCE_MS);
-    expect(fs.existsSync(indexFilePath(root))).toBe(true);
-    const written = JSON.parse(fs.readFileSync(indexFilePath(root), 'utf-8'));
+    const written = await waitForIndex(root);
     // Both notes made it into the single, coalesced write.
     expect(JSON.stringify(written)).toContain('a.md');
     expect(JSON.stringify(written)).toContain('b.md');


### PR DESCRIPTION
`tests/main/search/index.test.ts` failed intermittently on CI (surfaced on #1510's run, but pre-existing and unrelated to it):

```
FAIL … schedulePersist writes after the debounce delay elapses
expected false to be true   // fs.existsSync(indexFilePath(root))
```

## Cause
The test slept a fixed `DEBOUNCE_MS` (50ms) then **immediately** asserted the file existed — leaving ~25ms of slack for a `setTimeout(…,50)` **plus** the async `provider.save()` fs write. On a loaded runner (the failing run took **430s**) timers slip well past that.

Fake timers are the wrong tool — the file's own header already explains why (the timer callback does real fs I/O that settles on libuv's thread pool, not vitest's fake clock). I confirmed it: with fake timers the callback fires but the write hasn't flushed, so the file exists **empty** and `JSON.parse` throws.

## Fix
Keep real timers, but **poll** for the write via `waitForIndex` — read until the file is present, non-empty, and parseable (up to 5s) — instead of assuming a fixed sleep landed it. That waits out both the timer slip and the async flush. Also bumped the shrunk debounce 50→200ms so the "not yet written" negative assertions keep a comfortable margin. Green across repeated local runs.

No production code changed; pure test hardening.