### PR TITLE
test(a11y): drive the proposals panel from the left sidebar

### DIFF
--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -241,16 +241,11 @@ test('proposals panel: no NEW serious a11y violations (real-browser, incl. color
       await g.__minervaE2E.seedProposal();
     });
 
-    // Open the right sidebar by firing the same menu IPC its menu item sends
-    // (native menus can't be clicked in Playwright, and there's no title-bar
-    // toggle button). Then navigate Activity group → Proposals sub-tab.
-    await app.evaluate(({ BrowserWindow }) => {
-      for (const w of BrowserWindow.getAllWindows()) w.webContents.send('menu:toggleRightSidebar');
-    });
-    await expect(win.locator('aside.right-sidebar')).toBeVisible({ timeout: 8000 });
-    await win.locator('.group-tab[title="Activity"]').first().click();
-    await win.waitForTimeout(200);
-    await win.locator('.sub-tab[title="Proposals"]').first().click();
+    // The Proposals panel now lives in the LEFT sidebar (#1526, after the
+    // right-sidebar surface was retired in #1540) — open it via its panel tab.
+    // The left sidebar is already visible (we clicked a note in it above), so
+    // no toggle is needed.
+    await win.locator('.panel-tab[title="Proposals"]').first().click();
     await win.waitForTimeout(400);
     // Expand the seeded proposal's review detail (payloads + Approve/Reject).
     const firstProposal = win.locator('.proposal-item').first();


### PR DESCRIPTION
## Problem
The e2e a11y job times out (30s) on `tests/e2e/a11y.spec.ts:218` — the proposals-panel test:

```
TimeoutError: locator.click: Timeout 30000ms exceeded.
  waiting for locator('.group-tab[title="Activity"]').first()
```

Same root cause as #1548 (the ProposalsPanel unit test): the proposals panel **moved to the left sidebar** (#1526) and the right-sidebar surface was **retired** (#1540), but this test still opened the right sidebar and navigated `Activity group → Proposals sub-tab` — selectors that no longer exist.

## Fix
Open the panel via its left-sidebar tab (`.panel-tab[title="Proposals"]`). The left sidebar is already visible (the test clicks a note in it just above), so the right-sidebar toggle is dropped. The panel component is unchanged, so `.proposal-item` and the axe scan are untouched.

## Verification
Ran it locally against the current build:

```
playwright test tests/e2e/a11y.spec.ts -g "proposals panel"
→ 1 passed (3.4s)
```

axe reports only the known/tolerated `scrollable-region-focusable` violation (the editor's `.cm-scroller`, already in the baseline) — **no new a11y regressions** in the left-sidebar proposals panel.

Unrelated to the tutorial-thoughtbase epic (#1518); a separate fix off `main` to green the e2e job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)