### PR TITLE
feat(objects): property model — schema-driven coercion + read-back (#1063)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -31,6 +31,7 @@ export {
   getSourceDetail, getReadingQueueSourceIds, sourcesByReadStatus, citationsForNote, getExcerptSource,
 } from './queries';
 export type { AliasEntry, SchemaEntry, GraphSchema, ReadingQueueView } from './queries';
+export { getNoteTypedProperties } from './note-properties';
 export { neighborhood, expandNode } from './neighborhood';
 export type {
   NeighborhoodResult, NeighborhoodNode, NeighborhoodEdge, NeighborhoodOptions, NeighborhoodHop,

--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -43,6 +43,7 @@ import {
 } from './state';
 import { loadTypeCatalog } from '../types/loader';
 import { materializeTypeClasses } from '../types/compile';
+import type { PropertyType } from '../../shared/objects/type-def';
 
 import { checkLLMWriteGuard } from './write-guard';
 
@@ -224,13 +225,18 @@ function emitFrontmatterValue(
   graph: $rdf.NamedNode,
   rc: LinkResolveCtx,
   depth: number,
+  // When the key is a declared property of the note's type (#1063), its declared
+  // property-type drives the RDF datatype (schema over value-guessing) — so a
+  // `text` value that looks like a year stays a string, a numeric string becomes
+  // xsd:integer, etc. Undefined for untyped notes / undeclared keys (unchanged).
+  declaredType?: PropertyType,
 ): void {
   if (depth > 8) return;
   const recovered = recoverYamlEatenWikiLink(value);
   if (recovered === null || recovered === undefined) return;
   if (Array.isArray(recovered)) {
     for (const item of recovered) {
-      emitFrontmatterValue(state, store, subject, keyPredicate, item, graph, rc, depth + 1);
+      emitFrontmatterValue(state, store, subject, keyPredicate, item, graph, rc, depth + 1, declaredType);
     }
     return;
   }
@@ -249,11 +255,11 @@ function emitFrontmatterValue(
     if (childCount > 0) store.add(subject, keyPredicate, bnode, graph);
     return;
   }
-  const edge = frontmatterValueToEdge(recovered, state, keyPredicate, rc);
+  const edge = frontmatterValueToEdge(recovered, state, keyPredicate, rc, declaredType);
   if (edge) store.add(subject, edge.predicate, edge.term, graph);
 }
 
-function resolveFrontmatterPredicate(key: string) {
+export function resolveFrontmatterPredicate(key: string) {
   const mapped: FrontmatterPredicate | null = mapFrontmatterKey(key);
   if (!mapped) return MINERVA(`meta-${key}`);
   switch (mapped.ns) {
@@ -295,9 +301,14 @@ function frontmatterValueToEdge(
   state: GraphState,
   keyPredicate: ReturnType<typeof resolveFrontmatterPredicate>,
   rc: LinkResolveCtx,
+  declaredType?: PropertyType,
 ) {
   type Term = ReturnType<typeof resolveLinkTarget> | ReturnType<typeof $rdf.lit>;
   const plain = (term: Term) => ({ predicate: keyPredicate, term });
+
+  // Schema-driven coercion (#1063): when the type declares this property, the
+  // declared type — not a guess from the value's shape — picks the RDF datatype.
+  if (declaredType) return coerceDeclared(value, declaredType, state, keyPredicate, rc);
 
   if (value instanceof Date) return plain($rdf.lit(value.toISOString(), undefined, XSD('dateTime')));
   if (typeof value === 'boolean') return plain($rdf.lit(String(value), undefined, XSD('boolean')));
@@ -334,6 +345,62 @@ function frontmatterValueToEdge(
   if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value)) return plain($rdf.lit(value, undefined, XSD('dateTime')));
   if (/^\d{4}$/.test(value)) return plain($rdf.lit(value, undefined, XSD('gYear')));
   return plain($rdf.lit(value));
+}
+
+/**
+ * Coerce a frontmatter value to the datatype its type DECLARES (#1063), rather
+ * than guessing from the value's shape. `text`/`enum` are always plain strings
+ * (so an isbn `978…` or a title `2020` isn't mis-typed as a number/year);
+ * `number` rescues numeric strings; `date` accepts the ISO shapes; `link-to-type`
+ * resolves a whole-value wiki-link to its target (edge-labeling is #1073), else a
+ * string. Anything that can't be coerced falls back to a plain string literal.
+ */
+function coerceDeclared(
+  value: FrontmatterScalarNonNull,
+  declaredType: PropertyType,
+  state: GraphState,
+  keyPredicate: ReturnType<typeof resolveFrontmatterPredicate>,
+  rc: LinkResolveCtx,
+) {
+  type Term = ReturnType<typeof resolveLinkTarget> | ReturnType<typeof $rdf.lit>;
+  const plain = (term: Term) => ({ predicate: keyPredicate, term });
+  const str = value instanceof Date ? value.toISOString() : String(value);
+  const asString = () => plain($rdf.lit(str));
+
+  switch (declaredType) {
+    case 'text':
+    case 'enum':
+      return asString();
+    case 'number': {
+      const n = typeof value === 'number' ? value : Number(str.trim());
+      if (str.trim() !== '' && Number.isFinite(n)) {
+        return plain($rdf.lit(String(n), undefined, XSD(Number.isInteger(n) ? 'integer' : 'decimal')));
+      }
+      return asString();
+    }
+    case 'date': {
+      if (value instanceof Date) return plain($rdf.lit(str.slice(0, 10), undefined, XSD('date')));
+      const s = str.trim();
+      if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return plain($rdf.lit(s, undefined, XSD('date')));
+      if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(s)) return plain($rdf.lit(s, undefined, XSD('dateTime')));
+      if (/^\d{4}-\d{2}$/.test(s)) return plain($rdf.lit(s, undefined, XSD('gYearMonth')));
+      if (/^\d{4}$/.test(s)) return plain($rdf.lit(s, undefined, XSD('gYear')));
+      return asString();
+    }
+    case 'link-to-type': {
+      const inner = state.baseUri ? str.match(WHOLE_WIKILINK_RE) : null;
+      if (inner) {
+        const link = parseWikiInner(inner[1]!);
+        if (!link.type && link.target.startsWith('sources/')) {
+          const sid = link.target.slice('sources/'.length);
+          if (sid) return plain(sourceUri(state, sid));
+        }
+        const anchor = link.anchor ? link.anchor.slice(1) : undefined;
+        return { predicate: keyPredicate, term: resolveLinkTarget(state, getLinkType('references'), link.target, rc, anchor) };
+      }
+      return asString();
+    }
+  }
 }
 
 /**
@@ -574,10 +641,16 @@ export async function indexNote(
   // id is ignored (no class edge) — properties expected, never enforced. `type`
   // is in the frontmatter skip-list below so it isn't also emitted as a literal.
   const fmType = parsed.frontmatter.type;
+  // Declared property name → declared PropertyType, for schema-driven value
+  // coercion in the frontmatter loop below (#1063).
+  let declaredProps: Map<string, PropertyType> | undefined;
   if (fmType !== undefined) {
     for (const typeId of flattenFrontmatterStrings(fmType)) {
       const def = state.typeCatalog.types.find((t) => t.id === typeId.trim().toLowerCase());
-      if (def) store.add(subject, RDF('type'), TYPES(def.classLocalName), graph);
+      if (!def) continue;
+      store.add(subject, RDF('type'), TYPES(def.classLocalName), graph);
+      declaredProps ??= new Map();
+      for (const p of def.properties) if (!declaredProps.has(p.name)) declaredProps.set(p.name, p.type);
     }
   }
 
@@ -618,8 +691,9 @@ export async function indexNote(
     if (key === 'title' || key === 'tags' || key === 'publish' || key === 'type') continue;
     // A typed wiki-link value (`[[supports::x]]`) overrides keyPredicate with
     // its own type; a nested mapping materialises as a blank node; everything
-    // else stays a scalar edge under the key's predicate.
-    emitFrontmatterValue(state, store, subject, resolveFrontmatterPredicate(key), value, graph, linkCtx, 0);
+    // else stays a scalar edge under the key's predicate. A declared property's
+    // type drives datatype coercion (#1063).
+    emitFrontmatterValue(state, store, subject, resolveFrontmatterPredicate(key), value, graph, linkCtx, 0, declaredProps?.get(key));
   }
 
   // Embedded turtle blocks — parse into the note's named graph

--- a/src/main/graph/note-properties.ts
+++ b/src/main/graph/note-properties.ts
@@ -1,0 +1,53 @@
+/**
+ * Typed-property read-back (#1063). Projects a note's declared properties — the
+ * schema of its type crossed with the values indexed on the note — for the
+ * property form (#1066) and type-keyed renderers (#1071).
+ *
+ * A SPARQL projection over the instance: each declared property resolves to the
+ * SAME predicate the indexer wrote it under (`resolveFrontmatterPredicate`), so
+ * the read-back is robust to frontmatter-key aliasing (a Book's `author` and a
+ * formatter-canonicalized `creator` both resolve to `dc:creator`). Declared-but-
+ * empty properties come back with `value: null` so the form can show every field.
+ */
+import type { ProjectContext } from '../project-context-types';
+import { getState } from './state';
+import { noteUriFor, queryGraph } from './queries';
+import { resolveFrontmatterPredicate } from './indexers';
+import { toTypeInfo, type NoteTypedProperties } from '../../shared/objects/type-def';
+
+export async function getNoteTypedProperties(
+  ctx: ProjectContext,
+  relativePath: string,
+): Promise<NoteTypedProperties> {
+  const state = getState(ctx);
+  const noteIri = noteUriFor(ctx, relativePath);
+  if (!state || !noteIri) return { type: null, properties: [] };
+
+  // Resolve the note's type via its class edge (only domain classes carry
+  // minerva:typeId, so this skips minerva:Note). First match wins.
+  const { results: typeRows } = await queryGraph(
+    ctx,
+    `SELECT ?id WHERE { <${noteIri}> a ?c . ?c minerva:typeId ?id } LIMIT 1`,
+  );
+  const typeId = (typeRows as Array<{ id?: string }>)[0]?.id;
+  const def = typeId ? state.typeCatalog.types.find((t) => t.id === typeId) : undefined;
+  if (!def) return { type: null, properties: [] };
+
+  // One pass over the note's predicate→value pairs, then map to declared props.
+  const { results: rows } = await queryGraph(ctx, `SELECT ?p ?v WHERE { <${noteIri}> ?p ?v }`);
+  const byPredicate = new Map<string, string>();
+  for (const r of rows as Array<{ p?: string; v?: string }>) {
+    if (r.p && r.v !== undefined && !byPredicate.has(r.p)) byPredicate.set(r.p, r.v);
+  }
+
+  const properties = def.properties.map((pd) => ({
+    name: pd.name,
+    type: pd.type,
+    label: pd.label,
+    options: pd.options,
+    targetType: pd.targetType,
+    value: byPredicate.get(resolveFrontmatterPredicate(pd.name).value) ?? null,
+  }));
+
+  return { type: toTypeInfo(def), properties };
+}

--- a/src/main/ipc/register-types.ts
+++ b/src/main/ipc/register-types.ts
@@ -7,7 +7,9 @@
  */
 import { Channels } from '../../shared/channels';
 import { loadTypeCatalog } from '../types/loader';
-import { toTypeInfo, type TypeCatalogInfo } from '../../shared/objects/type-def';
+import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
+import { toTypeInfo, type TypeCatalogInfo, type NoteTypedProperties } from '../../shared/objects/type-def';
 import { handle } from './typed-ipc';
 import { withRootPathOr } from './helpers';
 
@@ -18,5 +20,15 @@ export function registerTypes(): void {
       const catalog = await loadTypeCatalog(rootPath);
       return { types: catalog.types.map(toTypeInfo), errors: catalog.errors };
     }),
+  );
+
+  // A note's declared properties + current values, for the property form (#1066)
+  // and type-keyed renderers (#1071). Projects over the already-indexed graph.
+  handle(
+    Channels.TYPES_NOTE_PROPERTIES,
+    withRootPathOr<[string], NoteTypedProperties | Promise<NoteTypedProperties>>(
+      { type: null, properties: [] },
+      (rootPath, relativePath: string) => graph.getNoteTypedProperties(projectContext(rootPath), relativePath),
+    ),
   );
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -467,6 +467,7 @@ contextBridge.exposeInMainWorld('api', {
   },
   types: {
     list: () => invoke(Channels.TYPES_LIST),
+    noteProperties: (relativePath: string) => invoke(Channels.TYPES_NOTE_PROPERTIES, relativePath),
   },
   skills: {
     list: () => invoke(Channels.SKILLS_LIST),

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -750,6 +750,8 @@ export interface ToolsApi {
 export interface TypesApi {
   /** The current project's type catalog (stock + in-tree user types, #1062). */
   list(): Promise<import('../../../shared/objects/type-def').TypeCatalogInfo>;
+  /** A note's declared properties + current values, keyed to its type (#1063). */
+  noteProperties(relativePath: string): Promise<import('../../../shared/objects/type-def').NoteTypedProperties>;
 }
 
 export interface SkillsApi {

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -428,6 +428,8 @@ export const Channels = {
   // Typed objects (type registry — #1062)
   /** List the current project's type catalog (stock + in-tree user types). */
   TYPES_LIST: 'types:list',
+  /** A note's declared properties + current values, keyed to its type (#1063). */
+  TYPES_NOTE_PROPERTIES: 'types:noteProperties',
 
   // Skills (markdown skill files — #622)
   /** List the loaded skill catalog (metadata + load errors). */

--- a/src/shared/frontmatter-canonical-keys.ts
+++ b/src/shared/frontmatter-canonical-keys.ts
@@ -60,4 +60,6 @@ export const CANONICAL_FRONTMATTER_KEYS: readonly string[] = [
 
   // Universally-supported but predicate-free
   'tags',
+  // Typed objects (#1063): selects a note's domain type + its property schema.
+  'type',
 ];

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -55,7 +55,7 @@ import type {
   ConnectionCheckResult,
 } from './tools/types';
 import type { SkillCatalogInfo } from './skills/types';
-import type { TypeCatalogInfo } from './objects/type-def';
+import type { TypeCatalogInfo, NoteTypedProperties } from './objects/type-def';
 import type { ProviderId } from './tools/providers';
 import type { MenuConfig } from './skills/menu-config';
 import type {
@@ -383,6 +383,7 @@ export interface ChannelMap {
 
   // Typed objects (type registry — #1062)
   'types:list': () => TypeCatalogInfo;
+  'types:noteProperties': (relativePath: string) => NoteTypedProperties;
 
   // Skills (markdown skill files — #622)
   'skills:list': () => SkillCatalogInfo;

--- a/src/shared/objects/type-def.ts
+++ b/src/shared/objects/type-def.ts
@@ -90,6 +90,27 @@ export function toTypeInfo(t: TypeDef): TypeInfo {
 
 export const EMPTY_TYPE_CATALOG: TypeCatalog = { types: [], errors: [] };
 
+/** One declared property of a typed note, with its current value (#1063). Used
+ *  by the property form (#1066) and type-keyed renderers (#1071). */
+export interface NoteTypedPropertyValue {
+  name: string;
+  type: PropertyType;
+  label?: string | undefined;
+  options?: string[] | undefined;
+  targetType?: string | undefined;
+  /** Lexical value from the graph (e.g. `"5"`, `"2020-01-01"`, a target IRI),
+   *  or null when the note doesn't set this declared property. */
+  value: string | null;
+}
+
+/** A note's typed properties, keyed to its type's declared schema (#1063). */
+export interface NoteTypedProperties {
+  /** The note's type, or null when it has none / an unknown one. */
+  type: TypeInfo | null;
+  /** Every property the type declares, including ones the note leaves empty. */
+  properties: NoteTypedPropertyValue[];
+}
+
 /** `article-source` → `ArticleSource`; used for the ontology class local name. */
 export function pascalCase(id: string): string {
   return id

--- a/tests/main/graph/typed-properties.test.ts
+++ b/tests/main/graph/typed-properties.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Typed-object property model (#1063): schema-driven datatype coercion, the
+ * frontmatter⇄graph round-trip, no-enforcement, and the read-back projection.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexAllNotes, indexNote, queryGraph, getNoteTypedProperties } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+function writeNote(rel: string, content: string): void {
+  const fp = path.join(root, rel);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content, 'utf-8');
+}
+
+async function datatypeOf(title: string, predicate: string): Promise<string | undefined> {
+  const { results } = await queryGraph(
+    ctx,
+    `SELECT (DATATYPE(?v) AS ?dt) WHERE { ?n dc:title "${title}" ; ${predicate} ?v }`,
+  );
+  return (results as Array<{ dt?: string }>)[0]?.dt;
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-typed-props-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('typed properties: datatype coercion (#1063)', () => {
+  it('a declared `number` becomes xsd:integer — even from a string', async () => {
+    writeNote('A.md', `---\ntitle: A\ntype: book\nrating: 5\n---\n`);
+    writeNote('B.md', `---\ntitle: B\ntype: book\nrating: "4"\n---\n`);
+    await indexAllNotes(ctx);
+    expect(await datatypeOf('A', 'minerva:meta-rating')).toMatch(/#integer$/);
+    expect(await datatypeOf('B', 'minerva:meta-rating')).toMatch(/#integer$/); // coerced from string
+  });
+
+  it('a declared `date` becomes xsd:date', async () => {
+    writeNote('A.md', `---\ntitle: A\ntype: book\npublished: 2020-06-01\n---\n`);
+    await indexAllNotes(ctx);
+    expect(await datatypeOf('A', 'minerva:meta-published')).toMatch(/#date$/);
+  });
+
+  it('a declared `text` stays a plain string — not mis-inferred as a number/year', async () => {
+    // isbn is declared text; a bare-year-looking value must NOT become xsd:gYear.
+    writeNote('A.md', `---\ntitle: A\ntype: book\nisbn: 2020\n---\n`);
+    await indexAllNotes(ctx);
+    expect(await datatypeOf('A', 'bibo:isbn')).toMatch(/#string$/);
+  });
+
+  it('a `link-to-type` value that is a wiki-link resolves to the target note', async () => {
+    writeNote('Alice.md', `---\ntitle: Alice\ntype: person\n---\n`);
+    writeNote('Roadmap.md', `---\ntitle: Roadmap\ntype: project\nowner: "[[Alice]]"\n---\n`);
+    await indexAllNotes(ctx);
+    const { results } = await queryGraph(
+      ctx,
+      `SELECT ?o WHERE { ?n dc:title "Roadmap" ; minerva:meta-owner ?o }`,
+    );
+    const owner = (results as Array<{ o?: string }>)[0]?.o ?? '';
+    expect(owner).toContain('/note/Alice'); // an object ref, not a literal
+  });
+
+  it('a note missing an expected property still indexes cleanly (no enforcement)', async () => {
+    writeNote('A.md', `---\ntitle: A\ntype: book\n---\n# A\n`);
+    await expect(indexAllNotes(ctx)).resolves.toBeGreaterThanOrEqual(1);
+    const { results } = await queryGraph(ctx, `SELECT ?t WHERE { ?n dc:title "A" ; a types:Book . BIND("ok" AS ?t) }`);
+    expect(results).toHaveLength(1);
+  });
+});
+
+describe('typed properties: read-back (#1063)', () => {
+  it('returns every declared property, incl. declared-but-empty, with values', async () => {
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: book\nauthor: Frank Herbert\nrating: 5\n---\n`);
+    await indexAllNotes(ctx);
+
+    const rb = await getNoteTypedProperties(ctx, 'Dune.md');
+    expect(rb.type?.id).toBe('book');
+    const byName = new Map(rb.properties.map((p) => [p.name, p]));
+    // Book declares author, published, rating, status, isbn — all present.
+    for (const name of ['author', 'published', 'rating', 'status', 'isbn']) {
+      expect(byName.has(name)).toBe(true);
+    }
+    expect(byName.get('author')!.value).toBe('Frank Herbert');
+    expect(byName.get('rating')!.value).toBe('5');
+    expect(byName.get('published')!.value).toBeNull(); // declared but empty
+    // Schema carried through for the form (enum options).
+    expect(byName.get('status')!.type).toBe('enum');
+    expect(byName.get('status')!.options).toContain('reading');
+  });
+
+  it('returns an empty projection for an untyped note', async () => {
+    writeNote('Plain.md', `---\ntitle: Plain\n---\n`);
+    await indexAllNotes(ctx);
+    const rb = await getNoteTypedProperties(ctx, 'Plain.md');
+    expect(rb.type).toBeNull();
+    expect(rb.properties).toEqual([]);
+  });
+});
+
+describe('typed properties: write→reindex round-trip (#1063)', () => {
+  it('values survive a single-note reindex', async () => {
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: book\nrating: 5\n---\n`);
+    await indexAllNotes(ctx);
+    // Re-index just this note (as write-pipeline does on save).
+    await indexNote(ctx, 'Dune.md', fs.readFileSync(path.join(root, 'Dune.md'), 'utf-8'));
+    expect(await datatypeOf('Dune', 'minerva:meta-rating')).toMatch(/#integer$/);
+    const rb = await getNoteTypedProperties(ctx, 'Dune.md');
+    expect(rb.properties.find((p) => p.name === 'rating')?.value).toBe('5');
+  });
+});

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -229,6 +229,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "tool:prepareConversation",
   "tool:setSettings",
   "types:list",
+  "types:noteProperties",
   "youtube:thumbnail",
 ]
 `;

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -392,6 +392,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
   ],
   "types": [
     "list",
+    "noteProperties",
   ],
   "view": [
     "getZoomFactor",


### PR DESCRIPTION
Closes #1063 — gives types **properties** and wires the frontmatter⇄graph round-trip. Depends on the #1062 registry (merged). **Data layer only** — the property form is #1066.

## What's here
- **Schema-driven datatype coercion.** A declared property's type — not a guess from the value's shape — picks the RDF datatype:
  - `number` → `xsd:integer`/`decimal`, **even from a string** (`rating: "5"` → integer)
  - `date` → the `xsd:date`/`dateTime`/`gYear(Month)` shapes
  - `text` / `enum` → plain strings, so an `isbn: 2020` or a title-like value **isn't mis-inferred** as a year/number
  - `link-to-type` → resolves a whole-value wiki-link to its target note/source (labeled edges are #1073)

  Threaded through `emitFrontmatterValue` → `frontmatterValueToEdge` as an optional declared type. **Untyped notes and undeclared keys are byte-for-byte unchanged** — predicates still come from the existing `resolveFrontmatterPredicate` (the issue's "extend, don't bypass").
- **Read-back API** — `getNoteTypedProperties(ctx, relativePath)`: a SPARQL projection returning every property the note's type declares, **including declared-but-empty ones** (`value: null`), with enum `options`/`targetType` carried for the form (#1066) and renderers (#1071). Robust to frontmatter-key aliasing — both indexing and read-back resolve the same predicate, so a Book's `author` and a formatter-canonicalized `creator` both land on `dc:creator`.
- **`api.types.noteProperties()`** IPC (channel/contract/handler/preload/client; snapshots updated). Canonical **`type`** key registered.

## No enforcement (house UX)
A missing / extra / out-of-options value indexes cleanly; enum `options` are carried so the form can validate, never rejected.

## Acceptance criteria
- [x] `type: book` + `author`/`rating`/`published` index with correct `xsd` datatypes.
- [x] Property values survive a write→reindex round-trip.
- [x] A note missing an expected property still indexes cleanly.
- [x] Read-back returns properties keyed to the declared schema, incl. declared-but-empty.

## Out of scope
The property **form UI** (#1066); labeled/role-bearing `link-to-type` edges + role-aware backlinks (#1073); multi-value/computed/unit (deferred).

## Tests
`tests/main/graph/typed-properties.test.ts` — coercion datatypes (number-from-string, date, text-stays-string, link-to-type resolves), read-back (all declared props incl. empty; untyped → empty projection), and the write→reindex round-trip. `pnpm lint` clean; affected suites (graph/types/ipc/preload/shared — 1466) green; IPC ratchet happy (`types:noteProperties` typed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)