### PR TITLE
feat(objects): objects-by-type sidebar browser (#1068)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -584,6 +584,7 @@
     }
     editor.flushAutoSave(); // cancel pending auto-save, save immediately
     sidebar?.refreshTags();
+    sidebar?.refreshObjects();
     rightSidebar?.refresh();
     graphRevision++;
     void refreshBacklinkCount();

--- a/src/renderer/lib/app/ipc-wiring.ts
+++ b/src/renderer/lib/app/ipc-wiring.ts
@@ -55,6 +55,7 @@ interface EditorRef {
 /** Sidebar panels refreshed on watcher / open events. */
 interface SidebarRef {
   refreshTags(): void;
+  refreshObjects?(): void;
   refreshSources(): void;
   refreshTables(): void;
 }
@@ -156,6 +157,7 @@ export function registerAppIpc(ctx: IpcWiringCtx): void {
   // Auto-save
   editor.onAutoSaved = () => {
     ctx.getSidebar()?.refreshTags();
+    ctx.getSidebar()?.refreshObjects?.();
     ctx.getRightSidebar()?.refresh();
     ctx.bumpGraphRevision();
     ctx.refreshBacklinkCount();
@@ -182,6 +184,7 @@ export function registerAppIpc(ctx: IpcWiringCtx): void {
     const result = await originalOpen();
     setTimeout(() => {
       ctx.getSidebar()?.refreshTags();
+    ctx.getSidebar()?.refreshObjects?.();
       ctx.getSidebar()?.refreshSources();
       ctx.getSidebar()?.refreshTables();
       void ctx.refreshSourcesCache();
@@ -392,6 +395,7 @@ export function registerAppIpc(ctx: IpcWiringCtx): void {
     await bookmarkStore.load();
     await loadFormatSettings();
     ctx.getSidebar()?.refreshTags();
+    ctx.getSidebar()?.refreshObjects?.();
     ctx.getSidebar()?.refreshSources();
     ctx.getSidebar()?.refreshTables();
     await ctx.refreshSourcesCache();

--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -24,7 +24,7 @@ import type { SafeDeleteBlocker } from '../../../shared/types';
 
 /** Minimal structural views of the bind:this component refs the note-ops touch. */
 interface EditorRef { restorePosition(offset: number, scrollTop: number): void; gotoLineColumn(line: number, col: number): void; }
-interface SidebarRef { getSelectionPaths(): string[]; refreshTags(): void; clearSelection(): void; }
+interface SidebarRef { getSelectionPaths(): string[]; refreshTags(): void; refreshObjects?(): void; clearSelection(): void; }
 interface SafeDeleteState { selectionCount: number; targets: string[]; blockers: SafeDeleteBlocker[]; proceed: () => void | Promise<void>; }
 
 export interface NoteOpsCtx {
@@ -101,6 +101,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       requestAnimationFrame(() => ctx.getEditorComponent()?.restorePosition(offset, 0));
     }
     ctx.getSidebar()?.refreshTags();
+    ctx.getSidebar()?.refreshObjects?.();
   }
 
   /**
@@ -132,6 +133,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     await api.notebase.writeFile(`${title}.md`, content);
     await notebase.refresh();
     ctx.getSidebar()?.refreshTags();
+    ctx.getSidebar()?.refreshObjects?.();
     return title;
   }
 
@@ -250,6 +252,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
 
     await notebase.refresh();
     ctx.getSidebar()?.refreshTags();
+    ctx.getSidebar()?.refreshObjects?.();
     ctx.getSidebar()?.clearSelection();
 
     if (failures.length > 0) {

--- a/src/renderer/lib/components/ObjectsPanel.svelte
+++ b/src/renderer/lib/components/ObjectsPanel.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  /**
+   * Objects-by-type browser (#1068). Top level = the registry's types (icon +
+   * label + live instance count); expanding one projects `?x rdf:type :Type`
+   * over the graph and lists its instances; clicking opens the note. Zero-
+   * instance types stay visible so "create your first Book" is discoverable.
+   *
+   * A pure projection of the graph the #1062/#1063 indexing already builds — the
+   * host calls `refresh()` on write/reindex (mirroring the Tags panel).
+   */
+  import { api } from '../ipc/client';
+  import type { TypeInfo } from '../../../shared/objects/type-def';
+
+  interface Props {
+    onFileSelect: (relativePath: string) => void;
+  }
+  let { onFileSelect }: Props = $props();
+
+  interface TypeRow { type: TypeInfo; count: number; }
+  interface Instance { title: string; path: string; }
+
+  let rows = $state<TypeRow[]>([]);
+  let expanded = $state<Set<string>>(new Set());
+  let instances = $state<Record<string, Instance[]>>({});
+
+  async function loadCounts(): Promise<Record<string, number>> {
+    const { results } = await api.graph.query(
+      `SELECT ?id (COUNT(?x) AS ?n) WHERE { ?x a ?c . ?c minerva:typeId ?id } GROUP BY ?id`,
+    );
+    const out: Record<string, number> = {};
+    for (const r of results as Array<{ id?: string; n?: string }>) {
+      if (r.id) out[r.id] = Number(r.n ?? 0);
+    }
+    return out;
+  }
+
+  async function loadInstances(typeId: string): Promise<void> {
+    const row = rows.find((r) => r.type.id === typeId);
+    if (!row) return;
+    const { results } = await api.graph.query(
+      `SELECT ?path ?title WHERE {
+         ?n a types:${row.type.classLocalName} ; minerva:relativePath ?path .
+         OPTIONAL { ?n dc:title ?title }
+       } ORDER BY ?title`,
+    );
+    instances[typeId] = (results as Array<{ path?: string; title?: string }>)
+      .filter((r): r is { path: string; title?: string } => !!r.path)
+      .map((r) => ({ path: r.path, title: r.title || basename(r.path) }));
+    instances = { ...instances };
+  }
+
+  function basename(path: string): string {
+    return path.replace(/\.md$/i, '').split('/').pop() || path;
+  }
+
+  /** Reload counts, and re-project any expanded type. Called on mount + by the
+   *  host after a write/reindex. */
+  export async function refresh(): Promise<void> {
+    const [cat, counts] = await Promise.all([api.types.list(), loadCounts()]);
+    rows = cat.types.map((type) => ({ type, count: counts[type.id] ?? 0 }));
+    await Promise.all([...expanded].map((id) => loadInstances(id)));
+  }
+
+  async function toggle(typeId: string): Promise<void> {
+    if (expanded.has(typeId)) expanded.delete(typeId);
+    else { expanded.add(typeId); await loadInstances(typeId); }
+    expanded = new Set(expanded);
+  }
+
+  // Populate whenever the panel is switched into (mount), not only on refresh().
+  $effect(() => { void refresh(); });
+</script>
+
+<div class="objects-panel">
+  {#if rows.length === 0}
+    <p class="empty">No types in this project yet.</p>
+  {:else}
+    {#each rows as row (row.type.id)}
+      {@const open = expanded.has(row.type.id)}
+      <button class="type-row" onclick={() => toggle(row.type.id)} aria-expanded={open}>
+        <span class="chevron" class:open>▸</span>
+        <span class="type-icon" style={row.type.color ? `color:${row.type.color}` : undefined}>{row.type.icon ?? '◆'}</span>
+        <span class="type-label">{row.type.label}</span>
+        <span class="type-count">{row.count}</span>
+      </button>
+      {#if open}
+        {#if (instances[row.type.id] ?? []).length === 0}
+          <p class="no-instances">No {row.type.label.toLowerCase()} yet</p>
+        {:else}
+          {#each instances[row.type.id] ?? [] as inst (inst.path)}
+            <button
+              class="instance-row"
+              onclick={() => onFileSelect(inst.path)}
+              ondblclick={() => onFileSelect(inst.path)}
+              title={inst.path}
+            >{inst.title}</button>
+          {/each}
+        {/if}
+      {/if}
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .objects-panel { display: flex; flex-direction: column; padding: 4px; }
+  .empty { font-size: 12px; color: var(--text-faint); padding: 12px 8px; }
+  .type-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 13px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .type-row:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  .chevron {
+    font-size: 9px;
+    color: var(--text-faint);
+    transition: transform 0.12s ease;
+    width: 9px;
+    flex-shrink: 0;
+  }
+  .chevron.open { transform: rotate(90deg); }
+  .type-icon { width: 16px; font-size: 13px; line-height: 1; text-align: center; flex-shrink: 0; }
+  .type-label { flex: 1; font-weight: 500; }
+  .type-count {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+  .instance-row {
+    display: block;
+    width: 100%;
+    padding: 4px 8px 4px 30px;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 12.5px;
+    cursor: pointer;
+    text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .instance-row:hover { background: color-mix(in oklch, var(--text) 4%, transparent); color: var(--text); }
+  .no-instances {
+    font-size: 11.5px;
+    color: var(--text-faint);
+    font-style: italic;
+    padding: 4px 8px 4px 30px;
+    margin: 0;
+  }
+</style>

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -4,6 +4,7 @@
   import TagPanel from './TagPanel.svelte';
   import SourcesPanel from './SourcesPanel.svelte';
   import TablesPanel from './TablesPanel.svelte';
+  import ObjectsPanel from './ObjectsPanel.svelte';
   import BookmarksPanel from './BookmarksPanel.svelte';
   import ProposalsPanel from './ProposalsPanel.svelte';
   import Icon from './Icon.svelte';
@@ -15,15 +16,16 @@
   import { getSidebarSettings, setSidebarSettings } from '../sidebar/settings';
   import { tick, untrack } from 'svelte';
 
-  type PanelType = 'notes' | 'sites' | 'tags' | 'tables' | 'bookmarks' | 'proposals';
+  type PanelType = 'notes' | 'sites' | 'tags' | 'tables' | 'objects' | 'bookmarks' | 'proposals';
 
   /** Hybrid icon-rail definition: the active tab shows the label, the
    *  others are icon-only. Per IMPLEMENTATION.md §5.1. */
-  const PANELS: ReadonlyArray<{ id: PanelType; label: string; icon: 'notes' | 'sites' | 'tags' | 'tables' | 'bookmark' | 'proposals' }> = [
+  const PANELS: ReadonlyArray<{ id: PanelType; label: string; icon: 'notes' | 'sites' | 'tags' | 'tables' | 'objects' | 'bookmark' | 'proposals' }> = [
     { id: 'notes',     label: 'Notes',     icon: 'notes' },
     { id: 'sites',     label: 'Sources',   icon: 'sites' },
     { id: 'tags',      label: 'Tags',      icon: 'tags' },
     { id: 'tables',    label: 'Tables',    icon: 'tables' },
+    { id: 'objects',   label: 'Objects',   icon: 'objects' },
     { id: 'bookmarks', label: 'Bookmarks', icon: 'bookmark' },
     { id: 'proposals', label: 'Proposals', icon: 'proposals' },
   ];
@@ -100,6 +102,7 @@
   let tagPanel = $state<TagPanel>();
   let sourcesPanel = $state<SourcesPanel>();
   let tablesPanel = $state<TablesPanel>();
+  let objectsPanel = $state<ObjectsPanel>();
   let contextMenu = $state<{ x: number; y: number } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
 
@@ -486,6 +489,10 @@
     tablesPanel?.refresh();
   }
 
+  export function refreshObjects() {
+    void objectsPanel?.refresh();
+  }
+
   /** Switch the active left-sidebar view (e.g. App opens 'proposals' when the
    *  status-bar pending badge is clicked, #1528). */
   export function showPanel(panel: PanelType) {
@@ -650,6 +657,8 @@
       {/if}
     {:else if activePanel === 'tags'}
       <TagPanel bind:this={tagPanel} {onFileSelect} {...(onSourceSelect !== undefined ? { onSourceSelect } : {})} />
+    {:else if activePanel === 'objects'}
+      <ObjectsPanel bind:this={objectsPanel} {onFileSelect} />
     {:else if activePanel === 'tables'}
       {#if onTableClick && onOpenCsv && onOpenNote}
         <TablesPanel bind:this={tablesPanel} {onTableClick} {onOpenCsv} {onOpenNote} />

--- a/src/renderer/lib/components/icons/registry.ts
+++ b/src/renderer/lib/components/icons/registry.ts
@@ -30,6 +30,11 @@ export const ICONS = {
     '<rect x="2.5" y="3" width="11" height="10" rx=".5"/>' +
     '<path d="M2.5 6h11M2.5 9.5h11M6.5 6v7M10 6v7"/>',
 
+  // Typed objects (#1068) — an isometric cube.
+  objects:
+    '<path d="M8 2.5 3 5v6l5 2.5 5-2.5V5Z"/>' +
+    '<path d="M3 5l5 2.5 5-2.5M8 7.5V13.5"/>',
+
   // ── Right sidebar panels ──────────────────────────────────────────
   outline: '<path d="M3 4h2M3 8h2M3 12h2"/><path d="M7 4h6M7 8h5M7 12h4"/>',
   footnotes:

--- a/tests/main/graph/objects-projection.test.ts
+++ b/tests/main/graph/objects-projection.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The graph projection behind the Objects-by-type sidebar (#1068): the exact
+ * SPARQL ObjectsPanel runs to count instances per type and list them.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexAllNotes, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+function writeNote(rel: string, content: string): void {
+  const fp = path.join(root, rel);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content, 'utf-8');
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-objproj-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('objects-by-type projection (#1068)', () => {
+  it('counts instances per type', async () => {
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: book\n---\n`);
+    writeNote('Neuromancer.md', `---\ntitle: Neuromancer\ntype: book\n---\n`);
+    writeNote('Ada.md', `---\ntitle: Ada\ntype: person\n---\n`);
+    await indexAllNotes(ctx);
+
+    const { results } = await queryGraph(
+      ctx,
+      `SELECT ?id (COUNT(?x) AS ?n) WHERE { ?x a ?c . ?c minerva:typeId ?id } GROUP BY ?id`,
+    );
+    const counts = Object.fromEntries((results as Array<{ id: string; n: string }>).map((r) => [r.id, Number(r.n)]));
+    expect(counts.book).toBe(2);
+    expect(counts.person).toBe(1);
+  });
+
+  it('lists a type’s instances with path + title', async () => {
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: book\n---\n`);
+    writeNote('Neuromancer.md', `---\ntitle: Neuromancer\ntype: book\n---\n`);
+    await indexAllNotes(ctx);
+
+    const { results } = await queryGraph(
+      ctx,
+      `SELECT ?path ?title WHERE { ?n a types:Book ; minerva:relativePath ?path . OPTIONAL { ?n dc:title ?title } } ORDER BY ?title`,
+    );
+    const rows = results as Array<{ path: string; title: string }>;
+    expect(rows.map((r) => r.title)).toEqual(['Dune', 'Neuromancer']);
+    expect(rows.map((r) => r.path)).toEqual(['Dune.md', 'Neuromancer.md']);
+  });
+
+  it('a zero-instance type simply has no rows (the panel shows it from the registry)', async () => {
+    await indexAllNotes(ctx);
+    const { results } = await queryGraph(ctx, `SELECT ?path WHERE { ?n a types:Meeting ; minerva:relativePath ?path }`);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/tests/renderer/components/ObjectsPanel.test.ts
+++ b/tests/renderer/components/ObjectsPanel.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Objects-by-type sidebar (#1068): lists registry types with live instance
+ * counts (zero-instance types visible), expands to instances via a graph
+ * projection, and opens a note on click.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+
+const { typesMock, queryMock } = vi.hoisted(() => ({ typesMock: vi.fn(), queryMock: vi.fn() }));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { types: { list: typesMock }, graph: { query: queryMock } },
+}));
+
+import ObjectsPanel from '../../../src/renderer/lib/components/ObjectsPanel.svelte';
+
+const BOOK = { id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock', icon: '📖', properties: [] };
+const MEETING = { id: 'meeting', label: 'Meeting', classLocalName: 'Meeting', source: 'stock', icon: '🗓️', properties: [] };
+
+beforeEach(() => {
+  typesMock.mockResolvedValue({ types: [BOOK, MEETING], errors: [] });
+  queryMock.mockImplementation((sparql: string) => {
+    if (sparql.includes('COUNT')) return Promise.resolve({ results: [{ id: 'book', n: '2' }], columns: [] });
+    if (sparql.includes('types:Book')) {
+      return Promise.resolve({ results: [{ path: 'Dune.md', title: 'Dune' }, { path: 'Neuro.md', title: 'Neuromancer' }], columns: [] });
+    }
+    return Promise.resolve({ results: [], columns: [] });
+  });
+});
+afterEach(() => { cleanup(); typesMock.mockReset(); queryMock.mockReset(); });
+
+describe('ObjectsPanel (#1068)', () => {
+  it('lists types with instance counts, including a zero-instance type', async () => {
+    render(ObjectsPanel, { onFileSelect: vi.fn() });
+    await waitFor(() => expect(screen.getByText('Book')).toBeTruthy());
+    expect(screen.getByText('Meeting')).toBeTruthy(); // zero-instance, still shown
+    expect(screen.getByText('2')).toBeTruthy(); // Book count
+    expect(screen.getByText('0')).toBeTruthy(); // Meeting count
+  });
+
+  it('expands a type to its instances and opens a note on click', async () => {
+    const onFileSelect = vi.fn();
+    render(ObjectsPanel, { onFileSelect });
+    const bookRow = await screen.findByText('Book');
+    await fireEvent.click(bookRow);
+    const dune = await screen.findByText('Dune');
+    expect(screen.getByText('Neuromancer')).toBeTruthy();
+    await fireEvent.click(dune);
+    expect(onFileSelect).toHaveBeenCalledWith('Dune.md');
+  });
+
+  it('shows an empty state for an expanded type with no instances', async () => {
+    render(ObjectsPanel, { onFileSelect: vi.fn() });
+    const meetingRow = await screen.findByText('Meeting');
+    await fireEvent.click(meetingRow);
+    await waitFor(() => expect(screen.getByText(/no meeting yet/i)).toBeTruthy());
+  });
+});


### PR DESCRIPTION
Closes #1068 — opens **Phase 2** of the Typed Objects epic (#1060): a new left-sidebar **"Objects"** panel, types → instances. "Show me all my People / every Project" without writing a query. Per the epic, the highest visible payoff per unit work — a pure projection of the graph #1062/#1063 already build. Depends on #1062/#1063 (merged).

## What's here
- **`ObjectsPanel.svelte`** — top level = the registry's types (icon/color + label + **live instance count**, one grouped `COUNT` over `?x rdf:type ?c ; ?c minerva:typeId ?id`). Expanding a type projects `?n a types:<Class> ; minerva:relativePath ?path` and lists its instances; **clicking opens the note**. **Zero-instance types stay visible** (so "create your first Book" is discoverable), consistent with empty-folder display.
- New **"Objects"** panel + an isometric-cube icon in `Sidebar.svelte`, mirroring the Tags panel (mount-refresh + host-driven `refresh()`).
- **Live:** `refreshObjects()` wired alongside `refreshTags` at the create/delete sites (note-ops) and the auto-save/reindex hook (ipc-wiring/App) — so creating/deleting/promoting a typed note updates the tree with no manual refresh. Optional on the `SidebarRef` so existing consumers/mocks don't all change.

## Acceptance criteria
- [x] An "Objects" panel lists registered types with instance counts.
- [x] Expanding a type lists its instances via a live SPARQL projection; click opens the note.
- [x] Creating/deleting/promoting a typed note updates the tree without a manual refresh.
- [x] Zero-instance types are visible, not hidden.

## Out of scope
The right-pane multi-view (table/gallery/cards) over instances (#1070); Excerpt as a browsable type (#1069); saved views (#1072).

## Tests
`objects-projection.test.ts` — the exact SPARQL the panel runs (per-type counts; instance list with path+title, ordered; zero-instance → no rows). `ObjectsPanel.test.ts` — types + counts incl. a zero-instance type; expand → instances → open on click; per-type empty state. `pnpm lint` clean; renderer + graph suites (2168) green.

The panel's a nice visual — happy to attach a screen capture on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)