### PR TITLE
feat(proposals): status-bar + dock badges off pendingCount (#1528)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -19,11 +19,16 @@ import { registerClipper } from './ipc/register-clipper';
 import { registerApp } from './ipc/register-app';
 import { onProposalsChanged } from './llm/proposal-events';
 import { broadcastProposalsChanged } from './ipc/helpers';
+import { updateDockBadge } from './project-context';
 
 export function registerIpcHandlers(): void {
   // Turn Electron-free proposal-lifecycle events (fired by the shared approval
-  // engine, in-app or via the substrate server) into a renderer broadcast (#1524).
-  onProposalsChanged(broadcastProposalsChanged);
+  // engine, in-app or via the substrate server) into a renderer broadcast (#1524)
+  // plus a dock-badge refresh (#1528).
+  onProposalsChanged((rootPath) => {
+    broadcastProposalsChanged(rootPath);
+    void updateDockBadge();
+  });
 
   registerNotebase();
   registerLinks();

--- a/src/main/project-context.ts
+++ b/src/main/project-context.ts
@@ -10,8 +10,10 @@
  * and releases on close.
  */
 
+import { app } from 'electron';
 import * as graph from './graph/index';
 import * as search from './search/index';
+import { listProposals } from './llm/approval';
 import * as tables from './sources/tables';
 import * as vectors from './embeddings/vector-store';
 import { getSharedEmbedder } from './embeddings/shared-embedder';
@@ -99,6 +101,9 @@ export async function acquireProject(rootPath: string, winId: number): Promise<P
       // route proposals + semantic search through us instead of racing our
       // files. Best-effort; awaited so the advert exists the moment open resolves.
       await registerProject(ctx);
+      // Reflect any proposals filed while this project was closed in the dock
+      // badge the moment it opens (#1528).
+      void updateDockBadge();
     })();
     rec = { ctx, rootPath, acquirers: new Set(), initPromise };
     projects.set(rootPath, rec);
@@ -137,11 +142,33 @@ export async function releaseProject(rootPath: string, winId: number): Promise<v
   // each (#1085). Disposal has no cross-store ordering dependency, unlike init.
   await disposeAllProjectStores(rec.ctx);
   projects.delete(rootPath);
+  // Drop this project's pending proposals from the dock badge (#1528).
+  void updateDockBadge();
 }
 
 /** Resolve the live ProjectContext for a rootPath, if currently held. */
 export function getProjectContext(rootPath: string): ProjectContext | null {
   return projects.get(rootPath)?.ctx ?? null;
+}
+
+/**
+ * Refresh the OS dock/taskbar badge with the total pending-proposal count
+ * across every open project (#1528) — so "you have N proposals" is visible even
+ * when Minerva is unfocused, and stays live as proposals are filed (in-app or
+ * out-of-process), approved, rejected, expired, or as projects open/close.
+ * Best-effort: `app.setBadgeCount` is a no-op on platforms without a badge
+ * (Windows), and a failure must never disrupt the change that triggered it.
+ */
+export async function updateDockBadge(): Promise<void> {
+  try {
+    let total = 0;
+    for (const rec of projects.values()) {
+      total += (await listProposals(rec.ctx, 'pending')).length;
+    }
+    app.setBadgeCount(total);
+  } catch (err) {
+    console.warn('[project-context] dock badge update failed:', err);
+  }
 }
 
 /**

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -82,6 +82,7 @@
   import { clampFontSize } from './lib/editor/font-size';
   import { getConversationsStore } from './lib/stores/conversations.svelte';
   import { getBookmarksStore, collectBookmarksForPath } from './lib/stores/bookmarks.svelte';
+  import { getProposalsStore } from './lib/stores/proposals.svelte';
   import { CONFIRM_KEYS } from './lib/confirm-keys';
   import { sectionAnchorAt } from './lib/markdown/headings';
   import { isMissingApiKeyError } from '../shared/llm-errors';
@@ -109,6 +110,9 @@
   const nav = getNavigationStore();
   const conversationsStore = getConversationsStore();
   const bookmarkStore = getBookmarksStore();
+  // Pending-proposals count drives the status-bar badge (#1528); the store also
+  // powers the left Proposals panel and self-updates on out-of-process changes.
+  const proposalsStore = getProposalsStore();
   const voice = getVoiceStore();
   // Position-bearing bookmarks are resolved per pane at the Editor mount via
   // `collectBookmarksForPath(bookmarkStore.tree, <that pane's file>)` (#813),
@@ -1222,6 +1226,7 @@
             fontSize={editorFontSize}
             theme={themeLabel}
             {inspectionCount}
+            pendingCount={proposalsStore.pendingCount}
             {backlinkCount}
             backfill={embeddingProgress}
             isDirty={editor.isDirty}
@@ -1232,6 +1237,10 @@
             onShowBacklinks={() => {
               rightSidebarVisible = true;
               rightSidebar?.showPanel('backlinks');
+            }}
+            onShowProposals={() => {
+              sidebarVisible = true;
+              sidebar?.showPanel('proposals');
             }}
             onToggleDictation={() => { void toggleEditorDictation(editorComponent?.getView() ?? null); }}
             dictationActive={voice.surface === 'editor' && voice.busy}

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -481,6 +481,12 @@
     tablesPanel?.refresh();
   }
 
+  /** Switch the active left-sidebar view (e.g. App opens 'proposals' when the
+   *  status-bar pending badge is clicked, #1528). */
+  export function showPanel(panel: PanelType) {
+    activePanel = panel;
+  }
+
   export function selectTag(tag: string) {
     activePanel = 'tags';
     // Wait for TagPanel to mount before driving it — bind:this resolves

--- a/src/renderer/lib/components/StatusBar.svelte
+++ b/src/renderer/lib/components/StatusBar.svelte
@@ -11,6 +11,9 @@
      *  checked item in the picker. */
     theme: ThemeMode;
     inspectionCount?: number;
+    /** Pending proposals awaiting review (#1528). 0 hides the badge; clicking
+     *  it opens the left Proposals panel. Complements the always-on dock badge. */
+    pendingCount?: number;
     /** Number of incoming wiki-links to the active note (#472). 0
      *  hides the item entirely — keeps the bar tidy for unlinked
      *  notes; we'll revisit if anyone wants the affirmative signal. */
@@ -29,6 +32,9 @@
     /** Click handler for the backlink-count item — App reveals + focuses
      *  the right-sidebar Backlinks panel. */
     onShowBacklinks?: () => void;
+    /** Click handler for the pending-proposals badge — App opens the left
+     *  Proposals panel (#1528). */
+    onShowProposals?: () => void;
     /** Semantic-index backfill progress (#836); null hides the indicator. */
     backfill?: { done: number; total: number } | null;
     /** Toggle voice dictation into the editor — same action as the right-click
@@ -43,9 +49,9 @@
 
   let {
     cursor, fontSize, theme,
-    inspectionCount = 0, backlinkCount = 0,
+    inspectionCount = 0, pendingCount = 0, backlinkCount = 0,
     isDirty = false, hasActiveNote = false,
-    onGotoLine, onSelectTheme, onShowInspections, onShowBacklinks,
+    onGotoLine, onSelectTheme, onShowInspections, onShowBacklinks, onShowProposals,
     backfill = null,
     onToggleDictation, dictationActive = false, dictationDisabled = false,
   }: Props = $props();
@@ -134,6 +140,16 @@
       <button class="status-item clickable inspection-count" onclick={onShowInspections} title="Show inspections">
         <Icon name="warn" size={12} />
         <span class="nums">{inspectionCount}</span>
+      </button>
+    {/if}
+    {#if pendingCount > 0}
+      <button
+        class="status-item clickable pending-count"
+        onclick={onShowProposals}
+        title="{pendingCount} proposal{pendingCount === 1 ? '' : 's'} awaiting review — open Proposals"
+      >
+        <Icon name="proposals" size={12} />
+        <span class="nums">{pendingCount}</span>
       </button>
     {/if}
     <span class="rule" aria-hidden="true"></span>
@@ -303,6 +319,16 @@
   }
   .inspection-count:hover {
     color: var(--rust);
+    opacity: 0.85;
+  }
+
+  /* Pending-proposals badge uses --accent — a prompt to review, not a warning
+     (no danger styling per CLAUDE.md). */
+  .pending-count {
+    color: var(--accent);
+  }
+  .pending-count:hover {
+    color: var(--accent);
     opacity: 0.85;
   }
 </style>


### PR DESCRIPTION
Part of #1523 (make proposals visible). Builds on #1525 (store `pendingCount`) + #1526 (left panel), both merged.

## What

The "you have N proposals" arrival signal — prominent but non-modal/dismissable (reviewing clears it), per CLAUDE.md. Driven entirely by the store's derived `pendingCount`.

- **Status-bar pending badge** (`StatusBar.svelte`): clones the `inspectionCount` badge, gated on `pendingCount > 0`, **accent-colored** (a review prompt, not a warning — no danger styling). Clicking opens the left Proposals panel via a new `Sidebar.showPanel('proposals')` + `sidebarVisible`. App reads the store and passes the count.
- **OS dock/taskbar badge** (`project-context.ts` `updateDockBadge`): sums pending across all open projects and calls `app.setBadgeCount`, so the count shows **even when Minerva is unfocused** (and on any tab, covering the case where the note-gated status bar is hidden). Fires on every proposal change (via the `onProposalsChanged` subscription in `ipc.ts`, alongside the #1524 broadcast) and on project open/close.

Net: a proposal filed out-of-process by a CLI/MCP agent (#1524) bumps both badges **live**; approve/reject/expire decrements them.

## Verification

Drove the built app under Playwright: seeding a pending proposal makes the status-bar badge appear ("1") and drives `app.getBadgeCount()` 0→1; clicking the badge opens the Proposals panel; approving clears both to 0. Screenshot in review notes shows the accent `⊘ 1` badge in the status bar. `pnpm lint` clean.

## Deferred (issue items 3–4, marked optional)

Arrival **toast** and unfocused **native notification** — the two badges already deliver the core prominent signal, and a shared toast infra is net-new. Easy follow-up if wanted.

This completes the alerting child. Remaining epic work: **#1527** (retire the right-sidebar proposals surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)