### PR TITLE
feat(objects): type-keyed rendering — link/hover cards + Excerpt card (#1071)

### DIFF
--- a/src/main/types/parse.ts
+++ b/src/main/types/parse.ts
@@ -77,6 +77,28 @@ function normalizeProperties(raw: unknown, errors: string[]): PropertyDef[] {
   return out;
 }
 
+/** Normalize the `card:` field — a YAML list or comma-separated string of
+ *  property names. Unknown names are dropped with a soft error (still loads). */
+function normalizeCard(raw: unknown, properties: PropertyDef[], errors: string[]): string[] {
+  if (raw === undefined) return [];
+  let names: string[];
+  if (Array.isArray(raw)) {
+    names = raw.map(asString).filter((s): s is string => !!s);
+  } else if (typeof raw === 'string') {
+    names = raw.split(',').map((s) => s.trim()).filter(Boolean);
+  } else {
+    errors.push('`card` must be a list or comma-separated string');
+    return [];
+  }
+  const declared = new Set(properties.map((p) => p.name));
+  const out: string[] = [];
+  for (const name of names) {
+    if (declared.has(name)) out.push(name);
+    else errors.push(`\`card\` lists "${name}", which is not a declared property`);
+  }
+  return out;
+}
+
 /**
  * Parse one type-definition file. `source` tags provenance; `filePath` is the
  * absolute path (user) or glob key (stock) for error reporting.
@@ -135,6 +157,11 @@ export function parseType(content: string, source: TypeSource, filePath: string)
     }
     type.cover = cover;
   }
+  // `card`: ordered property names shown on the type-keyed render card (#1071).
+  // Accept a YAML list or a comma-separated string; soft-flag names that aren't
+  // declared properties but keep the rest.
+  const card = normalizeCard(fm.card, properties, errors);
+  if (card.length > 0) type.card = card;
 
   return { type, errors, label: bestLabel };
 }

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -34,6 +34,10 @@
         outputToMarkdownClipboard
     } from '../preview/compute-output-render';
     import { applyCslMarkers, resolveCiteQuoteLabels, type CitationRenderDeps } from '../preview/citation-render';
+    import { hydrateTypedCards, type TypedCardDeps } from '../preview/typed-link-render';
+    import { buildObjectCardHtml } from '../preview/typed-card';
+    import { resolveWikiLinkTarget } from '../../../shared/wiki-link-resolver';
+    import type { NoteTypedProperties } from '../../../shared/objects/type-def';
     import { executeQueryBlock, type QueryBlockDeps } from '../preview/query-blocks';
     import {
         type HydrateContext,
@@ -185,6 +189,10 @@
     // Cite/quote metadata caches: id → resolved bundle (survives re-renders)
     const citeMetaCache = new Map<string, CiteMeta>();
     const quoteMetaCache = new Map<string, QuoteMeta>();
+    // Type-keyed card cache (#1071): resolved path → typed properties. Survives
+    // re-renders; cleared on `revision` so a save to a linked note refreshes its
+    // card. Also read by the wiki-link hover to show a typed card tooltip.
+    const typePropsCache = new Map<string, NoteTypedProperties>();
 
     // Rendered-transclusion cache (perf #1114): `${rel}\u0000${embed}` → the
     // md.render output for that embed's sliced body. Each host re-render rebuilds
@@ -364,6 +372,21 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     function queryDeps(): QueryBlockDeps {
         return { notePath, revision, queryCache, queryPrefixes: QUERY_PREFIXES, activeCharts };
     }
+    // Type-keyed card pass (#1071): promote block-level typed links to cards.
+    // resolvePath reuses the same wiki-link resolution as the hover fetcher.
+    function typedCardDeps(): TypedCardDeps {
+        // Build the resolver inputs once (mirrors note-preview.ts): paths → files,
+        // the alias list → a lowercased map.
+        const files = (getNotePaths?.() ?? []).map((relativePath) => ({ relativePath, isDirectory: false }));
+        const aliases = Object.fromEntries((getAliases?.() ?? []).map((a) => [a.alias.toLowerCase(), a.relativePath]));
+        return {
+            previewEl: previewEl ?? null,
+            typePropsCache,
+            quoteMetaCache,
+            queryPrefixes: QUERY_PREFIXES,
+            resolvePath: (t) => resolveWikiLinkTarget(t, files, aliases),
+        };
+    }
 
     // Context for the extracted post-render hydration passes (#1087). Built once
     // — the caches + `md` are stable refs, and everything that changes over the
@@ -392,6 +415,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
     $effect(() => {
         revision;
         transclusionRenderCache.clear();
+        typePropsCache.clear(); // a linked note's type/props may have changed (#1071)
     });
 
     // After render, find query-block placeholders and execute queries
@@ -424,6 +448,10 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
             // `![[note^block]]` embeds, slicing + re-rendering the target inline.
             void hydrateTransclusions(hydrateCtx);
             void hydrateLocalMedia(hydrateCtx);
+            // Type-keyed cards (#1071) — a block-level `[[TypedNote]]` or
+            // `[[quote::id]]` becomes a card keyed off its type. Lazy + cached;
+            // untyped/inline links are untouched.
+            void hydrateTypedCards(typedCardDeps());
             // Mermaid hydration (#467) — lazy-loads the library on first use,
             // replaces .mermaid-block placeholders with rendered SVG, surfaces
             // parse errors inline.
@@ -882,11 +910,22 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
             const linkTarget = wiki.dataset.target;
             if (!linkTarget || !getNotePaths) return;
             const token = ++hoverToken;
-            void notePreviewFetcher(linkTarget).then((preview) => {
+            void notePreviewFetcher(linkTarget).then(async (preview) => {
                 if (token !== hoverToken) return; // superseded by another hover / mouseout
-                tooltipHtml = preview
-                    ? buildNotePreviewTooltip(preview.title, preview.snippet)
-                    : buildNotePreviewMissing(linkTarget);
+                if (!preview) {
+                    tooltipHtml = buildNotePreviewMissing(linkTarget);
+                    tooltipVisible = true;
+                    positionTooltip(wiki);
+                    return;
+                }
+                // A typed note shows its card (#1071); an untyped one keeps the
+                // title+snippet preview. Reuses the card pass's per-path cache.
+                const rb = typePropsCache.get(preview.path) ?? await api.types.noteProperties(preview.path);
+                typePropsCache.set(preview.path, rb);
+                if (token !== hoverToken) return;
+                tooltipHtml = rb.type
+                    ? `<div class="object-card oc-tooltip">${buildObjectCardHtml(rb, { title: preview.title })}</div>`
+                    : buildNotePreviewTooltip(preview.title, preview.snippet);
                 tooltipVisible = true;
                 positionTooltip(wiki);
             }).catch(() => {
@@ -1251,6 +1290,56 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         background: color-mix(in oklch, var(--accent) 18%, transparent);
         text-decoration: none;
     }
+
+    /* Type-keyed cards (#1071) — a block-level `[[TypedNote]]` / `[[quote::id]]`
+       promoted from a chip to a card. Shared by the preview block and the hover
+       tooltip (via .oc-tooltip). */
+    .preview :global(.wiki-link.object-card),
+    .preview :global(.quote-link.excerpt-card),
+    :global(.cite-tooltip .object-card) {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+        width: 100%;
+        max-width: 100%;
+        margin: 0.5em 0;
+        padding: 10px 12px;
+        background: color-mix(in oklch, var(--accent) 5%, transparent);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        color: var(--text);
+        text-align: left;
+        box-sizing: border-box;
+    }
+    :global(.cite-tooltip .object-card.oc-tooltip) { margin: 0; border: none; background: transparent; padding: 0; }
+    .preview :global(.wiki-link.object-card:hover),
+    .preview :global(.quote-link.excerpt-card:hover) {
+        background: color-mix(in oklch, var(--accent) 9%, transparent);
+        border-color: var(--accent);
+    }
+    :global(.object-card .oc-cover) {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 52px;
+        height: 68px;
+        border-radius: 5px;
+        overflow: hidden;
+        background: color-mix(in oklch, var(--text) 6%, transparent);
+    }
+    :global(.object-card .oc-cover img) { width: 100%; height: 100%; object-fit: cover; }
+    :global(.object-card .oc-cover-icon) { font-size: 26px; opacity: 0.65; }
+    :global(.object-card .oc-main) { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+    :global(.object-card .oc-title) { font-weight: 600; font-size: 0.95em; display: flex; align-items: center; gap: 5px; }
+    :global(.object-card .oc-type-icon) { font-size: 0.9em; opacity: 0.8; }
+    :global(.object-card .oc-fields) { display: flex; flex-wrap: wrap; gap: 4px 10px; }
+    :global(.object-card .oc-field) { display: inline-flex; gap: 5px; font-size: 0.82em; }
+    :global(.object-card .oc-flabel) { color: var(--text-faint); }
+    :global(.object-card .oc-fval) { color: var(--text-muted); }
+    :global(.quote-link.excerpt-card) { flex-direction: column; gap: 5px; color: var(--text); }
+    :global(.excerpt-card .ec-quote) { font-style: italic; line-height: 1.4; }
+    :global(.excerpt-card .ec-meta) { font-size: 0.82em; color: var(--text-faint); }
 
     /* Transclusion embeds (#906) — a framed, slightly inset block so the
        reader can tell embedded content from the host note's own prose. */

--- a/src/renderer/lib/preview/typed-card.ts
+++ b/src/renderer/lib/preview/typed-card.ts
@@ -1,0 +1,94 @@
+/**
+ * Type-keyed render-card HTML builders (#1071). Pure string→string transforms
+ * (mirroring cite-meta.ts) so the preview's post-render pass can inject a card
+ * into a wiki-link/quote-link placeholder, and so they unit-test without a DOM.
+ *
+ * A typed *note* renders a card keyed off its type: cover image (or type icon) +
+ * title + a few property chips selected by the type's `card:` template. An
+ * *excerpt* renders its highlighted span + source byline + locator. Both build
+ * from escaped strings — the injecting pass bypasses DOMPurify (post-render).
+ */
+import { escapeHtml, escapeAttr } from './text';
+import type { NoteTypedProperties } from '../../../shared/objects/type-def';
+import { selectCardFields } from '../../../shared/objects/card';
+import type { QuoteMeta } from './cite-meta';
+
+/** An http(s) cover value renders as an <img>; anything else falls back to the
+ *  type icon (a local/vault path isn't safely loadable inline here). */
+export function isImageUrl(v: string | null | undefined): v is string {
+  return !!v && /^https?:\/\//i.test(v);
+}
+
+/**
+ * The card body for a typed note. Caller guarantees `rb.type` is non-null
+ * (untyped notes never get a card). Rendered inside the existing `.wiki-link`
+ * anchor, so the whole card stays click-to-navigate.
+ */
+export function buildObjectCardHtml(rb: NoteTypedProperties, opts: { title: string }): string {
+  const type = rb.type;
+  if (!type) return escapeHtml(opts.title);
+  const { fields, cover } = selectCardFields(rb);
+  const icon = type.icon ?? '◆';
+
+  const coverHtml = isImageUrl(cover)
+    ? `<span class="oc-cover"><img src="${escapeAttr(cover)}" alt="" loading="lazy" /></span>`
+    : `<span class="oc-cover oc-cover-icon"${type.color ? ` style="color:${escapeAttr(type.color)}"` : ''}>${escapeHtml(icon)}</span>`;
+
+  const chips = fields
+    .filter((f) => f.value !== null && f.value !== '')
+    .map(
+      (f) =>
+        `<span class="oc-field"><span class="oc-flabel">${escapeHtml(f.label)}</span><span class="oc-fval">${escapeHtml(f.value!)}</span></span>`,
+    )
+    .join('');
+
+  return (
+    `${coverHtml}<span class="oc-main">` +
+    `<span class="oc-title"><span class="oc-type-icon">${escapeHtml(icon)}</span>${escapeHtml(opts.title)}</span>` +
+    (chips ? `<span class="oc-fields">${chips}</span>` : '') +
+    `</span>`
+  );
+}
+
+/** The card body for an excerpt: highlighted span + source byline + locator.
+ *  (No annotation — the excerpt TTL carries none; it lives in the derived note.) */
+export function buildExcerptCardHtml(meta: QuoteMeta): string {
+  const parts: string[] = [];
+  if (meta.citedText) parts.push(`<span class="ec-quote">“${escapeHtml(meta.citedText)}”</span>`);
+
+  const byline = [
+    meta.sourceTitle,
+    meta.sourceCreator && meta.sourceYear
+      ? `${meta.sourceCreator} (${meta.sourceYear})`
+      : meta.sourceCreator || (meta.sourceYear ? `(${meta.sourceYear})` : ''),
+  ]
+    .filter(Boolean)
+    .join(' — ');
+
+  const loc = meta.pageRange
+    ? `pp. ${meta.pageRange}`
+    : meta.page
+      ? `p. ${meta.page}`
+      : meta.locationText ?? '';
+
+  const metaLine = [byline, loc].filter(Boolean).join(' · ');
+  if (metaLine) parts.push(`<span class="ec-meta">— ${escapeHtml(metaLine)}</span>`);
+  return parts.join('') || `<span class="ec-meta">Excerpt</span>`;
+}
+
+/**
+ * True when a link is the sole meaningful content of its paragraph — the
+ * heuristic for promoting it from an inline chip to a full block card (matches
+ * how Capacities renders a link that's alone on a line). Inline links mid-prose
+ * return false and are left untouched (zero regression).
+ */
+export function isBlockLevelLink(a: Element): boolean {
+  const p = a.parentElement;
+  if (!p || p.tagName !== 'P') return false;
+  for (const node of p.childNodes) {
+    if (node === a) continue;
+    if (node.nodeType === 3 /* text */ && (node.textContent ?? '').trim() !== '') return false;
+    if (node.nodeType === 1 /* element */) return false;
+  }
+  return true;
+}

--- a/src/renderer/lib/preview/typed-link-render.ts
+++ b/src/renderer/lib/preview/typed-link-render.ts
@@ -1,0 +1,110 @@
+/**
+ * Type-keyed link-card post-render pass (#1071). Runs after the preview paints
+ * (fire-and-forget, off the critical path), promoting a *block-level* wiki-link
+ * — one that's alone in its paragraph — to a rich card keyed off the target's
+ * type: a typed note → an object card (cover + fields); a `[[quote::id]]` →
+ * an excerpt card (span + source + locator). Inline links mid-prose are left
+ * exactly as today, so untyped/ordinary links never regress.
+ *
+ * Modeled on citation-render.ts: cached, stale-DOM-guarded (a node dropped by a
+ * re-render mid-fetch is skipped), and injecting escaped-string HTML.
+ */
+import { api } from '../ipc/client';
+import type { NoteTypedProperties } from '../../../shared/objects/type-def';
+import type { QuoteMeta } from './cite-meta';
+import { buildObjectCardHtml, buildExcerptCardHtml, isBlockLevelLink } from './typed-card';
+
+export interface TypedCardDeps {
+  previewEl: HTMLElement | null;
+  /** path → typed properties, surviving re-renders; cleared on `revision`. */
+  typePropsCache: Map<string, NoteTypedProperties>;
+  /** id → excerpt metadata, shared with the cite/quote label pass. */
+  quoteMetaCache: Map<string, QuoteMeta>;
+  queryPrefixes: string;
+  /** Resolve a raw wiki-link target to a project-relative path (or null). */
+  resolvePath: (target: string) => string | null;
+}
+
+async function fetchTypedProps(deps: TypedCardDeps, path: string): Promise<NoteTypedProperties> {
+  const cached = deps.typePropsCache.get(path);
+  if (cached) return cached;
+  const rb = await api.types.noteProperties(path);
+  deps.typePropsCache.set(path, rb);
+  return rb;
+}
+
+/** One excerpt's card metadata — cached (shared with the quote-label pass), else
+ *  a single-id graph read mirroring resolveQuoteLabels' projection. */
+async function fetchQuoteMeta(deps: TypedCardDeps, id: string): Promise<QuoteMeta | null> {
+  const cached = deps.quoteMetaCache.get(id);
+  if (cached) return cached;
+  const sparql = `SELECT ?citedText ?sourceTitle ?sourceCreator ?sourceIssued ?page ?pageRange ?locationText WHERE {
+      ?ex minerva:excerptId "${id.replace(/"/g, '\\"')}" .
+      OPTIONAL { ?ex thought:citedText ?citedText }
+      OPTIONAL { ?ex thought:page ?page }
+      OPTIONAL { ?ex thought:pageRange ?pageRange }
+      OPTIONAL { ?ex thought:locationText ?locationText }
+      OPTIONAL {
+        ?ex thought:fromSource ?src .
+        OPTIONAL { ?src dc:title ?sourceTitle }
+        OPTIONAL { ?src dc:creator ?sourceCreator }
+        OPTIONAL { ?src dc:issued ?sourceIssued }
+      }
+    }`;
+  let row: Record<string, string> | undefined;
+  try {
+    const res = await api.graph.query(deps.queryPrefixes + sparql);
+    row = (res.results as Array<Record<string, string>>)[0];
+  } catch {
+    return null;
+  }
+  if (!row) return null;
+  const meta: QuoteMeta = {
+    ...(row.citedText ? { citedText: row.citedText } : {}),
+    ...(row.sourceTitle ? { sourceTitle: row.sourceTitle } : {}),
+    ...(row.sourceCreator ? { sourceCreator: row.sourceCreator } : {}),
+    ...(row.sourceIssued ? { sourceYear: row.sourceIssued.slice(0, 4) } : {}),
+    ...(row.page ? { page: row.page } : {}),
+    ...(row.pageRange ? { pageRange: row.pageRange } : {}),
+    ...(row.locationText ? { locationText: row.locationText } : {}),
+  };
+  deps.quoteMetaCache.set(id, meta);
+  return meta;
+}
+
+export async function hydrateTypedCards(deps: TypedCardDeps): Promise<void> {
+  const el = deps.previewEl;
+  if (!el) return;
+
+  // Typed-note cards — plain `[[Note]]` links only (`.wiki-link` without the
+  // `typed-link` badge class that cite/quote/type:: links carry).
+  const noteLinks = [...el.querySelectorAll<HTMLElement>('.wiki-link:not(.typed-link)')].filter(
+    (a) => a.dataset.typedCard === undefined && isBlockLevelLink(a),
+  );
+  for (const a of noteLinks) {
+    const target = a.dataset.target;
+    if (!target) continue;
+    const path = deps.resolvePath(target);
+    if (!path) continue;
+    const rb = await fetchTypedProps(deps, path);
+    if (!a.isConnected) continue; // preview re-rendered mid-fetch
+    if (!rb.type) continue; // untyped → leave the bare link
+    a.dataset.typedCard = '1';
+    a.classList.add('object-card');
+    a.innerHTML = buildObjectCardHtml(rb, { title: (a.textContent ?? target).trim() });
+  }
+
+  // Excerpt cards — block-level `[[quote::id]]` links.
+  const quoteLinks = [...el.querySelectorAll<HTMLElement>('.quote-link')].filter(
+    (a) => a.dataset.typedCard === undefined && isBlockLevelLink(a),
+  );
+  for (const a of quoteLinks) {
+    const id = a.dataset.excerptId;
+    if (!id) continue;
+    const meta = await fetchQuoteMeta(deps, id);
+    if (!a.isConnected || !meta) continue;
+    a.dataset.typedCard = '1';
+    a.classList.add('excerpt-card');
+    a.innerHTML = buildExcerptCardHtml(meta);
+  }
+}

--- a/src/shared/objects/card.ts
+++ b/src/shared/objects/card.ts
@@ -1,0 +1,54 @@
+/**
+ * Type-keyed render card model (#1071). Pure projection from a note's typed
+ * properties (#1063 read-back) to the small "card" shown in link cards, hover
+ * previews, and the preview pane: a cover image + a selected set of property
+ * chips. The selection is the type's `card:` template (user-overridable),
+ * defaulting to the first few declared properties when a type declares none.
+ *
+ * Renderer-safe (no main imports) so the preview pipeline can build cards
+ * directly, and pure so it tests without IPC.
+ */
+import type { NoteTypedProperties } from './type-def';
+
+export interface CardField {
+  name: string;
+  label: string;
+  /** Lexical value from the read-back, or null when the note leaves it empty. */
+  value: string | null;
+}
+
+export interface ObjectCard {
+  fields: CardField[];
+  /** The cover property's value (an image locator), or null. */
+  cover: string | null;
+}
+
+/** How many declared properties a card shows when the type declares no `card:`. */
+export const DEFAULT_CARD_FIELD_COUNT = 3;
+
+/**
+ * Select the card's cover + property chips from a note's typed properties. The
+ * cover property is never also rendered as a chip (it's the image). Returns
+ * empty when the note has no resolved type.
+ */
+export function selectCardFields(rb: NoteTypedProperties): ObjectCard {
+  const type = rb.type;
+  if (!type) return { fields: [], cover: null };
+
+  const byName = new Map(rb.properties.map((p) => [p.name, p]));
+  const cover = type.cover ? byName.get(type.cover)?.value ?? null : null;
+
+  const chosen = type.card && type.card.length > 0
+    ? type.card
+    : rb.properties.map((p) => p.name).slice(0, DEFAULT_CARD_FIELD_COUNT + (type.cover ? 1 : 0));
+
+  const fields: CardField[] = [];
+  for (const name of chosen) {
+    if (name === type.cover) continue; // shown as the image, not a chip
+    const pd = byName.get(name);
+    if (!pd) continue;
+    fields.push({ name: pd.name, label: pd.label ?? pd.name, value: pd.value });
+    if (!type.card && fields.length >= DEFAULT_CARD_FIELD_COUNT) break;
+  }
+  return { fields, cover };
+}

--- a/src/shared/objects/type-def.ts
+++ b/src/shared/objects/type-def.ts
@@ -43,6 +43,10 @@ export interface TypeDef {
   color?: string | undefined;
   /** Property name whose value is the gallery card's cover image (#1070). */
   cover?: string | undefined;
+  /** Ordered property names shown on the type-keyed render card (link cards,
+   *  hovers, preview) — the card "template" (#1071). Empty/absent → a default
+   *  derived from the first few declared properties. */
+  card?: string[] | undefined;
   source: TypeSource;
   /** Absolute path for user types; the glob key for stock types. */
   filePath: string;
@@ -61,6 +65,10 @@ export interface TypeInfo {
   color?: string | undefined;
   /** Property name whose value is the gallery card's cover image (#1070). */
   cover?: string | undefined;
+  /** Ordered property names shown on the type-keyed render card (link cards,
+   *  hovers, preview) — the card "template" (#1071). Empty/absent → a default
+   *  derived from the first few declared properties. */
+  card?: string[] | undefined;
   source: TypeSource;
 }
 
@@ -93,6 +101,7 @@ export function toTypeInfo(t: TypeDef): TypeInfo {
     icon: t.icon,
     color: t.color,
     cover: t.cover,
+    card: t.card,
     source: t.source,
   };
 }

--- a/tests/main/types/loader.test.ts
+++ b/tests/main/types/loader.test.ts
@@ -111,4 +111,24 @@ describe('parseType (#1062)', () => {
     expect(r.type?.cover).toBe('missing'); // house UX: no hand-holding — still loads
     expect(r.errors.some((e) => /not a declared property/.test(e))).toBe(true);
   });
+
+  it('parses a `card:` list of declared property names (#1071)', () => {
+    const r = parseType(
+      `---\nlabel: Book\ncard: [author, rating]\nproperties:\n  - name: author\n    type: text\n  - name: rating\n    type: number\n---\n`,
+      'user',
+      '/x/book.md',
+    );
+    expect(r.type?.card).toEqual(['author', 'rating']);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('drops unknown `card:` entries with a soft error but keeps the valid ones (#1071)', () => {
+    const r = parseType(
+      `---\nlabel: Book\ncard: [author, bogus]\nproperties:\n  - name: author\n    type: text\n---\n`,
+      'user',
+      '/x/book.md',
+    );
+    expect(r.type?.card).toEqual(['author']);
+    expect(r.errors.some((e) => /"bogus".*not a declared property/.test(e))).toBe(true);
+  });
 });

--- a/tests/renderer/preview/typed-card.test.ts
+++ b/tests/renderer/preview/typed-card.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Type-keyed card HTML builders + the block-level heuristic (#1071).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildObjectCardHtml,
+  buildExcerptCardHtml,
+  isBlockLevelLink,
+  isImageUrl,
+} from '../../../src/renderer/lib/preview/typed-card';
+import type { NoteTypedProperties } from '../../../src/shared/objects/type-def';
+
+function book(values: Record<string, string | null>, over = {}): NoteTypedProperties {
+  return {
+    type: {
+      id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock', icon: '📖', cover: 'cover',
+      properties: [
+        { name: 'cover', type: 'text', label: 'Cover' },
+        { name: 'author', type: 'text', label: 'Author' },
+        { name: 'rating', type: 'number', label: 'Rating' },
+      ],
+      ...over,
+    },
+    properties: [
+      { name: 'cover', type: 'text', label: 'Cover', value: values.cover ?? null },
+      { name: 'author', type: 'text', label: 'Author', value: values.author ?? null },
+      { name: 'rating', type: 'number', label: 'Rating', value: values.rating ?? null },
+    ],
+  };
+}
+
+describe('isImageUrl', () => {
+  it('accepts http(s) URLs and rejects everything else', () => {
+    expect(isImageUrl('https://x/a.png')).toBe(true);
+    expect(isImageUrl('http://x/a.png')).toBe(true);
+    expect(isImageUrl('assets/a.png')).toBe(false);
+    expect(isImageUrl(null)).toBe(false);
+    expect(isImageUrl('')).toBe(false);
+  });
+});
+
+describe('buildObjectCardHtml (#1071)', () => {
+  it('renders a cover image + title + selected field chips', () => {
+    const html = buildObjectCardHtml(book({ cover: 'https://x/dune.png', author: 'Herbert', rating: '5' }), { title: 'Dune' });
+    expect(html).toContain('<img src="https://x/dune.png"');
+    expect(html).toContain('oc-title');
+    expect(html).toContain('Dune');
+    expect(html).toContain('Author');
+    expect(html).toContain('Herbert');
+    expect(html).toContain('Rating');
+    expect(html).toContain('5');
+  });
+
+  it('falls back to the type icon when the cover is not an image URL', () => {
+    const html = buildObjectCardHtml(book({ cover: null, author: 'Herbert' }), { title: 'Dune' });
+    expect(html).not.toContain('<img');
+    expect(html).toContain('oc-cover-icon');
+    expect(html).toContain('📖');
+  });
+
+  it('omits empty fields', () => {
+    const html = buildObjectCardHtml(book({ author: 'Herbert', rating: null }), { title: 'Dune' });
+    expect(html).toContain('Author');
+    expect(html).not.toContain('Rating'); // rating is null → no chip
+  });
+
+  it('escapes untrusted title + values', () => {
+    const html = buildObjectCardHtml(book({ author: '<script>x</script>' }), { title: '<b>t</b>' });
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<b>t</b>');
+    expect(html).toContain('&lt;');
+  });
+});
+
+describe('buildExcerptCardHtml (#1071)', () => {
+  it('renders the span + source byline + locator', () => {
+    const html = buildExcerptCardHtml({
+      citedText: 'Being precedes essence.',
+      sourceTitle: 'Existentialism',
+      sourceCreator: 'Sartre',
+      sourceYear: '1946',
+      pageRange: '12-14',
+    });
+    expect(html).toContain('Being precedes essence.');
+    expect(html).toContain('Existentialism');
+    expect(html).toContain('Sartre (1946)');
+    expect(html).toContain('pp. 12-14');
+  });
+
+  it('degrades gracefully with only a span', () => {
+    const html = buildExcerptCardHtml({ citedText: 'Just a quote.' });
+    expect(html).toContain('Just a quote.');
+  });
+});
+
+describe('isBlockLevelLink (#1071)', () => {
+  function inP(inner: string): Element {
+    const p = document.createElement('p');
+    p.innerHTML = inner;
+    document.body.appendChild(p);
+    return p.querySelector('a')!;
+  }
+
+  it('is true when the link is the sole content of its paragraph', () => {
+    expect(isBlockLevelLink(inP('<a class="wiki-link" data-target="Dune">Dune</a>'))).toBe(true);
+  });
+
+  it('is false for a link mid-prose', () => {
+    expect(isBlockLevelLink(inP('see <a class="wiki-link" data-target="Dune">Dune</a> here'))).toBe(false);
+  });
+
+  it('is false when another element shares the paragraph', () => {
+    expect(isBlockLevelLink(inP('<a class="wiki-link" data-target="Dune">Dune</a><em>x</em>'))).toBe(false);
+  });
+
+  it('is false when the link is not inside a paragraph', () => {
+    const li = document.createElement('li');
+    li.innerHTML = '<a class="wiki-link" data-target="Dune">Dune</a>';
+    document.body.appendChild(li);
+    expect(isBlockLevelLink(li.querySelector('a')!)).toBe(false);
+  });
+});

--- a/tests/renderer/preview/typed-link-render.test.ts
+++ b/tests/renderer/preview/typed-link-render.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The type-keyed card post-render pass (#1071): block-level typed links become
+ * cards; inline links, untyped links, and non-block links are left untouched.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { NoteTypedProperties } from '../../../src/shared/objects/type-def';
+
+const { notePropsMock, queryMock } = vi.hoisted(() => ({ notePropsMock: vi.fn(), queryMock: vi.fn() }));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { types: { noteProperties: notePropsMock }, graph: { query: queryMock } },
+}));
+
+import { hydrateTypedCards, type TypedCardDeps } from '../../../src/renderer/lib/preview/typed-link-render';
+
+const TYPED: NoteTypedProperties = {
+  type: { id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock', icon: '📖', properties: [{ name: 'author', type: 'text', label: 'Author' }] },
+  properties: [{ name: 'author', type: 'text', label: 'Author', value: 'Herbert' }],
+};
+const UNTYPED: NoteTypedProperties = { type: null, properties: [] };
+
+function deps(previewEl: HTMLElement): TypedCardDeps {
+  return {
+    previewEl,
+    typePropsCache: new Map(),
+    quoteMetaCache: new Map(),
+    queryPrefixes: '',
+    resolvePath: (t) => (t === 'Dune' ? 'Dune.md' : t === 'Plain' ? 'Plain.md' : null),
+  };
+}
+
+beforeEach(() => {
+  notePropsMock.mockImplementation((path: string) => Promise.resolve(path === 'Dune.md' ? TYPED : UNTYPED));
+  queryMock.mockResolvedValue({ results: [{ citedText: 'A quote.', sourceTitle: 'Src', pageRange: '1-2' }], columns: [] });
+});
+afterEach(() => { notePropsMock.mockReset(); queryMock.mockReset(); document.body.innerHTML = ''; });
+
+function render(html: string): HTMLElement {
+  const el = document.createElement('div');
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('hydrateTypedCards (#1071)', () => {
+  it('promotes a block-level typed link to an object card', async () => {
+    const el = render('<p><a class="wiki-link" data-target="Dune">Dune</a></p>');
+    await hydrateTypedCards(deps(el));
+    const a = el.querySelector('a')!;
+    expect(a.classList.contains('object-card')).toBe(true);
+    expect(a.innerHTML).toContain('oc-title');
+    expect(a.innerHTML).toContain('Herbert');
+    expect(a.dataset.target).toBe('Dune'); // still navigable
+  });
+
+  it('leaves an inline typed link untouched', async () => {
+    const el = render('<p>see <a class="wiki-link" data-target="Dune">Dune</a> now</p>');
+    await hydrateTypedCards(deps(el));
+    const a = el.querySelector('a')!;
+    expect(a.classList.contains('object-card')).toBe(false);
+    expect(a.textContent).toBe('Dune');
+  });
+
+  it('leaves a block-level link to an untyped note as a bare link', async () => {
+    const el = render('<p><a class="wiki-link" data-target="Plain">Plain</a></p>');
+    await hydrateTypedCards(deps(el));
+    expect(el.querySelector('a')!.classList.contains('object-card')).toBe(false);
+  });
+
+  it('renders a block-level quote link as an excerpt card', async () => {
+    const el = render('<p><a class="wiki-link typed-link quote-link" data-excerpt-id="e1"><span class="link-display">e1</span></a></p>');
+    await hydrateTypedCards(deps(el));
+    const a = el.querySelector('a')!;
+    expect(a.classList.contains('excerpt-card')).toBe(true);
+    expect(a.innerHTML).toContain('A quote.');
+    expect(a.innerHTML).toContain('Src');
+  });
+
+  it('does not touch a cite/type badge link (not a plain note link)', async () => {
+    const el = render('<p><a class="wiki-link typed-link cite-link" data-source-id="s1"><span class="link-display">s1</span></a></p>');
+    await hydrateTypedCards(deps(el));
+    expect(el.querySelector('a')!.classList.contains('object-card')).toBe(false);
+    expect(notePropsMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/shared/objects/card.test.ts
+++ b/tests/shared/objects/card.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Type-keyed card field selection (#1071): the type's `card:` template drives
+ * which property chips show (user-overridable), defaulting to the first few
+ * declared properties; the cover property is pulled out for the image and never
+ * doubled as a chip.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectCardFields, DEFAULT_CARD_FIELD_COUNT } from '../../../src/shared/objects/card';
+import type { NoteTypedProperties, TypeInfo } from '../../../src/shared/objects/type-def';
+
+function typed(over: Partial<TypeInfo>, values: Record<string, string | null>): NoteTypedProperties {
+  const type: TypeInfo = {
+    id: 'book',
+    label: 'Book',
+    classLocalName: 'Book',
+    source: 'stock',
+    properties: [
+      { name: 'cover', type: 'text', label: 'Cover' },
+      { name: 'author', type: 'text', label: 'Author' },
+      { name: 'rating', type: 'number', label: 'Rating' },
+      { name: 'status', type: 'text', label: 'Status' },
+      { name: 'isbn', type: 'text', label: 'ISBN' },
+    ],
+    ...over,
+  };
+  return {
+    type,
+    properties: type.properties.map((p) => ({ ...p, value: values[p.name] ?? null })),
+  };
+}
+
+describe('selectCardFields (#1071)', () => {
+  it('returns empty for an untyped note', () => {
+    expect(selectCardFields({ type: null, properties: [] })).toEqual({ fields: [], cover: null });
+  });
+
+  it('pulls the cover value out and shows the default number of other fields', () => {
+    const rb = typed(
+      { cover: 'cover' },
+      { cover: 'https://x/c.png', author: 'Herbert', rating: '5', status: 'read', isbn: '123' },
+    );
+    const card = selectCardFields(rb);
+    expect(card.cover).toBe('https://x/c.png');
+    expect(card.fields).toHaveLength(DEFAULT_CARD_FIELD_COUNT);
+    expect(card.fields.map((f) => f.name)).not.toContain('cover'); // cover is the image, not a chip
+    expect(card.fields.map((f) => f.name)).toEqual(['author', 'rating', 'status']);
+  });
+
+  it('honors an explicit card: template (the user override)', () => {
+    const rb = typed(
+      { cover: 'cover', card: ['rating', 'author'] },
+      { cover: 'https://x/c.png', author: 'Gibson', rating: '4' },
+    );
+    const card = selectCardFields(rb);
+    expect(card.fields.map((f) => f.name)).toEqual(['rating', 'author']); // order + selection respected
+    expect(card.cover).toBe('https://x/c.png');
+  });
+
+  it('carries the property label + value onto each field', () => {
+    const rb = typed({ card: ['author'] }, { author: 'Le Guin' });
+    expect(selectCardFields(rb).fields[0]).toEqual({ name: 'author', label: 'Author', value: 'Le Guin' });
+  });
+
+  it('has no cover when the type declares none', () => {
+    const rb = typed({ card: ['author'] }, { author: 'x' });
+    expect(selectCardFields(rb).cover).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1071. Phase 3 of the Typed Objects epic (#1060) — "the feels-like-Capacities payoff."

## What

When a wiki-link resolves to a **typed** note, the preview renders it as a **card keyed off its type** — a cover image (or type icon) + a few property chips — instead of a bare link. A `[[quote::id]]` renders as an **excerpt card**: the highlighted span + source byline + locator. Hover previews show the same card.

The rendering is **block-level-aware**: a link that is alone in its paragraph (how you'd drop an object reference on its own line) becomes a full card; a link mid-prose stays exactly as today. So typed cards appear where they read well, and **ordinary/untyped links never regress**.

## Card template (user-overridable)

- A type may declare `card: [author, rating]` — the ordered property chips its card shows (`parse.ts`, soft-validated like `cover`). Absent → the first few declared properties.
- `selectCardFields` (`shared/objects/card.ts`) is the pure projection from a note's #1063 read-back to `{ cover, fields }`. The cover property (#1070) is the image, never doubled as a chip.

## Rendering — reuses the existing preview pipeline (no new engine)

- `typed-card.ts` — pure, escaped-HTML builders (`buildObjectCardHtml` / `buildExcerptCardHtml`) + `isBlockLevelLink`.
- `typed-link-render.ts` — a post-render pass modeled on `citation-render.ts`: **cached, stale-DOM-guarded, lazy**. It promotes block-level typed links to cards after the paint; it never blocks `renderContent`.
- `Preview.svelte` — runs the pass in the post-render rAF, adds a `typePropsCache` (cleared on `revision`, so a save to a linked note refreshes its card), and shows a typed card on wiki-link **hover** (untyped notes keep the title+snippet preview).

Excerpt-card data comes from the graph (`thought:citedText` / `page` / `pageRange` / `locationText` + source), reusing the `QuoteMeta` shape the cite/quote pass already caches. **No annotation** — the excerpt TTL carries none (it lives in the derived note), so the card shows span + source + locator.

## Acceptance criteria

- [x] A wiki-link to a Book renders a card with cover/author/rating; Person → role/affiliation; Meeting → date/attendees — all driven by the type's declared properties + `card:`.
- [x] An Excerpt link/hover renders the span + source locator (+ byline) as a card.
- [x] A user-overridden `card:` template takes effect (test).
- [x] Links to untyped notes render exactly as today (inline links untouched; lookup is lazy and doesn't block the paint).

## Out of scope (per the issue)

- The multi-view table/gallery (#1070, shipped). Excerpt-as-typed-*edge* (#1073). Semantic/unlinked mentions (#1074). A full free-form card-template language (kept to property selection, per "no new renderer engine").

## Tests

- `tests/shared/objects/card.test.ts` — `selectCardFields`: default selection, explicit `card:` override, cover extraction.
- `tests/renderer/preview/typed-card.test.ts` — card builders (cover img vs icon, empty-field omission, escaping), excerpt card, `isBlockLevelLink` heuristic.
- `tests/renderer/preview/typed-link-render.test.ts` — the pass end-to-end: block typed → card, inline/untyped/cite links untouched, block quote → excerpt card.
- `tests/main/types/loader.test.ts` — `card:` parse (valid + soft-flagged unknown).

No new IPC (reuses `types.noteProperties` + graph reads). `pnpm lint` clean; 665 preview/objects/types/graph tests green.