### PR TITLE
feat: rewrite proposals on base-IRI rebase instead of blocking (#1443)

### DIFF
--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -1347,17 +1347,63 @@ function captureProposalStatements(store: $rdf.IndexedFormula): $rdf.Statement[]
   return out;
 }
 
-function restoreProposalStatements(store: $rdf.IndexedFormula, stmts: $rdf.Statement[]): void {
-  for (const st of stmts) store.add(st.subject, st.predicate, st.object);
+/**
+ * Rewrite a term whose IRI/literal carries the old base to the new base
+ * (#1443 Part B — rewrite-on-rebase). NamedNodes under `from` are re-pointed;
+ * literals containing `from` (the proposal's `thought:payloadJson`, which
+ * embeds base IRIs in its turtle) get every occurrence replaced. The base is a
+ * unique URL prefix, so this can't touch the fixed `minerva:`/`thought:`/`prov:`
+ * ontology namespaces. Other terms pass through untouched.
+ */
+function rebaseTerm(term: $rdf.Node, from: string, to: string): $rdf.Node {
+  if (term.termType === 'NamedNode' && term.value.startsWith(from)) {
+    return $rdf.sym(to + term.value.slice(from.length));
+  }
+  if (term.termType === 'Literal' && term.value.includes(from)) {
+    const lit = term as $rdf.Literal;
+    return $rdf.literal(lit.value.split(from).join(to), lit.language || lit.datatype);
+  }
+  return term;
 }
 
-export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
+function restoreProposalStatements(
+  store: $rdf.IndexedFormula,
+  stmts: $rdf.Statement[],
+  rebase?: { from: string; to: string },
+): void {
+  for (const st of stmts) {
+    if (rebase) {
+      // Predicates are ontology terms (never base-derived), so leave them.
+      store.add(
+        rebaseTerm(st.subject, rebase.from, rebase.to) as $rdf.NamedNode,
+        st.predicate,
+        rebaseTerm(st.object as $rdf.Node, rebase.from, rebase.to),
+      );
+    } else {
+      store.add(st.subject, st.predicate, st.object);
+    }
+  }
+}
+
+/**
+ * `rebaseFrom` (#1443 Part B): the previous base IRI when this rebuild is a
+ * rebase. Pending/approved proposals aren't re-derivable from files, so they're
+ * carried across the reset — and, when rebasing, their base-prefixed IRIs +
+ * payload turtle are rewritten to the (already-updated) `state.baseUri` so they
+ * neither dangle on apply nor break the trust-integrity join for approved ones.
+ */
+export interface IndexAllNotesOptions { rebaseFrom?: string }
+
+export async function indexAllNotes(ctx: ProjectContext, opts?: IndexAllNotesOptions): Promise<number> {
   const state = getState(ctx);
   if (!state) return 0;
   const { rootPath } = state;
 
   // Carry proposals across the from-scratch reset below (see the helper's note).
   const preservedProposals = captureProposalStatements(state.store);
+  const rebase = opts?.rebaseFrom && opts.rebaseFrom !== state.baseUri
+    ? { from: opts.rebaseFrom, to: state.baseUri }
+    : undefined;
 
   // Reset and rebuild from scratch with ontology. The wholesale store swap is
   // the one mutation the incremental N3 mirror can't track, so drop the mirror
@@ -1372,7 +1418,7 @@ export async function indexAllNotes(ctx: ProjectContext): Promise<number> {
   state.indexedNotePaths.clear();
 
   ensureProject(state);
-  restoreProposalStatements(state.store, preservedProposals);
+  restoreProposalStatements(state.store, preservedProposals, rebase);
 
   // Two-pass build (#469): the first walk just reads frontmatter
   // aliases so the alias map is fully populated before any link gets

--- a/src/main/graph/rebase-guard.ts
+++ b/src/main/graph/rebase-guard.ts
@@ -1,24 +1,16 @@
 /**
- * Pure precheck for a base-IRI rebase (#1443 Part B). Kept separate from the IPC
- * handler so the two load-bearing rules are unit-testable without a live graph:
- *   1. the new base must be an absolute http(s) IRI ending in '/', and
- *   2. the review queue must be empty — pending proposals reference notes by
- *      absolute IRI and are copied verbatim across the rebuild that a rebase
- *      triggers, so they'd dangle under the new base (the #1 invariant #1443
- *      flags). Clearing the queue first is the mitigation.
+ * Pure validation for a base-IRI rebase (#1443 Part B). Kept separate from the
+ * IPC handler so it's unit-testable without a live graph: the new base must be
+ * an absolute http(s) IRI ending in '/'. (Proposals are rewritten old→new
+ * during the rebuild — see indexAllNotes `rebaseFrom` — so, unlike the original
+ * design, a non-empty review queue is no longer a blocker.)
  */
 export type RebaseCheck = { ok: true; uri: string } | { ok: false; error: string };
 
-export function checkRebase(uri: string, pendingProposalCount: number): RebaseCheck {
+export function checkRebase(uri: string): RebaseCheck {
   const trimmed = (uri ?? '').trim();
   if (!/^https?:\/\/\S+\/$/.test(trimmed)) {
     return { ok: false, error: 'Base IRI must be an absolute http(s) URL ending in "/".' };
-  }
-  if (pendingProposalCount > 0) {
-    return {
-      ok: false,
-      error: `Resolve the ${pendingProposalCount} pending proposal${pendingProposalCount === 1 ? '' : 's'} in the review queue before changing the base IRI.`,
-    };
   }
   return { ok: true, uri: trimmed };
 }

--- a/src/main/ipc/register-graph.ts
+++ b/src/main/ipc/register-graph.ts
@@ -9,8 +9,7 @@ import * as tables from '../sources/tables';
 import type { QueryResult, TableInfo } from '../sources/tables';
 import * as healthChecks from '../graph/health-checks';
 import type { Inspection } from '../graph/health-checks';
-import { patchProjectConfig } from '../project-config';
-import { listProposals } from '../llm/proposal-persistence';
+import { patchProjectConfig, readProjectConfig } from '../project-config';
 import { checkRebase } from '../graph/rebase-guard';
 import { withRootPath, withRootPathOr, withRootPathWin } from './helpers';
 
@@ -21,19 +20,23 @@ export function registerGraph(): void {
 
   // Rebase the graph to a new base IRI (#1443 Part B). No in-place triple
   // rewriting: persist the new base, point the live state at it, then rebuild
-  // every index from the files (indexAllNotes) so all IRIs regenerate. Refuses
-  // while the review queue is non-empty — pending proposals hold absolute note
-  // IRIs that are copied verbatim across a rebuild and would dangle otherwise.
+  // every index from the files (indexAllNotes) so all IRIs regenerate. Proposals
+  // aren't file-derived, so their base-prefixed IRIs + payload turtle are
+  // rewritten old→new during the rebuild (indexAllNotes `rebaseFrom`) — no need
+  // to refuse while the review queue is non-empty.
   handle(Channels.GRAPH_SET_BASE_URI, withRootPathWin(async (rootPath, win, rawUri: string) => {
     const ctx = projectContext(rootPath);
-    const pending = await listProposals(ctx, 'pending');
-    const check = checkRebase(rawUri, pending.length);
+    const check = checkRebase(rawUri);
     if (!check.ok) return check;
+    const oldBase = readProjectConfig(rootPath).baseUri;
     patchProjectConfig(rootPath, { baseUri: check.uri });
     graph.setBaseUri(ctx, check.uri);
     // Same rebuild sequence as "Rebuild All Indexes" (menu.ts) — CSVs after the
     // store reset so their schema triples survive; note tables last (#1358).
-    await Promise.all([graph.indexAllNotes(ctx), search.indexAllNotes(ctx)]);
+    await Promise.all([
+      graph.indexAllNotes(ctx, oldBase ? { rebaseFrom: oldBase } : undefined),
+      search.indexAllNotes(ctx),
+    ]);
     await tables.registerAllCsvs(ctx);
     await tables.registerAllNoteTables(ctx);
     if (win && !win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);

--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -9,7 +9,6 @@ import { renameAnchor } from '../notebase/rename-anchor';
 import { renameSource, renameExcerpt } from '../notebase/rename-source-excerpt';
 import { getOrFetchRemoteImage } from '../images/remote-image-cache';
 import { resolveDisplayName, setDisplayName, getDisplayName, readProjectConfig } from '../project-config';
-import { listProposals } from '../llm/proposal-persistence';
 import { getOrFetchThumbnail } from '../youtube/thumbnail-cache';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
@@ -363,13 +362,11 @@ export function registerNotebase(): void {
   // Thoughtbase Properties (#1443). Read the current display name + folder
   // basename for the dialog; set the display name and return fresh meta so the
   // renderer's notebase store updates the label everywhere immediately.
-  handle(Channels.NOTEBASE_GET_PROPERTIES, withRootPath(async (rootPath) => ({
+  handle(Channels.NOTEBASE_GET_PROPERTIES, withRootPath((rootPath) => ({
     displayName: getDisplayName(rootPath) ?? '',
     folderName: path.basename(rootPath),
-    // Base IRI + review-queue size drive the dialog's advanced tier (#1443 B):
-    // the field shows the current base and disables when proposals are pending.
+    // Base IRI drives the dialog's advanced tier (#1443 B).
     baseUri: readProjectConfig(rootPath).baseUri ?? '',
-    pendingProposalCount: (await listProposals(projectContext(rootPath), 'pending')).length,
   })));
 
   handle(Channels.NOTEBASE_SET_DISPLAY_NAME, withRootPath((rootPath, name: string) => {

--- a/src/renderer/lib/components/ThoughtbaseProperties.svelte
+++ b/src/renderer/lib/components/ThoughtbaseProperties.svelte
@@ -24,13 +24,10 @@
   let folderName = $state('');
   let baseUri = $state('');
   let initialBaseUri = $state('');
-  let pendingCount = $state(0);
   let nameInput = $state<HTMLInputElement>();
 
   let saving = $state(false);
   let error = $state<string | null>(null);
-
-  const baseLocked = $derived(pendingCount > 0);
 
   onMount(async () => {
     try {
@@ -39,7 +36,6 @@
       folderName = p.folderName;
       baseUri = p.baseUri;
       initialBaseUri = p.baseUri;
-      pendingCount = p.pendingProposalCount;
     } catch (e) {
       console.warn('[thoughtbase] failed to load properties:', e);
     }
@@ -50,7 +46,7 @@
     if (saving) return;
     saving = true;
     error = null;
-    const baseChanged = !baseLocked && baseUri.trim() !== initialBaseUri;
+    const baseChanged = baseUri.trim() !== initialBaseUri;
     try {
       const r = await onSave({ name: name.trim(), ...(baseChanged ? { baseUri: baseUri.trim() } : {}) });
       if (!r.ok) error = r.error ?? 'Could not save.';
@@ -106,20 +102,13 @@
             class="input"
             autocomplete="off"
             spellcheck="false"
-            disabled={baseLocked}
           />
-          {#if baseLocked}
-            <p class="hint warn">
-              Locked while {pendingCount} proposal{pendingCount === 1 ? '' : 's'} await review — they
-              reference notes by absolute IRI and can't survive a rebase. Clear the review queue first.
-            </p>
-          {:else}
-            <p class="hint warn">
-              Rewrites every knowledge-graph identifier (a full re-index runs on save).
-              Existing exports and any hand-pasted IRIs that used the old base will no
-              longer resolve. Wiki-links are unaffected.
-            </p>
-          {/if}
+          <p class="hint warn">
+            Rewrites every knowledge-graph identifier (a full re-index runs on save).
+            Pending and reviewed proposals are migrated to the new base automatically;
+            wiki-links are unaffected. Existing exports and any hand-pasted IRIs that
+            used the old base will no longer resolve.
+          </p>
         </div>
       </details>
 

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -57,9 +57,8 @@ export interface NotebaseApi {
    *  new-thoughtbase onboarding modal. Default false; set on user opt-out. */
   getOnboardingDismissed(): Promise<boolean>;
   setOnboardingDismissed(dismissed: boolean): Promise<void>;
-  /** Thoughtbase Properties (#1443): display name, folder basename, base IRI,
-   *  and the review-queue size. */
-  getProperties(): Promise<{ displayName: string; folderName: string; baseUri: string; pendingProposalCount: number }>;
+  /** Thoughtbase Properties (#1443): display name, folder basename, base IRI. */
+  getProperties(): Promise<{ displayName: string; folderName: string; baseUri: string }>;
   /** Set the display name ('' clears → folder basename); resolves to fresh meta. */
   setDisplayName(name: string): Promise<import('../../../shared/types').NotebaseMeta>;
 }

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -117,9 +117,8 @@ export interface ChannelMap {
   'notebase:renameExcerpt': (oldId: string, newId: string) => { rewrittenPaths: string[] };
   'notebase:getOnboardingDismissed': () => boolean;
   'notebase:setOnboardingDismissed': (dismissed: boolean) => void;
-  /** Thoughtbase Properties (#1443): display name, folder basename, base IRI,
-   *  and the review-queue size (base-IRI edit is disabled while non-zero). */
-  'notebase:getProperties': () => { displayName: string; folderName: string; baseUri: string; pendingProposalCount: number };
+  /** Thoughtbase Properties (#1443): display name, folder basename, base IRI. */
+  'notebase:getProperties': () => { displayName: string; folderName: string; baseUri: string };
   /** Set the display name ('' clears → folder basename); returns fresh meta. */
   'notebase:setDisplayName': (name: string) => NotebaseMeta;
 

--- a/tests/main/graph/rebase-guard.test.ts
+++ b/tests/main/graph/rebase-guard.test.ts
@@ -1,32 +1,23 @@
 /**
- * Base-IRI rebase precheck (#1443 Part B) — the validation + the review-queue
- * invariant, unit-tested in isolation from the IPC handler / live graph.
+ * Base-IRI rebase validation (#1443 Part B) — unit-tested in isolation from the
+ * IPC handler / live graph. (The review-queue no longer blocks a rebase:
+ * proposals are rewritten old→new during the rebuild — see the
+ * indexAllNotes-rebase test.)
  */
 import { describe, it, expect } from 'vitest';
 import { checkRebase } from '../../../src/main/graph/rebase-guard';
 
 describe('checkRebase', () => {
-  it('accepts a trimmed absolute http(s) IRI ending in "/" when the queue is empty', () => {
-    expect(checkRebase('  https://project.minerva.dev/u/p/  ', 0)).toEqual({ ok: true, uri: 'https://project.minerva.dev/u/p/' });
-    expect(checkRebase('http://localhost:8080/base/', 0)).toEqual({ ok: true, uri: 'http://localhost:8080/base/' });
+  it('accepts a trimmed absolute http(s) IRI ending in "/"', () => {
+    expect(checkRebase('  https://project.minerva.dev/u/p/  ')).toEqual({ ok: true, uri: 'https://project.minerva.dev/u/p/' });
+    expect(checkRebase('http://localhost:8080/base/')).toEqual({ ok: true, uri: 'http://localhost:8080/base/' });
   });
 
   it('rejects a malformed base IRI', () => {
     for (const bad of ['', 'not-a-url', 'ftp://x/', 'https://no-trailing-slash', 'https://x /base/']) {
-      const r = checkRebase(bad, 0);
+      const r = checkRebase(bad);
       expect(r.ok).toBe(false);
       if (!r.ok) expect(r.error).toMatch(/absolute http/i);
     }
-  });
-
-  it('refuses while the review queue is non-empty (the #1 invariant), even for a valid IRI', () => {
-    const r = checkRebase('https://project.minerva.dev/u/p/', 3);
-    expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.error).toMatch(/3 pending proposals.*review queue/i);
-  });
-
-  it('singularises the refusal message for one pending proposal', () => {
-    const r = checkRebase('https://x/base/', 1);
-    if (!r.ok) expect(r.error).toMatch(/1 pending proposal in/i);
   });
 });

--- a/tests/main/graph/rebase-proposals.test.ts
+++ b/tests/main/graph/rebase-proposals.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Rewrite-on-rebase for proposals (#1443 Part B). Proposals aren't re-derivable
+ * from files, so on a base-IRI rebase their base-prefixed IRIs (subject,
+ * affectsNode) AND their `payloadJson` turtle are rewritten old→new during the
+ * rebuild — so a pending proposal doesn't dangle on apply, and an approved one's
+ * `affectsNode` still joins to its (rebased) component for the trust gate.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexAllNotes, setBaseUri } from '../../../src/main/graph/index';
+import { writeProposalToGraph, listProposals } from '../../../src/main/llm/proposal-persistence';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import type { Proposal } from '../../../src/main/llm/proposal-types';
+
+const OLD = 'https://project.minerva.dev/old-u/old-p/';
+const NEW = 'https://project.minerva.dev/new-u/new-p/';
+
+function makeProposal(id: string, status: Proposal['status']): Proposal {
+  const component = `${OLD}component/${id}`;
+  return {
+    uri: `${OLD}proposal/${id}`,
+    status,
+    operationType: 'new_claim',
+    payloads: [{
+      kind: 'graph-triples',
+      turtle: `<${component}> a thought:Claim ; thought:label "c-${id}" ; thought:extractedBy "llm:test" .`,
+      affectsNodeUris: [component],
+    }],
+    note: `proposal ${id}`,
+    affectsNodeUris: [component],
+    proposedBy: 'test',
+    proposedAt: '2026-01-01T00:00:00.000Z',
+    autoExpires: '2026-12-31T00:00:00.000Z',
+  };
+}
+
+let root: string;
+let ctx: ProjectContext;
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-rebase-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+});
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+describe('indexAllNotes rebaseFrom — proposal migration', () => {
+  it('rewrites pending + approved proposals from the old base to the new base', async () => {
+    setBaseUri(ctx, OLD); // pretend the graph currently lives at OLD
+    await writeProposalToGraph(ctx, makeProposal('a', 'pending'));
+    await writeProposalToGraph(ctx, makeProposal('b', 'approved'));
+
+    setBaseUri(ctx, NEW); // the rebase handler sets the new base, then rebuilds
+    await indexAllNotes(ctx, { rebaseFrom: OLD });
+
+    const props = await listProposals(ctx);
+    expect(props).toHaveLength(2);
+    for (const p of props) {
+      expect(p.uri.startsWith(NEW)).toBe(true);                 // subject rebased
+      expect(p.affectsNodeUris.every((u) => u.startsWith(NEW))).toBe(true);
+      const turtle = (p.payloads[0] as { turtle: string }).turtle;
+      expect(turtle).toContain(NEW);                            // payload turtle rebased
+      expect(turtle).not.toContain(OLD);
+    }
+    // Both statuses survived the migration.
+    expect(props.map((p) => p.status).sort()).toEqual(['approved', 'pending']);
+  });
+
+  it('a plain rebuild (no rebaseFrom) leaves the proposal at the old base', async () => {
+    setBaseUri(ctx, OLD);
+    await writeProposalToGraph(ctx, makeProposal('a', 'pending'));
+
+    setBaseUri(ctx, NEW);
+    await indexAllNotes(ctx); // no rebaseFrom → verbatim carry-over
+
+    const [p] = await listProposals(ctx);
+    expect(p!.uri.startsWith(OLD)).toBe(true);
+    expect((p!.payloads[0] as { turtle: string }).turtle).toContain(OLD);
+  });
+});

--- a/tests/renderer/components/ThoughtbaseProperties.test.ts
+++ b/tests/renderer/components/ThoughtbaseProperties.test.ts
@@ -2,8 +2,9 @@
  * @vitest-environment happy-dom
  *
  * ThoughtbaseProperties dialog (#1443). Rename (Part A) + the Advanced base-IRI
- * tier (Part B): change is sent only when edited, disabled while proposals are
- * pending, and a refusal/error from the save is surfaced inline.
+ * tier (Part B): the base change is sent only when edited, and a
+ * validation/refusal error from the save is surfaced inline. (Proposals are
+ * migrated during the rebase, so the field is no longer locked.)
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/svelte';
@@ -14,7 +15,6 @@ const api = vi.hoisted(() => ({
       displayName: 'Current',
       folderName: 'my-folder',
       baseUri: 'https://project.minerva.dev/u/p/',
-      pendingProposalCount: 0,
     })),
   },
 }));
@@ -46,23 +46,14 @@ describe('ThoughtbaseProperties', () => {
     expect(onSave).toHaveBeenCalledWith({ name: 'Current', baseUri: 'https://new.example/base/' });
   });
 
-  it('locks the base IRI field while proposals are pending', async () => {
-    api.notebase.getProperties.mockResolvedValueOnce({
-      displayName: 'Current', folderName: 'my-folder', baseUri: 'https://project.minerva.dev/u/p/', pendingProposalCount: 3,
-    });
-    const { getByLabelText, findByText } = render(ThoughtbaseProperties, { onSave: vi.fn(ok), onCancel: vi.fn() });
-    await findByText(/3 proposals await review/);
-    expect((getByLabelText('Graph base IRI') as HTMLInputElement).disabled).toBe(true);
-  });
-
-  it('surfaces a save refusal inline and keeps the dialog open', async () => {
-    const onSave = vi.fn(async () => ({ ok: false as const, error: 'Resolve the 2 pending proposal(s) first.' }));
+  it('surfaces a save error inline and keeps the dialog open', async () => {
+    const onSave = vi.fn(async () => ({ ok: false as const, error: 'Base IRI must be an absolute http(s) URL ending in "/".' }));
     const onCancel = vi.fn();
     const { getByLabelText, getByText, findByText, findByDisplayValue } = render(ThoughtbaseProperties, { onSave, onCancel });
     await findByDisplayValue('Current');
-    await fireEvent.input(getByLabelText('Graph base IRI'), { target: { value: 'https://new.example/base/' } });
+    await fireEvent.input(getByLabelText('Graph base IRI'), { target: { value: 'not-a-url' } });
     await fireEvent.click(getByText('Save'));
-    await findByText(/Resolve the 2 pending/);
+    await findByText(/absolute http/);
     expect(onCancel).not.toHaveBeenCalled(); // stays open
   });
 


### PR DESCRIPTION
Follow-up to #1513. Swaps the "refuse to rebase while the review queue is non-empty" guard for **automatic migration** of proposals to the new base — so changing the base IRI just works.

## Mechanism
Proposals aren't re-derivable from files, so `indexAllNotes` already carries them verbatim across its store reset. This adds an optional **`rebaseFrom`** (the old base): when set, the carried proposal statements are rewritten old→new at restore —
- base-prefixed IRIs (proposal subject, `thought:affectsNode`) via NamedNode re-pointing, and
- the `thought:payloadJson` literal (which embeds base IRIs in its turtle bundle) via string replace.

The base is a unique URL prefix, so this can't touch the fixed `minerva:`/`thought:`/`prov:` ontology namespaces.

## Bonus: fixes a gap the guard never covered
The old guard only blocked while **pending** proposals existed. But an **approved** proposal's `affectsNode` also kept the old base after a rebase, breaking the trust-integrity join (`findUnreviewedLLMWrites`) that pins LLM-attributed components to their approved proposal — so every LLM component would have been flagged as *unreviewed*. Migrating **all** proposals (not just pending) keeps that gate correct across a rebase.

## Changes
- `GRAPH_SET_BASE_URI` (register-graph): capture the old base, pass `{ rebaseFrom }` to `indexAllNotes`; **drop the pending-queue refusal**.
- `checkRebase`: IRI-validation only now (no pending arg). `getProperties` drops `pendingProposalCount`; the dialog drops the field lock and instead notes proposals migrate automatically.

## Tests
`rebase-proposals` drives a real graph: writes a **pending + an approved** proposal at the old base, rebases, and asserts each proposal's **subject / affectsNode / payload turtle** moved old→new — plus a **no-`rebaseFrom` control** proving the rewrite is what fixes it. Guard test trimmed to validation; dialog test trimmed. `pnpm lint` clean; graph + ipc + dialog + **trust-integrity** suites green (415).

Part of #1443. Stacks on the merged #1513.