### PR TITLE
fix(tools): source-scoped tools do nothing from an imported source (#1514)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1237,13 +1237,18 @@
             dictationActive={voice.surface === 'editor' && voice.busy}
             dictationDisabled={editor.viewMode === 'preview'}
           />
-          <ToolPanel
-            bind:this={toolPanelComponent}
-            onNoteCreated={() => { void notebase.refresh(); sidebar?.refreshTags(); }}
-            onOpenConversation={handleOpenConversationFromTool}
-            onMissingApiKey={() => { void handleMissingApiKey(); }}
-          />
         {/if}
+        <!-- ToolPanel is mounted for ANY active tab, not just notes (#1514):
+             source-scoped tools (e.g. Extract Key Claims) run from a source tab
+             and route through toolPanelComponent.startExecution(), which no-ops
+             if the panel isn't bound. It renders nothing until a tool runs, so
+             mounting it unconditionally is invisible on non-note tabs. -->
+        <ToolPanel
+          bind:this={toolPanelComponent}
+          onNoteCreated={() => { void notebase.refresh(); sidebar?.refreshTags(); }}
+          onOpenConversation={handleOpenConversationFromTool}
+          onMissingApiKey={() => { void handleMissingApiKey(); }}
+        />
       </div>
       {#if rightSidebarVisible && editor.activeTab?.type === 'note'}
         <RightSidebar


### PR DESCRIPTION
## Problem

Closes #1514. A user reported that **Extract Key Claims does nothing when invoked from an imported source**.

## Cause

In `App.svelte`, `<ToolPanel bind:this={toolPanelComponent}>` was nested inside the `{#if editor.activeTab?.type === 'note'}` block that gates `<StatusBar>`. On a **source** tab that branch doesn't render, so `toolPanelComponent` stayed `undefined` and the source-tool invocation path —

```
handleToolInvoke(id) → getToolPanelComponent()?.startExecution()
```

— hit the optional-chain no-op and silently did nothing.

## Fix

Move `<ToolPanel>` out of the note-only branch so it's mounted for any active tab. It draws no DOM while idle (`ToolPanel.svelte` only renders on the `configure`/`running`/`review` states), so an unconditional mount is invisible on non-note tabs and simply lets source-tab invocations reach `startExecution()`.

## Testing

- `pnpm lint` (tsc + svelte-check) — clean.
- The bug lives in App.svelte's template structure (the composition root, e2e-territory, not unit-tested). The existing e2e journeys drive `window.api` directly and never mount the tool-invocation UI, so they can't observe this render-gating regression; a dedicated UI-driven Playwright test would be entangled with API-key handling and is disproportionate to a one-line mount move. svelte-check + the traced call path cover the change.

Reported by @dotKokott.

🤖 Generated with [Claude Code](https://claude.com/claude-code)