### PR TITLE
feat(objects): typed-property form — "Fields" panel (#1066)

### DIFF
--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -3,6 +3,7 @@
   import HeadingGraphPanel from './right-sidebar/HeadingGraphPanel.svelte';
   import FootnotesPanel from './right-sidebar/FootnotesPanel.svelte';
   import PropertiesPanel from './right-sidebar/PropertiesPanel.svelte';
+  import TypePropertiesPanel from './right-sidebar/TypePropertiesPanel.svelte';
   import OutgoingLinksPanel from './right-sidebar/OutgoingLinksPanel.svelte';
   import BacklinksPanel from './right-sidebar/BacklinksPanel.svelte';
   import RelatedPanel from './right-sidebar/RelatedPanel.svelte';
@@ -15,7 +16,7 @@
   import type { IconName } from './icons/registry';
 
   type PanelType =
-    | 'outline' | 'headingGraph' | 'footnotes' | 'properties' | 'outgoing' | 'backlinks' | 'related' | 'tags' | 'tables' | 'citations'
+    | 'outline' | 'headingGraph' | 'footnotes' | 'properties' | 'fields' | 'outgoing' | 'backlinks' | 'related' | 'tags' | 'tables' | 'citations'
     | 'bookmarks' | 'inspections';
 
   type PanelGroupId = 'note' | 'links' | 'activity';
@@ -45,6 +46,7 @@
         { id: 'outline',    label: 'Outline',    icon: 'outline' },
         { id: 'headingGraph', label: 'Heading Map', icon: 'graph' },
         { id: 'properties', label: 'Properties', icon: 'properties' },
+        { id: 'fields',     label: 'Fields',     icon: 'properties' },
         { id: 'footnotes',  label: 'Footnotes',  icon: 'footnotes' },
         // Tags and Tables describe what's *inside* the active note's
         // content, not how it connects to other notes — they sit
@@ -242,6 +244,8 @@
       {:else}
         <div class="panel-disabled">No active note.</div>
       {/if}
+    {:else if activePanel === 'fields'}
+      <TypePropertiesPanel {activeFilePath} {content} {revision} {...(onContentChange !== undefined ? { onContentChange } : {})} />
     {:else if activePanel === 'outgoing'}
       <OutgoingLinksPanel {activeFilePath} {revision} {onFileSelect} {...(onOpenGraph !== undefined ? { onOpenGraph } : {})} />
     {:else if activePanel === 'backlinks'}

--- a/src/renderer/lib/components/right-sidebar/TypePropertiesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/TypePropertiesPanel.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  /**
+   * Typed-property form (#1066). For a note with a `type:`, renders the type's
+   * declared properties as typed inputs — the frontmatter updates underneath, so
+   * the user never hand-writes YAML. Schema comes from the #1063 read-back;
+   * VALUES are read from the live editor content (instant, reflects hand-edits
+   * with no reindex round-trip); edits write through the shared YAML patch.
+   *
+   * Nothing is ever required — clearing a field just empties the key. Raw
+   * frontmatter stays the escape hatch (the Properties tab + the note itself).
+   */
+  import { api } from '../../ipc/client';
+  import { getFrontmatterValues, setFrontmatterProperty } from '../../../../shared/frontmatter-edit';
+  import type { NoteTypedProperties } from '../../../../shared/objects/type-def';
+
+  interface Props {
+    activeFilePath: string | null;
+    content: string;
+    onContentChange?: (next: string) => void;
+    /** Bumped on reindex; re-fetches the schema so a hand-edited `type:` shows. */
+    revision?: number;
+  }
+
+  let { activeFilePath, content, onContentChange, revision = 0 }: Props = $props();
+
+  let schema = $state<NoteTypedProperties>({ type: null, properties: [] });
+
+  $effect(() => {
+    const path = activeFilePath;
+    void revision; // re-fetch on reindex (catches a hand-changed `type:`)
+    if (!path) { schema = { type: null, properties: [] }; return; }
+    let cancelled = false;
+    void api.types.noteProperties(path).then((r) => { if (!cancelled) schema = r; });
+    return () => { cancelled = true; };
+  });
+
+  const values = $derived(getFrontmatterValues(content));
+
+  function commit(name: string, raw: string, numeric: boolean) {
+    if (!onContentChange) return;
+    if (raw.trim() === '') { onContentChange(setFrontmatterProperty(content, name, '')); return; }
+    if (numeric) {
+      const n = Number(raw);
+      if (!Number.isFinite(n)) return;
+      onContentChange(setFrontmatterProperty(content, name, n));
+      return;
+    }
+    onContentChange(setFrontmatterProperty(content, name, raw));
+  }
+</script>
+
+<div class="type-props">
+  {#if schema.type}
+    <div class="type-head">
+      <span class="type-icon">{schema.type.icon ?? '◆'}</span>
+      <span class="type-label">{schema.type.label}</span>
+    </div>
+    {#if schema.properties.length === 0}
+      <p class="empty">This type declares no properties.</p>
+    {:else}
+      {#each schema.properties as p (p.name)}
+        {@const v = values[p.name] ?? ''}
+        <label class="field">
+          <span class="field-label">{p.label ?? p.name}</span>
+          {#if p.type === 'enum'}
+            <select value={v} onchange={(e) => commit(p.name, e.currentTarget.value, false)}>
+              <option value=""></option>
+              {#each p.options ?? [] as opt (opt)}<option value={opt}>{opt}</option>{/each}
+            </select>
+          {:else if p.type === 'number'}
+            <input type="number" value={v} onchange={(e) => commit(p.name, e.currentTarget.value, true)} />
+          {:else if p.type === 'date'}
+            <input type="date" value={v} onchange={(e) => commit(p.name, e.currentTarget.value, false)} />
+          {:else}
+            <input
+              type="text"
+              value={v}
+              placeholder={p.type === 'link-to-type' ? '[[Note]]' : ''}
+              onchange={(e) => commit(p.name, e.currentTarget.value, false)}
+            />
+          {/if}
+        </label>
+      {/each}
+    {/if}
+  {:else}
+    <p class="empty">
+      This note has no type. Create a note as a type, or add <code>type:</code> to its
+      frontmatter, to edit properties as a form.
+    </p>
+  {/if}
+</div>
+
+<style>
+  .type-props {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px 12px;
+  }
+  .type-head {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid var(--border);
+  }
+  .type-icon { font-size: 14px; line-height: 1; }
+  .type-label { font-size: 13px; font-weight: 600; color: var(--text); }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .field-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+  }
+  .field input,
+  .field select {
+    width: 100%;
+    padding: 5px 8px;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    background: var(--bg-inset);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 12.5px;
+    box-sizing: border-box;
+  }
+  .field input:focus,
+  .field select:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .empty {
+    font-size: 12px;
+    color: var(--text-faint);
+    line-height: 1.5;
+    margin: 4px 0;
+  }
+  .empty code {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    background: var(--bg-inset);
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+</style>

--- a/src/shared/frontmatter-edit.ts
+++ b/src/shared/frontmatter-edit.ts
@@ -1,0 +1,71 @@
+/**
+ * Patch a single frontmatter key in a note's content, and read current values,
+ * for the typed-property form (#1066). Edits round-trip through the YAML parser
+ * so the body, other keys, and comments survive — the form is a view over
+ * frontmatter, never a separate store (the vision's central hazard: YAML is the
+ * storage, never the interface).
+ */
+import YAML from 'yaml';
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
+
+/** Display string for a scalar YAML value (Date → `YYYY-MM-DD`); non-scalars → ''. */
+function toDisplay(v: unknown): string {
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return ''; // null, objects, arrays — no editable scalar
+}
+
+/** Current frontmatter values as a `key → display string` map. Empty if there's
+ *  no (or malformed) frontmatter. Non-scalar values become ''. */
+export function getFrontmatterValues(content: string): Record<string, string> {
+  const m = content.match(FRONTMATTER_RE);
+  if (!m) return {};
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(m[1]!);
+  } catch {
+    return {};
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    out[k] = toDisplay(v);
+  }
+  return out;
+}
+
+/**
+ * Set (or clear) one frontmatter key, returning the new content. An empty-string
+ * / null value keeps the key present but empty (`key:`) — matching the scaffold,
+ * so a form field the user clears doesn't drop out of the schema. Refuses to
+ * touch malformed frontmatter (returns content unchanged) so a WIP isn't lost.
+ */
+export function setFrontmatterProperty(content: string, key: string, value: string | number | null): string {
+  const clear = value === '' || value === null;
+  const m = content.match(FRONTMATTER_RE);
+  if (!m) {
+    if (clear) return content; // nothing to clear
+    const doc = new YAML.Document({});
+    doc.set(key, value);
+    return `---\n${doc.toString().trimEnd()}\n---\n${content}`;
+  }
+  let doc: YAML.Document.Parsed;
+  try {
+    doc = YAML.parseDocument(m[1]!);
+    if (doc.errors.length > 0) return content;
+  } catch {
+    return content;
+  }
+  if (clear) doc.delete(key);
+  else doc.set(key, value);
+
+  const body = content.slice(m[0].length);
+  // A cleared last key would leave an empty `---\n\n---` block — drop it instead.
+  if (YAML.isMap(doc.contents) && doc.contents.items.length === 0) return body;
+
+  let serialised = doc.toString();
+  if (serialised.endsWith('\n')) serialised = serialised.slice(0, -1);
+  return `---\n${serialised}\n---\n${body}`;
+}

--- a/tests/renderer/components/TypePropertiesPanel.test.ts
+++ b/tests/renderer/components/TypePropertiesPanel.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Typed-property form (#1066): renders the type's declared fields from the
+ * #1063 read-back, seeds values from the live content, and writes edits back
+ * through to the frontmatter. Untyped notes show no form.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+
+const { notePropsMock } = vi.hoisted(() => ({ notePropsMock: vi.fn() }));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { types: { noteProperties: notePropsMock } },
+}));
+
+import TypePropertiesPanel from '../../../src/renderer/lib/components/right-sidebar/TypePropertiesPanel.svelte';
+
+const BOOK = {
+  type: { id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock', icon: '📖', properties: [] },
+  properties: [
+    { name: 'author', type: 'text', label: 'Author', value: null },
+    { name: 'rating', type: 'number', label: 'Rating', value: null },
+    { name: 'status', type: 'enum', label: 'Status', options: ['to-read', 'reading', 'read'], value: null },
+  ],
+};
+
+afterEach(() => { cleanup(); notePropsMock.mockReset(); });
+
+describe('TypePropertiesPanel (#1066)', () => {
+  it('renders declared fields seeded from the note content', async () => {
+    notePropsMock.mockResolvedValue(BOOK);
+    render(TypePropertiesPanel, {
+      activeFilePath: 'Dune.md',
+      content: '---\ntype: book\nauthor: Frank Herbert\nrating: 5\n---\n',
+      onContentChange: vi.fn(),
+      revision: 0,
+    });
+    await waitFor(() => expect(screen.getByDisplayValue('Frank Herbert')).toBeTruthy());
+    expect(screen.getByDisplayValue('5').type).toBe('number');
+  });
+
+  it('editing a field writes the value through to the frontmatter', async () => {
+    notePropsMock.mockResolvedValue(BOOK);
+    const onContentChange = vi.fn();
+    render(TypePropertiesPanel, {
+      activeFilePath: 'Dune.md',
+      content: '---\ntype: book\nauthor: Frank Herbert\n---\n# Dune\n',
+      onContentChange,
+      revision: 0,
+    });
+    const author = await screen.findByDisplayValue('Frank Herbert');
+    await fireEvent.change(author, { target: { value: 'F. Herbert' } });
+    expect(onContentChange).toHaveBeenCalledTimes(1);
+    const next = onContentChange.mock.calls[0]![0] as string;
+    expect(next).toContain('author: F. Herbert');
+    expect(next).toContain('# Dune'); // body preserved
+  });
+
+  it('shows no form for an untyped note', async () => {
+    notePropsMock.mockResolvedValue({ type: null, properties: [] });
+    render(TypePropertiesPanel, { activeFilePath: 'Plain.md', content: '# Plain\n', onContentChange: vi.fn(), revision: 0 });
+    await waitFor(() => expect(screen.getByText(/no type/i)).toBeTruthy());
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+});

--- a/tests/shared/frontmatter-edit.test.ts
+++ b/tests/shared/frontmatter-edit.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Frontmatter patch + read for the typed-property form (#1066). The form is a
+ * view over frontmatter: edits must round-trip through YAML without disturbing
+ * the body, other keys, or comments.
+ */
+import { describe, it, expect } from 'vitest';
+import { setFrontmatterProperty, getFrontmatterValues } from '../../src/shared/frontmatter-edit';
+
+const NOTE = `---
+type: book
+author: Frank Herbert
+rating: 4
+---
+# Dune
+
+Body text.
+`;
+
+describe('setFrontmatterProperty (#1066)', () => {
+  it('updates an existing key, leaving body + other keys intact', () => {
+    const out = setFrontmatterProperty(NOTE, 'rating', 5);
+    expect(out).toContain('rating: 5');
+    expect(out).toContain('author: Frank Herbert');
+    expect(out).toContain('type: book');
+    expect(out).toContain('# Dune\n\nBody text.');
+  });
+
+  it('adds a new key not yet present', () => {
+    const out = setFrontmatterProperty(NOTE, 'published', '1965-08-01');
+    expect(out).toMatch(/published: '?1965-08-01'?/);
+    expect(out).toContain('# Dune');
+  });
+
+  it('clearing a value removes the key (the form still renders it from schema)', () => {
+    const out = setFrontmatterProperty(NOTE, 'author', '');
+    expect(out).not.toContain('author');
+    expect(out).toContain('rating: 4'); // siblings + body intact
+    expect(out).toContain('# Dune');
+    expect(getFrontmatterValues(out).author).toBeUndefined();
+  });
+
+  it('dropping the last key removes the whole frontmatter block', () => {
+    const out = setFrontmatterProperty('---\nonly: x\n---\nbody\n', 'only', '');
+    expect(out).toBe('body\n');
+  });
+
+  it('creates a frontmatter block when the note has none', () => {
+    const out = setFrontmatterProperty('# Just a body\n', 'type', 'idea');
+    expect(out).toBe('---\ntype: idea\n---\n# Just a body\n');
+  });
+
+  it('refuses to touch malformed frontmatter (returns unchanged)', () => {
+    const bad = '---\nkey: [unclosed\n---\nbody';
+    expect(setFrontmatterProperty(bad, 'x', '1')).toBe(bad);
+  });
+
+  it('writes a number unquoted and a string as text', () => {
+    expect(setFrontmatterProperty(NOTE, 'rating', 3)).toContain('rating: 3');
+    expect(setFrontmatterProperty(NOTE, 'author', 'Herbert')).toContain('author: Herbert');
+  });
+});
+
+describe('getFrontmatterValues (#1066)', () => {
+  it('reads scalars as display strings', () => {
+    const v = getFrontmatterValues(NOTE);
+    expect(v).toMatchObject({ type: 'book', author: 'Frank Herbert', rating: '4' });
+  });
+
+  it('renders a date value as YYYY-MM-DD', () => {
+    const v = getFrontmatterValues('---\npublished: 2020-06-01\n---\n');
+    expect(v.published).toBe('2020-06-01');
+  });
+
+  it('is empty for a note with no frontmatter', () => {
+    expect(getFrontmatterValues('# no frontmatter')).toEqual({});
+  });
+
+  it('preserves a wiki-link value verbatim (link-to-type)', () => {
+    const v = getFrontmatterValues('---\nowner: "[[Alice]]"\n---\n');
+    expect(v.owner).toBe('[[Alice]]');
+  });
+});


### PR DESCRIPTION
Closes #1066 — **the epic's central hazard, closed:** property editing as a *form*, not YAML. Depends on #1062/#1063 (merged).

## What's here
- **New right-sidebar "Fields" tab** (`TypePropertiesPanel`). For a note with a `type:`, its declared properties render as typed inputs — text/number/date fields, an enum `<select>`, and a text field for `link-to-type` (accepts `[[Note]]`; a constrained note-picker is a follow-up). Empty declared properties show as **blank fields, not hidden**. An **untyped note shows an empty state, never a form** (no regression to plain editing).
- **Schema** from the #1063 read-back (`api.types.noteProperties`), re-fetched on reindex so a hand-changed `type:` re-renders the form. **Values** are read from the **live editor content** — instant, and reflects raw-frontmatter hand-edits with no round-trip (better than the graph's lagged/lexical values for an *editable* surface).
- **Write-through**: a shared `frontmatter-edit` helper patches one key through the YAML parser — body, other keys, and comments preserved; malformed WIP left untouched; clearing a field drops the key (the form still renders it from the schema); an emptied block is removed. Flushed via `onContentChange` → the normal write path → reindex (#1063). **The form is a view over frontmatter, never a separate store. Nothing is required.**
- Raw frontmatter stays the **escape hatch**: the Properties tab + the note itself.

## Acceptance criteria
- [x] A `type: book` note shows a form with author/rating/published fields matching the schema.
- [x] Editing a field writes valid frontmatter and reindexes (triple changes — the write-through is the #1063 path).
- [x] Hand-editing the frontmatter updates the form (values derive from live content).
- [x] Untyped notes show no form.
- [x] No field is ever required to save.

## Placement note
I gave it a distinct **"Fields"** tab rather than folding into the raw **Properties** tab — clean separation (typed form vs. the raw all-keys editor) and no duplicated key rows. A future polish could merge them (form for declared keys, raw rows for the rest).

## Out of scope
Required-field enforcement (never — house UX); the note *card* preview (#1071); labeled-edge semantics for link-to-type (#1073).

## Tests
`frontmatter-edit.test.ts` (update/add/clear/create/malformed/empty-block; date + wiki-link read-back) and `TypePropertiesPanel.test.ts` (renders declared fields seeded from content; an edit writes through preserving the body; untyped → no form). `pnpm lint` clean; renderer + shared suites (2766) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)