### PR TITLE
feat(objects): Excerpt as a browsable type in the Objects panel (#1069)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -936,6 +936,7 @@
           onBookmark={(path) => bookmarkStore.add(path.split('/').pop()?.replace(/\.(md|ttl|csv)$/, '') ?? path, path)}
           onToggleEntrypoint={handleToggleEntrypoint}
           onSourceSelect={(id) => handleOpenSource(id)}
+          onOpenExcerpt={handleOpenExcerpt}
           onSourceDeleted={handleSourceDeleted}
           onShowConfirm={showConfirm}
           onShowPrompt={showPrompt}

--- a/src/renderer/lib/components/ExcerptsBrowser.svelte
+++ b/src/renderer/lib/components/ExcerptsBrowser.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  /**
+   * Excerpts-as-a-browsable-type list (#1069). Projects `thought:Excerpt` (the
+   * anchored quotations #indexExcerpt already writes — no data-model change) and
+   * lets the user narrow by source, by a source tag, or by a citing note.
+   * Clicking an excerpt opens its source at the anchor.
+   *
+   * Rendered inside the Objects panel (#1068) under the built-in "Excerpts" type.
+   */
+  import { api } from '../ipc/client';
+
+  interface Props {
+    onOpenExcerpt: (excerptId: string) => void;
+  }
+  let { onOpenExcerpt }: Props = $props();
+
+  interface Excerpt { id: string; text: string; sourceTitle: string; }
+  interface Opt { value: string; label: string; }
+
+  let excerpts = $state<Excerpt[]>([]);
+  let sourceOpts = $state<Opt[]>([]);
+  let tagOpts = $state<Opt[]>([]);
+  let noteOpts = $state<Opt[]>([]);
+
+  // Active filters (empty = all).
+  let sourceFilter = $state('');
+  let tagFilter = $state('');
+  let noteFilter = $state('');
+
+  /** SPARQL string-literal escape for an interpolated filter value. */
+  function lit(v: string): string {
+    return `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+
+  function excerptQuery(): string {
+    const clauses = [
+      `?e a thought:Excerpt ; minerva:excerptId ?id ; thought:citedText ?text .`,
+      `OPTIONAL { ?e thought:fromSource ?src . OPTIONAL { ?src dc:title ?srcTitle } }`,
+    ];
+    if (sourceFilter) clauses.push(`?e thought:fromSource ?fs . ?fs minerva:sourceId ${lit(sourceFilter)} .`);
+    if (tagFilter) clauses.push(`?e thought:fromSource ?ts . ?ts minerva:hasTag ?tt . ?tt minerva:tagName ${lit(tagFilter)} .`);
+    if (noteFilter) clauses.push(`?fn thought:quotes ?e ; minerva:relativePath ${lit(noteFilter)} .`);
+    return `SELECT ?id ?text ?srcTitle WHERE { ${clauses.join('\n')} } ORDER BY ?text`;
+  }
+
+  async function loadExcerpts(): Promise<void> {
+    const { results } = await api.graph.query(excerptQuery());
+    excerpts = (results as Array<{ id?: string; text?: string; srcTitle?: string }>)
+      .filter((r): r is { id: string; text: string; srcTitle?: string } => !!r.id)
+      .map((r) => ({ id: r.id, text: r.text ?? '', sourceTitle: r.srcTitle ?? '' }));
+  }
+
+  async function loadFilterOptions(): Promise<void> {
+    const [srcs, tags, notes] = await Promise.all([
+      api.graph.query(`SELECT DISTINCT ?src ?title WHERE { ?e a thought:Excerpt ; thought:fromSource ?s . ?s minerva:sourceId ?src . OPTIONAL { ?s dc:title ?title } } ORDER BY ?title`),
+      api.graph.query(`SELECT DISTINCT ?tag WHERE { ?e a thought:Excerpt ; thought:fromSource ?s . ?s minerva:hasTag ?t . ?t minerva:tagName ?tag } ORDER BY ?tag`),
+      api.graph.query(`SELECT DISTINCT ?path ?title WHERE { ?note thought:quotes ?e . ?e a thought:Excerpt . ?note minerva:relativePath ?path . OPTIONAL { ?note dc:title ?title } } ORDER BY ?title`),
+    ]);
+    sourceOpts = (srcs.results as Array<{ src: string; title?: string }>).map((r) => ({ value: r.src, label: r.title || r.src }));
+    tagOpts = (tags.results as Array<{ tag: string }>).map((r) => ({ value: r.tag, label: r.tag }));
+    noteOpts = (notes.results as Array<{ path: string; title?: string }>).map((r) => ({ value: r.path, label: r.title || r.path.replace(/\.md$/i, '').split('/').pop() || r.path }));
+  }
+
+  // Re-run the excerpt query whenever a filter changes; options load once.
+  $effect(() => { sourceFilter; tagFilter; noteFilter; void loadExcerpts(); });
+  $effect(() => { void loadFilterOptions(); });
+
+  function snippet(text: string): string {
+    const t = text.trim().replace(/\s+/g, ' ');
+    return t.length > 90 ? t.slice(0, 88) + '…' : t;
+  }
+</script>
+
+<div class="excerpts">
+  <div class="filters">
+    <select bind:value={sourceFilter} title="Filter by source">
+      <option value="">All sources</option>
+      {#each sourceOpts as o (o.value)}<option value={o.value}>{o.label}</option>{/each}
+    </select>
+    <select bind:value={tagFilter} title="Filter by source tag">
+      <option value="">All tags</option>
+      {#each tagOpts as o (o.value)}<option value={o.value}>#{o.label}</option>{/each}
+    </select>
+    <select bind:value={noteFilter} title="Filter by citing note">
+      <option value="">Any citing note</option>
+      {#each noteOpts as o (o.value)}<option value={o.value}>{o.label}</option>{/each}
+    </select>
+  </div>
+
+  {#if excerpts.length === 0}
+    <p class="empty">No excerpts{sourceFilter || tagFilter || noteFilter ? ' match these filters' : ' yet'}.</p>
+  {:else}
+    {#each excerpts as ex (ex.id)}
+      <button class="excerpt-row" onclick={() => onOpenExcerpt(ex.id)} title={ex.text}>
+        <span class="excerpt-text">“{snippet(ex.text)}”</span>
+        {#if ex.sourceTitle}<span class="excerpt-source">{ex.sourceTitle}</span>{/if}
+      </button>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .excerpts { display: flex; flex-direction: column; gap: 3px; padding: 4px 8px 6px 30px; }
+  .filters { display: flex; flex-direction: column; gap: 4px; margin-bottom: 4px; }
+  .filters select {
+    width: 100%;
+    padding: 3px 6px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-inset);
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 11px;
+    box-sizing: border-box;
+  }
+  .filters select:focus { outline: none; border-color: var(--accent); }
+  .excerpt-row {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 5px 7px;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+  .excerpt-row:hover { background: color-mix(in oklch, var(--text) 4%, transparent); color: var(--text); }
+  .excerpt-text { font-size: 12px; line-height: 1.35; }
+  .excerpt-source {
+    font-size: 10px;
+    color: var(--text-faint);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .empty { font-size: 11.5px; color: var(--text-faint); font-style: italic; padding: 4px 0; margin: 0; }
+</style>

--- a/src/renderer/lib/components/ObjectsPanel.svelte
+++ b/src/renderer/lib/components/ObjectsPanel.svelte
@@ -9,12 +9,15 @@
    * host calls `refresh()` on write/reindex (mirroring the Tags panel).
    */
   import { api } from '../ipc/client';
+  import ExcerptsBrowser from './ExcerptsBrowser.svelte';
   import type { TypeInfo } from '../../../shared/objects/type-def';
 
   interface Props {
     onFileSelect: (relativePath: string) => void;
+    /** Open an excerpt (source at its anchor) — for the built-in Excerpts type (#1069). */
+    onOpenExcerpt?: (excerptId: string) => void;
   }
-  let { onFileSelect }: Props = $props();
+  let { onFileSelect, onOpenExcerpt }: Props = $props();
 
   interface TypeRow { type: TypeInfo; count: number; }
   interface Instance { title: string; path: string; }
@@ -22,6 +25,9 @@
   let rows = $state<TypeRow[]>([]);
   let expanded = $state<Set<string>>(new Set());
   let instances = $state<Record<string, Instance[]>>({});
+  // Built-in Excerpts type (#1069) — thought:Excerpt, not a registry type.
+  let excerptCount = $state(0);
+  let excerptsOpen = $state(false);
 
   async function loadCounts(): Promise<Record<string, number>> {
     const { results } = await api.graph.query(
@@ -55,9 +61,15 @@
 
   /** Reload counts, and re-project any expanded type. Called on mount + by the
    *  host after a write/reindex. */
+  async function loadExcerptCount(): Promise<number> {
+    const { results } = await api.graph.query(`SELECT (COUNT(?e) AS ?n) WHERE { ?e a thought:Excerpt }`);
+    return Number((results as Array<{ n?: string }>)[0]?.n ?? 0);
+  }
+
   export async function refresh(): Promise<void> {
-    const [cat, counts] = await Promise.all([api.types.list(), loadCounts()]);
+    const [cat, counts, exCount] = await Promise.all([api.types.list(), loadCounts(), loadExcerptCount()]);
     rows = cat.types.map((type) => ({ type, count: counts[type.id] ?? 0 }));
+    excerptCount = exCount;
     await Promise.all([...expanded].map((id) => loadInstances(id)));
   }
 
@@ -72,32 +84,45 @@
 </script>
 
 <div class="objects-panel">
-  {#if rows.length === 0}
-    <p class="empty">No types in this project yet.</p>
-  {:else}
-    {#each rows as row (row.type.id)}
-      {@const open = expanded.has(row.type.id)}
-      <button class="type-row" onclick={() => toggle(row.type.id)} aria-expanded={open}>
-        <span class="chevron" class:open>▸</span>
-        <span class="type-icon" style={row.type.color ? `color:${row.type.color}` : undefined}>{row.type.icon ?? '◆'}</span>
-        <span class="type-label">{row.type.label}</span>
-        <span class="type-count">{row.count}</span>
-      </button>
-      {#if open}
-        {#if (instances[row.type.id] ?? []).length === 0}
-          <p class="no-instances">No {row.type.label.toLowerCase()} yet</p>
-        {:else}
-          {#each instances[row.type.id] ?? [] as inst (inst.path)}
-            <button
-              class="instance-row"
-              onclick={() => onFileSelect(inst.path)}
-              ondblclick={() => onFileSelect(inst.path)}
-              title={inst.path}
-            >{inst.title}</button>
-          {/each}
-        {/if}
+  {#each rows as row (row.type.id)}
+    {@const open = expanded.has(row.type.id)}
+    <button class="type-row" onclick={() => toggle(row.type.id)} aria-expanded={open}>
+      <span class="chevron" class:open>▸</span>
+      <span class="type-icon" style={row.type.color ? `color:${row.type.color}` : undefined}>{row.type.icon ?? '◆'}</span>
+      <span class="type-label">{row.type.label}</span>
+      <span class="type-count">{row.count}</span>
+    </button>
+    {#if open}
+      {#if (instances[row.type.id] ?? []).length === 0}
+        <p class="no-instances">No {row.type.label.toLowerCase()} yet</p>
+      {:else}
+        {#each instances[row.type.id] ?? [] as inst (inst.path)}
+          <button
+            class="instance-row"
+            onclick={() => onFileSelect(inst.path)}
+            ondblclick={() => onFileSelect(inst.path)}
+            title={inst.path}
+          >{inst.title}</button>
+        {/each}
       {/if}
-    {/each}
+    {/if}
+  {/each}
+
+  <!-- Built-in Excerpts type (#1069): thought:Excerpt, browsable + filterable. -->
+  <button class="type-row" onclick={() => (excerptsOpen = !excerptsOpen)} aria-expanded={excerptsOpen}>
+    <span class="chevron" class:open={excerptsOpen}>▸</span>
+    <span class="type-icon">✂️</span>
+    <span class="type-label">Excerpts</span>
+    <span class="type-count">{excerptCount}</span>
+  </button>
+  {#if excerptsOpen}
+    {#if onOpenExcerpt}
+      <ExcerptsBrowser {onOpenExcerpt} />
+    {/if}
+  {/if}
+
+  {#if rows.length === 0 && excerptCount === 0}
+    <p class="empty">No types or excerpts in this project yet.</p>
   {/if}
 </div>
 

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -75,6 +75,9 @@
      *  passed through to FileTree for the context-menu item. */
     onToggleEntrypoint?: (relativePath: string, currentlyEntrypoint: boolean) => void;
     onSourceSelect?: (sourceId: string) => void;
+    /** Open an excerpt (source at its anchor) — for the Objects panel's built-in
+     *  Excerpts type (#1069). */
+    onOpenExcerpt?: (excerptId: string) => void;
     onSourceDeleted?: (sourceId: string) => void;
     onShowConfirm?: (message: string, key: string, label?: string) => Promise<boolean>;
     onShowPrompt?: (message: string, initialOrOptions?: string | { suggestions?: string[]; initial?: string }) => Promise<string | null>;
@@ -86,7 +89,7 @@
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onAddProperty, onRemoveProperty, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onOpenNote, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onAddProperty, onRemoveProperty, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onOpenExcerpt, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onOpenNote, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -658,7 +661,7 @@
     {:else if activePanel === 'tags'}
       <TagPanel bind:this={tagPanel} {onFileSelect} {...(onSourceSelect !== undefined ? { onSourceSelect } : {})} />
     {:else if activePanel === 'objects'}
-      <ObjectsPanel bind:this={objectsPanel} {onFileSelect} />
+      <ObjectsPanel bind:this={objectsPanel} {onFileSelect} {...(onOpenExcerpt !== undefined ? { onOpenExcerpt } : {})} />
     {:else if activePanel === 'tables'}
       {#if onTableClick && onOpenCsv && onOpenNote}
         <TablesPanel bind:this={tablesPanel} {onTableClick} {onOpenCsv} {onOpenNote} />

--- a/tests/main/graph/excerpts-browser.test.ts
+++ b/tests/main/graph/excerpts-browser.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The graph projection behind Excerpts-as-a-browsable-type (#1069): the count,
+ * the list, and the three filters (by source, by source tag, by citing note).
+ * Rides existing indexExcerpt — no data-model change.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexAllNotes, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+function writeSource(id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'sources', id);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'meta.ttl'), ttl, 'utf-8');
+}
+function writeExcerpt(id: string, ttl: string): void {
+  const dir = path.join(root, '.minerva', 'excerpts');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${id}.ttl`), ttl, 'utf-8');
+}
+function writeNote(rel: string, content: string): void {
+  const fp = path.join(root, rel);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content, 'utf-8');
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-excerpts-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+
+  writeSource('smith-2023', `this: a thought:Article ; dc:title "Smith 2023" ; minerva:tag "philosophy" .`);
+  writeSource('jones-2024', `this: a thought:Article ; dc:title "Jones 2024" .`);
+  writeExcerpt('smith-2023-a', `this: a thought:Excerpt ; thought:fromSource sources:smith-2023 ; thought:citedText "Being precedes essence." .`);
+  writeExcerpt('jones-2024-a', `this: a thought:Excerpt ; thought:fromSource sources:jones-2024 ; thought:citedText "Nothing is fixed." .`);
+  // A note that quotes the Smith excerpt.
+  writeNote('Argument.md', `---\ntitle: Argument\n---\nSee [[quote::smith-2023-a]].\n`);
+  await indexAllNotes(ctx);
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+const listQuery = (extra = '') =>
+  `SELECT ?id ?text ?srcTitle WHERE {
+     ?e a thought:Excerpt ; minerva:excerptId ?id ; thought:citedText ?text .
+     OPTIONAL { ?e thought:fromSource ?src . OPTIONAL { ?src dc:title ?srcTitle } }
+     ${extra}
+   } ORDER BY ?text`;
+
+async function ids(sparql: string): Promise<string[]> {
+  const { results } = await queryGraph(ctx, sparql);
+  return (results as Array<{ id: string }>).map((r) => r.id);
+}
+
+describe('excerpts browser projection (#1069)', () => {
+  it('counts all excerpts', async () => {
+    const { results } = await queryGraph(ctx, `SELECT (COUNT(?e) AS ?n) WHERE { ?e a thought:Excerpt }`);
+    expect(Number((results as Array<{ n: string }>)[0]!.n)).toBe(2);
+  });
+
+  it('lists every excerpt with cited text + source title', async () => {
+    const { results } = await queryGraph(ctx, listQuery());
+    const rows = results as Array<{ id: string; text: string; srcTitle: string }>;
+    expect(rows.map((r) => r.id).sort()).toEqual(['jones-2024-a', 'smith-2023-a']);
+    const smith = rows.find((r) => r.id === 'smith-2023-a')!;
+    expect(smith.text).toContain('Being precedes essence');
+    expect(smith.srcTitle).toBe('Smith 2023');
+  });
+
+  it('filters by source', async () => {
+    expect(await ids(listQuery(`?e thought:fromSource ?fs . ?fs minerva:sourceId "smith-2023" .`))).toEqual(['smith-2023-a']);
+  });
+
+  it('filters by a source tag', async () => {
+    expect(await ids(listQuery(`?e thought:fromSource ?ts . ?ts minerva:hasTag ?tt . ?tt minerva:tagName "philosophy" .`))).toEqual(['smith-2023-a']);
+  });
+
+  it('filters by citing note', async () => {
+    expect(await ids(listQuery(`?fn thought:quotes ?e ; minerva:relativePath "Argument.md" .`))).toEqual(['smith-2023-a']);
+  });
+});

--- a/tests/renderer/components/ExcerptsBrowser.test.ts
+++ b/tests/renderer/components/ExcerptsBrowser.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Excerpts browser (#1069): lists thought:Excerpt with source, narrows by the
+ * source/tag/citing-note filters, and opens an excerpt on click.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+
+const { queryMock } = vi.hoisted(() => ({ queryMock: vi.fn() }));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: { graph: { query: queryMock } } }));
+
+import ExcerptsBrowser from '../../../src/renderer/lib/components/ExcerptsBrowser.svelte';
+
+const ALL = [
+  { id: 'smith-2023-a', text: 'Being precedes essence.', srcTitle: 'Smith 2023' },
+  { id: 'jones-2024-a', text: 'Nothing is fixed.', srcTitle: 'Jones 2024' },
+];
+const SMITH_ONLY = [ALL[0]];
+
+beforeEach(() => {
+  queryMock.mockImplementation((sparql: string) => {
+    if (sparql.includes('DISTINCT ?src')) return Promise.resolve({ results: [{ src: 'smith-2023', title: 'Smith 2023' }], columns: [] });
+    if (sparql.includes('DISTINCT ?tag')) return Promise.resolve({ results: [{ tag: 'philosophy' }], columns: [] });
+    if (sparql.includes('DISTINCT ?path')) return Promise.resolve({ results: [{ path: 'Argument.md', title: 'Argument' }], columns: [] });
+    // the excerpt list
+    const filtered = /sourceId "|tagName "|relativePath "/.test(sparql);
+    return Promise.resolve({ results: filtered ? SMITH_ONLY : ALL, columns: [] });
+  });
+});
+afterEach(() => { cleanup(); queryMock.mockReset(); });
+
+describe('ExcerptsBrowser (#1069)', () => {
+  it('lists all excerpts with their source', async () => {
+    render(ExcerptsBrowser, { onOpenExcerpt: vi.fn() });
+    await waitFor(() => expect(screen.getByText(/Being precedes essence/)).toBeTruthy());
+    expect(screen.getByText(/Nothing is fixed/)).toBeTruthy();
+    expect(screen.getAllByText('Smith 2023').length).toBeGreaterThan(0); // option + source label
+  });
+
+  it('wires up the source / tag / citing-note filters', async () => {
+    // Query correctness for the filter constraints is covered by the graph test
+    // (excerpts-browser.test.ts); here we verify the options load + render.
+    render(ExcerptsBrowser, { onOpenExcerpt: vi.fn() });
+    await waitFor(() => expect(screen.getByText(/Being precedes essence/)).toBeTruthy());
+    const sparqls = queryMock.mock.calls.map((c) => String(c[0]));
+    expect(sparqls.some((s) => s.includes('DISTINCT ?src'))).toBe(true);
+    expect(sparqls.some((s) => s.includes('DISTINCT ?tag'))).toBe(true);
+    expect(sparqls.some((s) => s.includes('DISTINCT ?path'))).toBe(true);
+    await waitFor(() => expect(screen.getByRole('option', { name: /Smith 2023/ })).toBeTruthy());
+    expect(screen.getByRole('option', { name: /philosophy/ })).toBeTruthy();
+  });
+
+  it('opens an excerpt on click', async () => {
+    const onOpenExcerpt = vi.fn();
+    render(ExcerptsBrowser, { onOpenExcerpt });
+    const row = await screen.findByText(/Being precedes essence/);
+    await fireEvent.click(row);
+    expect(onOpenExcerpt).toHaveBeenCalledWith('smith-2023-a');
+  });
+});

--- a/tests/renderer/components/ObjectsPanel.test.ts
+++ b/tests/renderer/components/ObjectsPanel.test.ts
@@ -21,6 +21,7 @@ const MEETING = { id: 'meeting', label: 'Meeting', classLocalName: 'Meeting', so
 beforeEach(() => {
   typesMock.mockResolvedValue({ types: [BOOK, MEETING], errors: [] });
   queryMock.mockImplementation((sparql: string) => {
+    if (sparql.includes('thought:Excerpt')) return Promise.resolve({ results: [{ n: '7' }], columns: [] }); // excerpt count
     if (sparql.includes('COUNT')) return Promise.resolve({ results: [{ id: 'book', n: '2' }], columns: [] });
     if (sparql.includes('types:Book')) {
       return Promise.resolve({ results: [{ path: 'Dune.md', title: 'Dune' }, { path: 'Neuro.md', title: 'Neuromancer' }], columns: [] });
@@ -37,6 +38,8 @@ describe('ObjectsPanel (#1068)', () => {
     expect(screen.getByText('Meeting')).toBeTruthy(); // zero-instance, still shown
     expect(screen.getByText('2')).toBeTruthy(); // Book count
     expect(screen.getByText('0')).toBeTruthy(); // Meeting count
+    expect(screen.getByText('Excerpts')).toBeTruthy(); // built-in Excerpts type (#1069)
+    expect(screen.getByText('7')).toBeTruthy(); // excerpt count
   });
 
   it('expands a type to its instances and opens a note on click', async () => {


### PR DESCRIPTION
Closes #1069. Phase 2 of the Typed Objects epic (#1060) — makes `thought:Excerpt` a first-class browsable type in the Objects sidebar built in #1068.

## What

Excerpts — the anchored quotations `indexExcerpt` already writes when a source is clipped — become a built-in **Excerpts** row in the Objects panel, alongside the registry types. **Zero data-model change:** it rides the existing graph projection.

- **`ExcerptsBrowser.svelte`** (new): lists each excerpt (cited text snippet + source title) and narrows by three filters:
  - **by source** (`minerva:sourceId`)
  - **by a source tag** (the excerpt's source's `minerva:hasTag`)
  - **by a citing note** (`thought:quotes` → `minerva:relativePath`)

  Clicking an excerpt calls `onOpenExcerpt` → `handleOpenExcerpt` (nav-view) → opens the source at its anchor.
- **`ObjectsPanel`**: a built-in "Excerpts" row (✂️) below the registry types with a live count, expanding to the browser. The empty state now accounts for excerpts too.
- Threads `onOpenExcerpt` through `Sidebar` → `App` (`handleOpenExcerpt` was already defined and wired for source-viewer surfaces).

## Tests

- `tests/main/graph/excerpts-browser.test.ts` — the graph projection: count, list (text + source title), and each of the three filters, against a seeded thoughtbase (two sources, two excerpts, one citing note). 5/5.
- `tests/renderer/components/ObjectsPanel.test.ts` — Excerpts row renders with its count.
- `tests/renderer/components/ExcerptsBrowser.test.ts` — renders excerpts, loads/renders the filter options, opens on click.

`pnpm lint` clean; all three suites green.