### PR TITLE
feat(eval): live model-call half of the skill-eval harness (#1522 PR2)

### DIFF
--- a/src/cli/eval.ts
+++ b/src/cli/eval.ts
@@ -28,10 +28,23 @@ import {
   resolveToolModel,
 } from '../main/tools/executor';
 import { buildConversationTools } from '../main/llm/tools/registry';
+import {
+  complete,
+  completeWithTools,
+  type CompleteOptions,
+  type CompleteWithToolsOptions,
+  type CompleteWithToolsResult,
+  type StreamCallbacks,
+} from '../main/llm/index';
 import type { ThinkingToolDef } from '../shared/tools/types';
 import type { ConversationToolKey } from '../shared/conversation-tools';
+import type { TurnUsage } from '../shared/types';
 import { jsonStringify } from './json';
 import { buildEvalContext, type CaseContextRefs, type InlineInputs } from './eval-context';
+
+// Injected by the CLI build (vite.cli.config.ts); absent under vitest — the
+// `typeof` guard at the use site falls back to 'unknown', matching register-app.ts.
+declare const __APP_COMMIT__: string;
 
 /** The human-authored `input/case.json`. */
 export interface EvalCaseManifest {
@@ -69,6 +82,32 @@ export interface EvalMeta {
   skill: string;
   model?: string;
   outputMode: string;
+  /** Live-run fields (#1522 PR 2) — present only when `--live` made a real call. */
+  usage?: TurnUsage;
+  usageModel?: string;
+  /** Wall-clock duration of the model call, milliseconds. */
+  timingMs?: number;
+  /** Number of proposal drafts the model produced (mirrors drafts.json length). */
+  draftCount?: number;
+  /** Short git commit of the CLI build that produced this run. */
+  harnessVersion?: string;
+}
+
+/** A proposal draft captured from the live agentic loop via a `StreamCallbacks`
+ *  callback (propose_notes → `onDraft`, etc.). `kind` names the callback so the
+ *  reviewer can tell note vs claim vs source drafts apart. */
+export interface CapturedDraft {
+  kind: string;
+  draft: unknown;
+}
+
+/** The non-deterministic half of a case — only produced by a `--live` run. */
+export interface LiveOutput {
+  response: string;
+  drafts: CapturedDraft[];
+  usage?: TurnUsage;
+  usageModel?: string;
+  timingMs: number;
 }
 
 export interface EvalResult {
@@ -76,13 +115,31 @@ export interface EvalResult {
   caseDir: string;
   request: PackagedRequest;
   meta: EvalMeta;
+  /** Present only when `opts.live` made a real model call. */
+  live?: LiveOutput;
 }
+
+/** The two model-call entry points the harness drives, injectable so the live
+ *  path is testable without a real provider / API key. Defaults to the real
+ *  `complete` / `completeWithTools`. */
+export interface LlmSeam {
+  complete(prompt: string, opts?: CompleteOptions): Promise<string>;
+  completeWithTools(opts: CompleteWithToolsOptions): Promise<CompleteWithToolsResult>;
+}
+
+const REAL_LLM: LlmSeam = { complete, completeWithTools };
 
 export interface RunEvalOptions {
   cwd: string;
   /** Write each case's `output/` (overwriting). Default true; the snapshot test
    *  passes false to compare against the committed files without mutating them. */
   write?: boolean;
+  /** Make a real model call and capture `response.md` + `drafts.json` (#1522 PR
+   *  2). Opt-in, off by default; needs a provider API key in the environment. */
+  live?: boolean;
+  /** Injectable LLM seam for the live path. Defaults to the real provider calls;
+   *  tests pass a fake to exercise capture without spending tokens. */
+  llm?: LlmSeam;
   /** User-skills dir to load on top of stock. Defaults to stock-only (an
    *  intentionally-absent path) so the catalog — and thus the packaged prompt —
    *  is identical on every machine and in CI. */
@@ -163,8 +220,83 @@ async function packageCase(
 }
 
 /**
+ * Drive a real model call for a packaged case and capture the non-deterministic
+ * half — the response text and any proposal drafts (#1522 PR 2). Reuses the exact
+ * runtime call: `complete` for one-shot skills, `completeWithTools` for
+ * conversation skills, with a notebase `toolContext` and the same draft callbacks
+ * `register-conversation.ts` wires — so `propose_notes` etc. surface as captured
+ * drafts (they fire the callback and only touch the graph on human approval, so
+ * nothing is written to the thoughtbase here).
+ */
+async function runLive(
+  request: PackagedRequest,
+  rootPath: string,
+  caseName: string,
+  llm: LlmSeam,
+): Promise<LiveOutput> {
+  const drafts: CapturedDraft[] = [];
+  const capture = (kind: string) => (draft: unknown) => {
+    drafts.push({ kind, draft });
+  };
+  const start = Date.now();
+
+  // A one-shot skill (no system prompt) is a plain completion — no tools, no
+  // drafts.
+  if (request.system === undefined) {
+    let usage: TurnUsage | undefined;
+    let usageModel: string | undefined;
+    const text = await llm.complete(request.messages[0]!.content, {
+      ...(request.model ? { model: request.model } : {}),
+      onUsage: (u, m) => {
+        usage = u;
+        usageModel = m;
+      },
+    });
+    return {
+      response: text,
+      drafts,
+      ...(usage ? { usage } : {}),
+      ...(usageModel ? { usageModel } : {}),
+      timingMs: Date.now() - start,
+    };
+  }
+
+  const callbacks: StreamCallbacks = {
+    onChunk: () => {},
+    onDraft: capture('notes'),
+    onSourceDraft: capture('sources'),
+    onPropertyDraft: capture('properties'),
+    onSourcePropertyDraft: capture('source_properties'),
+    onClaimsDraft: capture('claims'),
+    onComputeDraft: capture('compute'),
+    onRefactorDraft: capture('refactor'),
+    onReorgDraft: capture('reorg'),
+    onDeleteDraft: capture('delete'),
+    onNoteBodyDraft: capture('note_body'),
+  };
+  const result = await llm.completeWithTools({
+    system: request.system,
+    messages: request.messages,
+    toolContext: { rootPath, conversationId: `eval:${caseName}` },
+    ...(request.model ? { model: request.model } : {}),
+    ...(request.requiresTools ? { extraTools: request.requiresTools } : {}),
+    callbacks,
+  });
+  return {
+    response: result.text,
+    drafts,
+    usage: result.usage,
+    usageModel: result.usageModel,
+    timingMs: Date.now() - start,
+  };
+}
+
+/**
  * Run one or more eval cases. Packages each case's prompt as Minerva would and,
- * unless `write` is false, overwrites the case's `output/{request.json,meta.json}`.
+ * unless `write` is false, overwrites the case's `output/`. Writes `request.json`
+ * + `meta.json` always; a `--live` run additionally makes a real model call and
+ * writes `response.md` + `drafts.json` (and enriches `meta.json` with usage +
+ * timing).
  */
 export async function runEval(caseDirs: string[], opts: RunEvalOptions): Promise<EvalResult[]> {
   const catalog = await loadSkillCatalog(opts.userSkillsDir ?? stockOnlyDir(opts.cwd));
@@ -202,14 +334,28 @@ export async function runEval(caseDirs: string[], opts: RunEvalOptions): Promise
 
     const { request, meta } = await packageCase(manifest, inline, def, ctx, settings);
 
+    let live: LiveOutput | undefined;
+    if (opts.live) {
+      live = await runLive(request, ctx.rootPath, path.basename(caseDir), opts.llm ?? REAL_LLM);
+      meta.timingMs = live.timingMs;
+      meta.draftCount = live.drafts.length;
+      meta.harnessVersion = typeof __APP_COMMIT__ === 'string' ? __APP_COMMIT__ : 'unknown';
+      if (live.usage) meta.usage = live.usage;
+      if (live.usageModel) meta.usageModel = live.usageModel;
+    }
+
     if (opts.write !== false) {
       const outDir = path.join(caseDir, 'output');
       await fs.mkdir(outDir, { recursive: true });
       await fs.writeFile(path.join(outDir, 'request.json'), `${jsonStringify(request, true)}\n`, 'utf-8');
       await fs.writeFile(path.join(outDir, 'meta.json'), `${jsonStringify(meta, true)}\n`, 'utf-8');
+      if (live) {
+        await fs.writeFile(path.join(outDir, 'response.md'), `${live.response.replace(/\n*$/, '')}\n`, 'utf-8');
+        await fs.writeFile(path.join(outDir, 'drafts.json'), `${jsonStringify(live.drafts, true)}\n`, 'utf-8');
+      }
     }
 
-    results.push({ caseDir: given, request, meta });
+    results.push({ caseDir: given, request, meta, ...(live ? { live } : {}) });
   }
   return results;
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -63,8 +63,8 @@ Commands:
                         tools to agent clients (Claude Desktop, coding agents…).
   eval <case-dir>…      Package a skill's prompt exactly as Minerva does and
                         overwrite each case's output/. Deterministic (no LLM
-                        call). Diff the output to review prompt/context changes
-                        (#1522).                                       [--all]
+                        call) unless --live. Diff the output to review
+                        prompt/context changes (#1522).        [--all] [--live]
 
 Options:
   --project <path>      Thoughtbase root (default: current directory).
@@ -73,6 +73,8 @@ Options:
   --case-sensitive      Match case exactly (grep; default: case-insensitive).
   --by <client-id>      Provenance for propose-note (default: cli).
   --all                 eval: run every case under tests/skills-eval/.
+  --live                eval: make a real model call, capturing response.md +
+                        drafts.json. Opt-in; needs a provider key in the env.
   --help, -h            Show this help.
 
 Results are JSON on stdout, grounded with node IRIs / note paths so the output
@@ -88,6 +90,7 @@ interface ParsedArgs {
   regex: boolean;
   caseSensitive: boolean;
   all: boolean;
+  live: boolean;
   help: boolean;
 }
 
@@ -102,6 +105,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let regex = false;
   let caseSensitive = false;
   let all = false;
+  let live = false;
   let help = false;
 
   for (let i = 0; i < argv.length; i++) {
@@ -126,12 +130,14 @@ export function parseArgs(argv: string[]): ParsedArgs {
       caseSensitive = true;
     } else if (arg === '--all') {
       all = true;
+    } else if (arg === '--live') {
+      live = true;
     } else {
       positionals.push(arg);
     }
   }
 
-  return { command: positionals.shift(), positionals, project, limit, by, regex, caseSensitive, all, help };
+  return { command: positionals.shift(), positionals, project, limit, by, regex, caseSensitive, all, live, help };
 }
 
 function json(value: unknown): string {
@@ -200,7 +206,7 @@ export async function runCli(argv: string[], opts: RunOptions): Promise<CliResul
       if (caseDirs.length === 0) {
         throw new UsageError('eval: pass one or more case directories, or --all.');
       }
-      const results = await runEval(caseDirs, { cwd: opts.cwd });
+      const results = await runEval(caseDirs, { cwd: opts.cwd, live: args.live });
       return {
         stdout: json(
           results.map((r) => ({
@@ -208,6 +214,9 @@ export async function runCli(argv: string[], opts: RunOptions): Promise<CliResul
             skill: r.meta.skill,
             model: r.meta.model ?? null,
             outputMode: r.meta.outputMode,
+            ...(r.live
+              ? { responseChars: r.live.response.length, drafts: r.live.drafts.length, timingMs: r.live.timingMs }
+              : {}),
           })),
         ),
         stderr: '',

--- a/tests/cli/eval-live.test.ts
+++ b/tests/cli/eval-live.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Skill-eval harness — the live half (#1522, PR 2).
+ *
+ * The `--live` path makes a real model call and captures the non-deterministic
+ * artifacts (`response.md`, `drafts.json`) plus usage/timing in `meta.json`.
+ * This test exercises that capture + serialization with an **injected fake LLM
+ * seam** — no provider, no API key, no tokens — so it can run in CI while the
+ * real calls stay opt-in. It asserts:
+ *   - one-shot skills go through `complete` (no drafts);
+ *   - conversation skills go through `completeWithTools`, and every draft the
+ *     agentic loop emits is captured into `drafts.json` with its kind;
+ *   - a non-live run writes neither `response.md` nor `drafts.json`.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { runEval, type LlmSeam } from '../../src/cli/eval';
+import type { TurnUsage } from '../../src/shared/types';
+
+const USAGE: TurnUsage = { inputTokens: 11, outputTokens: 22, cacheCreationTokens: 0, cacheReadTokens: 0 };
+
+/** A fake seam: `complete` returns canned text (reporting usage); `completeWithTools`
+ *  fires two draft callbacks (a note + a claim) before returning. */
+function fakeLlm(): LlmSeam {
+  return {
+    async complete(_prompt, opts) {
+      opts?.onUsage?.(USAGE, opts.model ?? 'fake-model');
+      return 'ONE-SHOT RESPONSE TEXT';
+    },
+    async completeWithTools(opts) {
+      opts.callbacks?.onDraft?.({ conversationId: 'x', notes: [{ relativePath: 'n.md', content: '# N' }] } as never);
+      opts.callbacks?.onClaimsDraft?.({ conversationId: 'x', claims: [{ label: 'c' }] } as never);
+      return {
+        text: 'CONVERSATION RESPONSE TEXT',
+        citations: [],
+        usage: USAGE,
+        usageModel: opts.model ?? 'fake-model',
+      };
+    },
+  };
+}
+
+let cwd: string;
+
+beforeAll(async () => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-eval-live-'));
+  // A conversation-skill case (inline note + selection) and a one-shot-skill case.
+  const conv = path.join(cwd, 'conv-case', 'input');
+  await fsp.mkdir(conv, { recursive: true });
+  await fsp.writeFile(
+    path.join(conv, 'case.json'),
+    JSON.stringify({ skill: 'analysis.antithesize', model: 'claude-opus-5', context: { noteTitle: 'T' } }),
+    'utf-8',
+  );
+  await fsp.writeFile(path.join(conv, 'note.md'), '# T\n\nA claim worth opposing.\n', 'utf-8');
+
+  const one = path.join(cwd, 'oneshot-case', 'input');
+  await fsp.mkdir(one, { recursive: true });
+  await fsp.writeFile(
+    path.join(one, 'case.json'),
+    JSON.stringify({ skill: 'planning.steelman', model: 'claude-opus-5', context: { noteTitle: 'T' } }),
+    'utf-8',
+  );
+  await fsp.writeFile(path.join(one, 'note.md'), '# T\n\nA position to steelman.\n', 'utf-8');
+});
+
+afterAll(async () => {
+  await fsp.rm(cwd, { recursive: true, force: true });
+});
+
+describe('skill-eval harness — live capture (#1522 PR 2)', () => {
+  it('conversation skill: captures response + every draft, and enriches meta', async () => {
+    const [res] = await runEval(['conv-case'], { cwd, live: true, llm: fakeLlm() });
+    expect(res!.live).toBeDefined();
+    expect(res!.live!.response).toBe('CONVERSATION RESPONSE TEXT');
+    // Both draft callbacks captured, labelled by kind.
+    expect(res!.live!.drafts.map((d) => d.kind)).toEqual(['notes', 'claims']);
+
+    const out = path.join(cwd, 'conv-case', 'output');
+    expect(fs.readFileSync(path.join(out, 'response.md'), 'utf-8')).toBe('CONVERSATION RESPONSE TEXT\n');
+    const drafts = JSON.parse(fs.readFileSync(path.join(out, 'drafts.json'), 'utf-8'));
+    expect(drafts).toHaveLength(2);
+    expect(drafts[0].kind).toBe('notes');
+
+    const meta = JSON.parse(fs.readFileSync(path.join(out, 'meta.json'), 'utf-8'));
+    expect(meta.usage).toEqual(USAGE);
+    expect(meta.usageModel).toBe('claude-opus-5');
+    expect(meta.draftCount).toBe(2);
+    expect(typeof meta.timingMs).toBe('number');
+    expect(meta.harnessVersion).toBeDefined();
+  });
+
+  it('one-shot skill: goes through complete, no drafts', async () => {
+    const [res] = await runEval(['oneshot-case'], { cwd, live: true, llm: fakeLlm() });
+    expect(res!.live!.response).toBe('ONE-SHOT RESPONSE TEXT');
+    expect(res!.live!.drafts).toEqual([]);
+    const out = path.join(cwd, 'oneshot-case', 'output');
+    expect(fs.readFileSync(path.join(out, 'response.md'), 'utf-8')).toBe('ONE-SHOT RESPONSE TEXT\n');
+    expect(JSON.parse(fs.readFileSync(path.join(out, 'drafts.json'), 'utf-8'))).toEqual([]);
+  });
+
+  it('a non-live run writes neither response.md nor drafts.json', async () => {
+    // A fresh case that never saw a live run, so the live-only artifacts can
+    // only be absent because non-live skips them.
+    const fresh = path.join(cwd, 'fresh-case', 'input');
+    await fsp.mkdir(fresh, { recursive: true });
+    await fsp.writeFile(
+      path.join(fresh, 'case.json'),
+      JSON.stringify({ skill: 'planning.steelman', model: 'claude-opus-5', context: { noteTitle: 'T' } }),
+      'utf-8',
+    );
+    await fsp.writeFile(path.join(fresh, 'note.md'), '# T\n\nnope\n', 'utf-8');
+
+    const [res] = await runEval(['fresh-case'], { cwd, live: false, llm: fakeLlm() });
+    expect(res!.live).toBeUndefined();
+    const out = path.join(cwd, 'fresh-case', 'output');
+    expect(fs.existsSync(path.join(out, 'request.json'))).toBe(true); // always written
+    expect(fs.existsSync(path.join(out, 'response.md'))).toBe(false);
+    expect(fs.existsSync(path.join(out, 'drafts.json'))).toBe(false);
+  });
+});

--- a/tests/skills-eval/README.md
+++ b/tests/skills-eval/README.md
@@ -11,8 +11,10 @@ result to `output/` for review with a diff tool.
     note.md        # (optional) inline note body for synthetic cases
     selection.txt  # (optional) inline selection
   output/          # OVERWRITTEN by the harness; committed so diffs are reviewable
-    request.json   # the packaged LLM request ("just as Minerva does")
-    meta.json      # skill, resolved model, outputMode
+    request.json   # the packaged LLM request ("just as Minerva does") — deterministic
+    meta.json      # skill, resolved model, outputMode (+ usage/timing on a --live run)
+    response.md    # the model's text response      — only after a --live run
+    drafts.json    # captured proposal drafts        — only after a --live run
 ```
 
 ## Running
@@ -20,10 +22,23 @@ result to `output/` for review with a diff tool.
 ```
 pnpm cli eval tests/skills-eval/steelman-essential-complexity   # one case
 pnpm cli eval --all                                             # every case
+pnpm cli eval --all --live                                      # + real model call
 ```
 
 Each run overwrites the case's `output/`. Review the change with `git diff` (or
 IntelliJ's diff) as skills, prompts, models, and the context pipeline evolve.
+
+## Live runs (`--live`)
+
+Without `--live` the harness only packages the prompt — no model call, no key.
+`--live` additionally makes the **real** call (`complete` for one-shot skills,
+`completeWithTools` for conversation skills, with the same draft callbacks
+Minerva wires) and writes `response.md` + `drafts.json`, enriching `meta.json`
+with token usage + timing. It needs a provider key in the environment
+(`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`), costs money, and is
+**never run in CI** — it's the overwrite-and-human-diff artifact. `propose_*`
+tools surface as captured drafts; nothing is written to a thoughtbase (drafts
+only touch the graph on human approval in Minerva).
 
 ## Two context modes
 
@@ -39,5 +54,6 @@ IntelliJ's diff) as skills, prompts, models, and the context pipeline evolve.
 `request.json` is deterministic — same skill + context + params ⇒ identical
 bytes — and is asserted in CI by `tests/cli/eval.test.ts` **without any LLM call
 or API key**. Pin `model` per case so a model swap is a visible diff. The
-non-deterministic model output (`response.md` / `drafts.json`) is a later,
-opt-in addition (PR 2) and is never asserted.
+non-deterministic model output (`response.md` / `drafts.json`, from `--live`) is
+overwrite-and-human-diff only and is **never asserted** — the live capture path
+itself is covered with a fake LLM seam in `tests/cli/eval-live.test.ts`.


### PR DESCRIPTION
Second slice of the skill-eval harness epic (#1522), on top of PR 1 (#1529).
Adds the **non-deterministic half** behind an opt-in `--live` flag.

## What this does

Without `--live`, `eval` stays the deterministic prompt-packager from PR 1
(request.json + minimal meta.json, no LLM call, no key). With `--live`, the
harness makes the **real** model call the way Minerva does and captures the
output for overwrite-and-human-diff review:

- **one-shot skills** → `complete(prompt, { model, onUsage })`
- **conversation skills** → `completeWithTools({ system, messages, toolContext, model, callbacks })`
  with a notebase `toolContext` (`{ rootPath, conversationId }`) and the same
  draft callbacks `register-conversation.ts` wires — so `propose_*` tools surface
  as **captured drafts** (they fire the callback and only touch the graph on human
  approval, so nothing is written to a thoughtbase).

Writes `response.md` + `drafts.json` and enriches `meta.json` with token usage,
timing, draft count, and the CLI build's git commit.

```
pnpm cli eval --all --live      # opt-in; needs a provider key in the env
```

## Safety / cost

The live path is **opt-in, needs a provider key from the env, and is never run in
CI**. The seed cases' `response.md`/`drafts.json` are author-generated on demand
(this PR doesn't spend tokens committing them).

## Testable without a key

The LLM is an **injectable seam** on `runEval` (default = real `complete` /
`completeWithTools`). `tests/cli/eval-live.test.ts` drives the capture +
serialization with a **fake** — no provider, no key, no tokens — asserting:
- one-shot goes through `complete` (no drafts); conversation goes through
  `completeWithTools`;
- every draft the agentic loop emits is captured into `drafts.json` with its kind;
- `meta.json` gains usage / usageModel / timingMs / draftCount / harnessVersion;
- a non-live run writes neither `response.md` nor `drafts.json`.

## Files

- `src/cli/eval.ts` — `runLive`, the injectable `LlmSeam`, `--live` wiring, live meta.
- `src/cli/run.ts` — `--live` flag + help + richer eval summary.
- `tests/cli/eval-live.test.ts` — fake-seam coverage of the live path.
- `tests/skills-eval/README.md` — document `--live`.

## Verification

- `pnpm test tests/cli/ tests/main/tools/build-conversation-payload.test.ts tests/main/skills-analysis.test.ts` — 88 pass. ✓
- `pnpm lint` — 0 errors. ✓
- `pnpm cli:build` + `eval --all` (non-live) — zero output churn (still deterministic). ✓

## Remaining in the epic

**PR 3+:** the rich purpose-built testing thoughtbase and one canonical case per
stock skill (so every skill has something real to bite on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)