### PR TITLE
feat(objects): type picker in New Note + template-on-instantiation (#1064)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1572,6 +1572,7 @@
     <OnboardingDialog
       onAccept={(answers, dontAskAgain) => { void handleOnboardingAccept(answers, dontAskAgain); }}
       onDecline={(dontAskAgain) => { void handleOnboardingDecline(dontAskAgain); }}
+      onStartFromType={() => { showOnboarding = false; void handleNewNote(); }}
     />
   {/if}
 

--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -15,6 +15,7 @@ import { getClipboardStore } from '../stores/clipboard.svelte';
 import { resolveSelectionTargets, expandSelectionToNoteFiles, pathExistsInTree } from '../sidebar-tree-utils';
 import { describeDeleteNoun, describeDeleteMessage, offsetToLineCol } from './text-helpers';
 import { substituteTemplate } from '../../../shared/templates';
+import { buildTypedNoteScaffold } from '../../../shared/objects/scaffold';
 import { CONFIRM_KEYS } from '../confirm-keys';
 import type { SafeDeleteBlocker } from '../../../shared/types';
 
@@ -51,7 +52,22 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     // return cancels: the file isn't written and the flow ends.
     let initialContent = '';
     let caretOffset: number | null = null;
-    if (result.templateFilename) {
+    if (result.type) {
+      // Created *as* a type (#1064): frontmatter `type:` + a scaffold of the
+      // type's declared property keys, then its (substituted) template body.
+      let body = '';
+      if (result.type.template) {
+        const sub = await substituteTemplate(result.type.template, {
+          title: result.name,
+          prompt: (label: string) => showPrompt(`${label}:`),
+        });
+        if (sub.cancelled) return;
+        body = sub.content;
+      }
+      const scaffold = buildTypedNoteScaffold(result.type, body);
+      initialContent = scaffold.content;
+      caretOffset = scaffold.caretOffset;
+    } else if (result.templateFilename) {
       const body = await api.templates.get(result.templateFilename);
       if (body !== null) {
         const sub = await substituteTemplate(body, {

--- a/src/renderer/lib/components/NewNoteDialog.svelte
+++ b/src/renderer/lib/components/NewNoteDialog.svelte
@@ -13,6 +13,7 @@
   import Icon from './Icon.svelte';
   import type { IconName } from './icons/registry';
   import { api, type TemplateInfo } from '../ipc/client';
+  import type { TypeInfo } from '../../../shared/objects/type-def';
   import type { NoteExt, NewNoteResult } from './new-note-dialog-types';
 
   interface TypeOption {
@@ -48,19 +49,35 @@
   /** `null` = blank file. Empty string from the select element maps
    *  to null on read; the select stores filenames. */
   let templateFilename = $state<string | null>(null);
+  /** Domain types from the live registry (#1064). Creating a note *as* a type
+   *  seeds its template + property scaffold. */
+  let types = $state<TypeInfo[]>([]);
+  let selectedType = $state<TypeInfo | null>(null);
 
   $effect(() => { inputEl?.focus(); });
 
-  // Load templates once on mount; the list is small and refreshing
-  // on every keystroke would be wasteful.
+  // Load templates + types once on mount; both lists are small.
   $effect(() => {
     void api.templates.list().then((list) => { templates = list; });
+    void api.types.list().then((cat) => { types = cat.types; });
   });
 
-  /** Templates only make sense for markdown notes — substitution
-   *  produces markdown content. Hide the slot for other types so the
-   *  user doesn't pick a template that won't apply. */
-  const templatesApply = $derived(ext === '.md');
+  /** Pick a plain file kind — clears any domain type. */
+  function pickExt(next: NoteExt) {
+    ext = next;
+    selectedType = null;
+    inputEl?.focus();
+  }
+  /** Create *as* a domain type — always a markdown note (#1064). */
+  function pickType(t: TypeInfo) {
+    selectedType = t;
+    ext = '.md';
+    inputEl?.focus();
+  }
+
+  /** Templates only make sense for a plain markdown note — a domain type brings
+   *  its own template, and other file kinds don't take one. */
+  const templatesApply = $derived(ext === '.md' && !selectedType);
 
   /** Strip the chosen type's extension from the typed name if the
    *  user typed it explicitly — keeps the on-disk filename clean
@@ -76,6 +93,7 @@
       name: stripped,
       ext,
       templateFilename: templatesApply ? templateFilename : null,
+      type: selectedType,
     };
   }
 
@@ -94,7 +112,7 @@
   <div class="dialog" role="dialog" aria-modal="true">
     <header class="card-header">
       <div class="eyebrow">New</div>
-      <h2 class="title">New Note</h2>
+      <h2 class="title">{selectedType ? `New ${selectedType.label}` : 'New Note'}</h2>
     </header>
 
     <div class="body">
@@ -102,14 +120,14 @@
            pinch the horizontal layout. -->
       <div class="type-list" role="radiogroup" aria-label="Note type">
         {#each TYPES as t (t.ext)}
-          {@const active = ext === t.ext}
+          {@const active = ext === t.ext && !selectedType}
           <button
             type="button"
             class="type-row"
             class:active
             role="radio"
             aria-checked={active}
-            onclick={() => { ext = t.ext; inputEl?.focus(); }}
+            onclick={() => pickExt(t.ext)}
           >
             <Icon name={t.icon} size={14} color={active ? 'var(--accent)' : 'currentColor'} />
             <span class="type-text">
@@ -119,6 +137,29 @@
             <span class="type-ext">{t.ext}</span>
           </button>
         {/each}
+
+        <!-- Domain types (#1064): "New Book" is a menu choice, not a syntax. -->
+        {#if types.length > 0}
+          <div class="type-divider">Types</div>
+          {#each types as t (t.id)}
+            {@const active = selectedType?.id === t.id}
+            <button
+              type="button"
+              class="type-row"
+              class:active
+              role="radio"
+              aria-checked={active}
+              onclick={() => pickType(t)}
+              title={t.source === 'user' ? 'Your type' : 'Built-in type'}
+            >
+              <span class="type-emoji" style={t.color ? `color:${t.color}` : undefined}>{t.icon ?? '◆'}</span>
+              <span class="type-text">
+                <span class="type-label">{t.label}</span>
+                <span class="type-desc">{t.properties.length} field{t.properties.length === 1 ? '' : 's'}</span>
+              </span>
+            </button>
+          {/each}
+        {/if}
       </div>
 
       <!-- Right: name + reserved Template slot. -->
@@ -298,6 +339,21 @@
     flex-shrink: 0;
   }
   .type-row.active .type-ext { color: var(--accent); opacity: 0.8; }
+  .type-divider {
+    font-family: var(--font-mono);
+    font-size: 9.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    padding: 8px 9px 3px;
+  }
+  .type-emoji {
+    width: 14px;
+    font-size: 13px;
+    line-height: 1;
+    text-align: center;
+    flex-shrink: 0;
+  }
 
   /* ── Form (right column) ───────────────────────────────────────── */
   .form {

--- a/src/renderer/lib/components/OnboardingDialog.svelte
+++ b/src/renderer/lib/components/OnboardingDialog.svelte
@@ -20,9 +20,12 @@
   interface Props {
     onAccept: (answers: OnboardingAnswers, dontAskAgain: boolean) => void;
     onDecline: (dontAskAgain: boolean) => void;
+    /** Second on-ramp (#1064): dismiss onboarding and open the New Note dialog,
+     *  where the user can start *as* a type (Book, Person, Meeting…). */
+    onStartFromType: () => void;
   }
 
-  let { onAccept, onDecline }: Props = $props();
+  let { onAccept, onDecline, onStartFromType }: Props = $props();
 
   let subject = $state('');
   let expertise = $state<OnboardingAnswers['expertise']>('familiar');
@@ -153,6 +156,7 @@
           Draft my thoughtbase
         </button>
         <button class="btn secondary" onclick={handleDecline}>I'll start from scratch</button>
+        <button class="btn secondary" onclick={onStartFromType}>Start from a type…</button>
         <span class="spacer-inline"></span>
         <label class="dont-ask">
           <input type="checkbox" bind:checked={dontAskAgain} />

--- a/src/renderer/lib/components/new-note-dialog-types.ts
+++ b/src/renderer/lib/components/new-note-dialog-types.ts
@@ -6,6 +6,8 @@
  * just for two types is heavier than a sibling file.
  */
 
+import type { TypeInfo } from '../../../shared/objects/type-def';
+
 export type NoteExt = '.md' | '.ttl' | '.csv' | '.py';
 
 export interface NewNoteResult {
@@ -14,4 +16,8 @@ export interface NewNoteResult {
   /** Filename of the chosen template (`.md` types only), or null
    *  for a blank file. */
   templateFilename: string | null;
+  /** The domain type the note was created *as* (#1064), or null for a plain
+   *  note. When set, `ext` is always `.md` and `templateFilename` is null —
+   *  the type's own template + property scaffold apply instead. */
+  type?: TypeInfo | null;
 }

--- a/src/shared/objects/scaffold.ts
+++ b/src/shared/objects/scaffold.ts
@@ -1,0 +1,29 @@
+/**
+ * Build the initial content for a note created *as* a type (#1064): the `type:`
+ * frontmatter, an empty scaffold of the type's declared property keys, then the
+ * (already-substituted) template body. Shared so the type picker (#1064) and
+ * inline `/book` creation (#1065) produce identical notes.
+ *
+ * Frontmatter is the storage format, never the interface — the scaffold gives
+ * the property form (#1066) its keys, but the user never has to hand-write them.
+ */
+import type { TypeInfo } from './type-def';
+
+export interface TypedNoteScaffold {
+  content: string;
+  /** Caret offset — start of the body, past the frontmatter. */
+  caretOffset: number;
+}
+
+/** `body` is the type's template body, already run through substituteTemplate. */
+export function buildTypedNoteScaffold(type: TypeInfo, body: string): TypedNoteScaffold {
+  const fm = ['---', `type: ${type.id}`];
+  for (const p of type.properties) fm.push(`${p.name}:`);
+  fm.push('---', '');
+  const prefix = fm.join('\n'); // ends with `---\n` (the trailing '' adds the newline)
+  const trimmedBody = body.replace(/^\n+/, '');
+  return {
+    content: trimmedBody ? `${prefix}\n${trimmedBody}${trimmedBody.endsWith('\n') ? '' : '\n'}` : prefix,
+    caretOffset: prefix.length + 1,
+  };
+}

--- a/src/shared/objects/type-def.ts
+++ b/src/shared/objects/type-def.ts
@@ -46,12 +46,15 @@ export interface TypeDef {
   filePath: string;
 }
 
-/** Serializable metadata sent to the renderer over IPC — no template body. */
+/** Serializable metadata sent to the renderer over IPC. Carries the template
+ *  body (a plain note scaffold, unlike a skill's LLM-prompt body) so the type
+ *  picker (#1064) / inline creation (#1065) can instantiate without a round-trip. */
 export interface TypeInfo {
   id: string;
   label: string;
   classLocalName: string;
   properties: PropertyDef[];
+  template?: string | undefined;
   icon?: string | undefined;
   color?: string | undefined;
   source: TypeSource;
@@ -82,6 +85,7 @@ export function toTypeInfo(t: TypeDef): TypeInfo {
     label: t.label,
     classLocalName: t.classLocalName,
     properties: t.properties,
+    template: t.template,
     icon: t.icon,
     color: t.color,
     source: t.source,

--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -230,6 +230,24 @@ describe('handleNewNote — template & guard paths', () => {
     expect(editorComp.restorePosition).toHaveBeenCalledWith(11, 0);
   });
 
+  it('creates a note *as* a type — type: frontmatter + property scaffold + template body (#1064)', async () => {
+    h.dialog.showNewNoteDialog.mockResolvedValue({
+      name: 'Dune', ext: '.md', templateFilename: null,
+      type: {
+        id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock',
+        template: '## Summary',
+        properties: [{ name: 'author', type: 'text' }, { name: 'rating', type: 'number' }],
+      },
+    });
+    await ops.handleNewNote('');
+    const [pathArg, contentArg] = h.api.notebase.writeFile.mock.calls[0] as [string, string];
+    expect(pathArg).toBe('Dune.md');
+    expect(contentArg).toMatch(/^---\ntype: book\nauthor:\nrating:\n---/);
+    expect(contentArg).toContain('## Summary');
+    expect(h.api.notebase.createFile).not.toHaveBeenCalled();
+    expect(h.api.templates.get).not.toHaveBeenCalled(); // type template, not a file template
+  });
+
   it('cancels silently (no write) when an interactive {{prompt:…}} is dismissed', async () => {
     h.dialog.showNewNoteDialog.mockResolvedValue({ name: 'fresh', ext: '.md', templateFilename: 'daily.md' });
     h.api.templates.get.mockResolvedValue('a{{prompt:Label}}b');

--- a/tests/shared/objects/scaffold.test.ts
+++ b/tests/shared/objects/scaffold.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Typed-note scaffold builder (#1064): `type:` frontmatter + declared property
+ * keys + template body.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildTypedNoteScaffold } from '../../../src/shared/objects/scaffold';
+import type { TypeInfo } from '../../../src/shared/objects/type-def';
+
+const book: TypeInfo = {
+  id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock',
+  properties: [{ name: 'author', type: 'text' }, { name: 'rating', type: 'number' }],
+};
+
+describe('buildTypedNoteScaffold (#1064)', () => {
+  it('emits type: + a key per declared property, then the body', () => {
+    const { content, caretOffset } = buildTypedNoteScaffold(book, '## Summary\n');
+    expect(content).toBe('---\ntype: book\nauthor:\nrating:\n---\n\n## Summary\n');
+    // Caret lands past the frontmatter.
+    expect(content.slice(caretOffset)).toMatch(/^\n?## Summary/);
+  });
+
+  it('handles a type with no template (scaffold only)', () => {
+    const { content } = buildTypedNoteScaffold(book, '');
+    expect(content).toBe('---\ntype: book\nauthor:\nrating:\n---\n');
+  });
+
+  it('handles a type with no declared properties', () => {
+    const bare: TypeInfo = { id: 'idea', label: 'Idea', classLocalName: 'Idea', source: 'stock', properties: [] };
+    expect(buildTypedNoteScaffold(bare, '')).toMatchObject({ content: '---\ntype: idea\n---\n' });
+  });
+});


### PR DESCRIPTION
Closes #1064 — the first UI of the Typed Objects epic (#1060): **"New Book" as a menu choice, not a syntax.** Depends on #1062 (registry) + #1063 (property schema), both merged.

## What's here
- **Type picker in `NewNoteDialog`.** The live registry's types (stock + user, via `api.types.list()`) join the left picker under a **"Types"** divider — emoji/color from the def, a field-count hint. Picking a type creates a markdown note *as* that type (header reads **"New Book"**), and the file-template slot hides since the type brings its own template. Picking a plain kind (Note/Graph/Table/Script) is **byte-for-byte today's behavior** — no regression.
- **Template on instantiation.** A chosen type seeds `type:` frontmatter + a scaffold of its declared property keys, then its template body — run through the existing `substituteTemplate` so `{{title}}`/`{{prompt:}}` still work. Factored into a shared `buildTypedNoteScaffold()` so #1065 (inline `/book`) produces identical notes. `TypeInfo` now carries the template body (a plain note scaffold, unlike a skill's LLM-prompt body) so the picker instantiates without a round-trip.
- **OnboardingDialog on-ramp.** A second answer to the white rectangle: **"Start from a type…"** dismisses onboarding and opens New Note.

## Acceptance criteria
- [x] "New Book" produces a note with `type: book`, the Book template body, and an author/rating/… scaffold.
- [x] Types come from the live registry (stock + user), not a hardcoded list.
- [x] Picking no type reproduces today's plain-note behavior exactly.
- [x] OnboardingDialog offers a "start as a type" path.

## Out of scope
Inline `/book` creation (#1065); the property **form** (#1066 — here the scaffold is just empty frontmatter keys); promoting an existing note (#1067).

## Tests
`tests/shared/objects/scaffold.test.ts` (frontmatter + per-property keys + body; empty-template / no-property cases) and a new `handleNewNote` typed-path case (`type:` frontmatter + scaffold + template body, no file-template fetch). `pnpm lint` clean; renderer + shared suites (1725) green.

The picker UI is best seen live — I can attach a screenshot on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)