### PR TITLE
fix(cli): mask the punycode DEP0040 deprecation warning

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,9 @@
  * lives in `./run` so it stays testable without spawning a process. Built as a
  * standalone Node bundle via `vite.cli.config.ts` → `.vite/build/cli.js`.
  */
+// FIRST — install the punycode-deprecation mask before `./run` pulls in the RDF
+// + fetch stack that triggers DEP0040 on load (side-effect import, order matters).
+import './suppress-punycode-warning';
 import { runCli } from './run';
 
 /** Read all of stdin (the `propose-note` note body). Returns '' at a TTY, so an

--- a/src/cli/suppress-punycode-warning.ts
+++ b/src/cli/suppress-punycode-warning.ts
@@ -1,0 +1,35 @@
+/**
+ * Silence the Node `punycode` deprecation (DEP0040) for the CLI.
+ *
+ * The warning is emitted by transitive deps inside the bundled RDF + fetch stack
+ * (uri-js, whatwg-url → tr46) that still `require('punycode')`. We can't fix that
+ * upstream, and it prints on EVERY CLI invocation — pure noise on stderr. Node's
+ * builtin raises it through `process.emitWarning('…', 'DeprecationWarning',
+ * 'DEP0040')` (node:punycode line 7), so we wrap `emitWarning` and drop only that
+ * one warning; every other warning still passes through untouched.
+ *
+ * This must run BEFORE the deps that trigger it load, so it is imported FIRST
+ * (as a side effect) in `main.ts`, ahead of `./run`. Scoped to the CLI entry —
+ * `run.ts` (imported directly by tests) never patches the global.
+ */
+// Widen the opaque bound-overload type to a plain callable so forwarding the
+// captured args needs no per-call assertion.
+const original = process.emitWarning.bind(process) as (warning: string | Error, ...args: unknown[]) => void;
+
+// Recognise the punycode deprecation across emitWarning's overloads
+// (`(msg, type, code?, …)` and `(msg, { code })`): match the DEP0040 code or the
+// message text, so a change in how it's raised can't let it slip back through.
+function isPunycodeDeprecation(warning: string | Error, args: unknown[]): boolean {
+  const message = typeof warning === 'string' ? warning : warning?.message ?? '';
+  if (message.includes('punycode')) return true;
+  for (const a of args) {
+    if (a === 'DEP0040') return true;
+    if (a && typeof a === 'object' && (a as { code?: string }).code === 'DEP0040') return true;
+  }
+  return false;
+}
+
+process.emitWarning = function patchedEmitWarning(warning: string | Error, ...args: unknown[]): void {
+  if (isPunycodeDeprecation(warning, args)) return;
+  original(warning, ...args);
+};

--- a/tests/cli/suppress-punycode-warning.test.ts
+++ b/tests/cli/suppress-punycode-warning.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The CLI's punycode-deprecation mask must be SURGICAL: it drops only DEP0040,
+ * and every other warning still reaches Node's real emitter. This guards against
+ * the override quietly swallowing all warnings.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const realEmit = process.emitWarning;
+let downstream: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  // Stand in a spy as the "real" emitter BEFORE importing the module, so the
+  // module binds `original` to our spy; then it replaces process.emitWarning
+  // with its filtering wrapper.
+  downstream = vi.fn();
+  process.emitWarning = downstream as unknown as typeof process.emitWarning;
+  vi.resetModules();
+  await import('../../src/cli/suppress-punycode-warning');
+});
+
+afterEach(() => {
+  process.emitWarning = realEmit;
+  vi.resetModules();
+});
+
+describe('suppress-punycode-warning (CLI)', () => {
+  it('swallows the punycode deprecation by message', () => {
+    process.emitWarning('The `punycode` module is deprecated.', 'DeprecationWarning', 'DEP0040');
+    expect(downstream).not.toHaveBeenCalled();
+  });
+
+  it('swallows by the DEP0040 code even if the message changes', () => {
+    process.emitWarning('something else entirely', 'DeprecationWarning', 'DEP0040');
+    expect(downstream).not.toHaveBeenCalled();
+  });
+
+  it('swallows the object-options form ({ code: DEP0040 })', () => {
+    process.emitWarning('x', { type: 'DeprecationWarning', code: 'DEP0040' });
+    expect(downstream).not.toHaveBeenCalled();
+  });
+
+  it('passes every OTHER warning through untouched', () => {
+    process.emitWarning('a normal warning');
+    process.emitWarning('another deprecation', 'DeprecationWarning', 'DEP9999');
+    expect(downstream).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Problem
Every CLI invocation prints:

```
(node:88862) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```

`--trace-deprecation` bottoms out in Node internals — the `require('punycode')` is inside bundled transitive deps in the RDF + fetch stack (uri-js, whatwg-url → tr46) that still use the builtin. Not cleanly fixable upstream (multiple deps, and they legitimately use `node:punycode`), so this **masks** it, as requested — surgically.

## Fix
Node's builtin raises it via `process.emitWarning('…', 'DeprecationWarning', 'DEP0040')` (node:punycode line 7). A small module wraps `emitWarning` and drops **only** that warning — matched by the `DEP0040` code *or* the message — forwarding everything else untouched.

- Imported **first** in `main.ts` (side-effect import, ahead of `./run`) so the mask is installed before the deps that trigger it load.
- Scoped to the **CLI entry** — `run.ts` (imported directly by tests) and the Electron app never patch the global `emitWarning`.

## Verification
- Rebuilt `.vite/build/cli.js` → `--help` no longer prints the warning; normal output intact.
- Unit test pins that the mask is **surgical**: DEP0040 (by message, by code, and object-options form) is swallowed; any other warning still reaches the real emitter.
- Full `tests/cli` suite green (122); `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)