### PR TITLE
feat(tutorial): install plumbing for the tutorial thoughtbase (#1542)

### DIFF
--- a/resources/tutorial-thoughtbase/Start Here.md
+++ b/resources/tutorial-thoughtbase/Start Here.md
@@ -1,0 +1,20 @@
+---
+tags: [entrypoint]
+---
+
+# Welcome to Minerva
+
+This is the **Tutorial Thoughtbase** — a hands-on tour of Minerva that teaches
+the tool by *being* the tool. You're reading a note inside a real thoughtbase
+you now own: edit it, break it, experiment freely.
+
+> This is a placeholder tree that exercises the install plumbing (#1542). The
+> full curated curriculum — linked lessons, a live SPARQL cell, a chart bound to
+> a shipped CSV, a pre-ingested source, structured reasoning — is authored in
+> #1543 and will replace this note.
+
+## What to try right now
+
+- Open the sidebar and note that this thoughtbase is a plain folder of files.
+- This note is tagged `entrypoint`, which is why it opened automatically.
+- Everything here is yours. Delete it and start fresh whenever you like.

--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -1,4 +1,4 @@
-import { dialog } from 'electron';
+import { app, dialog } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
@@ -20,6 +20,7 @@ import { rebuildMenu } from '../menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, markPathHandled, windowsForProject } from '../window-manager';
 import { getOnboardingDismissed, setOnboardingDismissed } from '../project-config';
 import { dropImport } from '../notebase/drop-import';
+import { installTutorialThoughtbase, TUTORIAL_DEFAULT_NAME } from '../notebase/install-tutorial';
 import { searchInNotes, replaceInNotes, type SearchOptions, type ReplaceSelection } from '../notebase/search-in-notes';
 import { handle } from './typed-ipc';
 import {
@@ -61,6 +62,26 @@ export function registerNotebase(): void {
 
     const rootPath = result.filePaths[0]!;
     const win = winFromEvent(e);
+    await openProjectInWindow(win, rootPath);
+    return { rootPath, name: resolveDisplayName(rootPath) };
+  });
+
+  // Install the bundled tutorial thoughtbase (#1542, epic #1518). Prompt-with-
+  // default: a Save panel pre-filled at `~/Minerva Tutorial` lets the user
+  // confirm or relocate rather than silently creating a folder. The copy never
+  // clobbers — `installTutorialThoughtbase` suffixes ` 2`, ` 3`… on collision —
+  // so re-installing always yields a fresh, editable copy.
+  handle(Channels.NOTEBASE_INSTALL_TUTORIAL, async (e) => {
+    const win = winFromEvent(e);
+    const result = await dialog.showSaveDialog(win, {
+      title: 'Install Tutorial Thoughtbase',
+      defaultPath: path.join(app.getPath('home'), TUTORIAL_DEFAULT_NAME),
+      buttonLabel: 'Install Tutorial',
+      properties: ['createDirectory'],
+    });
+    if (result.canceled || !result.filePath) return null;
+
+    const rootPath = await installTutorialThoughtbase(result.filePath);
     await openProjectInWindow(win, rootPath);
     return { rootPath, name: resolveDisplayName(rootPath) };
   });

--- a/src/main/notebase/install-tutorial.ts
+++ b/src/main/notebase/install-tutorial.ts
@@ -1,0 +1,73 @@
+/**
+ * Install the bundled tutorial thoughtbase (#1542, part of the #1518 epic).
+ *
+ * The curated tutorial tree ships under `resources/tutorial-thoughtbase/` (via
+ * the blanket `extraResource: ['resources']` in `forge.config.ts`). Installing
+ * it is a recursive copy of that tree into a fresh directory the user picks —
+ * there is no external recursive copy elsewhere in `notebase/fs.ts` (`copyItem`
+ * is intra-project only), so this module owns it.
+ *
+ * Idempotent / re-installable: we NEVER mutate an existing directory in place —
+ * a collision suffixes ` 2`, ` 3`, … so re-installing always yields a clean copy
+ * (issue #1518 "installing again picks a fresh folder"). Once copied it's an
+ * ordinary thoughtbase — fully editable and deletable.
+ *
+ * The copy core is Electron-free (takes an explicit destination) so it unit-tests
+ * without a running app; the IPC handler in `ipc/register-notebase.ts` supplies
+ * the picked path and opens the result.
+ */
+import { app } from 'electron';
+import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+/** Folder name the tutorial ships under inside `resources/`. */
+const TUTORIAL_DIR_NAME = 'tutorial-thoughtbase';
+
+/** Default basename for a freshly installed tutorial thoughtbase. */
+export const TUTORIAL_DEFAULT_NAME = 'Minerva Tutorial';
+
+/**
+ * Absolute path to the bundled tutorial tree, resolved the same way as the
+ * help-docs corpus (`help-docs/corpus-store.ts`): `process.resourcesPath` when
+ * packaged, `process.cwd()` in dev. `resourcesBaseOverride` is a test seam.
+ */
+export function tutorialResourceDir(resourcesBaseOverride?: string): string {
+  const resourcesBase =
+    resourcesBaseOverride ??
+    (app?.isPackaged
+      ? path.join(process.resourcesPath, 'resources')
+      : path.join(process.cwd(), 'resources'));
+  return path.join(resourcesBase, TUTORIAL_DIR_NAME);
+}
+
+/**
+ * The first non-existent directory in the sequence `dir`, `dir 2`, `dir 3`, …
+ * so an install never clobbers an existing folder.
+ */
+export function firstAvailableDir(dir: string): string {
+  if (!existsSync(dir)) return dir;
+  const parent = path.dirname(dir);
+  const base = path.basename(dir);
+  for (let n = 2; ; n++) {
+    const candidate = path.join(parent, `${base} ${n}`);
+    if (!existsSync(candidate)) return candidate;
+  }
+}
+
+/**
+ * Copy the bundled tutorial tree into a fresh directory at (or suffixed from)
+ * `destDir`, returning the final destination path. Throws if the bundled tree
+ * is missing (a broken build). `sourceDir` is a test seam.
+ */
+export async function installTutorialThoughtbase(
+  destDir: string,
+  sourceDir: string = tutorialResourceDir(),
+): Promise<string> {
+  if (!existsSync(sourceDir)) {
+    throw new Error(`[tutorial] bundled thoughtbase not found at ${sourceDir}`);
+  }
+  const finalDest = firstAvailableDir(destDir);
+  await fs.cp(sourceDir, finalDest, { recursive: true });
+  return finalDest;
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -25,6 +25,7 @@ contextBridge.exposeInMainWorld('api', {
     openInNewWindow: () => invoke(Channels.NOTEBASE_OPEN_IN_NEW_WINDOW),
     newProjectInNewWindow: () => invoke(Channels.NOTEBASE_NEW_PROJECT_IN_NEW_WINDOW),
     openPathInNewWindow: (rootPath: string) => invoke(Channels.NOTEBASE_OPEN_PATH_IN_NEW_WINDOW, rootPath),
+    installTutorial: () => invoke(Channels.NOTEBASE_INSTALL_TUTORIAL),
     close: () => invoke(Channels.NOTEBASE_CLOSE),
     clearRecent: () => invoke(Channels.RECENT_CLEAR),
     listFiles: () => invoke(Channels.NOTEBASE_LIST_FILES),

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -13,6 +13,9 @@ export interface NotebaseApi {
   newProjectInNewWindow(): Promise<NotebaseMeta | null>;
   /** Open a known path in a fresh window (used by Recent Thoughtbases → new window). */
   openPathInNewWindow(rootPath: string): Promise<NotebaseMeta>;
+  /** Copy the bundled tutorial thoughtbase to a picked dir and open it (#1542).
+   *  Returns the installed meta, or null if the user cancelled the picker. */
+  installTutorial(): Promise<NotebaseMeta | null>;
   close(): Promise<null>;
   clearRecent(): Promise<void>;
   listFiles(): Promise<NoteFile[]>;

--- a/src/renderer/lib/stores/notebase.svelte.ts
+++ b/src/renderer/lib/stores/notebase.svelte.ts
@@ -30,6 +30,18 @@ export function getNotebaseStore() {
     return result;
   }
 
+  /** Install + open the bundled tutorial thoughtbase (#1542). Mutation (creates
+   *  a project) → store-owned; the main handler picks the destination, copies
+   *  the tree, and opens it, so we adopt the returned meta like `newProject`. */
+  async function installTutorial(): Promise<NotebaseMeta | null> {
+    const result = await api.notebase.installTutorial();
+    if (result) {
+      meta = result;
+      files = await api.notebase.listFiles();
+    }
+    return result;
+  }
+
   function close() {
     void api.notebase.close();
     meta = null;
@@ -79,6 +91,7 @@ export function getNotebaseStore() {
     open,
     openPath,
     newProject,
+    installTutorial,
     close,
     refresh,
     writeFile,

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -36,6 +36,8 @@ export const Channels = {
   NOTEBASE_OPEN_IN_NEW_WINDOW: 'notebase:openInNewWindow',
   NOTEBASE_NEW_PROJECT_IN_NEW_WINDOW: 'notebase:newProjectInNewWindow',
   NOTEBASE_OPEN_PATH_IN_NEW_WINDOW: 'notebase:openPathInNewWindow',
+  /** Copy the bundled tutorial thoughtbase to a picked dir and open it (#1542). */
+  NOTEBASE_INSTALL_TUTORIAL: 'notebase:installTutorial',
   /** Clear the recent-projects list. */
   RECENT_CLEAR: 'recent:clear',
   /** main → renderer: a project finished opening in this window. Payload is

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -92,6 +92,7 @@ export interface ChannelMap {
   'notebase:openInNewWindow': () => NotebaseMeta | null;
   'notebase:newProjectInNewWindow': () => NotebaseMeta | null;
   'notebase:openPathInNewWindow': (rootPath: string) => NotebaseMeta;
+  'notebase:installTutorial': () => NotebaseMeta | null;
   'notebase:close': () => null;
   'recent:clear': () => void;
   'notebase:listFiles': () => NoteFile[];

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -116,6 +116,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "notebase:fileExists",
   "notebase:getOnboardingDismissed",
   "notebase:getProperties",
+  "notebase:installTutorial",
   "notebase:listFiles",
   "notebase:merge",
   "notebase:mergePreview",

--- a/tests/main/notebase/install-tutorial.test.ts
+++ b/tests/main/notebase/install-tutorial.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tutorial-thoughtbase install mechanism (#1542, epic #1518).
+ *
+ * Covers the Electron-free copy core: it copies the bundled tree verbatim, and
+ * — the load-bearing invariant — NEVER mutates an existing directory in place,
+ * suffixing ` 2`, ` 3`… so a re-install always yields a clean copy.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  installTutorialThoughtbase,
+  firstAvailableDir,
+} from '../../../src/main/notebase/install-tutorial';
+
+let workdir: string;
+let source: string;
+
+beforeEach(async () => {
+  workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-tutorial-test-'));
+  // A stand-in bundled tree with a nested file, to prove recursion.
+  source = path.join(workdir, 'bundled');
+  await fsp.mkdir(path.join(source, '.minerva'), { recursive: true });
+  await fsp.writeFile(path.join(source, 'Start Here.md'), '---\ntags: [entrypoint]\n---\nhi', 'utf-8');
+  await fsp.writeFile(path.join(source, '.minerva', 'config.json'), '{}', 'utf-8');
+});
+
+afterEach(() => {
+  fs.rmSync(workdir, { recursive: true, force: true });
+});
+
+describe('installTutorialThoughtbase (#1542)', () => {
+  it('copies the tree recursively into the destination', async () => {
+    const dest = path.join(workdir, 'Minerva Tutorial');
+    const finalDest = await installTutorialThoughtbase(dest, source);
+
+    expect(finalDest).toBe(dest);
+    expect(fs.readFileSync(path.join(finalDest, 'Start Here.md'), 'utf-8')).toContain('entrypoint');
+    expect(fs.existsSync(path.join(finalDest, '.minerva', 'config.json'))).toBe(true);
+  });
+
+  it('never clobbers an existing dir — suffixes on collision', async () => {
+    const dest = path.join(workdir, 'Minerva Tutorial');
+    fs.mkdirSync(dest);
+    fs.writeFileSync(path.join(dest, 'user-note.md'), 'do not delete me', 'utf-8');
+
+    const finalDest = await installTutorialThoughtbase(dest, source);
+
+    expect(finalDest).toBe(path.join(workdir, 'Minerva Tutorial 2'));
+    // The pre-existing dir and its file are untouched.
+    expect(fs.readFileSync(path.join(dest, 'user-note.md'), 'utf-8')).toBe('do not delete me');
+    expect(fs.existsSync(path.join(finalDest, 'Start Here.md'))).toBe(true);
+  });
+
+  it('keeps suffixing past the first collision (3, then 4, …)', async () => {
+    const base = path.join(workdir, 'Minerva Tutorial');
+    fs.mkdirSync(base);
+    fs.mkdirSync(`${base} 2`);
+    expect(firstAvailableDir(base)).toBe(`${base} 3`);
+  });
+
+  it('throws when the bundled tree is missing (broken build)', async () => {
+    await expect(
+      installTutorialThoughtbase(path.join(workdir, 'dest'), path.join(workdir, 'nonexistent')),
+    ).rejects.toThrow(/bundled thoughtbase not found/);
+  });
+});

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -229,6 +229,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "fileExists",
     "getOnboardingDismissed",
     "getProperties",
+    "installTutorial",
     "listFiles",
     "merge",
     "mergePreview",


### PR DESCRIPTION
Closes #1542 (part of the #1518 tutorial-thoughtbase epic).

The packaging + install spine. Content authoring (#1543) and the entry-point UI (#1544) build on this — this PR ships a folder tree and copies it into a fresh thoughtbase, buildable against a stub tree so it doesn't block on the real content.

## What's here

- **Packaging is free.** `extraResource: ['resources']` in `forge.config.ts` already ships the whole `resources/` tree, so a stub `resources/tutorial-thoughtbase/` (one `entrypoint`-tagged note — the real curriculum lands in #1543) is all that's required.
- **`src/main/notebase/install-tutorial.ts`** — an Electron-free copy core:
  - `tutorialResourceDir()` resolves the bundled dir dev/packaged, the same `app.isPackaged ? process.resourcesPath : process.cwd()` pattern as `help-docs/corpus-store.ts`.
  - `installTutorialThoughtbase()` recursively copies into the picked dir and **never mutates an existing directory** — it suffixes ` 2`, ` 3`… on collision, so re-installing always yields a clean copy (there was no external recursive copy before; `notebase/fs.ts` `copyItem` is intra-project only).
- **`NOTEBASE_INSTALL_TUTORIAL` channel + handler** — a Save panel defaulted to `~/Minerva Tutorial` (prompt-with-default, parented to the window), copy, then the existing `openProjectInWindow`. The `entrypoint` tag makes `maybeOpenEntrypoints` land the user on the index note — no new landing machinery.
- **Renderer routing** — through the `notebase` store (`installTutorial()`, mirrors `newProject`) per the data-flow rule; preload + `client.ts` wired.

## Tests
- New `tests/main/notebase/install-tutorial.test.ts` — pins the copy/suffix invariant (recursive copy, never-clobber, keeps suffixing, throws on missing tree).
- Both required snapshot contracts updated: preload-bridge + ipc registration.
- `pnpm lint` clean; verified the real bundled tree resolves + installs end-to-end.

## Open questions deferred to the UI issue (#1544)
Default install location and prompt-vs-prompt-with-default (issue #1518 open question #3) — this PR implements prompt-with-default at `~/Minerva Tutorial` as the sensible default; #1544 can revisit when it wires the welcome button + Help menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)