### PR TITLE
feat(objects): multi-view over a type's instances — list/table/gallery (#1070)

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -31,7 +31,7 @@ export {
   getSourceDetail, getReadingQueueSourceIds, sourcesByReadStatus, citationsForNote, getExcerptSource,
 } from './queries';
 export type { AliasEntry, SchemaEntry, GraphSchema, ReadingQueueView } from './queries';
-export { getNoteTypedProperties } from './note-properties';
+export { getNoteTypedProperties, getTypeInstances } from './note-properties';
 export { neighborhood, expandNode } from './neighborhood';
 export type {
   NeighborhoodResult, NeighborhoodNode, NeighborhoodEdge, NeighborhoodOptions, NeighborhoodHop,

--- a/src/main/graph/note-properties.ts
+++ b/src/main/graph/note-properties.ts
@@ -13,7 +13,12 @@ import type { ProjectContext } from '../project-context-types';
 import { getState } from './state';
 import { noteUriFor, queryGraph } from './queries';
 import { resolveFrontmatterPredicate } from './indexers';
-import { toTypeInfo, type NoteTypedProperties } from '../../shared/objects/type-def';
+import {
+  toTypeInfo,
+  type NoteTypedProperties,
+  type TypeInstancesResult,
+  type TypeInstanceRow,
+} from '../../shared/objects/type-def';
 
 export async function getNoteTypedProperties(
   ctx: ProjectContext,
@@ -50,4 +55,64 @@ export async function getNoteTypedProperties(
   }));
 
   return { type: toTypeInfo(def), properties };
+}
+
+/**
+ * Project every instance of a type with its declared-property values (#1070) —
+ * the data behind the list/table/gallery multi-view. One SPARQL pass: each
+ * declared property becomes an OPTIONAL column bound through the SAME predicate
+ * the indexer wrote it under (`resolveFrontmatterPredicate`), so read-back is
+ * robust to frontmatter-key aliasing, exactly like the single-note read-back.
+ *
+ * First row wins per note (a multi-valued frontmatter key can yield >1 binding);
+ * mirrors `getNoteTypedProperties`' first-match-wins. No approval/write path —
+ * a pure read over the already-indexed graph.
+ */
+export async function getTypeInstances(
+  ctx: ProjectContext,
+  typeId: string,
+): Promise<TypeInstancesResult> {
+  const state = getState(ctx);
+  if (!state) return { type: null, instances: [] };
+  const def = state.typeCatalog.types.find((t) => t.id === typeId);
+  if (!def) return { type: null, instances: [] };
+
+  // A stable column alias per declared property (?c0, ?c1, …) avoids clashes
+  // when two properties happen to resolve to the same predicate IRI.
+  const cols = def.properties.map((pd, i) => ({
+    pd,
+    alias: `c${i}`,
+    predicate: resolveFrontmatterPredicate(pd.name).value,
+  }));
+  const optionals = cols
+    .map((c) => `OPTIONAL { ?n <${c.predicate}> ?${c.alias} }`)
+    .join('\n     ');
+  const selectCols = cols.map((c) => `?${c.alias}`).join(' ');
+
+  const { results } = await queryGraph(
+    ctx,
+    `SELECT ?path ?title ${selectCols} WHERE {
+       ?n a types:${def.classLocalName} ; minerva:relativePath ?path .
+       OPTIONAL { ?n dc:title ?title }
+       ${optionals}
+     } ORDER BY LCASE(?title) ?path`,
+  );
+
+  const seen = new Set<string>();
+  const instances: TypeInstanceRow[] = [];
+  for (const raw of results as Array<Record<string, string | undefined>>) {
+    const path = raw.path;
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    const values: Record<string, string | null> = {};
+    for (const c of cols) values[c.pd.name] = raw[c.alias] ?? null;
+    instances.push({
+      path,
+      title: raw.title ?? (path.replace(/\.md$/i, '').split('/').pop() ?? path),
+      values,
+      cover: def.cover ? values[def.cover] ?? null : null,
+    });
+  }
+
+  return { type: toTypeInfo(def), instances };
 }

--- a/src/main/ipc/register-types.ts
+++ b/src/main/ipc/register-types.ts
@@ -9,7 +9,7 @@ import { Channels } from '../../shared/channels';
 import { loadTypeCatalog } from '../types/loader';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
-import { toTypeInfo, type TypeCatalogInfo, type NoteTypedProperties } from '../../shared/objects/type-def';
+import { toTypeInfo, type TypeCatalogInfo, type NoteTypedProperties, type TypeInstancesResult } from '../../shared/objects/type-def';
 import { handle } from './typed-ipc';
 import { withRootPathOr } from './helpers';
 
@@ -29,6 +29,16 @@ export function registerTypes(): void {
     withRootPathOr<[string], NoteTypedProperties | Promise<NoteTypedProperties>>(
       { type: null, properties: [] },
       (rootPath, relativePath: string) => graph.getNoteTypedProperties(projectContext(rootPath), relativePath),
+    ),
+  );
+
+  // Every instance of a type + its declared-property values, for the list/table/
+  // gallery multi-view (#1070). A pure read over the already-indexed graph.
+  handle(
+    Channels.TYPES_INSTANCES,
+    withRootPathOr<[string], TypeInstancesResult | Promise<TypeInstancesResult>>(
+      { type: null, instances: [] },
+      (rootPath, typeId: string) => graph.getTypeInstances(projectContext(rootPath), typeId),
     ),
   );
 }

--- a/src/main/types/parse.ts
+++ b/src/main/types/parse.ts
@@ -126,6 +126,15 @@ export function parseType(content: string, source: TypeSource, filePath: string)
   if (icon) type.icon = icon;
   const color = asString(fm.color);
   if (color) type.color = color;
+  const cover = asString(fm.cover);
+  if (cover) {
+    // Soft-validate: `cover` must name a declared property (else the gallery has
+    // nothing to key off). Report but still load — house UX: no hand-holding.
+    if (!properties.some((p) => p.name === cover)) {
+      errors.push(`\`cover\` names "${cover}", which is not a declared property`);
+    }
+    type.cover = cover;
+  }
 
   return { type, errors, label: bestLabel };
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -468,6 +468,7 @@ contextBridge.exposeInMainWorld('api', {
   types: {
     list: () => invoke(Channels.TYPES_LIST),
     noteProperties: (relativePath: string) => invoke(Channels.TYPES_NOTE_PROPERTIES, relativePath),
+    instances: (typeId: string) => invoke(Channels.TYPES_INSTANCES, typeId),
   },
   skills: {
     list: () => invoke(Channels.SKILLS_LIST),

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -8,6 +8,7 @@
   import { collectGroupIds } from './lib/editor/layout-tree';
   import QueryPanel from './lib/components/QueryPanel.svelte';
   import NeighborhoodGraph from './lib/components/NeighborhoodGraph.svelte';
+  import TypeView from './lib/components/TypeView.svelte';
   import RightSidebar from './lib/components/RightSidebar.svelte';
   import StatusBar from './lib/components/StatusBar.svelte';
   import BreadcrumbsBar from './lib/components/BreadcrumbsBar.svelte';
@@ -650,6 +651,7 @@
   const {
     recordCurrentPosition, handleNavBack, handleNavForward, handleFileSelect, handleNavigate, handleOpenAtOffset, handleJumpToMatch,
     handleSourceDeleted, handleOpenSource, handleOpenPdf, handleShowMarkdownFromPdf, handleOpenExcerpt,
+    handleOpenTypeView,
   } = createNavView({
     getEditorComponent: () => editorComponent,
     setPendingSearchQuery: (s) => { pendingSearchQuery = s; },
@@ -937,6 +939,7 @@
           onToggleEntrypoint={handleToggleEntrypoint}
           onSourceSelect={(id) => handleOpenSource(id)}
           onOpenExcerpt={handleOpenExcerpt}
+          onOpenType={handleOpenTypeView}
           onSourceDeleted={handleSourceDeleted}
           onShowConfirm={showConfirm}
           onShowPrompt={showPrompt}
@@ -1217,6 +1220,16 @@
                     relativePath={active.relativePath}
                     depth={active.depth}
                     revision={graphRevision}
+                    onOpenNote={(p) => handleFileSelect(p)}
+                  />
+                {/key}
+              {:else if active?.type === 'type-view'}
+                {#key active.typeId}
+                  <TypeView
+                    typeId={active.typeId}
+                    layout={active.layout}
+                    revision={graphRevision}
+                    onLayoutChange={(l) => editor.setTypeViewLayout(active.typeId, l)}
                     onOpenNote={(p) => handleFileSelect(p)}
                   />
                 {/key}

--- a/src/renderer/lib/app/nav-view.ts
+++ b/src/renderer/lib/app/nav-view.ts
@@ -167,6 +167,11 @@ export function createNavView(ctx: NavViewCtx) {
     handleOpenSource(result.sourceId, excerptId);
   }
 
+  /** Open the list/table/gallery multi-view over a type's instances (#1070). */
+  function handleOpenTypeView(typeId: string) {
+    editor.openTypeView(typeId);
+  }
+
   function recordCurrentPosition() {
     const activeTab = editor.activeTab;
     if (!activeTab) return;
@@ -214,5 +219,6 @@ export function createNavView(ctx: NavViewCtx) {
     recordCurrentPosition, handleNavBack, handleNavForward, handleFileSelect, handleNavigate,
     handleOpenAtOffset, handleJumpToMatch,
     handleSourceDeleted, handleOpenSource, handleOpenPdf, handleShowMarkdownFromPdf, handleOpenExcerpt,
+    handleOpenTypeView,
   };
 }

--- a/src/renderer/lib/components/ObjectsPanel.svelte
+++ b/src/renderer/lib/components/ObjectsPanel.svelte
@@ -16,8 +16,10 @@
     onFileSelect: (relativePath: string) => void;
     /** Open an excerpt (source at its anchor) — for the built-in Excerpts type (#1069). */
     onOpenExcerpt?: (excerptId: string) => void;
+    /** Open a type's instances in the main-pane list/table/gallery view (#1070). */
+    onOpenType?: (typeId: string) => void;
   }
-  let { onFileSelect, onOpenExcerpt }: Props = $props();
+  let { onFileSelect, onOpenExcerpt, onOpenType }: Props = $props();
 
   interface TypeRow { type: TypeInfo; count: number; }
   interface Instance { title: string; path: string; }
@@ -86,12 +88,18 @@
 <div class="objects-panel">
   {#each rows as row (row.type.id)}
     {@const open = expanded.has(row.type.id)}
-    <button class="type-row" onclick={() => toggle(row.type.id)} aria-expanded={open}>
-      <span class="chevron" class:open>▸</span>
-      <span class="type-icon" style={row.type.color ? `color:${row.type.color}` : undefined}>{row.type.icon ?? '◆'}</span>
-      <span class="type-label">{row.type.label}</span>
-      <span class="type-count">{row.count}</span>
-    </button>
+    <div class="type-row-wrap">
+      <button class="type-row" onclick={() => toggle(row.type.id)} aria-expanded={open}>
+        <span class="chevron" class:open>▸</span>
+        <span class="type-icon" style={row.type.color ? `color:${row.type.color}` : undefined}>{row.type.icon ?? '◆'}</span>
+        <span class="type-label">{row.type.label}</span>
+        <span class="type-count">{row.count}</span>
+      </button>
+      {#if onOpenType}
+        <!-- Open all instances of this type in the main-pane multi-view (#1070). -->
+        <button class="open-view" title={`Open ${row.type.label} view`} aria-label={`Open ${row.type.label} view`} onclick={() => onOpenType(row.type.id)}>⤢</button>
+      {/if}
+    </div>
     {#if open}
       {#if (instances[row.type.id] ?? []).length === 0}
         <p class="no-instances">No {row.type.label.toLowerCase()} yet</p>
@@ -129,7 +137,10 @@
 <style>
   .objects-panel { display: flex; flex-direction: column; padding: 4px; }
   .empty { font-size: 12px; color: var(--text-faint); padding: 12px 8px; }
+  .type-row-wrap { position: relative; display: flex; align-items: center; }
   .type-row {
+    flex: 1;
+    min-width: 0;
     display: flex;
     align-items: center;
     gap: 6px;
@@ -144,6 +155,28 @@
     text-align: left;
   }
   .type-row:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  /* Hover-revealed "open in main view" affordance — stays out of the way until
+     the row is hovered/focused (house UX: quiet contextual actions, #1070). */
+  .open-view {
+    position: absolute;
+    right: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border: none;
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text-muted);
+    font-size: 12px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.1s ease;
+  }
+  .type-row-wrap:hover .open-view,
+  .open-view:focus-visible { opacity: 1; }
+  .open-view:hover { color: var(--text); }
   .chevron {
     font-size: 9px;
     color: var(--text-faint);

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -78,6 +78,8 @@
     /** Open an excerpt (source at its anchor) — for the Objects panel's built-in
      *  Excerpts type (#1069). */
     onOpenExcerpt?: (excerptId: string) => void;
+    /** Open a type's instances in the main-pane multi-view (#1070). */
+    onOpenType?: (typeId: string) => void;
     onSourceDeleted?: (sourceId: string) => void;
     onShowConfirm?: (message: string, key: string, label?: string) => Promise<boolean>;
     onShowPrompt?: (message: string, initialOrOptions?: string | { suggestions?: string[]; initial?: string }) => Promise<string | null>;
@@ -89,7 +91,7 @@
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onAddProperty, onRemoveProperty, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onOpenExcerpt, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onOpenNote, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onAddProperty, onRemoveProperty, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onOpenExcerpt, onOpenType, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onOpenNote, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -661,7 +663,7 @@
     {:else if activePanel === 'tags'}
       <TagPanel bind:this={tagPanel} {onFileSelect} {...(onSourceSelect !== undefined ? { onSourceSelect } : {})} />
     {:else if activePanel === 'objects'}
-      <ObjectsPanel bind:this={objectsPanel} {onFileSelect} {...(onOpenExcerpt !== undefined ? { onOpenExcerpt } : {})} />
+      <ObjectsPanel bind:this={objectsPanel} {onFileSelect} {...(onOpenExcerpt !== undefined ? { onOpenExcerpt } : {})} {...(onOpenType !== undefined ? { onOpenType } : {})} />
     {:else if activePanel === 'tables'}
       {#if onTableClick && onOpenCsv && onOpenNote}
         <TablesPanel bind:this={tablesPanel} {onTableClick} {onOpenCsv} {onOpenNote} />

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -114,9 +114,11 @@
               ? `PDF: ${sourceTabLabel(tab.sourceId)}`
               : tab.type === 'graph'
                 ? `Graph: ${tab.relativePath}`
-                : tab.type === 'unsupported'
-                  ? tab.relativePath
-                  : `Source: ${sourceTabLabel(tab.sourceId)}`}
+                : tab.type === 'type-view'
+                  ? `Type: ${tab.typeId}`
+                  : tab.type === 'unsupported'
+                    ? tab.relativePath
+                    : `Source: ${sourceTabLabel(tab.sourceId)}`}
       >
         <!-- Leading slot: dirty pip OR type icon. The pip wins when the
              note is dirty so the visual cue can't be missed (§7.2). -->
@@ -131,6 +133,8 @@
             <Icon name="source" size={13} color="var(--text-faint)" />
           {:else if tab.type === 'graph'}
             <Icon name="graph" size={13} color="var(--text-faint)" />
+          {:else if tab.type === 'type-view'}
+            <Icon name="objects" size={13} color="var(--text-faint)" />
           {:else}
             <Icon name="notes" size={13} color="var(--text-faint)" />
           {/if}
@@ -140,6 +144,7 @@
           {:else if tab.type === 'query'}{tab.title}
           {:else if tab.type === 'pdf'}{sourceTabLabel(tab.sourceId)} (PDF)
           {:else if tab.type === 'graph'}{(tab.relativePath.split('/').pop() ?? tab.relativePath).replace(/\.md$/, '')} (Graph)
+          {:else if tab.type === 'type-view'}{tab.typeId.charAt(0).toUpperCase() + tab.typeId.slice(1)}
           {:else if tab.type === 'unsupported'}{tab.fileName}
           {:else}{sourceTabLabel(tab.sourceId)}{/if}
         </span>

--- a/src/renderer/lib/components/TypeView.svelte
+++ b/src/renderer/lib/components/TypeView.svelte
@@ -1,0 +1,306 @@
+<script lang="ts">
+  /**
+   * Multi-view over all instances of a typed-object type (#1070) — the same
+   * typed notes rendered as a list, a table (declared properties as columns), or
+   * a gallery of cards keyed off a designated cover property. "Switch the view,
+   * same data": every projection reads the one `api.types.instances(typeId)`
+   * result, so toggling never re-queries the instance set.
+   *
+   * A read-only surface: rows/cards deep-link to the note (the property form
+   * #1066 is where values are edited); table cells never mutate the graph.
+   */
+  import { api } from '../ipc/client';
+  import type { PropertyDef, TypeInfo, TypeInstanceRow } from '../../../shared/objects/type-def';
+
+  type Layout = 'list' | 'table' | 'gallery';
+
+  interface Props {
+    typeId: string;
+    layout: Layout;
+    /** Bumped by the host on write/reindex so the view re-projects (#1070). */
+    revision: number;
+    onLayoutChange: (layout: Layout) => void;
+    onOpenNote: (relativePath: string) => void;
+  }
+  let { typeId, layout, revision, onLayoutChange, onOpenNote }: Props = $props();
+
+  let type = $state<TypeInfo | null>(null);
+  let instances = $state<TypeInstanceRow[]>([]);
+  let loading = $state(true);
+
+  // Sort state (table view). `null` column = the intrinsic title/path order the
+  // projection already returns.
+  let sortCol = $state<string | null>(null);
+  let sortDir = $state<'asc' | 'desc'>('asc');
+
+  async function load(): Promise<void> {
+    loading = true;
+    const result = await api.types.instances(typeId);
+    type = result.type;
+    instances = result.instances;
+    loading = false;
+  }
+
+  // Re-project when the type changes or the graph is rewritten.
+  $effect(() => { typeId; revision; void load(); });
+
+  const columns = $derived<PropertyDef[]>(type?.properties ?? []);
+
+  /** Human-readable cell value: link-to-type IRIs collapse to their tail; other
+   *  types show their lexical string; null → an em dash. */
+  function display(prop: PropertyDef, value: string | null): string {
+    if (value === null || value === '') return '—';
+    if (prop.type === 'link-to-type') {
+      const tail = value.split(/[/#]/).pop() ?? value;
+      try { return decodeURIComponent(tail); } catch { return tail; }
+    }
+    return value;
+  }
+
+  /** First non-empty declared-property value — the list row's summary line. */
+  function summary(inst: TypeInstanceRow): string {
+    for (const col of columns) {
+      const v = inst.values[col.name];
+      if (v) return `${col.label ?? col.name}: ${display(col, v)}`;
+    }
+    return '';
+  }
+
+  function toggleSort(col: string): void {
+    if (sortCol === col) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+    else { sortCol = col; sortDir = 'asc'; }
+  }
+
+  function cellFor(inst: TypeInstanceRow, col: string): string | null {
+    return col === '__title' ? inst.title : inst.values[col] ?? null;
+  }
+
+  const sorted = $derived.by<TypeInstanceRow[]>(() => {
+    if (!sortCol) return instances;
+    const col = sortCol;
+    const numeric = col !== '__title' && columns.find((c) => c.name === col)?.type === 'number';
+    const dir = sortDir === 'asc' ? 1 : -1;
+    return [...instances].sort((a, b) => {
+      const av = cellFor(a, col);
+      const bv = cellFor(b, col);
+      // Empty values always sort last, regardless of direction.
+      if (av === null || av === '') return bv === null || bv === '' ? 0 : 1;
+      if (bv === null || bv === '') return -1;
+      const cmp = numeric
+        ? Number(av) - Number(bv)
+        : av.localeCompare(bv, undefined, { numeric: true, sensitivity: 'base' });
+      return cmp * dir;
+    });
+  });
+
+  function isImageUrl(v: string | null): v is string {
+    return !!v && /^https?:\/\//i.test(v);
+  }
+
+  const LAYOUTS: { id: Layout; label: string }[] = [
+    { id: 'list', label: 'List' },
+    { id: 'table', label: 'Table' },
+    { id: 'gallery', label: 'Gallery' },
+  ];
+</script>
+
+<div class="type-view">
+  <header class="tv-header">
+    <span class="tv-icon" style={type?.color ? `color:${type.color}` : undefined}>{type?.icon ?? '◆'}</span>
+    <h1 class="tv-title">{type?.label ?? typeId}</h1>
+    <span class="tv-count">{instances.length}</span>
+    <div class="tv-switch" role="tablist" aria-label="View">
+      {#each LAYOUTS as l (l.id)}
+        <button
+          role="tab"
+          aria-selected={layout === l.id}
+          class:active={layout === l.id}
+          onclick={() => onLayoutChange(l.id)}
+        >{l.label}</button>
+      {/each}
+    </div>
+  </header>
+
+  {#if loading}
+    <p class="tv-empty">Loading…</p>
+  {:else if !type}
+    <p class="tv-empty">This type is no longer defined.</p>
+  {:else if instances.length === 0}
+    <p class="tv-empty">No {type.label.toLowerCase()} instances yet.</p>
+  {:else if layout === 'list'}
+    <div class="tv-list">
+      {#each instances as inst (inst.path)}
+        <button class="tv-list-row" onclick={() => onOpenNote(inst.path)} title={inst.path}>
+          <span class="tv-list-title">{inst.title}</span>
+          {#if summary(inst)}<span class="tv-list-summary">{summary(inst)}</span>{/if}
+        </button>
+      {/each}
+    </div>
+  {:else if layout === 'table'}
+    <div class="tv-table-scroll">
+      <table class="tv-table">
+        <thead>
+          <tr>
+            <th
+              class="sortable"
+              class:sorted={sortCol === '__title'}
+              aria-sort={sortCol === '__title' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+              onclick={() => toggleSort('__title')}
+            >Title{#if sortCol === '__title'}<span class="arrow">{sortDir === 'asc' ? '▲' : '▼'}</span>{/if}</th>
+            {#each columns as col (col.name)}
+              <th
+                class="sortable"
+                class:sorted={sortCol === col.name}
+                aria-sort={sortCol === col.name ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+                onclick={() => toggleSort(col.name)}
+              >{col.label ?? col.name}{#if sortCol === col.name}<span class="arrow">{sortDir === 'asc' ? '▲' : '▼'}</span>{/if}</th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each sorted as inst (inst.path)}
+            <tr onclick={() => onOpenNote(inst.path)} title={inst.path}>
+              <td class="tv-cell-title">{inst.title}</td>
+              {#each columns as col (col.name)}
+                <td>{display(col, inst.values[col.name] ?? null)}</td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {:else}
+    <div class="tv-gallery">
+      {#each instances as inst (inst.path)}
+        <button class="tv-card" onclick={() => onOpenNote(inst.path)} title={inst.path}>
+          <div class="tv-card-cover">
+            {#if isImageUrl(inst.cover)}
+              <img src={inst.cover} alt="" loading="lazy" />
+            {:else}
+              <span class="tv-card-icon" style={type.color ? `color:${type.color}` : undefined}>{type.icon ?? '◆'}</span>
+            {/if}
+          </div>
+          <span class="tv-card-title">{inst.title}</span>
+          {#if summary(inst)}<span class="tv-card-summary">{summary(inst)}</span>{/if}
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .type-view { display: flex; flex-direction: column; height: 100%; overflow: hidden; }
+  .tv-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .tv-icon { font-size: 18px; line-height: 1; }
+  .tv-title { font-size: 15px; font-weight: 600; margin: 0; color: var(--text); }
+  .tv-count {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+  .tv-switch { margin-left: auto; display: flex; gap: 2px; }
+  .tv-switch button {
+    padding: 3px 10px;
+    border: 1px solid var(--border);
+    background: var(--bg-button);
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 11.5px;
+    cursor: pointer;
+  }
+  .tv-switch button:first-child { border-radius: 5px 0 0 5px; }
+  .tv-switch button:last-child { border-radius: 0 5px 5px 0; }
+  .tv-switch button:not(:first-child) { border-left: none; }
+  .tv-switch button.active { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+  .tv-empty { padding: 24px 16px; color: var(--text-faint); font-size: 13px; }
+
+  /* List */
+  .tv-list { overflow-y: auto; padding: 6px; }
+  .tv-list-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    width: 100%;
+    padding: 8px 10px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text);
+    font-family: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+  .tv-list-row:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  .tv-list-title { font-size: 13.5px; font-weight: 500; }
+  .tv-list-summary { font-size: 11.5px; color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  /* Table */
+  .tv-table-scroll { overflow: auto; padding: 4px; }
+  .tv-table { border-collapse: collapse; width: 100%; font-size: 12.5px; }
+  .tv-table th, .tv-table td {
+    text-align: left;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }
+  .tv-table th {
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    color: var(--text-muted);
+    font-weight: 600;
+    user-select: none;
+  }
+  .tv-table th.sortable { cursor: pointer; }
+  .tv-table th.sortable:hover { color: var(--text); }
+  .tv-table th.sorted { color: var(--text); }
+  .arrow { margin-left: 4px; font-size: 8px; }
+  .tv-table tbody tr { cursor: pointer; }
+  .tv-table tbody tr:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  .tv-cell-title { font-weight: 500; color: var(--text); }
+
+  /* Gallery */
+  .tv-gallery {
+    overflow-y: auto;
+    padding: 12px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 12px;
+    align-content: start;
+  }
+  .tv-card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 0 0 8px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-family: inherit;
+    cursor: pointer;
+    text-align: left;
+    overflow: hidden;
+  }
+  .tv-card:hover { border-color: var(--accent); }
+  .tv-card-cover {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    aspect-ratio: 3 / 2;
+    background: color-mix(in oklch, var(--text) 5%, transparent);
+    overflow: hidden;
+  }
+  .tv-card-cover img { width: 100%; height: 100%; object-fit: cover; }
+  .tv-card-icon { font-size: 32px; opacity: 0.5; }
+  .tv-card-title { font-size: 12.5px; font-weight: 500; padding: 0 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tv-card-summary { font-size: 11px; color: var(--text-faint); padding: 0 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+</style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -752,6 +752,8 @@ export interface TypesApi {
   list(): Promise<import('../../../shared/objects/type-def').TypeCatalogInfo>;
   /** A note's declared properties + current values, keyed to its type (#1063). */
   noteProperties(relativePath: string): Promise<import('../../../shared/objects/type-def').NoteTypedProperties>;
+  /** Every instance of a type + its property values, for the multi-view (#1070). */
+  instances(typeId: string): Promise<import('../../../shared/objects/type-def').TypeInstancesResult>;
 }
 
 export interface SkillsApi {

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -82,7 +82,18 @@ export interface UnsupportedTab {
   ext: string;
 }
 
-export type Tab = NoteTab | QueryTab | SourceTab | PdfTab | GraphTab | UnsupportedTab;
+/** Multi-view over all instances of a typed-object type (#1070). */
+export type TypeViewLayout = 'list' | 'table' | 'gallery';
+export interface TypeViewTab {
+  type: 'type-view';
+  /** The type whose instances are shown (e.g. `book`). */
+  typeId: string;
+  /** Which projection is showing; the viewer mutates it via `setTypeViewLayout`
+   *  so reopening the tab restores the chosen view. */
+  layout: TypeViewLayout;
+}
+
+export type Tab = NoteTab | QueryTab | SourceTab | PdfTab | GraphTab | TypeViewTab | UnsupportedTab;
 
 /**
  * Source / preview view mode. `'editor-preview'` = source editor + rendered
@@ -111,6 +122,7 @@ function isQuery(tab: Tab): tab is QueryTab { return tab.type === 'query'; }
 function isSource(tab: Tab): tab is SourceTab { return tab.type === 'source'; }
 function isPdf(tab: Tab): tab is PdfTab { return tab.type === 'pdf'; }
 function isGraph(tab: Tab): tab is GraphTab { return tab.type === 'graph'; }
+function isTypeView(tab: Tab): tab is TypeViewTab { return tab.type === 'type-view'; }
 function isUnsupported(tab: Tab): tab is UnsupportedTab { return tab.type === 'unsupported'; }
 
 let queryCounter = 0;
@@ -379,6 +391,28 @@ export function getEditorStore() {
     }
   }
 
+  /** Open (or refocus) the multi-view over a type's instances (#1070). One tab
+   *  per type; reopening refocuses rather than duplicating. */
+  function openTypeView(typeId: string, opts?: { layout?: TypeViewLayout; groupId?: string }) {
+    const found = locateTab((t) => isTypeView(t) && t.typeId === typeId);
+    if (found) { focusExistingTab(found); return; }
+    const grp = resolveGroup(opts?.groupId);
+    activeGroupId = grp.id;
+    const tab: TypeViewTab = { type: 'type-view', typeId, layout: opts?.layout ?? 'table' };
+    grp.tabs.push(tab);
+    grp.activeIndex = grp.tabs.length - 1;
+    schedulePersistTabs();
+  }
+
+  /** Update a type-view tab's projection (the list/table/gallery switch). */
+  function setTypeViewLayout(typeId: string, layout: TypeViewLayout) {
+    const found = locateTab((t) => isTypeView(t) && t.typeId === typeId);
+    if (found) {
+      (found.group.tabs[found.index] as TypeViewTab).layout = layout;
+      schedulePersistTabs();
+    }
+  }
+
   function openPdf(sourceId: string, opts?: { page?: number; groupId?: string }) {
     // Forbid duplicate open (#815): if this PDF is already open in any pane,
     // refocus it (jumping to the requested page) instead of opening a copy.
@@ -611,6 +645,8 @@ export function getEditorStore() {
       return { type: 'pdf', sourceId: t.sourceId, page: t.page };
     } else if (isGraph(t)) {
       return { type: 'graph', relativePath: t.relativePath, depth: t.depth };
+    } else if (isTypeView(t)) {
+      return { type: 'type-view', typeId: t.typeId, layout: t.layout };
     } else {
       return {
         type: 'source',
@@ -681,6 +717,8 @@ export function getEditorStore() {
       return { type: 'pdf', sourceId: saved.sourceId, page: saved.page ?? 1 };
     } else if (saved.type === 'graph') {
       return { type: 'graph', relativePath: saved.relativePath, depth: saved.depth ?? 1 };
+    } else if (saved.type === 'type-view') {
+      return { type: 'type-view', typeId: saved.typeId, layout: saved.layout ?? 'table' };
     } else {
       return { type: 'source', sourceId: saved.sourceId, highlightExcerptId: saved.highlightExcerptId };
     }
@@ -697,6 +735,7 @@ export function getEditorStore() {
     if (t.type === 'note') return `note:${t.relativePath}`;
     if (t.type === 'source') return `source:${t.sourceId}`;
     if (t.type === 'pdf') return `pdf:${t.sourceId}`;
+    if (t.type === 'type-view') return `type-view:${t.typeId}`;
     return null;
   }
 
@@ -1052,6 +1091,8 @@ export function getEditorStore() {
     openPdf,
     openNeighborhood,
     setGraphDepth,
+    openTypeView,
+    setTypeViewLayout,
     setPdfPage,
     save,
     isPathDirty,

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -430,6 +430,8 @@ export const Channels = {
   TYPES_LIST: 'types:list',
   /** A note's declared properties + current values, keyed to its type (#1063). */
   TYPES_NOTE_PROPERTIES: 'types:noteProperties',
+  /** Every instance of a type + its property values, for the multi-view (#1070). */
+  TYPES_INSTANCES: 'types:instances',
 
   // Skills (markdown skill files — #622)
   /** List the loaded skill catalog (metadata + load errors). */

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -55,7 +55,7 @@ import type {
   ConnectionCheckResult,
 } from './tools/types';
 import type { SkillCatalogInfo } from './skills/types';
-import type { TypeCatalogInfo, NoteTypedProperties } from './objects/type-def';
+import type { TypeCatalogInfo, NoteTypedProperties, TypeInstancesResult } from './objects/type-def';
 import type { ProviderId } from './tools/providers';
 import type { MenuConfig } from './skills/menu-config';
 import type {
@@ -384,6 +384,7 @@ export interface ChannelMap {
   // Typed objects (type registry — #1062)
   'types:list': () => TypeCatalogInfo;
   'types:noteProperties': (relativePath: string) => NoteTypedProperties;
+  'types:instances': (typeId: string) => TypeInstancesResult;
 
   // Skills (markdown skill files — #622)
   'skills:list': () => SkillCatalogInfo;

--- a/src/shared/objects/type-def.ts
+++ b/src/shared/objects/type-def.ts
@@ -41,6 +41,8 @@ export interface TypeDef {
   template?: string | undefined;
   icon?: string | undefined;
   color?: string | undefined;
+  /** Property name whose value is the gallery card's cover image (#1070). */
+  cover?: string | undefined;
   source: TypeSource;
   /** Absolute path for user types; the glob key for stock types. */
   filePath: string;
@@ -57,6 +59,8 @@ export interface TypeInfo {
   template?: string | undefined;
   icon?: string | undefined;
   color?: string | undefined;
+  /** Property name whose value is the gallery card's cover image (#1070). */
+  cover?: string | undefined;
   source: TypeSource;
 }
 
@@ -88,6 +92,7 @@ export function toTypeInfo(t: TypeDef): TypeInfo {
     template: t.template,
     icon: t.icon,
     color: t.color,
+    cover: t.cover,
     source: t.source,
   };
 }
@@ -113,6 +118,29 @@ export interface NoteTypedProperties {
   type: TypeInfo | null;
   /** Every property the type declares, including ones the note leaves empty. */
   properties: NoteTypedPropertyValue[];
+}
+
+/** One instance of a type — a typed note, with its declared property values
+ *  projected as columns for the multi-view (#1070). Values are the same lexical
+ *  strings the property read-back (#1063) returns; null when the note leaves a
+ *  declared property empty. */
+export interface TypeInstanceRow {
+  /** The note's project-relative path (the row's identity + deep-link target). */
+  path: string;
+  title: string;
+  /** Declared-property values keyed by property `name` (every declared property
+   *  present; null where the note doesn't set it). */
+  values: Record<string, string | null>;
+  /** The designated cover property's value, or null — for the gallery (#1070). */
+  cover: string | null;
+}
+
+/** A type plus all its instances, for the list/table/gallery multi-view (#1070). */
+export interface TypeInstancesResult {
+  /** The resolved type (its declared properties are the table columns), or null
+   *  when the id doesn't match a loaded type. */
+  type: TypeInfo | null;
+  instances: TypeInstanceRow[];
 }
 
 /** `article-source` → `ArticleSource`; used for the ontology class local name. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -242,7 +242,15 @@ export interface SavedGraphTab {
   depth?: number;
 }
 
-export type SavedTab = SavedNoteTab | SavedQueryTab | SavedSourceTab | SavedPdfTab | SavedGraphTab | SavedUnsupportedTab;
+export interface SavedTypeViewTab {
+  type: 'type-view';
+  /** The type whose instances the multi-view shows (#1070). */
+  typeId: string;
+  /** Chosen projection (list/table/gallery); restored on reload. */
+  layout?: 'list' | 'table' | 'gallery';
+}
+
+export type SavedTab = SavedNoteTab | SavedQueryTab | SavedSourceTab | SavedPdfTab | SavedGraphTab | SavedTypeViewTab | SavedUnsupportedTab;
 
 /** Legacy flat session: one group's tabs + active index. Superseded by
  *  {@link LayoutSession} (#816); still read on load and migrated to a single

--- a/tests/main/graph/type-instances.test.ts
+++ b/tests/main/graph/type-instances.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Type-instances projection behind the multi-view (#1070): the list of a type's
+ * instances with their declared-property values as columns, plus the designated
+ * cover property for the gallery. A pure read over the #1062/#1063 index.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexAllNotes, getTypeInstances } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+function writeNote(rel: string, content: string): void {
+  const fp = path.join(root, rel);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content, 'utf-8');
+}
+function writeType(id: string, frontmatter: string): void {
+  const dir = path.join(root, '.minerva', 'types');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${id}.md`), `---\n${frontmatter}\n---\n`, 'utf-8');
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-type-instances-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('type-instances projection (#1070)', () => {
+  it('lists every instance of a type with its declared-property values', async () => {
+    // `book` is a stock type declaring author, published, rating, status, isbn.
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: book\nauthor: Frank Herbert\nrating: 5\n---\n`);
+    writeNote('Neuro.md', `---\ntitle: Neuromancer\ntype: book\nauthor: William Gibson\nrating: 4\n---\n`);
+    await indexAllNotes(ctx);
+
+    const res = await getTypeInstances(ctx, 'book');
+    expect(res.type?.id).toBe('book');
+    // Ordered by LCASE(title): Dune before Neuromancer.
+    expect(res.instances.map((i) => i.title)).toEqual(['Dune', 'Neuromancer']);
+    expect(res.instances.map((i) => i.path)).toEqual(['Dune.md', 'Neuro.md']);
+
+    const dune = res.instances[0]!;
+    expect(dune.values.author).toBe('Frank Herbert');
+    expect(dune.values.rating).toBe('5');
+    expect(dune.values.published).toBeNull(); // declared but empty → column present, value null
+    // No cover declared on the stock book type.
+    expect(dune.cover).toBeNull();
+  });
+
+  it('returns an empty projection for an unknown type', async () => {
+    const res = await getTypeInstances(ctx, 'not-a-type');
+    expect(res.type).toBeNull();
+    expect(res.instances).toEqual([]);
+  });
+
+  it('projects the designated cover property for the gallery', async () => {
+    writeType('gadget', 'label: Gadget\nid: gadget\ncover: image\nproperties:\n  - name: image\n    type: text\n  - name: maker\n    type: text');
+    writeNote('Widget.md', `---\ntitle: Widget\ntype: gadget\nimage: https://example.com/widget.png\nmaker: Acme\n---\n`);
+    writeNote('Gizmo.md', `---\ntitle: Gizmo\ntype: gadget\nmaker: Globex\n---\n`);
+    await indexAllNotes(ctx);
+
+    const res = await getTypeInstances(ctx, 'gadget');
+    expect(res.instances).toHaveLength(2);
+    const byTitle = new Map(res.instances.map((i) => [i.title, i]));
+    expect(byTitle.get('Widget')!.cover).toBe('https://example.com/widget.png');
+    expect(byTitle.get('Widget')!.values.maker).toBe('Acme');
+    expect(byTitle.get('Gizmo')!.cover).toBeNull(); // no cover value → gallery falls back
+  });
+});

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -228,6 +228,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "tool:getSettings",
   "tool:prepareConversation",
   "tool:setSettings",
+  "types:instances",
   "types:list",
   "types:noteProperties",
   "youtube:thumbnail",

--- a/tests/main/types/loader.test.ts
+++ b/tests/main/types/loader.test.ts
@@ -99,4 +99,16 @@ describe('parseType (#1062)', () => {
     expect(r.type?.properties).toHaveLength(0);
     expect(r.errors.some((e) => /unknown type/.test(e))).toBe(true);
   });
+
+  it('carries a `cover` that names a declared property (#1070)', () => {
+    const r = parseType(`---\nlabel: Gadget\ncover: image\nproperties:\n  - name: image\n    type: text\n---\n`, 'user', '/x/gadget.md');
+    expect(r.type?.cover).toBe('image');
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('still loads but flags a `cover` that is not a declared property (#1070)', () => {
+    const r = parseType(`---\nlabel: Gadget\ncover: missing\nproperties:\n  - name: image\n    type: text\n---\n`, 'user', '/x/gadget.md');
+    expect(r.type?.cover).toBe('missing'); // house UX: no hand-holding — still loads
+    expect(r.errors.some((e) => /not a declared property/.test(e))).toBe(true);
+  });
 });

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -391,6 +391,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "setSettings",
   ],
   "types": [
+    "instances",
     "list",
     "noteProperties",
   ],

--- a/tests/renderer/components/TypeView.test.ts
+++ b/tests/renderer/components/TypeView.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Type multi-view (#1070): the same instance set rendered as list/table/gallery,
+ * sortable table columns, a cover-keyed gallery, and deep-linking a row to its
+ * note. The instance set comes once from api.types.instances — switching views
+ * never re-queries.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+
+const { instancesMock } = vi.hoisted(() => ({ instancesMock: vi.fn() }));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: { types: { instances: instancesMock } } }));
+
+import TypeView from '../../../src/renderer/lib/components/TypeView.svelte';
+
+const TYPE = {
+  id: 'book',
+  label: 'Book',
+  classLocalName: 'Book',
+  icon: '📖',
+  source: 'stock' as const,
+  properties: [
+    { name: 'author', type: 'text' as const, label: 'Author' },
+    { name: 'rating', type: 'number' as const, label: 'Rating' },
+  ],
+};
+const INSTANCES = [
+  { path: 'Dune.md', title: 'Dune', values: { author: 'Frank Herbert', rating: '5' }, cover: null },
+  { path: 'Neuro.md', title: 'Neuromancer', values: { author: 'William Gibson', rating: '4' }, cover: null },
+];
+
+function props(over: Record<string, unknown> = {}) {
+  return {
+    typeId: 'book',
+    layout: 'list' as const,
+    revision: 0,
+    onLayoutChange: vi.fn(),
+    onOpenNote: vi.fn(),
+    ...over,
+  };
+}
+
+beforeEach(() => { instancesMock.mockResolvedValue({ type: TYPE, instances: INSTANCES }); });
+afterEach(() => { cleanup(); instancesMock.mockReset(); });
+
+describe('TypeView (#1070)', () => {
+  it('renders the header (label + count) and a list of instances', async () => {
+    render(TypeView, props({ layout: 'list' }));
+    await waitFor(() => expect(screen.getByText('Dune')).toBeTruthy());
+    expect(screen.getByText('Neuromancer')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Book' })).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy(); // instance count
+  });
+
+  it('opens a note when an instance is clicked', async () => {
+    const onOpenNote = vi.fn();
+    render(TypeView, props({ layout: 'list', onOpenNote }));
+    await fireEvent.click(await screen.findByText('Dune'));
+    expect(onOpenNote).toHaveBeenCalledWith('Dune.md');
+  });
+
+  it('renders a column per declared property and sorts by a column', async () => {
+    const { container } = render(TypeView, props({ layout: 'table' }));
+    await waitFor(() => expect(screen.getByRole('columnheader', { name: /Author/ })).toBeTruthy());
+    expect(screen.getByRole('columnheader', { name: /Rating/ })).toBeTruthy();
+
+    const titles = () => [...container.querySelectorAll('tbody .tv-cell-title')].map((e) => e.textContent);
+    expect(titles()).toEqual(['Dune', 'Neuromancer']); // intrinsic order
+
+    // Sort by Rating asc: 4 (Neuromancer) before 5 (Dune).
+    await fireEvent.click(screen.getByRole('columnheader', { name: /Rating/ }));
+    await waitFor(() => expect(titles()).toEqual(['Neuromancer', 'Dune']));
+    // Toggle to desc.
+    await fireEvent.click(screen.getByRole('columnheader', { name: /Rating/ }));
+    await waitFor(() => expect(titles()).toEqual(['Dune', 'Neuromancer']));
+  });
+
+  it('keys the gallery off the cover property, falling back to an icon card', async () => {
+    instancesMock.mockResolvedValue({
+      type: TYPE,
+      instances: [
+        { path: 'Widget.md', title: 'Widget', values: {}, cover: 'https://example.com/w.png' },
+        { path: 'Gizmo.md', title: 'Gizmo', values: {}, cover: null },
+      ],
+    });
+    const { container } = render(TypeView, props({ layout: 'gallery' }));
+    await waitFor(() => expect(screen.getByText('Widget')).toBeTruthy());
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('https://example.com/w.png');
+    expect(container.querySelectorAll('img')).toHaveLength(1); // Gizmo falls back to an icon, no img
+  });
+
+  it('switches views without re-querying the instance set', async () => {
+    const onLayoutChange = vi.fn();
+    render(TypeView, props({ layout: 'list', onLayoutChange }));
+    await waitFor(() => expect(screen.getByText('Dune')).toBeTruthy());
+    await fireEvent.click(screen.getByRole('tab', { name: 'Table' }));
+    expect(onLayoutChange).toHaveBeenCalledWith('table');
+    expect(instancesMock).toHaveBeenCalledTimes(1); // one load, not one per view
+  });
+});


### PR DESCRIPTION
Closes #1070. Phase 3 of the Typed Objects epic (#1060) — the "switch the view, same data" surface.

## What

Selecting a type in the Objects browser (#1068) opens a **main-pane surface** listing all instances of that type, switchable between three projections over the one instance set:

- **List** — title + a summary line (first non-empty property).
- **Table** — a column per declared property, rows per instance, **sortable by any column** (numeric-aware for `number` properties). Read-only cells; the row deep-links to the note.
- **Gallery** — cards keyed off a type's designated **cover** property (an image URL), falling back to an icon card.

A **view switcher** toggles them; switching never re-queries — all three read the single `api.types.instances(typeId)` result, and the chosen layout persists across sessions.

## How it's wired

**Main** (pure read over the #1062/#1063 index — no write path, no approval surface):
- `getTypeInstances(ctx, typeId)` in `graph/note-properties.ts` projects each instance's declared-property values as columns, resolving every property through the **same predicate the indexer wrote it under** (`resolveFrontmatterPredicate`), so read-back survives frontmatter-key aliasing exactly like the single-note read-back. First row wins per note.
- Types may declare `cover: <propertyName>` (parsed + soft-validated in `parse.ts` — still loads if it names a non-property, per house UX).
- New `types:instances` IPC channel.

**Renderer:**
- New `TypeViewTab` surface in the editor store, modeled on `GraphTab`: one tab per type, reopening refocuses rather than duplicating; layout persists via `SavedTab`.
- `TypeView.svelte` renders the three views + switcher.
- `ObjectsPanel` gains a hover-revealed **"open view"** affordance per type row (leaves the existing expand-in-sidebar behavior from #1068 untouched); `onOpenType` threads Sidebar → App → `editor.openTypeView`.

## Out of scope (deferred, per the issue)

- Persisting a chosen view + sort as a named view → #1072.
- Per-cell editing (the property form #1066 owns value edits).
- Filters-as-objects / formulas / rollups (explicitly out per vision scope discipline).

## Tests

- `tests/main/graph/type-instances.test.ts` — projection: list + property columns + declared-but-empty nulls, unknown type → empty, cover keyed off the designated property with fallback.
- `tests/renderer/components/TypeView.test.ts` — list/table/gallery render, column sort (asc/desc, numeric), gallery cover keying + icon fallback, switch-without-re-query, open-on-click.
- `tests/main/types/loader.test.ts` — `cover` parse (valid + soft-flagged).
- IPC registration + preload-bridge snapshots updated.

`pnpm lint` clean; full suite green.