### PR TITLE
fix(conversation): honor a skill's declared web setting per conversation (#1533)

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -311,6 +311,14 @@ export function registerConversation(): void {
           return !/_(?:🔍 Searching|🌐 Fetching|⚙️ Running code)/.test(m.content);
         });
 
+      // Per-conversation web override (#1533): when the conversation pins web
+      // on/off (e.g. from a launching skill's `web:` declaration), send it as a
+      // `web` override — completeWithTools merges it over the global setting, so
+      // the user's global allow/block domain lists still apply. Unset ⇒ omit,
+      // and web resolves from the global setting exactly as before.
+      const webOverride =
+        conv.webEnabled !== undefined ? { web: { enabled: conv.webEnabled } } : {};
+
       let result: Awaited<ReturnType<typeof completeWithTools>>;
       try {
         result = await completeWithTools({
@@ -320,6 +328,7 @@ export function registerConversation(): void {
           model: conv.model,
           effort: conv.effort,
           extraTools,
+          ...webOverride,
           // Re-echo any prior turn's code-execution sandbox id. Required
           // by the API whenever the persisted message history still
           // contains a `server_tool_use` block; without it the next
@@ -351,6 +360,7 @@ export function registerConversation(): void {
           model: conv.model,
           effort: conv.effort,
           extraTools,
+          ...webOverride,
           callbacks: streamCallbacks,
         });
       }
@@ -921,9 +931,10 @@ async function compactConversation(
   // Archive the original (files the full transcript as a thought:Source —
   // recoverable) before opening the compacted continuation.
   await conversation.archive(convId);
-  const createOpts: { systemPrompt?: string; model?: string } = {};
+  const createOpts: { systemPrompt?: string; model?: string; webEnabled?: boolean } = {};
   if (conv.systemPrompt) createOpts.systemPrompt = conv.systemPrompt;
   if (conv.model) createOpts.model = conv.model;
+  if (conv.webEnabled !== undefined) createOpts.webEnabled = conv.webEnabled;
   const fresh = await conversation.create(
     conv.contextBundle,
     conv.triggerNodeUri,

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -83,7 +83,7 @@ function generateId(): string {
 export async function create(
   contextBundle: ContextBundle,
   triggerNodeUri?: string,
-  options?: { systemPrompt?: string; model?: string },
+  options?: { systemPrompt?: string; model?: string; webEnabled?: boolean },
 ): Promise<Conversation> {
   const dir = ensureDir();
   await fs.mkdir(dir, { recursive: true });
@@ -99,6 +99,7 @@ export async function create(
   };
   if (options?.systemPrompt) conv.systemPrompt = options.systemPrompt;
   if (options?.model) conv.model = options.model;
+  if (options?.webEnabled !== undefined) conv.webEnabled = options.webEnabled;
 
   await persist(conv);
   writeConversationToGraph(conv);

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -271,9 +271,10 @@ export async function completeWithTools(
   options: CompleteWithToolsOptions,
 ): Promise<CompleteWithToolsResult> {
   const { provider, model, web: providerWeb, effort: defaultEffort } = await getProvider(options.model);
-  // A per-call `web` override (e.g. the eval harness running a `web: false` skill)
-  // wins over the global setting; otherwise the provider's global web applies.
-  const web = options.web ?? providerWeb;
+  // A per-call `web` override (a `web: false` skill in the eval harness; a
+  // per-conversation web setting, #1533) merges over the global web — so a caller
+  // that overrides just `enabled` keeps the user's global allow/block domain lists.
+  const web = options.web ? { ...providerWeb, ...options.web } : providerWeb;
   const effort = resolveEffort(model, options.effort, defaultEffort);
   const { toolContext, callbacks, maxIterations = 10 } = options;
 

--- a/src/renderer/lib/app/conversation-ops.ts
+++ b/src/renderer/lib/app/conversation-ops.ts
@@ -163,6 +163,8 @@ export function createConversationOps(ctx: ConversationOpsCtx) {
       systemPrompt: prep.systemPrompt,
       ...(prep.model ? { model: prep.model } : {}),
       ...(prep.firstMessage ? { initialMessage: prep.firstMessage } : {}),
+      // Honor the skill's declared web preference on the conversation (#1533).
+      webEnabled: prep.webEnabled,
       ...(prep.requiresTools && prep.requiresTools.length > 0
         ? { extraTools: prep.requiresTools }
         : {}),

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -535,7 +535,7 @@ export interface ClipperApi {
 }
 
 export interface ConversationsApi {
-  create(contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }): Promise<Conversation>;
+  create(contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string; webEnabled?: boolean }): Promise<Conversation>;
   append(id: string, role: ConversationMessage['role'], content: string): Promise<Conversation>;
   archive(id: string): Promise<Conversation>;
   load(id: string): Promise<Conversation | null>;

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -457,6 +457,9 @@ async function openConversationTab(opts: {
   systemPrompt?: string;
   model?: string;
   initialMessage?: string;
+  /** Per-conversation web override (#1533) — from a launching skill's `web:`
+   *  declaration. Persisted on the conversation; the send handler applies it. */
+  webEnabled?: boolean;
   /** Template-scoped tools (e.g. `'ask_user'`) the agent should have in
    *  scope for this conversation. Mirrors ConversationTemplate's
    *  `requiresTools` and ThinkingTool's `requiresTools` (#514). */
@@ -464,9 +467,10 @@ async function openConversationTab(opts: {
 }): Promise<TabRuntime> {
   ensureSubscriptions();
   const bundle: ContextBundle = opts.notePath ? { notePath: opts.notePath } : {};
-  const createOpts: { systemPrompt?: string; model?: string } = {};
+  const createOpts: { systemPrompt?: string; model?: string; webEnabled?: boolean } = {};
   if (opts.systemPrompt) createOpts.systemPrompt = opts.systemPrompt;
   if (opts.model) createOpts.model = opts.model;
+  if (opts.webEnabled !== undefined) createOpts.webEnabled = opts.webEnabled;
   const conv = await api.conversations.create(
     bundle,
     undefined,
@@ -707,9 +711,10 @@ async function clearConversation(): Promise<void> {
     // regardless so the user still gets their clean slate.
     console.warn('[conv] /clear: archive failed', e);
   }
-  const createOpts: { systemPrompt?: string; model?: string } = {};
+  const createOpts: { systemPrompt?: string; model?: string; webEnabled?: boolean } = {};
   if (prev.systemPrompt) createOpts.systemPrompt = prev.systemPrompt;
   if (prev.model) createOpts.model = prev.model;
+  if (prev.webEnabled !== undefined) createOpts.webEnabled = prev.webEnabled;
   const fresh = await api.conversations.create(
     prev.contextBundle,
     prev.triggerNodeUri,

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -469,7 +469,7 @@ export interface ChannelMap {
   'proposal:expire': () => number;
 
   // Conversations
-  'conversation:create': (contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) => Conversation;
+  'conversation:create': (contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string; webEnabled?: boolean }) => Conversation;
   'conversation:append': (id: string, role: ConversationMessage['role'], content: string) => Conversation;
   'conversation:archive': (id: string) => Conversation;
   'conversation:load': (id: string) => Conversation | null;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -611,6 +611,14 @@ export interface Conversation {
    */
   systemPrompt?: string;
   /**
+   * Per-conversation web-search override (#1533). `undefined` inherits the
+   * global `LLMSettings.web.enabled`; `true`/`false` pin web on/off for this
+   * conversation. Set from a launching skill's `web:` declaration (via
+   * `ConversationToolPayload.webEnabled`). The global allow/block domain lists
+   * still apply. Mirrors the `model` / `effort` override pattern.
+   */
+  webEnabled?: boolean;
+  /**
    * Code-execution sandbox id returned by Anthropic when the model used a
    * `code_execution` server-side tool (which is how `web_search_20260209`
    * and `web_fetch_20260209` are wrapped). Every subsequent request whose

--- a/tests/main/llm/conversation-model.test.ts
+++ b/tests/main/llm/conversation-model.test.ts
@@ -68,3 +68,36 @@ describe('conversation.setModel (issue #168)', () => {
     await expect(setModel('nope', 'claude-opus-4-7')).rejects.toThrow(/not found/i);
   });
 });
+
+describe('conversation.create webEnabled (#1533 — per-conversation web)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+    initConversations(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('defaults to undefined (inherit the global web setting)', async () => {
+    const conv = await create({ notePath: 'x.md' });
+    expect(conv.webEnabled).toBeUndefined();
+    expect((await load(conv.id))?.webEnabled).toBeUndefined();
+  });
+
+  it('persists an explicit web:false from a launching skill', async () => {
+    const conv = await create({ notePath: 'x.md' }, undefined, { webEnabled: false });
+    expect(conv.webEnabled).toBe(false);
+    expect((await load(conv.id))?.webEnabled).toBe(false);
+  });
+
+  it('persists an explicit web:true', async () => {
+    const conv = await create({ notePath: 'x.md' }, undefined, { webEnabled: true });
+    expect((await load(conv.id))?.webEnabled).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #1533.

## The bug

Web search was **global-only**. `buildConversationPayload` computed
`payload.webEnabled` from a skill's `web:` field, but the renderer dropped it —
so a `web: false` skill still got web tools, and a `web: true` skill had web only
if the user's global toggle happened to be on. The `web:` field communicated
intent but changed nothing.

## The fix — thread `webEnabled` end to end

The `completeWithTools` per-call `web` override already existed (added in #1532);
this wires a per-conversation `webEnabled` into it:

- **Model** — `Conversation` gains `webEnabled?: boolean` (`shared/types.ts`),
  accepted by `conversation.create` and persisted (round-trips on load; no
  migration — `undefined` = inherit the global setting).
- **Create seam** — threaded through `conversation:create` (`ipc-contract.ts` +
  `client.ts`), `openConversationTab`, and `handleOpenConversationFromTool` now
  **forwards `prep.webEnabled`** instead of dropping it. Preserved across
  `/compact` and `/clear` re-creates.
- **Send** — `register-conversation.ts` passes `web: { enabled: conv.webEnabled }`
  to `completeWithTools` when set; unset ⇒ omitted, resolving from the global
  setting exactly as before.
- **Merge** — the `completeWithTools` `web` override now **merges** over the
  global web (`{ ...providerWeb, ...options.web }`) rather than replacing it, so
  overriding just `enabled` keeps the user's global allow/block domain lists.

## Semantics

Per-conversation `webEnabled` overrides the global default **both ways**;
`undefined` inherits it; the global allow/block domain lists always apply.

## Tests / verification

- New `conversation-model.test.ts` cases: `webEnabled` defaults to undefined and
  persists `true`/`false` across reload.
- Existing `eval-live.test.ts` already proves a `web:false` conversation's call
  receives the web-off override end to end.
- Full suite green (301 llm + preload tests), `pnpm lint` 0 errors, tsc +
  svelte-check clean across every threaded seam.
- **Manual E2E** (not automated): launch the app, invoke a `web: false` skill,
  confirm no `web_search`; invoke a `web: true` skill, confirm it searches.

## Out of scope

A per-conversation **web toggle in the composer** (so the user, not just the
launching skill, can flip it) — the `webEnabled` field it would bind to now
exists. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)