### PR TITLE
feat: set graph base IRI — Properties advanced tier (#1443 Part B)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -195,6 +195,17 @@ export function removeMatchingTriples(
   state.store.removeMatches($rdf.sym(subjectIri), $rdf.sym(predicateIri), undefined);
 }
 
+/**
+ * Point the in-memory graph state at a new base IRI (#1443 Part B). The caller
+ * persists it to config and runs `indexAllNotes`, which regenerates every note/
+ * tag/folder IRI from the files under the new base. No-op if the project isn't
+ * live. Does NOT rewrite triples in place — the rebuild is the mechanism.
+ */
+export function setBaseUri(ctx: ProjectContext, baseUri: string): void {
+  const state = getState(ctx);
+  if (state) state.baseUri = baseUri;
+}
+
 export function serializeGraph(ctx: ProjectContext): string {
   const state = getState(ctx);
   if (!state) return '';

--- a/src/main/graph/rebase-guard.ts
+++ b/src/main/graph/rebase-guard.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure precheck for a base-IRI rebase (#1443 Part B). Kept separate from the IPC
+ * handler so the two load-bearing rules are unit-testable without a live graph:
+ *   1. the new base must be an absolute http(s) IRI ending in '/', and
+ *   2. the review queue must be empty — pending proposals reference notes by
+ *      absolute IRI and are copied verbatim across the rebuild that a rebase
+ *      triggers, so they'd dangle under the new base (the #1 invariant #1443
+ *      flags). Clearing the queue first is the mitigation.
+ */
+export type RebaseCheck = { ok: true; uri: string } | { ok: false; error: string };
+
+export function checkRebase(uri: string, pendingProposalCount: number): RebaseCheck {
+  const trimmed = (uri ?? '').trim();
+  if (!/^https?:\/\/\S+\/$/.test(trimmed)) {
+    return { ok: false, error: 'Base IRI must be an absolute http(s) URL ending in "/".' };
+  }
+  if (pendingProposalCount > 0) {
+    return {
+      ok: false,
+      error: `Resolve the ${pendingProposalCount} pending proposal${pendingProposalCount === 1 ? '' : 's'} in the review queue before changing the base IRI.`,
+    };
+  }
+  return { ok: true, uri: trimmed };
+}

--- a/src/main/ipc/register-graph.ts
+++ b/src/main/ipc/register-graph.ts
@@ -3,17 +3,42 @@ import path from 'node:path';
 import { Channels } from '../../shared/channels';
 import { handle } from './typed-ipc';
 import * as graph from '../graph/index';
+import * as search from '../search/index';
 import { projectContext } from '../project-context-types';
 import * as tables from '../sources/tables';
 import type { QueryResult, TableInfo } from '../sources/tables';
 import * as healthChecks from '../graph/health-checks';
 import type { Inspection } from '../graph/health-checks';
-import { withRootPath, withRootPathOr } from './helpers';
+import { patchProjectConfig } from '../project-config';
+import { listProposals } from '../llm/proposal-persistence';
+import { checkRebase } from '../graph/rebase-guard';
+import { withRootPath, withRootPathOr, withRootPathWin } from './helpers';
 
 export function registerGraph(): void {
   // Graph
   handle(Channels.GRAPH_QUERY, withRootPath((rootPath, sparql: string) =>
     graph.queryGraph(projectContext(rootPath), sparql)));
+
+  // Rebase the graph to a new base IRI (#1443 Part B). No in-place triple
+  // rewriting: persist the new base, point the live state at it, then rebuild
+  // every index from the files (indexAllNotes) so all IRIs regenerate. Refuses
+  // while the review queue is non-empty — pending proposals hold absolute note
+  // IRIs that are copied verbatim across a rebuild and would dangle otherwise.
+  handle(Channels.GRAPH_SET_BASE_URI, withRootPathWin(async (rootPath, win, rawUri: string) => {
+    const ctx = projectContext(rootPath);
+    const pending = await listProposals(ctx, 'pending');
+    const check = checkRebase(rawUri, pending.length);
+    if (!check.ok) return check;
+    patchProjectConfig(rootPath, { baseUri: check.uri });
+    graph.setBaseUri(ctx, check.uri);
+    // Same rebuild sequence as "Rebuild All Indexes" (menu.ts) — CSVs after the
+    // store reset so their schema triples survive; note tables last (#1358).
+    await Promise.all([graph.indexAllNotes(ctx), search.indexAllNotes(ctx)]);
+    await tables.registerAllCsvs(ctx);
+    await tables.registerAllNoteTables(ctx);
+    if (win && !win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+    return { ok: true as const };
+  }));
 
   // Tables (DuckDB)
   handle(Channels.TABLES_QUERY, withRootPathOr<[string], QueryResult | Promise<QueryResult>>({ ok: false, error: 'No project open' }, (rootPath, sql: string) =>

--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -8,7 +8,8 @@ import { mergeNotes, previewMergeNotes } from '../notebase/merge';
 import { renameAnchor } from '../notebase/rename-anchor';
 import { renameSource, renameExcerpt } from '../notebase/rename-source-excerpt';
 import { getOrFetchRemoteImage } from '../images/remote-image-cache';
-import { resolveDisplayName, setDisplayName, getDisplayName } from '../project-config';
+import { resolveDisplayName, setDisplayName, getDisplayName, readProjectConfig } from '../project-config';
+import { listProposals } from '../llm/proposal-persistence';
 import { getOrFetchThumbnail } from '../youtube/thumbnail-cache';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
@@ -362,9 +363,13 @@ export function registerNotebase(): void {
   // Thoughtbase Properties (#1443). Read the current display name + folder
   // basename for the dialog; set the display name and return fresh meta so the
   // renderer's notebase store updates the label everywhere immediately.
-  handle(Channels.NOTEBASE_GET_PROPERTIES, withRootPath((rootPath) => ({
+  handle(Channels.NOTEBASE_GET_PROPERTIES, withRootPath(async (rootPath) => ({
     displayName: getDisplayName(rootPath) ?? '',
     folderName: path.basename(rootPath),
+    // Base IRI + review-queue size drive the dialog's advanced tier (#1443 B):
+    // the field shows the current base and disables when proposals are pending.
+    baseUri: readProjectConfig(rootPath).baseUri ?? '',
+    pendingProposalCount: (await listProposals(projectContext(rootPath), 'pending')).length,
   })));
 
   handle(Channels.NOTEBASE_SET_DISPLAY_NAME, withRootPath((rootPath, name: string) => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -118,6 +118,7 @@ contextBridge.exposeInMainWorld('api', {
   },
   graph: {
     query: (sparql: string) => invoke(Channels.GRAPH_QUERY, sparql),
+    setBaseUri: (uri: string) => invoke(Channels.GRAPH_SET_BASE_URI, uri),
     groundCheck: (claimText: string) => invoke(Channels.GRAPH_GROUND_CHECK, claimText),
     inspections: () => invoke(Channels.INSPECTIONS_LIST),
     runInspections: () => invoke(Channels.INSPECTIONS_RUN),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1525,7 +1525,15 @@
 
   {#if showThoughtbaseProperties}
     <ThoughtbaseProperties
-      onSave={(name) => { void notebase.setDisplayName(name); showThoughtbaseProperties = false; }}
+      onSave={async ({ name, baseUri }) => {
+        await notebase.setDisplayName(name);
+        if (baseUri !== undefined) {
+          const r = await notebase.setBaseUri(baseUri);
+          if (!r.ok) return r; // keep the dialog open to show the refusal/error
+        }
+        showThoughtbaseProperties = false;
+        return { ok: true };
+      }}
       onCancel={() => { showThoughtbaseProperties = false; }}
     />
   {/if}

--- a/src/renderer/lib/components/ThoughtbaseProperties.svelte
+++ b/src/renderer/lib/components/ThoughtbaseProperties.svelte
@@ -1,41 +1,72 @@
 <script lang="ts">
   /**
-   * Thoughtbase Properties dialog (#1443) — Part A: rename. The display name is
-   * decoupled from the folder (stored in .minerva/config.json); clearing it
-   * falls back to the folder basename. Base-IRI editing is the advanced tier,
-   * added in Part B. Reads its current values directly (reads are allowed in
-   * components); the save routes through the notebase store (mutation).
+   * Thoughtbase Properties dialog (#1443). Rename (safe, instant) plus an
+   * Advanced breakout to set the knowledge-graph base IRI — which rewrites every
+   * graph identifier via a full re-index, so it's tucked away, warned, and
+   * disabled while the review queue is non-empty (pending proposals hold
+   * absolute IRIs that a rebuild can't re-derive). Reads its values directly
+   * (reads are allowed in components); mutations route through the notebase
+   * store via the `onSave` callback.
    */
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
 
   interface Props {
-    /** Persist the trimmed name ('' clears → folder basename). */
-    onSave: (name: string) => void;
+    /** Persist name + (when changed) base IRI. Resolves to the outcome so a
+     *  validation error / review-queue refusal shows inline; the parent closes
+     *  the dialog on success. `baseUri` is omitted when unchanged. */
+    onSave: (p: { name: string; baseUri?: string }) => Promise<{ ok: boolean; error?: string }>;
     onCancel: () => void;
   }
   let { onSave, onCancel }: Props = $props();
 
   let name = $state('');
   let folderName = $state('');
-  let inputEl = $state<HTMLInputElement>();
+  let baseUri = $state('');
+  let initialBaseUri = $state('');
+  let pendingCount = $state(0);
+  let nameInput = $state<HTMLInputElement>();
+
+  let saving = $state(false);
+  let error = $state<string | null>(null);
+
+  const baseLocked = $derived(pendingCount > 0);
 
   onMount(async () => {
     try {
       const p = await api.notebase.getProperties();
       name = p.displayName;
       folderName = p.folderName;
+      baseUri = p.baseUri;
+      initialBaseUri = p.baseUri;
+      pendingCount = p.pendingProposalCount;
     } catch (e) {
       console.warn('[thoughtbase] failed to load properties:', e);
     }
-    inputEl?.select();
+    nameInput?.select();
   });
 
-  function save() { onSave(name.trim()); }
+  async function save() {
+    if (saving) return;
+    saving = true;
+    error = null;
+    const baseChanged = !baseLocked && baseUri.trim() !== initialBaseUri;
+    try {
+      const r = await onSave({ name: name.trim(), ...(baseChanged ? { baseUri: baseUri.trim() } : {}) });
+      if (!r.ok) error = r.error ?? 'Could not save.';
+      // On success the parent unmounts this dialog.
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      saving = false;
+    }
+  }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter') save();
-    else if (e.key === 'Escape') onCancel();
+    if (e.key === 'Escape') onCancel();
+    // Enter saves only from the name field — the base-IRI field is multiline-ish
+    // intent (paste a long URL), so don't hijack Enter there.
+    else if (e.key === 'Enter' && (e.target as HTMLElement)?.id === 'tb-props-name') void save();
   }
 </script>
 
@@ -51,7 +82,7 @@
       <label class="field-label" for="tb-props-name">Name</label>
       <input
         id="tb-props-name"
-        bind:this={inputEl}
+        bind:this={nameInput}
         bind:value={name}
         type="text"
         class="input"
@@ -63,13 +94,45 @@
         A display label, independent of the folder on disk. Leave blank to use
         the folder name{folderName ? ` (${folderName})` : ''}.
       </p>
+
+      <details class="advanced">
+        <summary>Advanced</summary>
+        <div class="advanced-body">
+          <label class="field-label" for="tb-props-base">Graph base IRI</label>
+          <input
+            id="tb-props-base"
+            bind:value={baseUri}
+            type="text"
+            class="input"
+            autocomplete="off"
+            spellcheck="false"
+            disabled={baseLocked}
+          />
+          {#if baseLocked}
+            <p class="hint warn">
+              Locked while {pendingCount} proposal{pendingCount === 1 ? '' : 's'} await review — they
+              reference notes by absolute IRI and can't survive a rebase. Clear the review queue first.
+            </p>
+          {:else}
+            <p class="hint warn">
+              Rewrites every knowledge-graph identifier (a full re-index runs on save).
+              Existing exports and any hand-pasted IRIs that used the old base will no
+              longer resolve. Wiki-links are unaffected.
+            </p>
+          {/if}
+        </div>
+      </details>
+
+      {#if error}
+        <p class="error-msg">✗ {error}</p>
+      {/if}
     </div>
 
     <footer class="card-footer">
       <span class="kbd-hint">esc · cancel · ↵ save</span>
       <span class="footer-actions">
         <button class="btn secondary" onclick={onCancel}>Cancel</button>
-        <button class="btn primary" onclick={save}>Save<span class="btn-kbd">↵</span></button>
+        <button class="btn primary" disabled={saving} onclick={save}>{saving ? 'Saving…' : 'Save'}<span class="btn-kbd">↵</span></button>
       </span>
     </footer>
   </div>
@@ -136,11 +199,31 @@
     outline: none;
     box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
   }
+  .input:disabled { opacity: 0.55; box-shadow: none; border-color: var(--border); }
   .hint {
     margin: 8px 0 0;
     font-size: 11px;
     color: var(--text-faint);
     line-height: 1.45;
+  }
+  .hint.warn { color: var(--text-muted); }
+  .advanced {
+    margin-top: 16px;
+    border-top: 1px solid var(--border);
+    padding-top: 12px;
+  }
+  .advanced summary {
+    cursor: pointer;
+    font-size: 11.5px;
+    color: var(--text-muted);
+    user-select: none;
+  }
+  .advanced summary:hover { color: var(--text); }
+  .advanced-body { padding-top: 12px; }
+  .error-msg {
+    margin: 12px 0 0;
+    font-size: 12px;
+    color: var(--rust, #c66);
   }
   .card-footer {
     display: flex;
@@ -172,6 +255,7 @@
   .secondary { background: transparent; color: var(--text-muted); }
   .secondary:hover { color: var(--text); border-color: var(--border-strong); }
   .primary { background: var(--accent); color: var(--accent-ink); border-color: var(--accent); font-weight: 600; }
-  .primary:hover { opacity: 0.92; }
+  .primary:hover:not(:disabled) { opacity: 0.92; }
+  .primary:disabled { opacity: 0.5; cursor: default; }
   .btn-kbd { font-family: var(--font-mono); font-size: 10px; opacity: 0.7; }
 </style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -57,8 +57,9 @@ export interface NotebaseApi {
    *  new-thoughtbase onboarding modal. Default false; set on user opt-out. */
   getOnboardingDismissed(): Promise<boolean>;
   setOnboardingDismissed(dismissed: boolean): Promise<void>;
-  /** Thoughtbase Properties (#1443): current display name + folder basename. */
-  getProperties(): Promise<{ displayName: string; folderName: string }>;
+  /** Thoughtbase Properties (#1443): display name, folder basename, base IRI,
+   *  and the review-queue size. */
+  getProperties(): Promise<{ displayName: string; folderName: string; baseUri: string; pendingProposalCount: number }>;
   /** Set the display name ('' clears → folder basename); resolves to fresh meta. */
   setDisplayName(name: string): Promise<import('../../../shared/types').NotebaseMeta>;
 }
@@ -120,6 +121,8 @@ export interface GitApi {
 
 export interface GraphApi {
   query(sparql: string): Promise<{ results: unknown[]; columns: string[]; error?: string }>;
+  /** Rebase to a new base IRI + rebuild indexes (#1443 Part B). */
+  setBaseUri(uri: string): Promise<{ ok: true } | { ok: false; error: string }>;
   groundCheck(claimText: string): Promise<{ node: string; label: string; type: string }[]>;
   inspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;
   runInspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;

--- a/src/renderer/lib/stores/notebase.svelte.ts
+++ b/src/renderer/lib/stores/notebase.svelte.ts
@@ -65,6 +65,14 @@ export function getNotebaseStore() {
     meta = await api.notebase.setDisplayName(name);
   }
 
+  /** Rebase the knowledge graph to a new base IRI (#1443 Part B). Mutation →
+   *  store-owned; persists + rebuilds all indexes main-side (refuses while the
+   *  review queue is non-empty). Returns the outcome so the dialog can surface
+   *  a refusal/validation error inline. */
+  function setBaseUri(uri: string): Promise<{ ok: true } | { ok: false; error: string }> {
+    return api.graph.setBaseUri(uri);
+  }
+
   return {
     get meta() { return meta; },
     get files() { return files; },
@@ -76,6 +84,7 @@ export function getNotebaseStore() {
     writeFile,
     replaceInNotes,
     setDisplayName,
+    setBaseUri,
     // ── File-change subscriptions (main → renderer) ───────────────────────
     // The store owns these `api.notebase.on*` subscriptions so components read
     // the effects without touching `api` directly (renderer data-flow rule).

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -110,6 +110,8 @@ export const Channels = {
 
   // Graph
   GRAPH_QUERY: 'graph:query',
+  /** Rebase the graph to a new base IRI + rebuild all indexes (#1443 Part B). */
+  GRAPH_SET_BASE_URI: 'graph:setBaseUri',
   /** Main→renderer: embedding backfill progress `{ done, total, running }` (#836). */
   EMBEDDINGS_BACKFILL_PROGRESS: 'embeddings:backfillProgress',
   /** Notes semantically related to a note, for the Related sidebar panel (#838). */

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -117,8 +117,9 @@ export interface ChannelMap {
   'notebase:renameExcerpt': (oldId: string, newId: string) => { rewrittenPaths: string[] };
   'notebase:getOnboardingDismissed': () => boolean;
   'notebase:setOnboardingDismissed': (dismissed: boolean) => void;
-  /** Thoughtbase Properties (#1443): current display name + the folder basename. */
-  'notebase:getProperties': () => { displayName: string; folderName: string };
+  /** Thoughtbase Properties (#1443): display name, folder basename, base IRI,
+   *  and the review-queue size (base-IRI edit is disabled while non-zero). */
+  'notebase:getProperties': () => { displayName: string; folderName: string; baseUri: string; pendingProposalCount: number };
   /** Set the display name ('' clears → folder basename); returns fresh meta. */
   'notebase:setDisplayName': (name: string) => NotebaseMeta;
 
@@ -194,6 +195,9 @@ export interface ChannelMap {
 
   // Graph
   'graph:query': (sparql: string) => { results: unknown[]; columns: string[]; error?: string };
+  /** Rebase to a new base IRI + rebuild indexes (#1443 Part B); refuses when the
+   *  review queue is non-empty. */
+  'graph:setBaseUri': (uri: string) => { ok: true } | { ok: false; error: string };
   'graph:groundCheck': (claimText: string) => { node: string; label: string; type: string }[];
   'graph:export': () => void;
   'graph:sourceDetail': (sourceId: string) => SourceDetail | null;

--- a/tests/main/graph/rebase-guard.test.ts
+++ b/tests/main/graph/rebase-guard.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Base-IRI rebase precheck (#1443 Part B) — the validation + the review-queue
+ * invariant, unit-tested in isolation from the IPC handler / live graph.
+ */
+import { describe, it, expect } from 'vitest';
+import { checkRebase } from '../../../src/main/graph/rebase-guard';
+
+describe('checkRebase', () => {
+  it('accepts a trimmed absolute http(s) IRI ending in "/" when the queue is empty', () => {
+    expect(checkRebase('  https://project.minerva.dev/u/p/  ', 0)).toEqual({ ok: true, uri: 'https://project.minerva.dev/u/p/' });
+    expect(checkRebase('http://localhost:8080/base/', 0)).toEqual({ ok: true, uri: 'http://localhost:8080/base/' });
+  });
+
+  it('rejects a malformed base IRI', () => {
+    for (const bad of ['', 'not-a-url', 'ftp://x/', 'https://no-trailing-slash', 'https://x /base/']) {
+      const r = checkRebase(bad, 0);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/absolute http/i);
+    }
+  });
+
+  it('refuses while the review queue is non-empty (the #1 invariant), even for a valid IRI', () => {
+    const r = checkRebase('https://project.minerva.dev/u/p/', 3);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/3 pending proposals.*review queue/i);
+  });
+
+  it('singularises the refusal message for one pending proposal', () => {
+    const r = checkRebase('https://x/base/', 1);
+    if (!r.ok) expect(r.error).toMatch(/1 pending proposal in/i);
+  });
+});

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -91,6 +91,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "graph:groundCheck",
   "graph:query",
   "graph:schemaForCompletion",
+  "graph:setBaseUri",
   "graph:sourceDetail",
   "images:cacheExternal",
   "ingest:getSettings",

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -135,6 +135,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "query",
     "runInspections",
     "schemaForCompletion",
+    "setBaseUri",
     "sourceDetail",
   ],
   "images": [

--- a/tests/renderer/components/ThoughtbaseProperties.test.ts
+++ b/tests/renderer/components/ThoughtbaseProperties.test.ts
@@ -1,15 +1,22 @@
 /**
  * @vitest-environment happy-dom
  *
- * ThoughtbaseProperties dialog (#1443, Part A). Loads current values, saves the
- * trimmed name via the `onSave` callback (App routes it through the notebase
- * store), and cancels cleanly.
+ * ThoughtbaseProperties dialog (#1443). Rename (Part A) + the Advanced base-IRI
+ * tier (Part B): change is sent only when edited, disabled while proposals are
+ * pending, and a refusal/error from the save is surfaced inline.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/svelte';
 
 const api = vi.hoisted(() => ({
-  notebase: { getProperties: vi.fn(async () => ({ displayName: 'Current', folderName: 'my-folder' })) },
+  notebase: {
+    getProperties: vi.fn(async () => ({
+      displayName: 'Current',
+      folderName: 'my-folder',
+      baseUri: 'https://project.minerva.dev/u/p/',
+      pendingProposalCount: 0,
+    })),
+  },
 }));
 vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api }));
 
@@ -18,23 +25,49 @@ import ThoughtbaseProperties from '../../../src/renderer/lib/components/Thoughtb
 beforeEach(() => vi.clearAllMocks());
 afterEach(() => cleanup());
 
+const ok = async () => ({ ok: true as const });
+
 describe('ThoughtbaseProperties', () => {
-  it('loads the current name and saves a trimmed new one', async () => {
-    const onSave = vi.fn();
+  it('renames, sending no baseUri when the base is unchanged', async () => {
+    const onSave = vi.fn(ok);
     const { getByLabelText, getByText, findByDisplayValue } = render(ThoughtbaseProperties, { onSave, onCancel: vi.fn() });
-    await findByDisplayValue('Current'); // getProperties resolved + populated
+    await findByDisplayValue('Current');
     await fireEvent.input(getByLabelText('Name'), { target: { value: '  Renamed  ' } });
     await fireEvent.click(getByText('Save'));
-    expect(onSave).toHaveBeenCalledWith('Renamed');
+    expect(onSave).toHaveBeenCalledWith({ name: 'Renamed' }); // no baseUri key
   });
 
-  it('shows the folder name as the placeholder (the blank-fallback)', async () => {
-    const { getByLabelText } = render(ThoughtbaseProperties, { onSave: vi.fn(), onCancel: vi.fn() });
-    await vi.waitFor(() => expect((getByLabelText('Name') as HTMLInputElement).placeholder).toBe('my-folder'));
+  it('sends the trimmed baseUri when the advanced field is edited', async () => {
+    const onSave = vi.fn(ok);
+    const { getByLabelText, getByText, findByDisplayValue } = render(ThoughtbaseProperties, { onSave, onCancel: vi.fn() });
+    await findByDisplayValue('Current');
+    await fireEvent.input(getByLabelText('Graph base IRI'), { target: { value: '  https://new.example/base/  ' } });
+    await fireEvent.click(getByText('Save'));
+    expect(onSave).toHaveBeenCalledWith({ name: 'Current', baseUri: 'https://new.example/base/' });
+  });
+
+  it('locks the base IRI field while proposals are pending', async () => {
+    api.notebase.getProperties.mockResolvedValueOnce({
+      displayName: 'Current', folderName: 'my-folder', baseUri: 'https://project.minerva.dev/u/p/', pendingProposalCount: 3,
+    });
+    const { getByLabelText, findByText } = render(ThoughtbaseProperties, { onSave: vi.fn(ok), onCancel: vi.fn() });
+    await findByText(/3 proposals await review/);
+    expect((getByLabelText('Graph base IRI') as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it('surfaces a save refusal inline and keeps the dialog open', async () => {
+    const onSave = vi.fn(async () => ({ ok: false as const, error: 'Resolve the 2 pending proposal(s) first.' }));
+    const onCancel = vi.fn();
+    const { getByLabelText, getByText, findByText, findByDisplayValue } = render(ThoughtbaseProperties, { onSave, onCancel });
+    await findByDisplayValue('Current');
+    await fireEvent.input(getByLabelText('Graph base IRI'), { target: { value: 'https://new.example/base/' } });
+    await fireEvent.click(getByText('Save'));
+    await findByText(/Resolve the 2 pending/);
+    expect(onCancel).not.toHaveBeenCalled(); // stays open
   });
 
   it('Cancel fires onCancel without saving', async () => {
-    const onSave = vi.fn();
+    const onSave = vi.fn(ok);
     const onCancel = vi.fn();
     const { getByText } = render(ThoughtbaseProperties, { onSave, onCancel });
     await fireEvent.click(getByText('Cancel'));


### PR DESCRIPTION
Second and final PR for #1443. Adds an **"Advanced" breakout** to the Thoughtbase Properties dialog for rebasing the knowledge graph's base IRI. No confirm gate (per your call) — a disclosure + a plain warning.

## Mechanism (no in-place triple rewriting, per the issue)
Persist the new `baseUri` → point the live graph state at it (`graph.setBaseUri`) → rebuild every index from the files (the **same `indexAllNotes` + search + tables sequence as "Rebuild All Indexes"**), which regenerates all note/tag/folder IRIs under the new base.

## The invariant it guards
Per #1443, the #1 breaking case is the **review queue**: pending proposals hold absolute note IRIs, copied verbatim across a rebuild, that would dangle under a new base. So the rebase **refuses while the queue is non-empty**. A pure `checkRebase(uri, pendingCount)` enforces that + validates the IRI (absolute http(s), trailing `/`). The dialog *also* disables the field while proposals pend, and warns that a rebase breaks existing exports + hand-pasted IRIs (wiki-links are unaffected — they re-resolve).

## Wiring
- `graph.setBaseUri(ctx)` updates the in-memory `state.baseUri` (which `indexAllNotes` reads); persistence uses `project-config.patchProjectConfig` (**merge** — not graph's full-overwrite `writeConfig`, so `displayName` etc. survive).
- IPC `graph:setBaseUri` (register-graph) → `{ ok } | { ok:false, error }`; refusals surface inline in the dialog. `notebase:getProperties` extended with `baseUri` + `pendingProposalCount`. Mutation routes through the notebase store.
- Dialog reworked to a single `onSave({ name, baseUri? })` returning the outcome, so a refusal keeps it open; `baseUri` is sent only when edited + unlocked.

## Deliberately not touched (per #1443's analysis)
`baseUri` coining, SPARQL prefix injection (fixed prefixes), health-check link classification (base-agnostic), and export/publish (works from markdown) — all unaffected. Invariants 2 (hand-pasted absolute IRIs) and 3 (external consumers of a published graph) are un-auto-fixable and are covered by the dialog warning.

## Tests
`rebase-guard` (IRI validation + queue invariant + message pluralisation); dialog (rename-only omits `baseUri`, edited base sent trimmed, **locked while pending**, refusal shown inline, cancel). `pnpm lint` clean; ipc + preload snapshots updated; suites green (89 across touched areas).

**Closes #1443.**