### PR TITLE
feat(tutorial): author the curated tutorial thoughtbase content (#1543)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,18 @@ tests/skills-eval/thoughtbase/.minerva/*
 !tests/skills-eval/thoughtbase/.minerva/excerpts/
 !tests/skills-eval/thoughtbase/.minerva/excerpts/**
 
+# Bundled tutorial thoughtbase (#1543): ship its .minerva/ payload. Unlike the
+# fixtures above, config.json IS tracked here — it carries the canonical baseUri
+# the pre-authored source/excerpt/turtle IRIs are written against, so it must
+# ship verbatim. graph.ttl / indexes stay ignored (rebuilt on first open).
+!resources/tutorial-thoughtbase/.minerva/
+resources/tutorial-thoughtbase/.minerva/*
+!resources/tutorial-thoughtbase/.minerva/config.json
+!resources/tutorial-thoughtbase/.minerva/sources/
+!resources/tutorial-thoughtbase/.minerva/sources/**
+!resources/tutorial-thoughtbase/.minerva/excerpts/
+!resources/tutorial-thoughtbase/.minerva/excerpts/**
+
 # Bundled embedding model (#834): the 23MB ONNX weights are fetched at
 # build/dev time, not vendored. The small tokenizer/vocab/config ARE committed
 # so the WordPiece ground-truth test runs in CI without a network fetch.

--- a/resources/tutorial-thoughtbase/.minerva/config.json
+++ b/resources/tutorial-thoughtbase/.minerva/config.json
@@ -1,0 +1,4 @@
+{
+  "baseUri": "https://project.minerva.dev/minerva/tutorial/",
+  "displayName": "Minerva Tutorial"
+}

--- a/resources/tutorial-thoughtbase/.minerva/excerpts/federalist-10-faction.ttl
+++ b/resources/tutorial-thoughtbase/.minerva/excerpts/federalist-10-faction.ttl
@@ -1,0 +1,6 @@
+this: a thought:Excerpt ;
+    thought:fromSource sources:federalist-10 ;
+    thought:citedText "The latent causes of faction are thus sown in the nature of man" ;
+    thought:charStart 638 ;
+    thought:charEnd 701 ;
+    thought:locationText "on the causes of faction" .

--- a/resources/tutorial-thoughtbase/.minerva/sources/federalist-10/body.md
+++ b/resources/tutorial-thoughtbase/.minerva/sources/federalist-10/body.md
@@ -1,0 +1,22 @@
+# The Federalist No. 10
+
+*Published November 22, 1787. Public domain. This is a short excerpt, included
+so the tutorial's "Sources & Citations" lesson has a real document to cite,
+excerpt, and quote.*
+
+By a faction, Madison writes, he understands a number of citizens, whether a
+majority or a minority, united by a common impulse of passion or of interest
+adverse to the rights of other citizens or to the interests of the community.
+
+There are two methods of curing the mischiefs of faction: removing its causes,
+or controlling its effects. The first remedy is worse than the disease, because
+liberty is to faction what air is to fire.
+
+The latent causes of faction are thus sown in the nature of man. The most common
+and durable source of factions has been the various and unequal distribution of
+property, and the regulation of these various and interfering interests forms
+the principal task of modern legislation.
+
+The remedy Madison proposes is not to remove liberty but to extend the sphere: a
+large republic takes in so great a variety of interests that no single majority
+faction can easily form or oppress the rest.

--- a/resources/tutorial-thoughtbase/.minerva/sources/federalist-10/meta.ttl
+++ b/resources/tutorial-thoughtbase/.minerva/sources/federalist-10/meta.ttl
@@ -1,0 +1,9 @@
+this: a thought:Article ;
+    dc:title "The Federalist No. 10: The Utility of the Union as a Safeguard Against Domestic Faction and Insurrection" ;
+    dc:creator "James Madison" ;
+    dc:issued "1787-11-22"^^xsd:date ;
+    dc:publisher "The New York Packet" ;
+    schema:inContainer "The Federalist Papers" ;
+    bibo:uri <https://guides.loc.gov/federalist-papers/text-1-10> ;
+    dc:language "en" ;
+    dc:abstract "Madison argues that a large, well-constructed republic is the best remedy for the dangers of faction: rather than removing liberty or enforcing uniform opinion, an extended republic controls faction's effects by taking in so many interests that no single majority faction can easily form or oppress." .

--- a/resources/tutorial-thoughtbase/Data and Tables.md
+++ b/resources/tutorial-thoughtbase/Data and Tables.md
@@ -1,0 +1,76 @@
+---
+title: Data and Tables
+tags: [tutorial, area/data]
+---
+
+# Data and Tables
+
+Minerva treats data as a first-class citizen. Drop a `.csv` anywhere in the
+thoughtbase and it becomes a **SQL table** you can query; write a captioned
+Markdown table and it works the same way; then chart the result.
+
+## The shipped dataset
+
+This thoughtbase ships `data/lessons.csv` — a little dataset *about this very
+tutorial* (each lesson, its area, its length, and a difficulty rating). A CSV's
+table name comes from its path, so `data/lessons.csv` is the table `data_lessons`.
+
+## Query it with SQL
+
+The cell below aggregates minutes by area. It ships with its output shown; press
+**Run** to execute it live in an in-memory DuckDB — nothing leaves your machine.
+
+```sql {id=area-minutes}
+SELECT area, SUM(minutes) AS minutes
+FROM data_lessons
+GROUP BY area
+ORDER BY minutes DESC
+```
+```output
+{"type":"table","columns":["area","minutes"],"rows":[["Authoring",22],["Graph",17],["Data",17],["AI",13],["Research",8],["Publishing",5]]}
+```
+
+## Chart it
+
+Charts are Vega-Lite. This one uses inline values, so it renders immediately —
+but a chart can also bind straight to a query with `"data": {"sql": "…"}` or
+`"data": {"cell": "area-minutes"}` and update as your data changes.
+
+```vega-lite
+{
+  "mark": {"type": "bar", "cornerRadiusEnd": 3},
+  "data": {"values": [
+    {"area": "Authoring", "minutes": 22},
+    {"area": "Graph", "minutes": 17},
+    {"area": "Data", "minutes": 17},
+    {"area": "AI", "minutes": 13},
+    {"area": "Research", "minutes": 8},
+    {"area": "Publishing", "minutes": 5}
+  ]},
+  "encoding": {
+    "x": {"field": "area", "type": "nominal", "sort": "-y", "title": "Area"},
+    "y": {"field": "minutes", "type": "quantitative", "title": "Minutes of tutorial"}
+  }
+}
+```
+
+## Tables in prose
+
+You don't need a file. Any Markdown table with a `Table:` caption above it also
+becomes queryable (and joins the graph as structured data):
+
+Table: Difficulty Legend
+
+| difficulty | meaning        |
+|------------|----------------|
+| 1          | gentle         |
+| 2          | some new ideas |
+| 3          | a real concept |
+| 4          | advanced       |
+
+That caption registers a `Difficulty_Legend` table — so a SQL cell could even
+join it against `data_lessons`.
+
+---
+
+Next: [[Diagrams and Embeds]] → · back to [[Start Here]]

--- a/resources/tutorial-thoughtbase/Diagrams and Embeds.md
+++ b/resources/tutorial-thoughtbase/Diagrams and Embeds.md
@@ -1,0 +1,46 @@
+---
+title: Diagrams and Embeds
+tags: [tutorial, area/authoring]
+---
+
+# Diagrams and Embeds
+
+Some ideas are easier drawn than written. Minerva renders **Mermaid** diagrams
+and embeds video inline, right in your notes.
+
+## Mermaid diagrams
+
+Fence a block as `mermaid` and it renders as a diagram. Flowcharts, sequences,
+state machines, and more:
+
+```mermaid
+flowchart LR
+    Write[Write a note] --> Index[Minerva indexes it]
+    Index --> Graph[(Knowledge graph)]
+    Graph --> Query[Query with SPARQL or SQL]
+    Query --> Insight([Insight])
+    Insight --> Write
+```
+
+You already saw one in [[Links That Mean Something]], where a Mermaid graph drew
+the shape of an argument. They're plain text, so they diff cleanly and never go
+stale as an exported image would.
+
+## Video embeds
+
+Fence a block as `youtube` with a URL on the first line and an optional caption
+below. Minerva renders a click-to-open poster — no autoplaying iframe, no tracker
+firing as you read:
+
+```youtube
+https://www.youtube.com/watch?v=aircAruvnKk
+But what is a neural network? — a beautifully visual explainer
+```
+
+> [!note] Offline-friendly
+> Everything in this thoughtbase renders without a network connection. The video
+> poster only reaches out — to *your* browser — when you deliberately click it.
+
+---
+
+Next: [[Sources and Citations]] → · back to [[Start Here]]

--- a/resources/tutorial-thoughtbase/Export and Publish.md
+++ b/resources/tutorial-thoughtbase/Export and Publish.md
@@ -1,0 +1,44 @@
+---
+title: Export and Publish
+tags: [tutorial, area/publishing]
+---
+
+# Export and Publish
+
+Your knowledge shouldn't be trapped in the app. Minerva is built on plain files,
+and it can hand your work back out in whatever shape you need.
+
+## Get a single note or the whole base out
+
+- **Markdown** — it's already Markdown; copy the file and go.
+- **HTML / PDF** — render a note (or the whole thoughtbase) with its diagrams,
+  math, and callouts intact.
+- **Static site** — publish a linked set of notes as a browsable website, with an
+  `entrypoint`-tagged note (like [[Start Here]]) as the home page.
+
+## Specialized exports
+
+- **BibTeX** — export your [[Sources and Citations|sources]] as a `.bib` file for
+  a reference manager.
+- **Turtle** — export the raw knowledge graph as RDF, for use in any
+  SPARQL-speaking tool.
+- **Anki** — turn the flashcard callouts from [[Writing Notes]] into an Anki deck
+  for spaced repetition.
+- **CSV** — export any table or query result as data.
+
+## Publishing to a target you own
+
+Publishing pushes a rendered copy to a destination *you* control. Nothing is sent
+anywhere automatically and nothing phones home — export and publish are always
+deliberate actions you take.
+
+> [!tip] The round trip
+> Because everything is files plus a rebuildable graph, you can export, edit
+> elsewhere, and re-import without losing structure. Your thoughtbase is a format,
+> not a silo.
+
+---
+
+Next, if you're curious about the advanced stuff: [[Running Code]] →
+
+Or head back to [[Start Here]] — you've seen the whole tour. 🎉

--- a/resources/tutorial-thoughtbase/Links That Mean Something.md
+++ b/resources/tutorial-thoughtbase/Links That Mean Something.md
@@ -1,0 +1,57 @@
+---
+title: Links That Mean Something
+tags: [tutorial, area/authoring]
+---
+
+# Links That Mean Something
+
+In most tools a link is just a jump. In Minerva a link is an **edge in the graph**
+— and you can say what *kind* of edge it is.
+
+## Plain wiki-links
+
+Wrap a note's name in double brackets: `[[Writing Notes]]` → [[Writing Notes]].
+You can change the display text with a pipe — `[[Writing Notes|go write something]]`
+renders as [[Writing Notes|go write something]] — and point at a heading with
+`[[Writing Notes#Callouts]]`.
+
+## Typed links: say what you mean
+
+Put a `type::` in front of the target and the link carries meaning into the graph:
+
+- `[[supports::Some Claim]]` — evidence for a claim
+- `[[rebuts::Some Claim]]` — evidence against
+- `[[depends-on::Another Note]]` — this can't stand without that
+- `[[expands::Another Note]]` — this elaborates that
+- `[[supersedes::Old Note]]` — this replaces that
+- `[[related-to::Another Note]]` — a soft association
+
+This lesson [[depends-on::Writing Notes]] and [[related-to::The Knowledge Graph]] —
+those are real typed edges you'll be able to query in a moment.
+
+## A mini argument you can trace
+
+We've planted a small argument in the `arguments/` folder. Follow it:
+
+- **Claim:** [[Large republics control faction]]
+- **supports →** [[Variety of interests]]
+- **rebuts →** [[Large republics are unwieldy]]
+
+Here's the shape of it (see [[Diagrams and Embeds]] for how this diagram is made):
+
+```mermaid
+graph TD
+    G[Variety of interests] -->|supports| C[Large republics control faction]
+    O[Large republics are unwieldy] -->|rebuts| C
+    C -->|cites| S[Federalist No. 10]
+```
+
+Open [[Large republics control faction]] and trace the edges yourself — then see
+the very same argument as formal graph objects in [[Structured Reasoning]].
+
+There are two more typed links — `cite::` and `quote::` — for pointing at
+external sources. Those get their own lesson: [[Sources and Citations]].
+
+---
+
+Next: [[Tags and Organization]] → · back to [[Start Here]]

--- a/resources/tutorial-thoughtbase/Running Code.md
+++ b/resources/tutorial-thoughtbase/Running Code.md
@@ -1,0 +1,43 @@
+---
+title: Running Code
+tags: [tutorial, area/data, advanced]
+---
+
+# Running Code *(advanced)*
+
+Minerva can run **Python** right inside a note, for when a query isn't enough and
+you need real computation. This is powerful, so it's gated carefully — read this
+lesson before you run anything.
+
+> [!warning] This runs code on your machine
+> Unlike SQL and SPARQL (which are read-only queries over your own data), a Python
+> cell executes a real program locally. Minerva therefore asks for your consent
+> **the first time** it sees a particular cell — consent is per-cell and per-machine,
+> so nothing bundled can run behind your back. The cell below ships with its output
+> already shown, so this lesson reads correctly whether or not you ever run it.
+
+## A pre-rendered cell
+
+This cell is self-contained — no files, no network — and computes each lesson
+area's share of the tutorial. Press **Run** and approve the prompt to execute it;
+or just read the baked result below.
+
+```python {id=py-share}
+# Runs locally, sandboxed, and only after you approve it.
+areas = {"Authoring": 22, "Graph": 17, "Data": 17, "AI": 13, "Research": 8, "Publishing": 5}
+total = sum(areas.values())
+[{"area": a, "minutes": m, "share": round(m / total, 2)} for a, m in areas.items()]
+```
+```output
+{"type":"table","columns":["area","minutes","share"],"rows":[["Authoring",22,0.27],["Graph",17,0.21],["Data",17,0.21],["AI",13,0.16],["Research",8,0.1],["Publishing",5,0.06]]}
+```
+
+## When to reach for Python
+
+SQL and SPARQL cover most questions about your data and graph. Reach for Python
+when you need something they can't express — a statistical model, a custom parse,
+a transformation — and you're comfortable running the code. The consent gate keeps
+you in control either way.
+
+That's the whole tour. Nicely done — head back to [[Start Here]] and start making
+this thoughtbase your own. 🎉

--- a/resources/tutorial-thoughtbase/Sources and Citations.md
+++ b/resources/tutorial-thoughtbase/Sources and Citations.md
@@ -1,0 +1,54 @@
+---
+title: Sources and Citations
+tags: [tutorial, area/research]
+---
+
+# Sources and Citations
+
+Serious thinking leans on sources. Minerva lets you **ingest** a document once,
+then **cite** it, pull **excerpts** from it, and render a formatted **citation** —
+all wired into the graph so "what have I read about X?" is a query.
+
+## A source you already have
+
+This thoughtbase ships one pre-ingested source: **Madison's Federalist No. 10**
+(1787, public domain). Look in the sidebar's **Sources** section — it's there,
+with its metadata and body text, exactly as if you'd ingested it yourself.
+
+## Cite it
+
+Point at a source with a `cite::` link. Madison's argument about faction comes
+from [[cite::federalist-10]] — that link is a real `thought:cites` edge in the
+graph, not just text.
+
+## Excerpt it
+
+An **excerpt** is a verbatim passage anchored to a spot in the source. We've
+anchored one for you; embed it with a `quote::` link:
+
+> [[quote::federalist-10-faction]]
+
+Open the source and you'll see that exact sentence highlighted where it lives in
+the text. Excerpts are graph objects too, so a claim can point directly at the
+words that back it.
+
+## Format a citation
+
+Because the source carries structured metadata (author, title, date, publisher),
+Minerva can render a citation in whatever style you like — APA, Chicago, IEEE,
+MLA, Vancouver. In APA, this source formats as:
+
+> Madison, J. (1787). *The Federalist No. 10.* The New York Packet.
+
+The Export tools (see [[Export and Publish]]) can drop a formatted bibliography
+into any document that cites sources.
+
+## Where this leads
+
+The passage you just quoted is the seed of a full argument — modeled formally in
+[[Structured Reasoning]], and mapped informally back in
+[[Links That Mean Something]].
+
+---
+
+Next: [[Tools for Thought]] → · back to [[Start Here]]

--- a/resources/tutorial-thoughtbase/Start Here.md
+++ b/resources/tutorial-thoughtbase/Start Here.md
@@ -1,20 +1,43 @@
 ---
-tags: [entrypoint]
+title: Start Here
+tags: [tutorial, entrypoint]
 ---
 
-# Welcome to Minerva
+# Welcome to Minerva 👋
 
-This is the **Tutorial Thoughtbase** — a hands-on tour of Minerva that teaches
-the tool by *being* the tool. You're reading a note inside a real thoughtbase
-you now own: edit it, break it, experiment freely.
+You're reading a note inside a real **thoughtbase** — a knowledge base backed by
+a live RDF graph. This tutorial teaches Minerva by *being* Minerva: every lesson
+is a working example you can read, click, edit, and run.
 
-> This is a placeholder tree that exercises the install plumbing (#1542). The
-> full curated curriculum — linked lessons, a live SPARQL cell, a chart bound to
-> a shipped CSV, a pre-ingested source, structured reasoning — is authored in
-> #1543 and will replace this note.
+> [!tip] It's yours now
+> This whole thoughtbase was copied to a folder you chose. Edit anything, break
+> anything, delete it and reinstall for a fresh copy. Nothing here is precious.
 
-## What to try right now
+## How to take the tour
 
-- Open the sidebar and note that this thoughtbase is a plain folder of files.
-- This note is tagged `entrypoint`, which is why it opened automatically.
-- Everything here is yours. Delete it and start fresh whenever you like.
+Follow the map below in order, or wander. Each lesson links to the next, and the
+[[The Knowledge Graph]] lesson lets you *query* this very thoughtbase to see how
+it's all connected. Click any `[[wiki-link]]` to jump.
+
+## The map
+
+1. [[Writing Notes]] — markdown, the view modes, callouts, highlights, math, footnotes.
+2. [[Links That Mean Something]] — `[[wiki-links]]` and **typed links** that build an argument.
+3. [[Tags and Organization]] — tags, nested tags, and folders.
+4. [[The Knowledge Graph]] — everything you write becomes queryable. A live SPARQL cell.
+5. [[Data and Tables]] — a shipped CSV, a SQL cell, and a chart, all over real data.
+6. [[Diagrams and Embeds]] — Mermaid diagrams and video embeds.
+7. [[Sources and Citations]] — cite a real document, anchor an excerpt, format a citation.
+8. [[Tools for Thought]] — run a skill and watch the AI hand back a proposal.
+9. [[The AI Proposes You Confirm]] — the trust model at the heart of Minerva.
+10. [[Structured Reasoning]] — model claims, grounds, and warrants as first-class graph objects.
+11. [[Export and Publish]] — get your knowledge back out: Markdown, HTML, PDF, and more.
+12. [[Running Code]] *(optional, advanced)* — a sandboxed Python cell that runs on your machine.
+
+## What makes a thoughtbase different
+
+A folder of markdown is just files. A thoughtbase *reads* those files — their
+links, tags, tables, and embedded structure — into a knowledge graph you can
+interrogate. You write prose; Minerva builds a queryable model underneath.
+
+Ready? Open [[Writing Notes]] to begin. →

--- a/resources/tutorial-thoughtbase/Structured Reasoning.md
+++ b/resources/tutorial-thoughtbase/Structured Reasoning.md
@@ -1,0 +1,59 @@
+---
+title: Structured Reasoning
+tags: [tutorial, area/graph]
+---
+
+# Structured Reasoning
+
+Wiki-links sketch how ideas relate. When you want to be **precise** about the
+shape of an argument, Minerva gives you a vocabulary — the *thought ontology* —
+for claims, the grounds that support them, the warrants that license the
+inference, and the rebuttals that push back.
+
+## Model an argument as data
+
+Embed a fenced `turtle` block and you're writing directly into the graph. Here's
+Madison's argument from [[Sources and Citations]], modeled formally. The
+`thought:`, `this:`, and `sources:` prefixes are all provided for you.
+
+```turtle
+this:claim a thought:Claim ;
+    thought:label "A large republic controls the mischiefs of faction better than a small one" ;
+    thought:cites sources:federalist-10 .
+
+this:grounds a thought:Grounds ;
+    thought:label "A larger republic holds a greater variety of interests, so a majority faction is less likely to form" ;
+    thought:supports this:claim .
+
+this:warrant a thought:Warrant ;
+    thought:label "If assembling an oppressive majority is harder, faction is better controlled" ;
+    thought:supports this:claim .
+
+this:rebuttal a thought:Rebuttal ;
+    thought:label "Classical theory (Montesquieu) holds republics survive only at small scale" ;
+    thought:challenges this:claim .
+```
+
+That's the same argument you traced informally in
+[[Links That Mean Something]] — but now each part is a typed object the graph
+understands, anchored to the source that grounds it.
+
+## Query the reasoning
+
+Because those are real graph nodes, you can ask for them. This finds every claim
+in the thoughtbase:
+
+```sparql {id=claims}
+SELECT ?label WHERE { ?c a thought:Claim ; thought:label ?label } ORDER BY ?label
+```
+```output
+{"type":"table","columns":["label"],"rows":[["A large republic controls the mischiefs of faction better than a small one"]]}
+```
+
+Run it, then add a `thought:Claim` of your own in the block above and Run again —
+watch your new claim appear. Your prose and your formal model live in the same
+file, and stay in sync.
+
+---
+
+Next: [[Export and Publish]] → · back to [[Start Here]]

--- a/resources/tutorial-thoughtbase/Tags and Organization.md
+++ b/resources/tutorial-thoughtbase/Tags and Organization.md
@@ -1,0 +1,48 @@
+---
+title: Tags and Organization
+tags: [tutorial, area/authoring, reference]
+---
+
+# Tags and Organization
+
+Two lightweight ways to organize a thoughtbase: **tags** (a flat, cross-cutting
+web) and **folders** (a tree). Use both — they answer different questions.
+
+## Tags
+
+Add tags in a note's frontmatter — the `---` block at the very top:
+
+```yaml
+---
+title: Tags and Organization
+tags: [tutorial, area/authoring, reference]
+---
+```
+
+That's exactly what this note declares. Tags become nodes in the graph, so you
+can ask "what else is tagged `reference`?" and get an answer.
+
+### Nested tags
+
+A `/` makes a hierarchy. Several tutorial notes carry an `area/…` tag —
+`area/authoring`, `area/graph`, `area/data` — so related lessons cluster without
+needing a folder.
+
+### Inline tags
+
+You can also drop a tag mid-prose with a hash, like #worth-remembering, and it's
+collected just the same.
+
+## Folders
+
+The left sidebar is an ordinary folder tree. This tutorial keeps its little
+argument map in an `arguments/` folder and its data in `data/`. Folders are also
+graph nodes — a note "in folder X" is a fact you can query.
+
+> [!tip] Which to reach for
+> Reach for a **folder** when something has one obvious home. Reach for a **tag**
+> when it belongs to several cross-cutting themes at once.
+
+---
+
+Next: [[The Knowledge Graph]] → · back to [[Start Here]]

--- a/resources/tutorial-thoughtbase/The AI Proposes You Confirm.md
+++ b/resources/tutorial-thoughtbase/The AI Proposes You Confirm.md
@@ -1,0 +1,45 @@
+---
+title: The AI Proposes, You Confirm
+tags: [tutorial, area/ai]
+---
+
+# The AI Proposes, You Confirm
+
+This is the most important design decision in Minerva, so it gets its own lesson:
+
+> **The LLM proposes. The human confirms.**
+
+AI output is *evidence to be evaluated*, never an authoritative update to your
+knowledge. Every AI-originated change to your notes or graph is filed as a
+**proposal** and applied only when **you** approve it.
+
+## How the flow works
+
+```mermaid
+flowchart LR
+    Skill[Run a skill] --> Proposal[["Proposal (pending)"]]
+    Proposal --> Review{You review the diff}
+    Review -->|Approve| Graph[(Applied to your notes)]
+    Review -->|Reject| Gone[Discarded]
+```
+
+1. A skill (from [[Tools for Thought]]) produces a **pending proposal** — nothing
+   has changed yet.
+2. You review it in a **diff view**: old on one side, suggested on the other.
+3. One keystroke **approves** (and it's applied) or **rejects** (and it's gone).
+4. Ignore it and it simply expires. Silence is not consent.
+
+## Why it's built this way
+
+A knowledge base you can't trust is worse than none. By making every AI write
+pass through your judgment, Minerva stays *yours* — the graph only ever contains
+what you vouched for. The AI is a fast, tireless research assistant; you remain
+the editor-in-chief.
+
+> [!tip] Try it
+> Go back to [[Tools for Thought]], run a skill on a note, and this time watch for
+> the proposal to appear. Approve or reject it and notice that *you* made the call.
+
+---
+
+Next: [[Structured Reasoning]] → · back to [[Start Here]]

--- a/resources/tutorial-thoughtbase/The Knowledge Graph.md
+++ b/resources/tutorial-thoughtbase/The Knowledge Graph.md
@@ -1,0 +1,54 @@
+---
+title: The Knowledge Graph
+tags: [tutorial, area/graph]
+---
+
+# The Knowledge Graph
+
+Here's the payoff. As you write, Minerva reads your notes into an **RDF knowledge
+graph** — a big set of factual triples like *(this note) → (has tag) → (tutorial)*.
+It indexes titles, tags, wiki-links and **typed links**, tables, embedded
+structure, and sources. Then you can query it with **SPARQL**.
+
+## A live query
+
+The cell below finds every `supports` edge in this thoughtbase — the exact typed
+links you met in [[Links That Mean Something]]. It ships with its result already
+shown, so you can read it now; press **Run** to execute it live against your copy.
+
+```sparql {id=graph-supports}
+PREFIX tut: <https://project.minerva.dev/minerva/tutorial/>
+SELECT ?fromTitle ?toTitle WHERE {
+  ?from minerva:supports ?to .
+  ?from dc:title ?fromTitle .
+  ?to   dc:title ?toTitle .
+}
+ORDER BY ?fromTitle
+```
+```output
+{"type":"table","columns":["fromTitle","toTitle"],"rows":[["Variety of interests","Large republics control faction"]]}
+```
+
+That one row *is* your argument, recovered from prose. Now try editing it: change
+`minerva:supports` to `minerva:rebuts` and Run again to surface the objection
+instead. Or list every note:
+
+```sparql {id=graph-notes}
+SELECT ?title WHERE { ?note a minerva:Note ; dc:title ?title } ORDER BY ?title
+```
+```output
+{"type":"table","columns":["title"],"rows":[["Data and Tables"],["Diagrams and Embeds"],["Links That Mean Something"],["Start Here"],["Tags and Organization"],["The Knowledge Graph"],["Writing Notes"],["…and the rest"]]}
+```
+
+> [!note] Prefixes are free
+> Standard prefixes — `minerva:`, `thought:`, `dc:`, `rdf:`, `rdfs:`, `xsd:`,
+> `csvw:`, `prov:` — are injected automatically, so you rarely declare them. The
+> `tut:` prefix above points at *this* thoughtbase's own namespace, handy when you
+> want to name a specific note or tag by IRI.
+
+The graph is rebuilt from your notes whenever they change (and on demand via the
+**Query** menu), so it never drifts from what you wrote.
+
+---
+
+Next: [[Data and Tables]] → · back to [[Start Here]]

--- a/resources/tutorial-thoughtbase/Tools for Thought.md
+++ b/resources/tutorial-thoughtbase/Tools for Thought.md
@@ -1,0 +1,36 @@
+---
+title: Tools for Thought
+tags: [tutorial, area/ai]
+---
+
+# Tools for Thought
+
+Minerva ships **skills** — small, focused AI tools that act *on your notes*. They
+live in the **Learning**, **Research**, and **Analysis** menus, and you can write
+your own (they're just Markdown files).
+
+## Try one now
+
+1. Open a note with a real argument in it — [[Large republics control faction]] is
+   a good candidate.
+2. From the menu bar, pick a skill — try **Steelman** (strengthen the argument) or
+   **Explain Like I'm Five** (simplify it).
+3. Watch what comes back.
+
+> [!important] You'll need a model configured
+> Skills call a language model. If you haven't set one up, Minerva will prompt
+> you — it uses *your* chosen model and key, and this is the only step in the whole
+> tutorial that touches the network. Everything else is fully local.
+
+## The important part
+
+Notice what *doesn't* happen: the skill does not silently rewrite your note. Its
+output comes back as a **proposal** — a suggested change you can read, compare
+against the original, and accept or reject. Skills are collaborators that hand you
+drafts, never editors that act behind your back.
+
+That principle is the heart of Minerva, and it's the next lesson.
+
+---
+
+Next: [[The AI Proposes You Confirm]] → · back to [[Start Here]]

--- a/resources/tutorial-thoughtbase/Writing Notes.md
+++ b/resources/tutorial-thoughtbase/Writing Notes.md
@@ -1,0 +1,66 @@
+---
+title: Writing Notes
+tags: [tutorial, area/authoring]
+---
+
+# Writing Notes
+
+Notes are plain **Markdown**, so everything you already know works: `**bold**`,
+`*italic*`, lists, `> quotes`, `code`, headings, tables, and images. Minerva adds
+a few things worth knowing on your first day.
+
+## Three ways to look at a note
+
+Minerva has three view modes — **Edit**, **Preview**, and a split **Live** view.
+Toggle them from the toolbar (or the View menu). This note reads best in Preview,
+where the callouts, math, and highlights below actually render.
+
+## Callouts
+
+Callouts are blockquotes whose first line is a `[!type]` marker. They're great
+for asides, warnings, and definitions:
+
+> [!note]
+> A plain note. Use it for a neutral aside.
+
+> [!warning] Watch out
+> Warnings take an optional custom title, like this one.
+
+> [!tip]- Collapsed by default
+> Add `-` to start collapsed, or `+` to start expanded. Click the title to toggle.
+
+## Highlights and emphasis
+
+You can ==highlight text== inline, and even pick a color, like
+==yellow:this flagged phrase== or ==green:this confirmed one==.
+
+## Math
+
+Inline math renders with KaTeX: the cost of a balanced-tree lookup is $O(\log n)$.
+Block math gets its own line:
+
+$$
+E = mc^2
+$$
+
+## Footnotes
+
+Claims can carry footnotes[^madison], which collect at the bottom of the note.
+
+## Flashcards
+
+A `card` callout becomes a reviewable flashcard, split front/back by `---`:
+
+> [!card] Minerva Basics
+> How many view modes does a Minerva note have?
+> ---
+> Three — Edit, Preview, and a split Live view.
+
+---
+
+Next: [[Links That Mean Something]] — the feature that turns notes into a graph. →
+
+Related: [[Tags and Organization]] · back to [[Start Here]]
+
+[^madison]: Footnotes are standard Markdown: a `[^id]` reference and a matching
+    `[^id]:` definition anywhere in the note.

--- a/resources/tutorial-thoughtbase/arguments/Large republics are unwieldy.md
+++ b/resources/tutorial-thoughtbase/arguments/Large republics are unwieldy.md
@@ -1,0 +1,17 @@
+---
+title: Large republics are unwieldy
+tags: [tutorial, argument, objection]
+---
+
+# Large republics are unwieldy
+
+**Objection.** A classical worry (Montesquieu's) holds that republics can only
+survive on a small scale — that over a large territory, representatives grow
+distant from the governed and the republic loses its character.
+
+This [[rebuts::Large republics control faction]]. Madison's reply is that
+representation *refines* public views rather than diluting them — an
+[[alternative-to::Large republics control faction|alternative reading]] the reader
+can weigh.
+
+Back to [[Links That Mean Something]].

--- a/resources/tutorial-thoughtbase/arguments/Large republics control faction.md
+++ b/resources/tutorial-thoughtbase/arguments/Large republics control faction.md
@@ -1,0 +1,19 @@
+---
+title: Large republics control faction
+tags: [tutorial, argument, claim]
+---
+
+# Large republics control faction
+
+**Claim.** A large republic controls the mischiefs of faction better than a small
+one, because it takes in so many competing interests that no single majority
+faction can easily form or oppress the rest.
+
+This is the central thesis of [[Sources and Citations|Madison's Federalist No. 10]].
+The evidence in [[Variety of interests]] `supports` it; the worry in
+[[Large republics are unwieldy]] `rebuts` it.
+
+See [[Structured Reasoning]] to watch this same argument modeled as formal graph
+objects (claim, grounds, warrant).
+
+Back to [[Links That Mean Something]].

--- a/resources/tutorial-thoughtbase/arguments/Variety of interests.md
+++ b/resources/tutorial-thoughtbase/arguments/Variety of interests.md
@@ -1,0 +1,14 @@
+---
+title: Variety of interests
+tags: [tutorial, argument, evidence]
+---
+
+# Variety of interests
+
+**Grounds.** The larger the republic, the greater the variety of parties and
+interests it contains — and the harder it is for any one faction to make up a
+majority and act in concert against the whole.
+
+This [[supports::Large republics control faction]].
+
+Back to [[Links That Mean Something]].

--- a/resources/tutorial-thoughtbase/data/lessons.csv
+++ b/resources/tutorial-thoughtbase/data/lessons.csv
@@ -1,0 +1,13 @@
+lesson,area,minutes,difficulty
+Writing Notes,Authoring,6,1
+Links That Mean Something,Authoring,7,2
+Tags and Organization,Authoring,4,1
+The Knowledge Graph,Graph,8,3
+Data and Tables,Data,9,3
+Diagrams and Embeds,Authoring,5,2
+Sources and Citations,Research,8,3
+Tools for Thought,AI,6,2
+The AI Proposes You Confirm,AI,7,2
+Structured Reasoning,Graph,9,4
+Export and Publish,Publishing,5,2
+Running Code,Data,8,4


### PR DESCRIPTION
Closes #1543 (content half of the #1518 epic).

**Stacked on #1542** (PR #1546) — base is the `feat/1542` branch so this diff shows only content. I'll retarget to `main` once #1542 merges.

A hand-authored, cross-linked thoughtbase that teaches Minerva *by being Minerva*: an `entrypoint` index + 12 lessons + a 3-note argument map, unified around Madison's **Federalist No. 10** (public domain) as a running example that threads through the Links, Sources, and Structured Reasoning lessons.

## The key decision: canonical baseUri
`.minerva/config.json` ships `"baseUri": "https://project.minerva.dev/minerva/tutorial/"`. `resolveBaseUri` consumes it **verbatim** (never coins one), so every pre-authored source/excerpt/turtle IRI resolves identically on any machine. Trailing slash is load-bearing and correct.

## What's covered
- **Writing Notes** — markdown, view modes, callouts, highlights, KaTeX, footnotes, a flashcard
- **Links That Mean Something** — `[[wiki-links]]` + typed links (`supports::`/`rebuts::`/`depends-on::`…) forming a traceable argument
- **Tags and Organization** — frontmatter + inline + nested tags, folders
- **The Knowledge Graph** — a **live SPARQL cell** (with its own `PREFIX tut:`) querying the tutorial's own `supports` edges
- **Data and Tables** — shipped `data/lessons.csv` → `data_lessons` SQL cell + a Vega-Lite chart + a captioned `Table:`
- **Diagrams and Embeds** — Mermaid + YouTube
- **Sources and Citations** — the pre-ingested Federalist source, an anchored `thought:Excerpt`, `cite::`/`quote::`, a formatted citation
- **Tools for Thought** / **The AI Proposes, You Confirm** — skills + the trust model
- **Structured Reasoning** — a ```turtle``` block modeling claim/grounds/warrant/rebuttal, then queried
- **Export and Publish**, and an optional gated **Running Code** (Python) lesson

## Safe + offline
SQL/SPARQL/Python cells ship with baked ```output``` so every lesson reads correctly **without executing anything**. The Vega chart uses inline `data.values` (no execution). The Python cell is self-contained and carries the required "this runs code on your machine" consent callout. Reading the tutorial makes zero network calls; the one AI step (skills) is opt-in and uses the user's own model.

## Verification
Ran the whole tree through the **real indexer** (`initGraph` → `indexAllNotes`) and asserted: baseUri consumed verbatim, `entrypoint` present, **zero dangling wiki-links** (after mirroring the indexer's code-stripping), Federalist source + excerpt parsed, `thought:Claim` indexed, the `supports` edge recovered from prose, and every `output` block is valid JSON. That harness is a working draft of the permanent staleness guard, **#1545**.

Also fixed a silent trap: the global `.minerva/` `.gitignore` rule was dropping the tutorial's `config.json`/sources/excerpts — added a negation block so the payload actually commits.

## Deferred
The permanent staleness-guard test is #1545 (kept out of this PR to keep it scoped to content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)