### PR TITLE
feat(proposals): store with live pendingCount (#1525)

### DIFF
--- a/src/renderer/lib/stores/proposals.svelte.ts
+++ b/src/renderer/lib/stores/proposals.svelte.ts
@@ -1,0 +1,73 @@
+/**
+ * Proposals store (#1525, epic #1523 — make proposals visible).
+ *
+ * The single source of truth for "what's pending review." Owns
+ * `api.proposals.list()` and — per the renderer data-flow rule (CLAUDE.md) —
+ * the `PROPOSALS_CHANGED` subscription, so the left Proposals panel (#1526),
+ * the status-bar badge, and the OS dock badge (#1528) all read one reactive
+ * list + `pendingCount` instead of each re-fetching on their own.
+ *
+ * It holds the FULL proposal set (not a status-filtered slice), because
+ * `pendingCount` must be global regardless of any panel's current filter — the
+ * panel filters this list client-side. It re-fetches on three signals:
+ *   1. `PROPOSALS_CHANGED` — a proposal was filed (in-app or routed from a
+ *      CLI/MCP client, #1524), approved, rejected, or expired.
+ *   2. `project:opened` — switching thoughtbase swaps the whole set.
+ *   3. an explicit `refresh()` for first paint.
+ *
+ * Actions (approve/reject) stay in `review.svelte.ts`; this store is read +
+ * subscribe only. Because approve/reject/expire now emit `PROPOSALS_CHANGED`,
+ * the list self-updates after a mutation with no manual refresh.
+ */
+import { api } from '../ipc/client';
+
+export interface Proposal {
+  uri: string;
+  status: string;
+  operationType: string;
+  note: string;
+  proposedBy: string;
+  proposedAt: string;
+  payloads: unknown[];
+}
+
+let proposals = $state<Proposal[]>([]);
+/** True once the first list() has resolved — lets a surface distinguish "no
+ *  proposals" from "not loaded yet" (e.g. skip a badge flash on boot). */
+let loaded = $state(false);
+
+/** Subscriptions are wired exactly once for the app session (module singleton). */
+let started = false;
+
+async function refresh(): Promise<void> {
+  proposals = (await api.proposals.list()) as Proposal[];
+  loaded = true;
+}
+
+function start(): void {
+  if (started) return;
+  started = true;
+  // A proposal was filed / approved / rejected / expired — re-list.
+  api.proposals.onChanged(() => void refresh());
+  // Thoughtbase switched — the whole set changes.
+  api.menu.onProjectOpened(() => void refresh());
+  void refresh();
+}
+
+export function getProposalsStore() {
+  start();
+  return {
+    get proposals(): Proposal[] {
+      return proposals;
+    },
+    /** Pending proposals awaiting review — the badge/count everything reads. */
+    get pendingCount(): number {
+      return proposals.filter((p) => p.status === 'pending').length;
+    },
+    get loaded(): boolean {
+      return loaded;
+    },
+    /** Force a re-list (first paint / manual). Subscriptions handle the rest. */
+    refresh,
+  };
+}

--- a/tests/renderer/stores/proposals-store.test.ts
+++ b/tests/renderer/stores/proposals-store.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Proposals store (#1525) — the single source of truth for pending review.
+ *
+ * Verifies it lists on the `PROPOSALS_CHANGED` event and on `project:opened`,
+ * derives a global `pendingCount`, and wires its subscriptions exactly once.
+ * The IPC client is mocked; the mock captures the store's event callbacks so
+ * the test can fire them.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let listResult: unknown[] = [];
+let onChangedCb: (() => void) | null = null;
+let onProjectOpenedCb: (() => void) | null = null;
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    proposals: {
+      list: vi.fn(async () => listResult),
+      onChanged: vi.fn((cb: () => void) => {
+        onChangedCb = cb;
+      }),
+    },
+    menu: {
+      onProjectOpened: vi.fn((cb: () => void) => {
+        onProjectOpenedCb = cb;
+      }),
+    },
+  },
+}));
+
+import { api } from '../../../src/renderer/lib/ipc/client';
+import { getProposalsStore } from '../../../src/renderer/lib/stores/proposals.svelte';
+
+function p(uri: string, status: string) {
+  return { uri, status, operationType: 'component_creation', note: '', proposedBy: 'cli', proposedAt: '2020-01-01', payloads: [] };
+}
+
+const store = getProposalsStore();
+
+beforeEach(async () => {
+  listResult = [];
+  await store.refresh();
+});
+
+describe('proposals store (#1525)', () => {
+  it('re-lists on PROPOSALS_CHANGED and derives a global pendingCount', async () => {
+    listResult = [p('a', 'pending'), p('b', 'pending'), p('c', 'approved')];
+    onChangedCb!(); // a proposal was filed / approved / rejected / expired
+    await vi.waitFor(() => expect(store.proposals).toHaveLength(3));
+    // pendingCount ignores the two non-pending, and isn't filtered by any panel.
+    expect(store.pendingCount).toBe(2);
+    expect(store.loaded).toBe(true);
+  });
+
+  it('re-lists on project:opened (thoughtbase switch swaps the whole set)', async () => {
+    listResult = [p('z', 'approved')];
+    onProjectOpenedCb!();
+    await vi.waitFor(() => expect(store.proposals.map((x) => x.uri)).toEqual(['z']));
+    expect(store.pendingCount).toBe(0);
+  });
+
+  it('refresh() re-lists on demand', async () => {
+    listResult = [p('x', 'pending')];
+    await store.refresh();
+    expect(store.pendingCount).toBe(1);
+  });
+
+  it('wires each subscription exactly once across multiple store accesses', () => {
+    getProposalsStore();
+    getProposalsStore();
+    expect(api.proposals.onChanged).toHaveBeenCalledTimes(1);
+    expect(api.menu.onProjectOpened).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Part of #1523 (make proposals visible). **Stacked on #1524** (PR #1536) — needs its `PROPOSALS_CHANGED` / `api.proposals.onChanged` surface. Review/merge after #1536.

## What

Adds `src/renderer/lib/stores/proposals.svelte.ts` — the single source of truth for "what's pending review," read by the left Proposals panel (#1526) and the status-bar + dock badges (#1528).

- Reactive singleton (module-level `$state`) holding the **full** proposal set, so `pendingCount` is global — independent of any panel's status filter (the panel filters this list client-side).
- Owns the `PROPOSALS_CHANGED` subscription (renderer data-flow rule: event subs live in a store) plus `project:opened`; re-lists on either. Because approve/reject/expire now emit `PROPOSALS_CHANGED` (#1524), the list self-updates after a mutation with no manual refresh.
- Subscriptions wired exactly once per session; `loaded` distinguishes "no proposals" from "not loaded yet." Actions stay in `review.svelte.ts` — this store is read + subscribe only.

## Tests

`tests/renderer/stores/proposals-store.test.ts` mocks the IPC client, captures the store's event callbacks, and asserts: re-list + `pendingCount` on `PROPOSALS_CHANGED`, re-list on `project:opened`, on-demand `refresh()`, and subscribe-once.

`pnpm lint` clean.

Next: #1526 (left-sidebar Proposals panel reads this store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)