### PR TITLE
feat(objects): type registry — loader, compile-to-ontology, api.types.list (#1062)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import * as uriHelpers from './uri-helpers';
 
 import type { ProjectContext } from '../project-context-types';
+import { EMPTY_TYPE_CATALOG } from '../../shared/objects/type-def';
 
 // ── Shared foundation (#671) ─────────────────────────────────────────────────
 // Per-project state, namespaces, the SPARQL/RDF plumbing, and the state-taking
@@ -114,6 +115,7 @@ export async function initGraph(ctx: ProjectContext): Promise<void> {
     store: $rdf.graph(),
     n3Cache: null,
     ontologyStatements: [],
+    typeCatalog: EMPTY_TYPE_CATALOG,
     headingsPerNote: new Map(),
     aliasMap: new Map(),
     aliasesPerNote: new Map(),

--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -36,11 +36,13 @@ import type { ProjectContext } from '../project-context-types';
 import {
   type GraphState, type HeadingSnapshot,
   getState, invalidate, resetN3Mirror, instrumentStoreMirror,
-  MINERVA, DC, RDF, RDFS, XSD, CSVW, OWL, BIBO, SCHEMA, PROV, THOUGHT,
+  MINERVA, DC, RDF, RDFS, XSD, CSVW, OWL, BIBO, SCHEMA, PROV, THOUGHT, TYPES,
   STANDARD_PREFIXES,
   noteUri, tagUri, folderUri, sourceUri, excerptUri, tableUri, projectUri,
   linkPredicate, dateLit,
 } from './state';
+import { loadTypeCatalog } from '../types/loader';
+import { materializeTypeClasses } from '../types/compile';
 
 import { checkLLMWriteGuard } from './write-guard';
 
@@ -566,6 +568,19 @@ export async function indexNote(
     store.add(subject, MINERVA('hasTag'), tagNode, graph);
   }
 
+  // Domain type (#1062): materialize the `type:` frontmatter as an `rdf:type`
+  // edge to the registered class (`types:Book`), so `?x rdf:type types:Book` is
+  // queryable. A typed object is just a Note + this extra type. An unknown type
+  // id is ignored (no class edge) — properties expected, never enforced. `type`
+  // is in the frontmatter skip-list below so it isn't also emitted as a literal.
+  const fmType = parsed.frontmatter.type;
+  if (fmType !== undefined) {
+    for (const typeId of flattenFrontmatterStrings(fmType)) {
+      const def = state.typeCatalog.types.find((t) => t.id === typeId.trim().toLowerCase());
+      if (def) store.add(subject, RDF('type'), TYPES(def.classLocalName), graph);
+    }
+  }
+
   // Frontmatter aliases (#469). Track per-note so the next reindex of
   // this same note can drop stale aliases; rebuild the resolver map
   // so subsequent link resolution sees current state. Aliases that
@@ -600,7 +615,7 @@ export async function indexNote(
     // `title`/`tags` handled above; `publish` is a nested block of static-site
     // publishing directives (#1136) — a publication concern, kept out of the
     // graph (and it's an object, not a materialisable scalar anyway).
-    if (key === 'title' || key === 'tags' || key === 'publish') continue;
+    if (key === 'title' || key === 'tags' || key === 'publish' || key === 'type') continue;
     // A typed wiki-link value (`[[supports::x]]`) overrides keyPredicate with
     // its own type; a nested mapping materialises as a blank node; everything
     // else stays a scalar edge under the key's predicate.
@@ -1419,6 +1434,13 @@ export async function indexAllNotes(ctx: ProjectContext, opts?: IndexAllNotesOpt
 
   ensureProject(state);
   restoreProposalStatements(state.store, preservedProposals, rebase);
+
+  // Typed objects (#1062): load this project's type catalog (stock + in-tree
+  // user types) and materialize the classes into the fresh store, so notes'
+  // `type:` frontmatter can resolve to a registered class below and the graph
+  // knows the classes exist. Reloaded on every full rebuild.
+  state.typeCatalog = await loadTypeCatalog(rootPath);
+  materializeTypeClasses(state.store, state.typeCatalog);
 
   // Two-pass build (#469): the first walk just reads frontmatter
   // aliases so the alias map is fully populated before any link gets

--- a/src/main/graph/state.ts
+++ b/src/main/graph/state.ts
@@ -17,6 +17,7 @@ import { performance } from 'node:perf_hooks';
 import * as uriHelpers from './uri-helpers';
 import type { LinkType } from '../../shared/link-types';
 import type { NeighborhoodResult } from '../../shared/types';
+import type { TypeCatalog } from '../../shared/objects/type-def';
 import type { ProjectContext } from '../project-context-types';
 import { createProjectStore } from '../project-store';
 
@@ -159,6 +160,7 @@ export const BIBO    = $rdf.Namespace('http://purl.org/ontology/bibo/');
 export const SCHEMA  = $rdf.Namespace('http://schema.org/');
 export const PROV    = $rdf.Namespace('http://www.w3.org/ns/prov#');
 export const THOUGHT = $rdf.Namespace('https://minerva.dev/ontology/thought#');
+export const TYPES   = $rdf.Namespace('https://minerva.dev/ontology/types#');
 
 export const STANDARD_PREFIXES: [string, string][] = [
   ['minerva', 'https://minerva.dev/ontology#'],
@@ -172,6 +174,7 @@ export const STANDARD_PREFIXES: [string, string][] = [
   ['prov', 'http://www.w3.org/ns/prov#'],
   ['bibo', 'http://purl.org/ontology/bibo/'],
   ['schema', 'http://schema.org/'],
+  ['types', 'https://minerva.dev/ontology/types#'],
 ];
 
 // ── Per-project state (#333) ────────────────────────────────────────────────
@@ -200,6 +203,10 @@ export interface GraphState {
   n3Cache: N3.Store | null;
   /** Cached parsed ontology triples; reloaded fresh on init, stripped before persist. */
   ontologyStatements: $rdf.Statement[];
+  /** Per-project typed-objects catalog (#1062): stock + this library's user
+   *  types, loaded by `indexAllNotes` so `indexNote` can resolve a note's
+   *  `type:` frontmatter to a registered class and the api can list it. */
+  typeCatalog: TypeCatalog;
   /** Heading snapshot per note for the rename-detection heuristic. */
   headingsPerNote: Map<string, HeadingSnapshot[]>;
   /**

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -9,6 +9,7 @@ import { registerGit } from './ipc/register-git';
 import { registerSites } from './ipc/register-sites';
 import { registerBibliography } from './ipc/register-bibliography';
 import { registerTools } from './ipc/register-tools';
+import { registerTypes } from './ipc/register-types';
 import { registerRefactor } from './ipc/register-refactor';
 import { registerSources } from './ipc/register-sources';
 import { registerCompute } from './ipc/register-compute';
@@ -41,6 +42,7 @@ export function registerIpcHandlers(): void {
   registerSites();
   registerBibliography();
   registerTools();
+  registerTypes();
   registerRefactor();
   registerSources();
   registerCompute();

--- a/src/main/ipc/register-types.ts
+++ b/src/main/ipc/register-types.ts
@@ -1,0 +1,22 @@
+/**
+ * Typed-objects registry IPC (#1062). Exposes the current project's type
+ * catalog to the renderer as serializable `TypeInfo` (mirrors
+ * `api.skills.list()`), so pickers/forms never touch raw definitions or the
+ * template bodies. Loads fresh per call so a user type dropped into
+ * `.minerva/types/` shows up without a full reindex.
+ */
+import { Channels } from '../../shared/channels';
+import { loadTypeCatalog } from '../types/loader';
+import { toTypeInfo, type TypeCatalogInfo } from '../../shared/objects/type-def';
+import { handle } from './typed-ipc';
+import { withRootPathOr } from './helpers';
+
+export function registerTypes(): void {
+  handle(
+    Channels.TYPES_LIST,
+    withRootPathOr<[], TypeCatalogInfo | Promise<TypeCatalogInfo>>({ types: [], errors: [] }, async (rootPath) => {
+      const catalog = await loadTypeCatalog(rootPath);
+      return { types: catalog.types.map(toTypeInfo), errors: catalog.errors };
+    }),
+  );
+}

--- a/src/main/types/compile.ts
+++ b/src/main/types/compile.ts
@@ -1,0 +1,27 @@
+/**
+ * Compile a type catalog into ontology triples (#1062). Each type becomes a
+ * class in the `types:` namespace — `rdf:type rdfs:Class`, `rdfs:label`, its
+ * expected property names, and optional icon/color — so `?x rdf:type types:Book`
+ * is queryable and the graph, not just the registry, knows the type exists.
+ *
+ * These are global (un-named-graph) resource triples like `ensureTag`; the
+ * wholesale store reset in `indexAllNotes` wipes and re-materializes them each
+ * rebuild, so they never go stale.
+ */
+import * as $rdf from 'rdflib';
+import { MINERVA, RDF, RDFS, TYPES } from '../graph/state';
+import type { TypeCatalog } from '../../shared/objects/type-def';
+
+export function materializeTypeClasses(store: $rdf.IndexedFormula, catalog: TypeCatalog): void {
+  for (const t of catalog.types) {
+    const cls = TYPES(t.classLocalName);
+    store.add(cls, RDF('type'), RDFS('Class'));
+    store.add(cls, RDFS('label'), $rdf.lit(t.label));
+    store.add(cls, MINERVA('typeId'), $rdf.lit(t.id));
+    if (t.icon) store.add(cls, MINERVA('typeIcon'), $rdf.lit(t.icon));
+    if (t.color) store.add(cls, MINERVA('typeColor'), $rdf.lit(t.color));
+    for (const p of t.properties) {
+      store.add(cls, TYPES('expectsProperty'), $rdf.lit(p.name));
+    }
+  }
+}

--- a/src/main/types/loader.ts
+++ b/src/main/types/loader.ts
@@ -1,0 +1,96 @@
+/**
+ * Type-registry loader (#1062). Stock types ship bundled via a Vite glob
+ * (mirroring skills/loader.ts); user types live in-tree at
+ * `<rootPath>/.minerva/types/*.md` so they travel with the library (decision 1
+ * in docs/vision/objects.md). Unlike skills, the catalog is PER-PROJECT — the
+ * user portion is a property of this thoughtbase's vocabulary, not the machine.
+ *
+ * Loading is additive and stock wins id collisions: a user type can't shadow a
+ * stock type.
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  type TypeCatalog,
+  type TypeDef,
+  type TypeLoadError,
+} from '../../shared/objects/type-def';
+import { parseType } from './parse';
+
+// Stock types inlined into the main bundle at build time (query:'?raw').
+const STOCK_RAW = import.meta.glob('./stock/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+/** Reserved in-tree home for user-authored types. */
+export function userTypesDir(rootPath: string): string {
+  return path.join(rootPath, '.minerva', 'types');
+}
+
+function loadStock(): { types: TypeDef[]; errors: TypeLoadError[] } {
+  const types: TypeDef[] = [];
+  const errors: TypeLoadError[] = [];
+  for (const [key, content] of Object.entries(STOCK_RAW)) {
+    const r = parseType(content, 'stock', key);
+    if (r.type) types.push(r.type);
+    else for (const message of r.errors) errors.push({ source: 'stock', filePath: key, label: r.label, message });
+  }
+  return { types, errors };
+}
+
+async function loadUser(dir: string): Promise<{ types: TypeDef[]; errors: TypeLoadError[] }> {
+  const types: TypeDef[] = [];
+  const errors: TypeLoadError[] = [];
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return { types, errors };
+    throw e;
+  }
+  for (const ent of entries) {
+    if (ent.name.startsWith('.')) continue;
+    if (!ent.isFile() || !ent.name.toLowerCase().endsWith('.md')) continue;
+    const fp = path.join(dir, ent.name);
+    const r = parseType(await fs.readFile(fp, 'utf-8'), 'user', fp);
+    if (r.type) types.push(r.type);
+    else for (const message of r.errors) errors.push({ source: 'user', filePath: fp, label: r.label, message });
+  }
+  return { types, errors };
+}
+
+/**
+ * Build the per-project type catalog. Stock loads first and wins id collisions;
+ * a user type colliding with stock (or an earlier user type) is rejected with an
+ * error. `rootPath` locates the in-tree user types.
+ */
+export async function loadTypeCatalog(rootPath: string): Promise<TypeCatalog> {
+  const stock = loadStock();
+  const user = await loadUser(userTypesDir(rootPath));
+
+  const byId = new Map<string, TypeDef>();
+  const errors: TypeLoadError[] = [...stock.errors, ...user.errors];
+
+  for (const t of stock.types) {
+    if (byId.has(t.id)) {
+      errors.push({ source: 'stock', filePath: t.filePath, label: t.label, message: `duplicate stock type id "${t.id}"` });
+      continue;
+    }
+    byId.set(t.id, t);
+  }
+  for (const t of user.types) {
+    const existing = byId.get(t.id);
+    if (existing) {
+      const clash = existing.source === 'stock'
+        ? `id "${t.id}" is already a stock type; user types can't override stock`
+        : `duplicate user type id "${t.id}"`;
+      errors.push({ source: 'user', filePath: t.filePath, label: t.label, message: clash });
+      continue;
+    }
+    byId.set(t.id, t);
+  }
+
+  return { types: [...byId.values()], errors };
+}

--- a/src/main/types/parse.ts
+++ b/src/main/types/parse.ts
@@ -1,0 +1,131 @@
+/**
+ * Type-definition parser (#1062). Splits YAML frontmatter from the template
+ * body, validates every field, and normalizes authoring shorthands into a
+ * `TypeDef`. Never throws on content problems — returns collected errors so one
+ * malformed type can't break the rest of the catalog (mirrors skills/parse.ts).
+ */
+import YAML from 'yaml';
+import {
+  PROPERTY_TYPES,
+  pascalCase,
+  type PropertyDef,
+  type PropertyType,
+  type TypeDef,
+  type TypeSource,
+} from '../../shared/objects/type-def';
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
+
+export interface ParseTypeResult {
+  type?: TypeDef;
+  errors: string[];
+  /** Best-effort label for error reporting even when the type is rejected. */
+  label: string;
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v.trim() || undefined : undefined;
+}
+
+function titleCase(s: string): string {
+  return s.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Normalize the `properties:` list; skips (with an error) any malformed entry. */
+function normalizeProperties(raw: unknown, errors: string[]): PropertyDef[] {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) {
+    errors.push('`properties` must be a list');
+    return [];
+  }
+  const out: PropertyDef[] = [];
+  raw.forEach((p, i) => {
+    if (typeof p !== 'object' || p === null) {
+      errors.push(`property #${i + 1} must be a mapping`);
+      return;
+    }
+    const obj = p as Record<string, unknown>;
+    const name = asString(obj.name);
+    if (!name) {
+      errors.push(`property #${i + 1} is missing \`name\``);
+      return;
+    }
+    const type = (asString(obj.type) ?? 'text') as PropertyType;
+    if (!PROPERTY_TYPES.includes(type)) {
+      errors.push(`property "${name}" has unknown type "${type}" (expected one of ${PROPERTY_TYPES.join(', ')})`);
+      return;
+    }
+    const def: PropertyDef = { name, type };
+    const label = asString(obj.label);
+    if (label) def.label = label; else def.label = titleCase(name);
+    if (type === 'enum') {
+      const options = Array.isArray(obj.options) ? obj.options.map(asString).filter((o): o is string => !!o) : [];
+      if (options.length === 0) errors.push(`enum property "${name}" has no \`options\``);
+      def.options = options;
+    }
+    if (type === 'link-to-type') {
+      const target = asString(obj.targetType ?? obj.target);
+      if (!target) errors.push(`link-to-type property "${name}" is missing \`targetType\``);
+      else def.targetType = slugify(target);
+    }
+    out.push(def);
+  });
+  return out;
+}
+
+/**
+ * Parse one type-definition file. `source` tags provenance; `filePath` is the
+ * absolute path (user) or glob key (stock) for error reporting.
+ */
+export function parseType(content: string, source: TypeSource, filePath: string): ParseTypeResult {
+  const errors: string[] = [];
+  const m = content.match(FRONTMATTER_RE);
+  if (!m) {
+    return { errors: ['missing YAML frontmatter (`---` block)'], label: filePath };
+  }
+
+  let fm: Record<string, unknown>;
+  try {
+    const parsed = YAML.parse(m[1]!) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return { errors: ['frontmatter must be a mapping'], label: filePath };
+    }
+    fm = parsed as Record<string, unknown>;
+  } catch (e) {
+    return { errors: [`invalid YAML: ${(e as Error).message}`], label: filePath };
+  }
+
+  const label = asString(fm.label) ?? asString(fm.name);
+  const id = asString(fm.id) ? slugify(asString(fm.id)!) : label ? slugify(label) : '';
+  const bestLabel = label ?? id ?? filePath;
+
+  if (!label) errors.push('missing `label`');
+  if (!id) errors.push('could not derive an id (needs `id` or `label`)');
+
+  const properties = normalizeProperties(fm.properties, errors);
+  const template = content.slice(m[0].length).trim() || undefined;
+
+  // Hard errors (no id/label) reject the type; soft errors (a bad property) are
+  // reported but the type still loads (house UX: no hand-holding).
+  if (!label || !id) return { errors, label: bestLabel };
+
+  const type: TypeDef = {
+    id,
+    label,
+    classLocalName: pascalCase(id),
+    properties,
+    source,
+    filePath,
+  };
+  if (template) type.template = template;
+  const icon = asString(fm.icon);
+  if (icon) type.icon = icon;
+  const color = asString(fm.color);
+  if (color) type.color = color;
+
+  return { type, errors, label: bestLabel };
+}

--- a/src/main/types/stock/article.md
+++ b/src/main/types/stock/article.md
@@ -1,0 +1,21 @@
+---
+label: Article
+icon: 📄
+color: "#88c0d0"
+properties:
+  - name: author
+    type: text
+  - name: published
+    type: date
+  - name: url
+    type: text
+  - name: read
+    type: enum
+    options: [unread, reading, read]
+---
+
+## Summary
+
+## Key points
+
+## Notes

--- a/src/main/types/stock/book.md
+++ b/src/main/types/stock/book.md
@@ -1,0 +1,23 @@
+---
+label: Book
+icon: 📖
+color: "#c8a45c"
+properties:
+  - name: author
+    type: text
+  - name: published
+    type: date
+  - name: rating
+    type: number
+  - name: status
+    type: enum
+    options: [to-read, reading, read]
+  - name: isbn
+    type: text
+---
+
+## Summary
+
+## Notes
+
+## Quotes

--- a/src/main/types/stock/idea.md
+++ b/src/main/types/stock/idea.md
@@ -1,0 +1,17 @@
+---
+label: Idea
+icon: 💡
+color: "#ebcb8b"
+properties:
+  - name: status
+    type: enum
+    options: [seed, developing, parked, promoted]
+  - name: created
+    type: date
+---
+
+## The idea
+
+## Why it matters
+
+## Open questions

--- a/src/main/types/stock/meeting.md
+++ b/src/main/types/stock/meeting.md
@@ -1,0 +1,21 @@
+---
+label: Meeting
+icon: 🗓️
+color: "#a3be8c"
+properties:
+  - name: date
+    type: date
+  - name: organizer
+    type: link-to-type
+    targetType: person
+  - name: attendees
+    type: text
+---
+
+## Agenda
+
+## Notes
+
+## Decisions
+
+## Action items

--- a/src/main/types/stock/person.md
+++ b/src/main/types/stock/person.md
@@ -1,0 +1,16 @@
+---
+label: Person
+icon: 👤
+color: "#7aa2c2"
+properties:
+  - name: role
+    type: text
+  - name: organization
+    type: text
+  - name: email
+    type: text
+---
+
+## About
+
+## Notes

--- a/src/main/types/stock/project.md
+++ b/src/main/types/stock/project.md
@@ -1,0 +1,20 @@
+---
+label: Project
+icon: 🚀
+color: "#b48ead"
+properties:
+  - name: status
+    type: enum
+    options: [active, paused, done, abandoned]
+  - name: started
+    type: date
+  - name: owner
+    type: link-to-type
+    targetType: person
+---
+
+## Goal
+
+## Status
+
+## Notes

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -465,6 +465,9 @@ contextBridge.exposeInMainWorld('api', {
       invoke(Channels.TOOL_CHECK_CONNECTION, providerId, candidateKey, baseURL),
     onInvoke: (cb: (toolId: string) => void) => subscribeIpc(Channels.TOOL_INVOKE, cb),
   },
+  types: {
+    list: () => invoke(Channels.TYPES_LIST),
+  },
   skills: {
     list: () => invoke(Channels.SKILLS_LIST),
     reload: () => invoke(Channels.SKILLS_RELOAD),

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -747,6 +747,11 @@ export interface ToolsApi {
   onInvoke(cb: (toolId: string) => void): void;
 }
 
+export interface TypesApi {
+  /** The current project's type catalog (stock + in-tree user types, #1062). */
+  list(): Promise<import('../../../shared/objects/type-def').TypeCatalogInfo>;
+}
+
 export interface SkillsApi {
   list(): Promise<import('../../../shared/skills/types').SkillCatalogInfo>;
   reload(): Promise<import('../../../shared/skills/types').SkillCatalogInfo>;
@@ -856,6 +861,7 @@ export interface IdeApi {
   proposals: ProposalsApi;
   tabs: TabsApi;
   tools: ToolsApi;
+  types: TypesApi;
   skills: SkillsApi;
   refactor: RefactorApi;
   formatter: FormatterApi;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -425,6 +425,10 @@ export const Channels = {
   /** Prepare the system prompt + first message + model for a conversational tool. */
   TOOL_PREPARE_CONVERSATION: 'tool:prepareConversation',
 
+  // Typed objects (type registry — #1062)
+  /** List the current project's type catalog (stock + in-tree user types). */
+  TYPES_LIST: 'types:list',
+
   // Skills (markdown skill files — #622)
   /** List the loaded skill catalog (metadata + load errors). */
   SKILLS_LIST: 'skills:list',

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -55,6 +55,7 @@ import type {
   ConnectionCheckResult,
 } from './tools/types';
 import type { SkillCatalogInfo } from './skills/types';
+import type { TypeCatalogInfo } from './objects/type-def';
 import type { ProviderId } from './tools/providers';
 import type { MenuConfig } from './skills/menu-config';
 import type {
@@ -379,6 +380,9 @@ export interface ChannelMap {
   'tool:setSettings': (update: LLMSettingsUpdate) => void;
   'tool:getKeyStorage': () => ApiKeyStorage;
   'tool:checkConnection': (providerId: ProviderId, candidateKey?: string, baseURL?: string) => ConnectionCheckResult;
+
+  // Typed objects (type registry — #1062)
+  'types:list': () => TypeCatalogInfo;
 
   // Skills (markdown skill files — #622)
   'skills:list': () => SkillCatalogInfo;

--- a/src/shared/objects/type-def.ts
+++ b/src/shared/objects/type-def.ts
@@ -1,0 +1,100 @@
+/**
+ * Typed-objects registry shapes (#1062, epic #1060 — Typed Objects).
+ *
+ * A "type" (Book, Person, Meeting, …) is declared once — a label, a set of
+ * expected properties, an optional template body, an optional icon/color — and
+ * compiles into the graph as an ontology class. Renderer-safe: no main-process
+ * imports, so pickers/forms can consume `TypeInfo` over IPC.
+ *
+ * See docs/vision/objects.md for the resolved design decisions this encodes:
+ * a typed object is a Note with an extra `rdf:type`; user types live in-tree at
+ * `.minerva/types/*.md`; stock types are bundled.
+ */
+
+/** The MVP five property types (decision 4). Deferred: computed, multi-value, units. */
+export const PROPERTY_TYPES = ['text', 'date', 'number', 'enum', 'link-to-type'] as const;
+export type PropertyType = (typeof PROPERTY_TYPES)[number];
+
+export interface PropertyDef {
+  /** Frontmatter key this property is stored under (e.g. `author`). */
+  name: string;
+  type: PropertyType;
+  /** Human label for the form; defaults to a title-cased `name`. */
+  label?: string | undefined;
+  /** enum only — the allowed values (validated-but-not-enforced). */
+  options?: string[] | undefined;
+  /** link-to-type only — the target type id (e.g. `person`). Seed for #1073. */
+  targetType?: string | undefined;
+}
+
+export type TypeSource = 'stock' | 'user';
+
+/** A fully-loaded type definition (main process). */
+export interface TypeDef {
+  /** Slug matched against a note's `type:` frontmatter (e.g. `book`). */
+  id: string;
+  label: string;
+  /** PascalCase local name for the ontology class IRI (`types:Book`). */
+  classLocalName: string;
+  properties: PropertyDef[];
+  /** Optional template body inserted on instantiation (#1064). */
+  template?: string | undefined;
+  icon?: string | undefined;
+  color?: string | undefined;
+  source: TypeSource;
+  /** Absolute path for user types; the glob key for stock types. */
+  filePath: string;
+}
+
+/** Serializable metadata sent to the renderer over IPC — no template body. */
+export interface TypeInfo {
+  id: string;
+  label: string;
+  classLocalName: string;
+  properties: PropertyDef[];
+  icon?: string | undefined;
+  color?: string | undefined;
+  source: TypeSource;
+}
+
+export interface TypeLoadError {
+  source: TypeSource;
+  /** File path or glob key the error came from. */
+  filePath: string;
+  /** Best-effort type label/id if it parsed far enough; else the filename. */
+  label: string;
+  message: string;
+}
+
+export interface TypeCatalog {
+  types: TypeDef[];
+  errors: TypeLoadError[];
+}
+
+export interface TypeCatalogInfo {
+  types: TypeInfo[];
+  errors: TypeLoadError[];
+}
+
+export function toTypeInfo(t: TypeDef): TypeInfo {
+  return {
+    id: t.id,
+    label: t.label,
+    classLocalName: t.classLocalName,
+    properties: t.properties,
+    icon: t.icon,
+    color: t.color,
+    source: t.source,
+  };
+}
+
+export const EMPTY_TYPE_CATALOG: TypeCatalog = { types: [], errors: [] };
+
+/** `article-source` → `ArticleSource`; used for the ontology class local name. */
+export function pascalCase(id: string): string {
+  return id
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join('');
+}

--- a/src/shared/sparql-completions.ts
+++ b/src/shared/sparql-completions.ts
@@ -56,6 +56,7 @@ export const STANDARD_PREFIXES: ReadonlyArray<{ prefix: string; iri: string }> =
   { prefix: 'prov', iri: 'http://www.w3.org/ns/prov#' },
   { prefix: 'bibo', iri: 'http://purl.org/ontology/bibo/' },
   { prefix: 'schema', iri: 'http://schema.org/' },
+  { prefix: 'types', iri: 'https://minerva.dev/ontology/types#' },
 ];
 
 // ── Phase detection ──────────────────────────────────────────────────────

--- a/tests/main/graph/sparql-prefix-injection.test.ts
+++ b/tests/main/graph/sparql-prefix-injection.test.ts
@@ -58,6 +58,7 @@ describe('injectSparqlPrefixes', () => {
       'PREFIX prov: <http://www.w3.org/ns/prov#>',
       'PREFIX bibo: <http://purl.org/ontology/bibo/>',
       'PREFIX schema: <http://schema.org/>',
+      'PREFIX types: <https://minerva.dev/ontology/types#>',
       'SELECT ?s WHERE { ?s ?p ?o }',
     ].join('\n');
     const out = injectSparqlPrefixes(input);

--- a/tests/main/graph/typed-objects.test.ts
+++ b/tests/main/graph/typed-objects.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Typed objects — frontmatter `type:` → graph class edge (#1062).
+ *
+ * A note with `type: book` becomes an instance of the registered `types:Book`
+ * class (a Note + an extra rdf:type), and the stock classes materialize so the
+ * graph — not just the registry — knows they exist. Unknown types stay plain
+ * notes (no enforcement).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexAllNotes, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+function writeNote(rel: string, content: string): void {
+  const fp = path.join(root, rel);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content, 'utf-8');
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-typed-obj-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('typed objects: frontmatter type → graph (#1062)', () => {
+  it('a `type: book` note is an instance of types:Book (queryable by class)', async () => {
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: book\nauthor: Frank Herbert\n---\n# Dune\n`);
+    await indexAllNotes(ctx);
+
+    const { results } = await queryGraph(ctx, `SELECT ?title WHERE { ?n a types:Book ; dc:title ?title }`);
+    expect((results as Array<{ title: string }>).map((r) => r.title)).toContain('Dune');
+  });
+
+  it('the note keeps its minerva:Note type too (it is a Note + extra type)', async () => {
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: book\n---\n`);
+    await indexAllNotes(ctx);
+    const { results } = await queryGraph(ctx, `SELECT ?t WHERE { ?n dc:title "Dune" ; a ?t }`);
+    const types = (results as Array<{ t: string }>).map((r) => r.t);
+    expect(types.some((t) => t.endsWith('ontology#Note'))).toBe(true);
+    expect(types.some((t) => t.endsWith('types#Book'))).toBe(true);
+  });
+
+  it('materializes the stock classes as rdfs:Class with a typeId', async () => {
+    await indexAllNotes(ctx);
+    const { results } = await queryGraph(ctx, `SELECT ?id WHERE { ?c a rdfs:Class ; minerva:typeId ?id } ORDER BY ?id`);
+    const ids = (results as Array<{ id: string }>).map((r) => r.id);
+    expect(ids).toContain('book');
+    expect(ids).toContain('person');
+  });
+
+  it('an unknown type id does not create a class edge (no enforcement)', async () => {
+    writeNote('Thing.md', `---\ntitle: Thing\ntype: nonexistent-type\n---\n`);
+    await indexAllNotes(ctx);
+    // Still a note; no types:* class edge beyond minerva:Note.
+    const { results } = await queryGraph(ctx, `
+      SELECT ?t WHERE {
+        ?n dc:title "Thing" ; a ?t .
+        FILTER(STRSTARTS(STR(?t), "https://minerva.dev/ontology/types#"))
+      }`);
+    expect(results).toHaveLength(0);
+  });
+
+  it('does not also emit `type` as an opaque minerva:meta-type literal', async () => {
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: book\n---\n`);
+    await indexAllNotes(ctx);
+    const { results } = await queryGraph(ctx, `SELECT ?v WHERE { ?n dc:title "Dune" ; minerva:meta-type ?v }`);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -228,6 +228,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "tool:getSettings",
   "tool:prepareConversation",
   "tool:setSettings",
+  "types:list",
   "youtube:thumbnail",
 ]
 `;

--- a/tests/main/types/loader.test.ts
+++ b/tests/main/types/loader.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Type-registry loader + parser (#1062). Stock loads; in-tree user types load
+ * additively; user can't shadow stock; malformed defs fail soft.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { loadTypeCatalog } from '../../../src/main/types/loader';
+import { parseType } from '../../../src/main/types/parse';
+
+let root: string;
+
+function writeUserType(name: string, content: string): void {
+  const dir = path.join(root, '.minerva', 'types');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), content, 'utf-8');
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-types-'));
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('loadTypeCatalog (#1062)', () => {
+  it('loads the stock types as classes with PascalCase IRIs', async () => {
+    const cat = await loadTypeCatalog(root);
+    const ids = cat.types.map((t) => t.id);
+    for (const id of ['book', 'person', 'meeting', 'project', 'idea', 'article']) {
+      expect(ids).toContain(id);
+    }
+    const book = cat.types.find((t) => t.id === 'book')!;
+    expect(book.classLocalName).toBe('Book');
+    expect(book.source).toBe('stock');
+    expect(book.properties.map((p) => p.name)).toContain('author');
+    expect(cat.errors.filter((e) => e.source === 'stock')).toEqual([]);
+  });
+
+  it('loads an in-tree user type additively', async () => {
+    writeUserType('recipe.md', `---\nlabel: Recipe\nicon: 🍳\nproperties:\n  - name: servings\n    type: number\n---\n## Ingredients\n`);
+    const cat = await loadTypeCatalog(root);
+    const recipe = cat.types.find((t) => t.id === 'recipe');
+    expect(recipe?.source).toBe('user');
+    expect(recipe?.classLocalName).toBe('Recipe');
+    expect(recipe?.properties[0]).toMatchObject({ name: 'servings', type: 'number' });
+  });
+
+  it("rejects a user type that shadows a stock id (stock wins)", async () => {
+    writeUserType('book.md', `---\nlabel: Book\n---\n`);
+    const cat = await loadTypeCatalog(root);
+    const books = cat.types.filter((t) => t.id === 'book');
+    expect(books).toHaveLength(1);
+    expect(books[0]!.source).toBe('stock'); // stock kept
+    expect(cat.errors.some((e) => /already a stock type/.test(e.message))).toBe(true);
+  });
+
+  it('fails soft on a malformed user type (logged, skipped, stock intact)', async () => {
+    writeUserType('bad.md', `no frontmatter here`);
+    const cat = await loadTypeCatalog(root);
+    expect(cat.types.some((t) => t.id === 'book')).toBe(true); // stock unaffected
+    expect(cat.errors.some((e) => e.source === 'user')).toBe(true);
+  });
+
+  it('missing user-types dir is fine (just stock)', async () => {
+    const cat = await loadTypeCatalog(root);
+    expect(cat.types.length).toBeGreaterThanOrEqual(6);
+  });
+});
+
+describe('parseType (#1062)', () => {
+  it('parses properties incl. enum options and link-to-type target', () => {
+    const r = parseType(
+      `---\nlabel: Task\nproperties:\n  - name: status\n    type: enum\n    options: [todo, done]\n  - name: owner\n    type: link-to-type\n    targetType: Person\n---\nbody`,
+      'user',
+      '/x/task.md',
+    );
+    expect(r.type?.id).toBe('task');
+    const status = r.type!.properties.find((p) => p.name === 'status')!;
+    expect(status.options).toEqual(['todo', 'done']);
+    const owner = r.type!.properties.find((p) => p.name === 'owner')!;
+    expect(owner.targetType).toBe('person'); // slugified
+    expect(r.type!.template).toBe('body');
+  });
+
+  it('rejects a def with no label', () => {
+    const r = parseType(`---\nicon: 📦\n---\n`, 'user', '/x/nolabel.md');
+    expect(r.type).toBeUndefined();
+    expect(r.errors.some((e) => /label/.test(e))).toBe(true);
+  });
+
+  it('soft-errors an enum with no options but still loads the type', () => {
+    const r = parseType(`---\nlabel: Thing\nproperties:\n  - name: kind\n    type: enum\n---\n`, 'user', '/x/thing.md');
+    expect(r.type?.id).toBe('thing');
+    expect(r.errors.some((e) => /no `options`/.test(e))).toBe(true);
+  });
+
+  it('skips an unknown property type with an error', () => {
+    const r = parseType(`---\nlabel: Thing\nproperties:\n  - name: x\n    type: bogus\n---\n`, 'user', '/x/thing.md');
+    expect(r.type?.properties).toHaveLength(0);
+    expect(r.errors.some((e) => /unknown type/.test(e))).toBe(true);
+  });
+});

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -390,6 +390,9 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "prepareConversation",
     "setSettings",
   ],
+  "types": [
+    "list",
+  ],
   "view": [
     "getZoomFactor",
     "setZoomFactor",

--- a/tests/preload/preload-bridge.test.ts
+++ b/tests/preload/preload-bridge.test.ts
@@ -58,7 +58,7 @@ describe('preload contextBridge contract (#676)', () => {
       'conversations', 'csl', 'embeddings', 'export', 'files', 'formatter', 'git', 'graph',
       'images', 'links', 'menu', 'notebase', 'proposals', 'publish', 'queries',
       'refactor', 'search', 'shell', 'sites', 'skills', 'sources', 'tables',
-      'tabs', 'tags', 'templates', 'tools', 'view', 'youtube',
+      'tabs', 'tags', 'templates', 'tools', 'types', 'view', 'youtube',
     ]);
   });
 


### PR DESCRIPTION
Closes #1062 — the foundation of Phase 1 of the Typed Objects epic (#1060). Depends on the decisions recorded in #1061 (PR #1555).

A **type** is declared once — label, expected properties, an optional template body + icon/color — and compiles into the graph as an ontology class, so `?x rdf:type types:Book` is queryable. Mirrors the skills model. **No UI** — pickers/forms (later Phase 1 issues) consume this.

## What's here
- **`src/main/types/{parse,loader,compile}.ts` + `stock/*.md`** — Book, Person, Meeting, Project, Idea, Article. Stock bundled via `import.meta.glob` (cloning `skills/loader.ts`); **user types load from the in-tree `.minerva/types/*.md`** so they travel with the library (deliberately unlike per-machine skills). Additive; **stock wins id collisions**; the parser **never throws** so one malformed type can't break the catalog.
- **New `types:` namespace** (`state.ts` + `STANDARD_PREFIXES` + renderer SPARQL completions). Classes materialized in `indexAllNotes` (`rdf:type rdfs:Class`, `rdfs:label`, `typeId`, icon/color, `expectsProperty`), reloaded each full rebuild.
- **`type:` frontmatter → `rdf:type types:<Class>`** in `indexNote` — a typed object is just a Note with one extra type (the minimal-blast-radius design from #1061; `PythonModule` precedent). Unknown ids ignored (no enforcement); `type` added to the frontmatter skip-list so it isn't double-emitted as an opaque `minerva:meta-type` literal.
- **`api.types.list()`** (`TYPES_LIST`) returns serializable `TypeInfo` (no template bodies), loaded fresh per call so a dropped-in user type shows up without a reindex. Channel/contract/handler/preload/client wired.

## Acceptance criteria
- [x] Stock types load + compile as classes; a SPARQL query for the class returns instances.
- [x] A user type in `.minerva/types/` loads additively without shadowing stock.
- [x] `api.types.list()` returns serializable metadata; preload-bridge snapshot updated.
- [x] Malformed def fails soft (logged, skipped), never crashes indexing.

## Out of scope (later issues)
Property **value** indexing with `xsd` datatypes (#1063); any UI — pickers/forms/browser (#1064-#1068).

## Tests
`tests/main/types/loader.test.ts` (stock loads, user additive, no-shadow-stock, fail-soft, parse edge cases) and `tests/main/graph/typed-objects.test.ts` (the frontmatter→graph round-trip: `type: book` → `types:Book` instance + queryable class, `minerva:Note` retained, unknown ignored, no `meta-type` literal). `pnpm lint` clean; affected suites (graph/types/ipc/preload/shared — 1458 tests) green; IPC ratchet happy (`types:list` typed in ChannelMap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)