### PR TITLE
feat(objects): inline /book typed creation (#1065)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -631,7 +631,7 @@
     setMergePickerSource: (s) => { mergePickerSource = s; },
   };
   const {
-    handleNewNote, handleNewFolder, handleDelete, openFirstReferenceFromSafeDelete,
+    handleNewNote, handleInlineTypeCreate, handleNewFolder, handleDelete, openFirstReferenceFromSafeDelete,
     handleCut, handleCopy, handleMove, handlePaste, handleMerge, performMerge,
     handleRename, handleCopyWithPrompt, handleMoveWithPrompt,
   } = createNoteOps(noteOpsCtx);
@@ -1100,6 +1100,7 @@
                           getNotePaths={() => flattenNotePaths(notebase.files)}
                           getSources={() => sourcesCache}
                           getAliases={() => aliasEntries}
+                          resolveInlineTypeCreate={handleInlineTypeCreate}
                           onBookmark={() => bookmarkStore.add(note.fileName.replace(/\.(md|ttl|csv)$/, ''), note.relativePath)}
                           onBookmarkSection={() => { void handleBookmarkSection(); }}
                           onBookmarkLine={handleBookmarkLine}

--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -13,7 +13,9 @@ import { getDialogStore } from '../stores/dialogs.svelte';
 import { getBusyStore } from '../stores/busy.svelte';
 import { getClipboardStore } from '../stores/clipboard.svelte';
 import { resolveSelectionTargets, expandSelectionToNoteFiles, pathExistsInTree } from '../sidebar-tree-utils';
-import { describeDeleteNoun, describeDeleteMessage, offsetToLineCol } from './text-helpers';
+import { describeDeleteNoun, describeDeleteMessage, offsetToLineCol, flattenNotePaths } from './text-helpers';
+import { resolveWikiLinkTarget } from '../../../shared/wiki-link-resolver';
+import type { TypeInfo } from '../../../shared/objects/type-def';
 import { substituteTemplate } from '../../../shared/templates';
 import { buildTypedNoteScaffold } from '../../../shared/objects/scaffold';
 import { CONFIRM_KEYS } from '../confirm-keys';
@@ -96,6 +98,38 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       requestAnimationFrame(() => ctx.getEditorComponent()?.restorePosition(offset, 0));
     }
     ctx.getSidebar()?.refreshTags();
+  }
+
+  /**
+   * Inline `/book` typed creation (#1065). Prompts for a title, then EITHER
+   * links an existing note that already resolves for it (link-don't-duplicate)
+   * OR creates a fresh typed note (`type:` + scaffold + template, the #1064
+   * path — no dialog, no open). Returns the wiki-link target for the editor to
+   * insert, or null if cancelled. The editor owns the doc edits.
+   */
+  async function handleInlineTypeCreate(type: TypeInfo): Promise<string | null> {
+    if (!notebase.meta) return null;
+    const title = (await showPrompt(`New ${type.label} — title:`))?.trim();
+    if (!title) return null;
+
+    // If a note already resolves for this title, link it instead of duplicating.
+    const files = flattenNotePaths(notebase.files).map((relativePath) => ({ relativePath, isDirectory: false }));
+    if (resolveWikiLinkTarget(title, files)) return title;
+
+    let body = '';
+    if (type.template) {
+      const sub = await substituteTemplate(type.template, {
+        title,
+        prompt: (label: string) => showPrompt(`${label}:`),
+      });
+      if (sub.cancelled) return null;
+      body = sub.content;
+    }
+    const { content } = buildTypedNoteScaffold(type, body);
+    await api.notebase.writeFile(`${title}.md`, content);
+    await notebase.refresh();
+    ctx.getSidebar()?.refreshTags();
+    return title;
   }
 
   async function handleNewFolder(directory: string = '') {
@@ -532,5 +566,5 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     await handleMove(relativePath, destDir);
   }
 
-  return { handleNewNote, handleNewFolder, handleDelete, executeDeletes, openFirstReferenceFromSafeDelete, handleCut, handleCopy, handleMove, handlePaste, handleMerge, performMerge, handleRename, handleCopyWithPrompt, handleMoveWithPrompt };
+  return { handleNewNote, handleInlineTypeCreate, handleNewFolder, handleDelete, executeDeletes, openFirstReferenceFromSafeDelete, handleCut, handleCopy, handleMove, handlePaste, handleMerge, performMerge, handleRename, handleCopyWithPrompt, handleMoveWithPrompt };
 }

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -47,6 +47,8 @@
   import { linkPreview } from '../editor/link-preview';
   import { footnoteDecorations } from '../editor/footnote-decorations';
   import { linkCompletionSource } from '../editor/link-autocomplete';
+  import { typeCreateCompletionSource } from '../editor/type-create-autocomplete';
+  import type { TypeInfo } from '../../../shared/objects/type-def';
   import { planBlockLink } from '../editor/block-link';
   import { toHistorySnapshot, canRestoreHistory } from '../editor/history-snapshot';
   import { DEFAULT_FONT, clampFontSize, parseStoredFontSize } from '../editor/font-size';
@@ -141,6 +143,10 @@
     /** Live list of frontmatter alias entries so wiki-link autocomplete
      *  can suggest aliases alongside note paths (#492). */
     getAliases?: () => readonly { alias: string; relativePath: string }[];
+    /** Inline `/book` typed-creation (#1065): given the picked type, prompt for
+     *  a title, create (or link an existing) typed note, and return the
+     *  wiki-link target — or null if cancelled. Wired by the host to note-ops. */
+    resolveInlineTypeCreate?: (type: TypeInfo) => Promise<string | null>;
     /**
      * Callback for image upload rejections — too-large, unsupported
      * MIME, etc. — so the host app can surface a toast / dialog (#455).
@@ -209,6 +215,7 @@
     getNotePaths,
     getSources,
     getAliases,
+    resolveInlineTypeCreate,
     initialHistory,
     onUploadError,
     onRunCell,
@@ -910,8 +917,24 @@
       readNote: (p) => api.notebase.readFile(p),
     });
 
+    // Inline `/book` typed creation (#1065). The apply removes the `/partial`,
+    // then the host prompt+create runs async and its target is linked at the
+    // same spot — type, template, and link in one gesture.
+    const typeCreateCompletion = typeCreateCompletionSource({
+      loadTypes: () => api.types.list().then((c) => c.types),
+      onPick: (type, view, from, to) => {
+        view.dispatch({ changes: { from, to, insert: '' } });
+        void resolveInlineTypeCreate?.(type).then((target) => {
+          if (!target || !view.dom.isConnected) return;
+          const link = `[[${target}]]`;
+          const at = Math.min(from, view.state.doc.length);
+          view.dispatch({ changes: { from: at, insert: link }, selection: { anchor: at + link.length } });
+        });
+      },
+    });
+
     const completion = autocompletion({
-      override: [tagCompletion, linkCompletion],
+      override: [tagCompletion, linkCompletion, typeCreateCompletion],
       activateOnTyping: true,
       closeOnBlur: true,
       // Our Enter binding (acceptCompletionEatTail) owns accept-on-Enter; the

--- a/src/renderer/lib/editor/type-create-autocomplete.ts
+++ b/src/renderer/lib/editor/type-create-autocomplete.ts
@@ -1,0 +1,57 @@
+/**
+ * Inline typed-creation autocomplete (#1065) — the headline `/book` gesture.
+ *
+ * Typing `/` at a word boundary in the note editor body offers the registry's
+ * types; picking one creates a typed note (template + scaffold, the #1064 path)
+ * and inserts a resolving wiki-link, in one gesture. Modeled on the wiki-link
+ * autocomplete; collision-free by construction — it only fires on a `/` sigil,
+ * never inside `[[…]]` (that's the wiki-link source) and never on a path/URL
+ * slash (the `/` must follow whitespace or a line start). The conversation
+ * `/`-slash-commands live in a separate composer, not this CodeMirror editor.
+ */
+import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
+import type { EditorView } from '@codemirror/view';
+import type { TypeInfo } from '../../../shared/objects/type-def';
+
+/** The `/partial` sigil directly before the cursor, or null. `from` is the `/`. */
+export function detectSlashPhase(before: string, pos: number): { from: number; prefix: string } | null {
+  // `/word` at the very end, where the `/` starts a token (line start or after
+  // whitespace) — so `http://x` and `a/b` paths don't trigger.
+  const m = before.match(/(?:^|\s)\/([\p{L}\p{N}-]*)$/u);
+  if (!m) return null;
+  // Not inside an open `[[…]]` — that belongs to the wiki-link source.
+  const openIdx = before.lastIndexOf('[[');
+  if (openIdx >= 0 && before.lastIndexOf(']]') < openIdx) return null;
+  const prefix = m[1] ?? '';
+  return { from: pos - prefix.length - 1, prefix }; // -1 for the `/`
+}
+
+export interface TypeCreateAutocompleteOptions {
+  /** Load the registry's types (cached after the first call). */
+  loadTypes: () => Promise<TypeInfo[]>;
+  /** Editor-side handler: delete the `/partial`, create/link, insert the link. */
+  onPick: (type: TypeInfo, view: EditorView, from: number, to: number) => void;
+}
+
+export function typeCreateCompletionSource(opts: TypeCreateAutocompleteOptions) {
+  let cache: TypeInfo[] | null = null;
+
+  return async function source(ctx: CompletionContext): Promise<CompletionResult | null> {
+    const before = ctx.state.doc.sliceString(Math.max(0, ctx.pos - 200), ctx.pos);
+    const phase = detectSlashPhase(before, ctx.pos);
+    if (!phase) return null;
+
+    cache ??= await opts.loadTypes();
+    const q = phase.prefix.toLowerCase();
+    const matches = cache.filter((t) => t.id.startsWith(q) || t.label.toLowerCase().startsWith(q));
+    if (matches.length === 0) return null;
+
+    const options: Completion[] = matches.map((t) => ({
+      label: `/${t.label}`,
+      detail: `new ${t.label}`,
+      type: 'class',
+      apply: (view: EditorView, _c: Completion, from: number, to: number) => opts.onPick(t, view, from, to),
+    }));
+    return { from: phase.from, options, validFor: /^\/[\p{L}\p{N}-]*$/u };
+  };
+}

--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -267,6 +267,39 @@ describe('handleNewNote — template & guard paths', () => {
   });
 });
 
+describe('handleInlineTypeCreate (#1065)', () => {
+  const book = {
+    id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock' as const,
+    template: '## Summary',
+    properties: [{ name: 'author', type: 'text' as const }],
+  };
+
+  it('creates a typed note and returns its wiki-link target', async () => {
+    h.notebase.files = [];
+    h.dialog.showPrompt.mockResolvedValue('Ada Lovelace');
+    const target = await ops.handleInlineTypeCreate(book);
+    expect(target).toBe('Ada Lovelace');
+    const [p, c] = h.api.notebase.writeFile.mock.calls[0] as [string, string];
+    expect(p).toBe('Ada Lovelace.md');
+    expect(c).toMatch(/^---\ntype: book\nauthor:\n---/);
+    expect(c).toContain('## Summary');
+  });
+
+  it('links an existing note instead of duplicating', async () => {
+    h.notebase.files = [file('Ada Lovelace.md')];
+    h.dialog.showPrompt.mockResolvedValue('Ada Lovelace');
+    const target = await ops.handleInlineTypeCreate(book);
+    expect(target).toBe('Ada Lovelace'); // resolves to the existing note
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('returns null (no write) when the title prompt is cancelled', async () => {
+    h.dialog.showPrompt.mockResolvedValue(null);
+    expect(await ops.handleInlineTypeCreate(book)).toBeNull();
+    expect(h.api.notebase.writeFile).not.toHaveBeenCalled();
+  });
+});
+
 describe('handleNewFolder', () => {
   it('creates the folder under the target directory', async () => {
     h.dialog.showPrompt.mockResolvedValue('Ideas');

--- a/tests/renderer/editor/type-create-autocomplete.test.ts
+++ b/tests/renderer/editor/type-create-autocomplete.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Inline `/book` sigil detection (#1065). The collision guarantees are the
+ * point: it fires on a `/` at a word boundary, but NOT inside `[[…]]`
+ * (wiki-links) and NOT on a path/URL slash.
+ */
+import { describe, it, expect } from 'vitest';
+import { detectSlashPhase } from '../../../src/renderer/lib/editor/type-create-autocomplete';
+
+/** Detect at the end of `before` (cursor = before.length). */
+function at(before: string) {
+  return detectSlashPhase(before, before.length);
+}
+
+describe('detectSlashPhase (#1065)', () => {
+  it('fires on `/word` at a line start', () => {
+    expect(at('/boo')).toEqual({ from: 0, prefix: 'boo' });
+  });
+
+  it('fires on `/` alone (empty prefix → full type list)', () => {
+    expect(at('some text /')).toEqual({ from: 10, prefix: '' });
+  });
+
+  it('fires after whitespace mid-line', () => {
+    expect(at('a note about /per')).toEqual({ from: 13, prefix: 'per' });
+  });
+
+  it('does NOT fire on a URL slash', () => {
+    expect(at('see https://example.com/pa')).toBeNull();
+  });
+
+  it('does NOT fire on a path slash (no preceding whitespace)', () => {
+    expect(at('folder/sub')).toBeNull();
+  });
+
+  it('does NOT fire inside an open `[[…]]` wiki-link', () => {
+    expect(at('link to [[Some/No')).toBeNull();
+    expect(at('[[cite::/x')).toBeNull();
+  });
+
+  it('fires again after a wiki-link has closed', () => {
+    expect(at('[[Done]] then /bo')).toEqual({ from: 14, prefix: 'bo' });
+  });
+
+  it('stops once a space follows the sigil token (type already chosen)', () => {
+    expect(at('/book ')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1065 — **the headline gesture** of the Typed Objects epic (#1060). Depends on #1062 (registry) + #1064 (scaffold path), both merged.

Type `/` in the note editor body → the registry's types appear → pick one → prompt for a title → a typed note is **created** (or an existing one **linked**) and a resolving **wiki-link is inserted at the cursor** — type, template, and link in one gesture (Capacities' `/person/Ada Lovelace`).

## What's here
- **`/` completion source** (`type-create-autocomplete.ts`) added to the editor's `override` array, per the #1061 sigil decision. **Collision-free by construction:** it fires only on a `/` at a word boundary — never inside `[[…]]` (the wiki-link source owns that), never on a path/URL slash — and the conversation `/`-slash-commands live in a *separate composer*, not this CodeMirror editor.
- **One-gesture create+link.** The completion `apply` removes the `/partial`; the host (`note-ops.handleInlineTypeCreate`) prompts for a title, then **links an existing note** that already resolves (link-don't-duplicate, via `resolveWikiLinkTarget`) **or creates a fresh typed note** through the #1064 scaffold path (no dialog, no open); the editor inserts `[[target]]` at the same spot. All doc edits stay in the editor layer; the App concern is one async callback.
- Preview (read-only) deliberately does **not** get the gesture.

## Acceptance criteria
- [x] Typing the sigil shows a type list from the live registry; picking one prompts for a title.
- [x] Completing creates a typed note (correct `type:`, template, scaffold) and inserts a resolving wiki-link in one gesture.
- [x] Existing-note match links instead of duplicating.
- [x] No collision/regression with `[[ ]]` autocomplete or `/` slash-commands.

## Out of scope
The property form the note opens into (#1066); rendering the link as a type-keyed card (#1071).

## Tests
`type-create-autocomplete.test.ts` — the collision guarantees (fires on `/word`; **not** on URLs/paths/inside `[[…]]`; re-fires after a link closes; stops once a space follows). `note-ops.test.ts` — `handleInlineTypeCreate` (creates `type:` + scaffold + template; links existing without duplicating; cancels cleanly). `pnpm lint` clean; editor + app + objects suites (663) green.

The live CodeMirror popup + insertion is best seen in the running app — happy to attach a screen capture on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)