### PR TITLE
feat(objects): saved views — persist a type's mode/sort/columns (#1072)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -10,6 +10,7 @@ import { registerSites } from './ipc/register-sites';
 import { registerBibliography } from './ipc/register-bibliography';
 import { registerTools } from './ipc/register-tools';
 import { registerTypes } from './ipc/register-types';
+import { registerViews } from './ipc/register-views';
 import { registerRefactor } from './ipc/register-refactor';
 import { registerSources } from './ipc/register-sources';
 import { registerCompute } from './ipc/register-compute';
@@ -43,6 +44,7 @@ export function registerIpcHandlers(): void {
   registerBibliography();
   registerTools();
   registerTypes();
+  registerViews();
   registerRefactor();
   registerSources();
   registerCompute();

--- a/src/main/ipc/register-views.ts
+++ b/src/main/ipc/register-views.ts
@@ -1,0 +1,25 @@
+/**
+ * Saved-views IPC (#1072) — CRUD + reorder over the typed-object multi-view
+ * presets, mirroring register-queries.ts. Project scope needs the event's root
+ * path; the store no-ops gracefully when none is open.
+ */
+import { Channels } from '../../shared/channels';
+import { handle } from './typed-ipc';
+import * as savedViews from '../saved-views';
+import type { SavedViewInput } from '../../shared/types';
+import { rootPathFromEvent } from './helpers';
+
+export function registerViews(): void {
+  handle(Channels.VIEWS_LIST, (e) => savedViews.listSavedViews(rootPathFromEvent(e)));
+
+  handle(Channels.VIEWS_SAVE, (e, scope: 'project' | 'global', input: SavedViewInput) =>
+    savedViews.saveView(rootPathFromEvent(e), scope, input));
+
+  handle(Channels.VIEWS_DELETE, (_e, filePath: string) => savedViews.deleteView(filePath));
+
+  handle(Channels.VIEWS_RENAME, (_e, filePath: string, newName: string) =>
+    savedViews.renameView(filePath, newName));
+
+  handle(Channels.VIEWS_SET_ORDER, (_e, entries: Array<{ filePath: string; order: number | null }>) =>
+    savedViews.setViewOrder(entries));
+}

--- a/src/main/saved-views.ts
+++ b/src/main/saved-views.ts
@@ -1,0 +1,172 @@
+/**
+ * Saved views (#1072) — a named preset over a type's multi-view (#1070): its
+ * mode (list/table/gallery), sort, and visible columns. Persistence mirrors
+ * `saved-queries.ts` per the #1061 decision ("a config entry, not a note"):
+ * one file per view, project scope under `.minerva/views/` (travels with the
+ * thoughtbase) or global under userData. Stored as JSON — a view is structured
+ * config, not a query body, so JSON beats a header-comment format.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import type { SavedView, SavedViewInput, ViewLayout, ViewScope } from '../shared/types';
+
+export type { SavedView, SavedViewInput, ViewLayout, ViewScope } from '../shared/types';
+
+function globalViewsDir(): string {
+  return path.join(app.getPath('userData'), 'views');
+}
+function projectViewsDir(rootPath: string): string {
+  return path.join(rootPath, '.minerva', 'views');
+}
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+export function sanitizeFilename(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 60);
+}
+
+/** Project views live under `.minerva/views/`; everything else is global. */
+function scopeFromPath(filePath: string): ViewScope {
+  return filePath.includes(`${path.sep}.minerva${path.sep}views${path.sep}`) ? 'project' : 'global';
+}
+
+const LAYOUTS: ViewLayout[] = ['list', 'table', 'gallery'];
+
+/** Coerce arbitrary JSON into a SavedViewInput, defaulting anything malformed
+ *  (house UX: a hand-edited file never crashes the list). */
+export function normalizeViewJson(raw: unknown, fallbackName: string): SavedViewInput {
+  const o = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  const layout = LAYOUTS.includes(o.layout as ViewLayout) ? (o.layout as ViewLayout) : 'table';
+  const columns = Array.isArray(o.columns) ? o.columns.filter((c): c is string => typeof c === 'string') : null;
+  return {
+    name: typeof o.name === 'string' && o.name.trim() ? o.name : fallbackName,
+    typeId: typeof o.typeId === 'string' ? o.typeId : '',
+    layout,
+    sortColumn: typeof o.sortColumn === 'string' ? o.sortColumn : null,
+    sortDir: o.sortDir === 'desc' ? 'desc' : 'asc',
+    columns,
+    order: typeof o.order === 'number' ? o.order : null,
+  };
+}
+
+export function serializeView(input: SavedViewInput): string {
+  const body: Record<string, unknown> = {
+    name: input.name,
+    typeId: input.typeId,
+    layout: input.layout,
+    sortColumn: input.sortColumn,
+    sortDir: input.sortDir,
+    columns: input.columns,
+  };
+  if (input.order != null) body.order = input.order;
+  return JSON.stringify(body, null, 2) + '\n';
+}
+
+function parseViewFile(filePath: string, scope: ViewScope): SavedView {
+  const id = path.basename(filePath, '.json');
+  let raw: unknown = {};
+  try {
+    raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    /* malformed → normalized to defaults below */
+  }
+  const input = normalizeViewJson(raw, id);
+  return {
+    id,
+    name: input.name,
+    typeId: input.typeId,
+    layout: input.layout,
+    sortColumn: input.sortColumn,
+    sortDir: input.sortDir,
+    columns: input.columns,
+    scope,
+    filePath,
+    order: input.order ?? null,
+  };
+}
+
+function listDir(dir: string, scope: ViewScope): SavedView[] {
+  try {
+    return fs.readdirSync(dir)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => parseViewFile(path.join(dir, f), scope));
+  } catch {
+    return [];
+  }
+}
+
+/** Explicit `order` first (ascending), then alphabetical by name. */
+function compareViews(a: SavedView, b: SavedView): number {
+  if (a.order != null && b.order != null) {
+    if (a.order !== b.order) return a.order - b.order;
+  } else if (a.order != null) {
+    return -1;
+  } else if (b.order != null) {
+    return 1;
+  }
+  return a.name.localeCompare(b.name);
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export function listSavedViews(rootPath: string | null): SavedView[] {
+  const global = listDir(globalViewsDir(), 'global').sort(compareViews);
+  const project = rootPath ? listDir(projectViewsDir(rootPath), 'project').sort(compareViews) : [];
+  return [...project, ...global];
+}
+
+export function saveView(rootPath: string | null, scope: ViewScope, input: SavedViewInput): SavedView {
+  const dir = scope === 'project' && rootPath ? projectViewsDir(rootPath) : globalViewsDir();
+  ensureDir(dir);
+  const id = sanitizeFilename(input.name) || 'view';
+  const filePath = path.join(dir, `${id}.json`);
+  fs.writeFileSync(filePath, serializeView(input), 'utf-8');
+  return {
+    id,
+    name: input.name,
+    typeId: input.typeId,
+    layout: input.layout,
+    sortColumn: input.sortColumn,
+    sortDir: input.sortDir,
+    columns: input.columns,
+    scope,
+    filePath,
+    order: input.order ?? null,
+  };
+}
+
+export function deleteView(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    /* already gone */
+  }
+}
+
+export function renameView(filePath: string, newName: string): string {
+  const input = normalizeViewJson(JSON.parse(fs.readFileSync(filePath, 'utf-8')), path.basename(filePath, '.json'));
+  input.name = newName;
+  const newPath = path.join(path.dirname(filePath), `${sanitizeFilename(newName) || 'view'}.json`);
+  fs.writeFileSync(newPath, serializeView(input), 'utf-8');
+  if (newPath !== filePath) {
+    try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+  }
+  return newPath;
+}
+
+/** Apply a new ordering across many views at once (drag-to-reorder produces one
+ *  "here's the new sequence" payload — mirrors setQueryOrder). */
+export function setViewOrder(entries: Array<{ filePath: string; order: number | null }>): void {
+  for (const { filePath, order } of entries) {
+    let parsed: unknown;
+    try { parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')); } catch { continue; }
+    const input = normalizeViewJson(parsed, path.basename(filePath, '.json'));
+    input.order = order;
+    fs.writeFileSync(filePath, serializeView(input), 'utf-8');
+  }
+}
+
+// Re-exported for tests / callers that need the scope heuristic.
+export { scopeFromPath };

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -111,6 +111,15 @@ contextBridge.exposeInMainWorld('api', {
     setOrder: (entries: Array<{ filePath: string; order: number | null }>) =>
       invoke(Channels.QUERIES_SET_ORDER, entries),
   },
+  views: {
+    list: () => invoke(Channels.VIEWS_LIST),
+    save: (scope: 'project' | 'global', input: Parameters<ChannelMap['views:save']>[1]) =>
+      invoke(Channels.VIEWS_SAVE, scope, input),
+    delete: (filePath: string) => invoke(Channels.VIEWS_DELETE, filePath),
+    rename: (filePath: string, newName: string) => invoke(Channels.VIEWS_RENAME, filePath, newName),
+    setOrder: (entries: Array<{ filePath: string; order: number | null }>) =>
+      invoke(Channels.VIEWS_SET_ORDER, entries),
+  },
   search: {
     query: (query: string) => invoke(Channels.SEARCH_QUERY, query),
   },

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -19,7 +19,8 @@
   import SourceDetail from './lib/components/SourceDetail.svelte';
   import { onMount } from 'svelte';
   import { getNotebaseStore } from './lib/stores/notebase.svelte';
-  import { getEditorStore } from './lib/stores/editor.svelte';
+  import { getEditorStore, type TypeViewTab } from './lib/stores/editor.svelte';
+  import { savedViewsStore } from './lib/stores/saved-views.svelte';
   import { getBusyStore } from './lib/stores/busy.svelte';
   import { getClipboardStore } from './lib/stores/clipboard.svelte';
   import { getSourceFlowStore } from './lib/stores/source-flow.svelte';
@@ -41,7 +42,7 @@
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
   import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
-  import type { SafeDeleteBlocker, MenuEditorState } from '../shared/types';
+  import type { SafeDeleteBlocker, MenuEditorState, SavedView } from '../shared/types';
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
   import { buildCommandRegistry } from './lib/command-palette/registry';
@@ -57,6 +58,7 @@
   import ShortcutsDialog from './lib/components/ShortcutsDialog.svelte';
   import GotoLineDialog from './lib/components/GotoLineDialog.svelte';
   import EditSavedQueriesDialog from './lib/components/EditSavedQueriesDialog.svelte';
+  import EditSavedViewsDialog from './lib/components/EditSavedViewsDialog.svelte';
   import SaveQueryDialog from './lib/components/SaveQueryDialog.svelte';
   import FindInNotesDialog from './lib/components/FindInNotesDialog.svelte';
   import GotoNoteDialog from './lib/components/GotoNoteDialog.svelte';
@@ -386,6 +388,34 @@
   const dialogs = getDialogStore();
   const linkDrag = getLinkDrag();
   const { showPrompt, showConfirm, showComputeConsent } = dialogs;
+
+  let showEditSavedViews = $state(false);
+
+  // Open a saved view (#1072): its exact projection — mode, sort, columns —
+  // re-applied onto (or opening) the type's multi-view tab.
+  function handleOpenSavedView(view: SavedView): void {
+    editor.openTypeView(view.typeId, {
+      layout: view.layout,
+      sortColumn: view.sortColumn,
+      sortDir: view.sortDir,
+      columns: view.columns,
+    });
+  }
+
+  // Save the active type-view's projection as a named view (#1072). Defaults to
+  // project scope so the preset travels with the thoughtbase.
+  async function handleSaveView(tab: TypeViewTab): Promise<void> {
+    const name = await showPrompt('Save view as:');
+    if (!name) return;
+    await savedViewsStore.save('project', {
+      name,
+      typeId: tab.typeId,
+      layout: tab.layout,
+      sortColumn: tab.sortColumn,
+      sortDir: tab.sortDir,
+      columns: tab.columns,
+    });
+  }
   // The format-family group id the Export menu launched with (#: export-menu-redesign).
   let exportDialogGroup = $state<string | null>(null);
   let publishDialogOpen = $state(false);
@@ -940,6 +970,8 @@
           onSourceSelect={(id) => handleOpenSource(id)}
           onOpenExcerpt={handleOpenExcerpt}
           onOpenType={handleOpenTypeView}
+          onOpenView={handleOpenSavedView}
+          onManageViews={() => { showEditSavedViews = true; }}
           onSourceDeleted={handleSourceDeleted}
           onShowConfirm={showConfirm}
           onShowPrompt={showPrompt}
@@ -1228,9 +1260,13 @@
                   <TypeView
                     typeId={active.typeId}
                     layout={active.layout}
+                    sortColumn={active.sortColumn}
+                    sortDir={active.sortDir}
+                    columns={active.columns}
                     revision={graphRevision}
-                    onLayoutChange={(l) => editor.setTypeViewLayout(active.typeId, l)}
+                    onStateChange={(patch) => editor.setTypeViewState(active.typeId, patch)}
                     onOpenNote={(p) => handleFileSelect(p)}
+                    {...(notebase.meta ? { onSaveView: () => handleSaveView(active) } : {})}
                   />
                 {/key}
               {:else if active?.type === 'unsupported'}
@@ -1402,6 +1438,9 @@
   {/if}
   {#if showEditSavedQueries}
     <EditSavedQueriesDialog projectOpen={!!notebase.meta} onClose={() => { showEditSavedQueries = false; }} />
+  {/if}
+  {#if showEditSavedViews}
+    <EditSavedViewsDialog onClose={() => { showEditSavedViews = false; }} />
   {/if}
   {#if saveQueryRequest}
     <SaveQueryDialog

--- a/src/renderer/lib/components/EditSavedViewsDialog.svelte
+++ b/src/renderer/lib/components/EditSavedViewsDialog.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  /**
+   * Manage saved views (#1072) — rename, delete, reorder. Mirrors
+   * EditSavedQueriesDialog but leaner: no scope-move, no groups. Views are
+   * grouped into Thoughtbase / Global sections; reorder is per-section via
+   * up/down, writing an explicit order across that section. All mutations go
+   * through the saved-views store (renderer data-flow rule #1086).
+   */
+  import { onMount } from 'svelte';
+  import { savedViewsStore } from '../stores/saved-views.svelte';
+  import type { SavedView, ViewScope } from '../../../shared/types';
+
+  interface Props {
+    onClose: () => void;
+  }
+  let { onClose }: Props = $props();
+
+  let renamingPath = $state<string | null>(null);
+  let renameValue = $state('');
+  let renameInput = $state<HTMLInputElement>();
+
+  onMount(() => { void savedViewsStore.refresh(); });
+
+  const sections = $derived<{ scope: ViewScope; label: string; items: SavedView[] }[]>(
+    (['project', 'global'] as ViewScope[])
+      .map((scope) => ({
+        scope,
+        label: scope === 'project' ? 'Thoughtbase' : 'Global',
+        items: savedViewsStore.views.filter((v) => v.scope === scope),
+      }))
+      .filter((s) => s.items.length > 0),
+  );
+
+  function startRename(v: SavedView): void {
+    renamingPath = v.filePath;
+    renameValue = v.name;
+    requestAnimationFrame(() => renameInput?.focus());
+  }
+  async function commitRename(): Promise<void> {
+    const path = renamingPath;
+    const name = renameValue.trim();
+    renamingPath = null;
+    if (path && name) await savedViewsStore.rename(path, name);
+  }
+
+  async function remove(v: SavedView): Promise<void> {
+    await savedViewsStore.remove(v.filePath);
+  }
+
+  /** Swap a view with its neighbour in the section and persist the new order. */
+  async function move(items: SavedView[], index: number, dir: -1 | 1): Promise<void> {
+    const j = index + dir;
+    if (j < 0 || j >= items.length) return;
+    const reordered = [...items];
+    [reordered[index], reordered[j]] = [reordered[j]!, reordered[index]!];
+    await savedViewsStore.reorder(reordered.map((v, i) => ({ filePath: v.filePath, order: i })));
+  }
+
+  function overlayKey(e: KeyboardEvent): void {
+    if (e.key === 'Escape') onClose();
+  }
+</script>
+
+<div class="overlay" onkeydown={overlayKey} onmousedown={(e) => { if (e.target === e.currentTarget) onClose(); }} role="presentation">
+  <div class="dialog" role="dialog" aria-modal="true" aria-label="Manage saved views">
+    <h3 class="title">Saved Views</h3>
+
+    {#if sections.length === 0}
+      <p class="empty">No saved views yet. Configure a type view and choose “Save view”.</p>
+    {:else}
+      {#each sections as section (section.scope)}
+        {#if sections.length > 1}<div class="section-label">{section.label}</div>{/if}
+        <ul class="list">
+          {#each section.items as v, i (v.filePath)}
+            <li class="row">
+              {#if renamingPath === v.filePath}
+                <input
+                  class="name-input"
+                  bind:this={renameInput}
+                  bind:value={renameValue}
+                  onblur={commitRename}
+                  onkeydown={(e) => { if (e.key === 'Enter') void commitRename(); else if (e.key === 'Escape') renamingPath = null; }}
+                />
+              {:else}
+                <span class="name" ondblclick={() => startRename(v)}>{v.name}</span>
+              {/if}
+              <span class="type-badge">{v.typeId}</span>
+              <span class="mode-badge">{v.layout}</span>
+              <span class="spacer"></span>
+              <button class="row-btn" title="Move up" aria-label="Move up" disabled={i === 0} onclick={() => move(section.items, i, -1)}>↑</button>
+              <button class="row-btn" title="Move down" aria-label="Move down" disabled={i === section.items.length - 1} onclick={() => move(section.items, i, 1)}>↓</button>
+              <button class="row-btn" onclick={() => startRename(v)}>Rename</button>
+              <button class="row-btn" onclick={() => remove(v)}>Delete</button>
+            </li>
+          {/each}
+        </ul>
+      {/each}
+    {/if}
+
+    <div class="actions">
+      <button class="btn" onclick={onClose}>Close</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+  .dialog {
+    width: 520px;
+    max-width: 90vw;
+    max-height: 80vh;
+    overflow-y: auto;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 18px 20px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+  }
+  .title { margin: 0 0 12px; font-size: 15px; color: var(--text); }
+  .empty { color: var(--text-faint); font-size: 13px; }
+  .section-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-faint);
+    margin: 12px 0 4px;
+  }
+  .list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 6px;
+    border-radius: 6px;
+  }
+  .row:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  .name { font-size: 13px; color: var(--text); cursor: text; }
+  .name-input {
+    font-size: 13px;
+    padding: 2px 6px;
+    background: var(--bg-inset);
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    color: var(--text);
+    font-family: inherit;
+  }
+  .type-badge, .mode-badge {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    background: color-mix(in oklch, var(--text) 6%, transparent);
+    color: var(--text-faint);
+  }
+  .spacer { flex: 1; }
+  .row-btn {
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-button);
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .row-btn:hover:not(:disabled) { color: var(--text); border-color: var(--accent); }
+  .row-btn:disabled { opacity: 0.4; cursor: default; }
+  .actions { display: flex; justify-content: flex-end; margin-top: 16px; }
+  .btn {
+    padding: 6px 16px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-button);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .btn:hover { border-color: var(--accent); }
+</style>

--- a/src/renderer/lib/components/ObjectsPanel.svelte
+++ b/src/renderer/lib/components/ObjectsPanel.svelte
@@ -10,7 +10,9 @@
    */
   import { api } from '../ipc/client';
   import ExcerptsBrowser from './ExcerptsBrowser.svelte';
+  import { savedViewsStore } from '../stores/saved-views.svelte';
   import type { TypeInfo } from '../../../shared/objects/type-def';
+  import type { SavedView } from '../../../shared/types';
 
   interface Props {
     onFileSelect: (relativePath: string) => void;
@@ -18,8 +20,12 @@
     onOpenExcerpt?: (excerptId: string) => void;
     /** Open a type's instances in the main-pane list/table/gallery view (#1070). */
     onOpenType?: (typeId: string) => void;
+    /** Open a saved view (its preset) in the main-pane multi-view (#1072). */
+    onOpenView?: (view: SavedView) => void;
+    /** Open the rename/delete/reorder dialog for saved views (#1072). */
+    onManageViews?: () => void;
   }
-  let { onFileSelect, onOpenExcerpt, onOpenType }: Props = $props();
+  let { onFileSelect, onOpenExcerpt, onOpenType, onOpenView, onManageViews }: Props = $props();
 
   interface TypeRow { type: TypeInfo; count: number; }
   interface Instance { title: string; path: string; }
@@ -69,7 +75,12 @@
   }
 
   export async function refresh(): Promise<void> {
-    const [cat, counts, exCount] = await Promise.all([api.types.list(), loadCounts(), loadExcerptCount()]);
+    const [cat, counts, exCount] = await Promise.all([
+      api.types.list(),
+      loadCounts(),
+      loadExcerptCount(),
+      savedViewsStore.refresh(), // #1072 — keep the saved-view sub-rows fresh
+    ]);
     rows = cat.types.map((type) => ({ type, count: counts[type.id] ?? 0 }));
     excerptCount = exCount;
     await Promise.all([...expanded].map((id) => loadInstances(id)));
@@ -100,6 +111,15 @@
         <button class="open-view" title={`Open ${row.type.label} view`} aria-label={`Open ${row.type.label} view`} onclick={() => onOpenType(row.type.id)}>⤢</button>
       {/if}
     </div>
+    <!-- Saved views for this type (#1072) — preset projections, always visible. -->
+    {#if onOpenView}
+      {#each savedViewsStore.forType(row.type.id) as view (view.id)}
+        <button class="view-row" onclick={() => onOpenView(view)} title={`Open saved view: ${view.name}`}>
+          <span class="view-icon">⊞</span>
+          <span class="view-name">{view.name}</span>
+        </button>
+      {/each}
+    {/if}
     {#if open}
       {#if (instances[row.type.id] ?? []).length === 0}
         <p class="no-instances">No {row.type.label.toLowerCase()} yet</p>
@@ -131,6 +151,10 @@
 
   {#if rows.length === 0 && excerptCount === 0}
     <p class="empty">No types or excerpts in this project yet.</p>
+  {/if}
+
+  {#if onManageViews && savedViewsStore.views.length > 0}
+    <button class="manage-views" onclick={() => onManageViews()}>Manage saved views…</button>
   {/if}
 </div>
 
@@ -218,4 +242,35 @@
     padding: 4px 8px 4px 30px;
     margin: 0;
   }
+  /* Saved-view sub-rows (#1072) — indented under their type. */
+  .view-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 3px 8px 3px 30px;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .view-row:hover { background: color-mix(in oklch, var(--text) 4%, transparent); color: var(--text); }
+  .view-icon { font-size: 11px; color: var(--text-faint); flex-shrink: 0; }
+  .view-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .manage-views {
+    margin-top: 6px;
+    padding: 5px 8px;
+    border: none;
+    background: transparent;
+    color: var(--text-faint);
+    font-family: inherit;
+    font-size: 11.5px;
+    text-align: left;
+    cursor: pointer;
+  }
+  .manage-views:hover { color: var(--text); }
 </style>

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -80,6 +80,9 @@
     onOpenExcerpt?: (excerptId: string) => void;
     /** Open a type's instances in the main-pane multi-view (#1070). */
     onOpenType?: (typeId: string) => void;
+    /** Open a saved view preset / manage saved views (#1072). */
+    onOpenView?: (view: import('../../../shared/types').SavedView) => void;
+    onManageViews?: () => void;
     onSourceDeleted?: (sourceId: string) => void;
     onShowConfirm?: (message: string, key: string, label?: string) => Promise<boolean>;
     onShowPrompt?: (message: string, initialOrOptions?: string | { suggestions?: string[]; initial?: string }) => Promise<string | null>;
@@ -91,7 +94,7 @@
     canPaste?: boolean;
   }
 
-  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onAddProperty, onRemoveProperty, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onOpenExcerpt, onOpenType, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onOpenNote, onExternalDrop, canPaste = false }: Props = $props();
+  let { files, rootName, activeFilePath, onFileSelect, onNavigate, onOpenAtOffset, onNewNote, onNewFolder, onDelete, onAddTag, onRemoveTag, onAddProperty, onRemoveProperty, onFormat, onRename, onMerge, onCut, onCopy, onPaste, onMove, onBookmark, onToggleEntrypoint, onSourceSelect, onOpenExcerpt, onOpenType, onOpenView, onManageViews, onSourceDeleted, onShowConfirm, onShowPrompt, onMineReferences, onTableClick, onOpenCsv, onOpenNote, onExternalDrop, canPaste = false }: Props = $props();
   let activePanel = $state<PanelType>('notes');
   let rootDropHover = $state(false);
   let rootExpanded = $state(true);
@@ -663,7 +666,7 @@
     {:else if activePanel === 'tags'}
       <TagPanel bind:this={tagPanel} {onFileSelect} {...(onSourceSelect !== undefined ? { onSourceSelect } : {})} />
     {:else if activePanel === 'objects'}
-      <ObjectsPanel bind:this={objectsPanel} {onFileSelect} {...(onOpenExcerpt !== undefined ? { onOpenExcerpt } : {})} {...(onOpenType !== undefined ? { onOpenType } : {})} />
+      <ObjectsPanel bind:this={objectsPanel} {onFileSelect} {...(onOpenExcerpt !== undefined ? { onOpenExcerpt } : {})} {...(onOpenType !== undefined ? { onOpenType } : {})} {...(onOpenView !== undefined ? { onOpenView } : {})} {...(onManageViews !== undefined ? { onManageViews } : {})} />
     {:else if activePanel === 'tables'}
       {#if onTableClick && onOpenCsv && onOpenNote}
         <TablesPanel bind:this={tablesPanel} {onTableClick} {onOpenCsv} {onOpenNote} />

--- a/src/renderer/lib/components/TypeView.svelte
+++ b/src/renderer/lib/components/TypeView.svelte
@@ -6,6 +6,10 @@
    * same data": every projection reads the one `api.types.instances(typeId)`
    * result, so toggling never re-queries the instance set.
    *
+   * Projection state (layout / sort / visible columns) is PROP-DRIVEN: it lives
+   * on the tab (persisted across sessions) and is mutated via `onStateChange`,
+   * so a saved view (#1072) restores it exactly and "Save view" can capture it.
+   *
    * A read-only surface: rows/cards deep-link to the note (the property form
    * #1066 is where values are edited); table cells never mutate the graph.
    */
@@ -13,25 +17,29 @@
   import type { PropertyDef, TypeInfo, TypeInstanceRow } from '../../../shared/objects/type-def';
 
   type Layout = 'list' | 'table' | 'gallery';
+  interface StatePatch { layout?: Layout; sortColumn?: string | null; sortDir?: 'asc' | 'desc'; columns?: string[] | null }
 
   interface Props {
     typeId: string;
     layout: Layout;
+    /** Sort key (property name, `__title`, or null) + direction — from the tab. */
+    sortColumn: string | null;
+    sortDir: 'asc' | 'desc';
+    /** Visible property names (table); null = every declared column. */
+    columns: string[] | null;
     /** Bumped by the host on write/reindex so the view re-projects (#1070). */
     revision: number;
-    onLayoutChange: (layout: Layout) => void;
+    onStateChange: (patch: StatePatch) => void;
     onOpenNote: (relativePath: string) => void;
+    /** Save the current projection as a named view (#1072); omitted when unavailable. */
+    onSaveView?: () => void;
   }
-  let { typeId, layout, revision, onLayoutChange, onOpenNote }: Props = $props();
+  let { typeId, layout, sortColumn, sortDir, columns, revision, onStateChange, onOpenNote, onSaveView }: Props = $props();
 
   let type = $state<TypeInfo | null>(null);
   let instances = $state<TypeInstanceRow[]>([]);
   let loading = $state(true);
-
-  // Sort state (table view). `null` column = the intrinsic title/path order the
-  // projection already returns.
-  let sortCol = $state<string | null>(null);
-  let sortDir = $state<'asc' | 'desc'>('asc');
+  let columnsMenuOpen = $state(false);
 
   async function load(): Promise<void> {
     loading = true;
@@ -40,14 +48,27 @@
     instances = result.instances;
     loading = false;
   }
-
   // Re-project when the type changes or the graph is rewritten.
   $effect(() => { typeId; revision; void load(); });
 
-  const columns = $derived<PropertyDef[]>(type?.properties ?? []);
+  const allColumns = $derived<PropertyDef[]>(type?.properties ?? []);
+  // Visible columns (table): null on the tab means "all". Order follows the
+  // type's declared order regardless of the saved set.
+  const visibleColumns = $derived<PropertyDef[]>(
+    columns === null ? allColumns : allColumns.filter((c) => columns.includes(c.name)),
+  );
 
-  /** Human-readable cell value: link-to-type IRIs collapse to their tail; other
-   *  types show their lexical string; null → an em dash. */
+  function isVisible(name: string): boolean {
+    return columns === null || columns.includes(name);
+  }
+  function toggleColumn(name: string): void {
+    const all = allColumns.map((c) => c.name);
+    const cur = new Set(columns ?? all);
+    if (cur.has(name)) cur.delete(name); else cur.add(name);
+    const next = all.filter((n) => cur.has(n));
+    onStateChange({ columns: next.length === all.length ? null : next });
+  }
+
   function display(prop: PropertyDef, value: string | null): string {
     if (value === null || value === '') return '—';
     if (prop.type === 'link-to-type') {
@@ -57,9 +78,8 @@
     return value;
   }
 
-  /** First non-empty declared-property value — the list row's summary line. */
   function summary(inst: TypeInstanceRow): string {
-    for (const col of columns) {
+    for (const col of allColumns) {
       const v = inst.values[col.name];
       if (v) return `${col.label ?? col.name}: ${display(col, v)}`;
     }
@@ -67,8 +87,8 @@
   }
 
   function toggleSort(col: string): void {
-    if (sortCol === col) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
-    else { sortCol = col; sortDir = 'asc'; }
+    if (sortColumn === col) onStateChange({ sortDir: sortDir === 'asc' ? 'desc' : 'asc' });
+    else onStateChange({ sortColumn: col, sortDir: 'asc' });
   }
 
   function cellFor(inst: TypeInstanceRow, col: string): string | null {
@@ -76,14 +96,13 @@
   }
 
   const sorted = $derived.by<TypeInstanceRow[]>(() => {
-    if (!sortCol) return instances;
-    const col = sortCol;
-    const numeric = col !== '__title' && columns.find((c) => c.name === col)?.type === 'number';
+    if (!sortColumn) return instances;
+    const col = sortColumn;
+    const numeric = col !== '__title' && allColumns.find((c) => c.name === col)?.type === 'number';
     const dir = sortDir === 'asc' ? 1 : -1;
     return [...instances].sort((a, b) => {
       const av = cellFor(a, col);
       const bv = cellFor(b, col);
-      // Empty values always sort last, regardless of direction.
       if (av === null || av === '') return bv === null || bv === '' ? 0 : 1;
       if (bv === null || bv === '') return -1;
       const cmp = numeric
@@ -109,15 +128,36 @@
     <span class="tv-icon" style={type?.color ? `color:${type.color}` : undefined}>{type?.icon ?? '◆'}</span>
     <h1 class="tv-title">{type?.label ?? typeId}</h1>
     <span class="tv-count">{instances.length}</span>
-    <div class="tv-switch" role="tablist" aria-label="View">
-      {#each LAYOUTS as l (l.id)}
-        <button
-          role="tab"
-          aria-selected={layout === l.id}
-          class:active={layout === l.id}
-          onclick={() => onLayoutChange(l.id)}
-        >{l.label}</button>
-      {/each}
+
+    <div class="tv-actions">
+      {#if layout === 'table' && allColumns.length > 0}
+        <div class="tv-columns">
+          <button class="tv-btn" aria-expanded={columnsMenuOpen} onclick={() => (columnsMenuOpen = !columnsMenuOpen)}>Columns ▾</button>
+          {#if columnsMenuOpen}
+            <div class="tv-columns-menu" role="menu">
+              {#each allColumns as col (col.name)}
+                <label>
+                  <input type="checkbox" checked={isVisible(col.name)} onchange={() => toggleColumn(col.name)} />
+                  {col.label ?? col.name}
+                </label>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/if}
+      {#if onSaveView}
+        <button class="tv-btn" onclick={() => onSaveView?.()}>Save view</button>
+      {/if}
+      <div class="tv-switch" role="tablist" aria-label="View">
+        {#each LAYOUTS as l (l.id)}
+          <button
+            role="tab"
+            aria-selected={layout === l.id}
+            class:active={layout === l.id}
+            onclick={() => onStateChange({ layout: l.id })}
+          >{l.label}</button>
+        {/each}
+      </div>
     </div>
   </header>
 
@@ -143,17 +183,17 @@
           <tr>
             <th
               class="sortable"
-              class:sorted={sortCol === '__title'}
-              aria-sort={sortCol === '__title' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+              class:sorted={sortColumn === '__title'}
+              aria-sort={sortColumn === '__title' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
               onclick={() => toggleSort('__title')}
-            >Title{#if sortCol === '__title'}<span class="arrow">{sortDir === 'asc' ? '▲' : '▼'}</span>{/if}</th>
-            {#each columns as col (col.name)}
+            >Title{#if sortColumn === '__title'}<span class="arrow">{sortDir === 'asc' ? '▲' : '▼'}</span>{/if}</th>
+            {#each visibleColumns as col (col.name)}
               <th
                 class="sortable"
-                class:sorted={sortCol === col.name}
-                aria-sort={sortCol === col.name ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+                class:sorted={sortColumn === col.name}
+                aria-sort={sortColumn === col.name ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
                 onclick={() => toggleSort(col.name)}
-              >{col.label ?? col.name}{#if sortCol === col.name}<span class="arrow">{sortDir === 'asc' ? '▲' : '▼'}</span>{/if}</th>
+              >{col.label ?? col.name}{#if sortColumn === col.name}<span class="arrow">{sortDir === 'asc' ? '▲' : '▼'}</span>{/if}</th>
             {/each}
           </tr>
         </thead>
@@ -161,7 +201,7 @@
           {#each sorted as inst (inst.path)}
             <tr onclick={() => onOpenNote(inst.path)} title={inst.path}>
               <td class="tv-cell-title">{inst.title}</td>
-              {#each columns as col (col.name)}
+              {#each visibleColumns as col (col.name)}
                 <td>{display(col, inst.values[col.name] ?? null)}</td>
               {/each}
             </tr>
@@ -206,7 +246,46 @@
     color: var(--text-faint);
     font-variant-numeric: tabular-nums;
   }
-  .tv-switch { margin-left: auto; display: flex; gap: 2px; }
+  .tv-actions { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+  .tv-btn {
+    padding: 3px 10px;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    background: var(--bg-button);
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 11.5px;
+    cursor: pointer;
+  }
+  .tv-btn:hover { color: var(--text); border-color: var(--accent); }
+  .tv-columns { position: relative; }
+  .tv-columns-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 150px;
+    padding: 6px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-elevated, var(--bg));
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  }
+  .tv-columns-menu label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 4px;
+    font-size: 12px;
+    color: var(--text);
+    cursor: pointer;
+    border-radius: 4px;
+  }
+  .tv-columns-menu label:hover { background: color-mix(in oklch, var(--text) 5%, transparent); }
+  .tv-switch { display: flex; gap: 0; }
   .tv-switch button {
     padding: 3px 10px;
     border: 1px solid var(--border);

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,4 +1,4 @@
-import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate, MenuEditorState } from '../../../shared/types';
+import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SavedView, SavedViewInput, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate, MenuEditorState } from '../../../shared/types';
 import type { ToolExecutionRequest, ToolExecutionResult, ConversationToolPayload } from '../../../shared/tools/types';
 import type { ClipperState } from '../../../shared/clipper-pairing';
 import type { ThemeMode } from '../../../shared/theme';
@@ -112,6 +112,15 @@ export interface QueriesApi {
   /** Re-tag a query's @group (#315). */
   setGroup(filePath: string, group: string | null): Promise<void>;
   /** Apply a new @order across many queries at once (#315 — drag-reorder). */
+  setOrder(entries: Array<{ filePath: string; order: number | null }>): Promise<void>;
+}
+
+/** Saved views (#1072) — named presets over a type's multi-view. */
+export interface ViewsApi {
+  list(): Promise<SavedView[]>;
+  save(scope: 'project' | 'global', input: SavedViewInput): Promise<SavedView>;
+  delete(filePath: string): Promise<void>;
+  rename(filePath: string, newName: string): Promise<string>;
   setOrder(entries: Array<{ filePath: string; order: number | null }>): Promise<void>;
 }
 
@@ -843,6 +852,7 @@ export interface IdeApi {
   notebase: NotebaseApi;
   links: LinksApi;
   queries: QueriesApi;
+  views: ViewsApi;
   search: SearchApi;
   git: GitApi;
   graph: GraphApi;

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -84,13 +84,21 @@ export interface UnsupportedTab {
 
 /** Multi-view over all instances of a typed-object type (#1070). */
 export type TypeViewLayout = 'list' | 'table' | 'gallery';
-export interface TypeViewTab {
+/** The view's mutable projection state — layout + sort + visible columns.
+ *  Carried on the tab (persisted across sessions) and captured into a saved
+ *  view (#1072). */
+export interface TypeViewState {
+  layout: TypeViewLayout;
+  /** Sort key: a property name, `__title`, or null for the intrinsic order. */
+  sortColumn: string | null;
+  sortDir: 'asc' | 'desc';
+  /** Visible property names (table); null = every declared column. */
+  columns: string[] | null;
+}
+export interface TypeViewTab extends TypeViewState {
   type: 'type-view';
   /** The type whose instances are shown (e.g. `book`). */
   typeId: string;
-  /** Which projection is showing; the viewer mutates it via `setTypeViewLayout`
-   *  so reopening the tab restores the chosen view. */
-  layout: TypeViewLayout;
 }
 
 export type Tab = NoteTab | QueryTab | SourceTab | PdfTab | GraphTab | TypeViewTab | UnsupportedTab;
@@ -392,23 +400,40 @@ export function getEditorStore() {
   }
 
   /** Open (or refocus) the multi-view over a type's instances (#1070). One tab
-   *  per type; reopening refocuses rather than duplicating. */
-  function openTypeView(typeId: string, opts?: { layout?: TypeViewLayout; groupId?: string }) {
+   *  per type; reopening refocuses rather than duplicating. A saved view (#1072)
+   *  opens through here with its state, re-applying the projection onto the
+   *  existing tab when one is already open. */
+  function openTypeView(typeId: string, opts?: Partial<TypeViewState> & { groupId?: string }) {
+    const state: TypeViewState = {
+      layout: opts?.layout ?? 'table',
+      sortColumn: opts?.sortColumn ?? null,
+      sortDir: opts?.sortDir ?? 'asc',
+      columns: opts?.columns ?? null,
+    };
     const found = locateTab((t) => isTypeView(t) && t.typeId === typeId);
-    if (found) { focusExistingTab(found); return; }
+    if (found) {
+      // Re-apply the incoming projection so opening a saved view re-configures
+      // the already-open tab (only when the caller passed explicit state).
+      if (opts && ('layout' in opts || 'sortColumn' in opts || 'columns' in opts)) {
+        Object.assign(found.group.tabs[found.index] as TypeViewTab, state);
+        schedulePersistTabs();
+      }
+      focusExistingTab(found);
+      return;
+    }
     const grp = resolveGroup(opts?.groupId);
     activeGroupId = grp.id;
-    const tab: TypeViewTab = { type: 'type-view', typeId, layout: opts?.layout ?? 'table' };
+    const tab: TypeViewTab = { type: 'type-view', typeId, ...state };
     grp.tabs.push(tab);
     grp.activeIndex = grp.tabs.length - 1;
     schedulePersistTabs();
   }
 
-  /** Update a type-view tab's projection (the list/table/gallery switch). */
-  function setTypeViewLayout(typeId: string, layout: TypeViewLayout) {
+  /** Update a type-view tab's projection state (layout switch, sort, columns). */
+  function setTypeViewState(typeId: string, patch: Partial<TypeViewState>) {
     const found = locateTab((t) => isTypeView(t) && t.typeId === typeId);
     if (found) {
-      (found.group.tabs[found.index] as TypeViewTab).layout = layout;
+      Object.assign(found.group.tabs[found.index] as TypeViewTab, patch);
       schedulePersistTabs();
     }
   }
@@ -646,7 +671,7 @@ export function getEditorStore() {
     } else if (isGraph(t)) {
       return { type: 'graph', relativePath: t.relativePath, depth: t.depth };
     } else if (isTypeView(t)) {
-      return { type: 'type-view', typeId: t.typeId, layout: t.layout };
+      return { type: 'type-view', typeId: t.typeId, layout: t.layout, sortColumn: t.sortColumn, sortDir: t.sortDir, columns: t.columns };
     } else {
       return {
         type: 'source',
@@ -718,7 +743,14 @@ export function getEditorStore() {
     } else if (saved.type === 'graph') {
       return { type: 'graph', relativePath: saved.relativePath, depth: saved.depth ?? 1 };
     } else if (saved.type === 'type-view') {
-      return { type: 'type-view', typeId: saved.typeId, layout: saved.layout ?? 'table' };
+      return {
+        type: 'type-view',
+        typeId: saved.typeId,
+        layout: saved.layout ?? 'table',
+        sortColumn: saved.sortColumn ?? null,
+        sortDir: saved.sortDir ?? 'asc',
+        columns: saved.columns ?? null,
+      };
     } else {
       return { type: 'source', sourceId: saved.sourceId, highlightExcerptId: saved.highlightExcerptId };
     }
@@ -1092,7 +1124,7 @@ export function getEditorStore() {
     openNeighborhood,
     setGraphDepth,
     openTypeView,
-    setTypeViewLayout,
+    setTypeViewState,
     setPdfPage,
     save,
     isPathDirty,

--- a/src/renderer/lib/stores/saved-views.svelte.ts
+++ b/src/renderer/lib/stores/saved-views.svelte.ts
@@ -1,0 +1,56 @@
+/**
+ * Saved-views store (#1072). Owns the `api.views.*` mutations + list state so
+ * components never call them directly (renderer data-flow rule #1086): the
+ * ObjectsPanel reads `forType()`, the Save-view flow calls `save()`, and the
+ * manage dialog calls `rename`/`remove`/`reorder`. Every mutation re-lists so
+ * the reactive view is always fresh.
+ */
+import { api } from '../ipc/client';
+import type { SavedView, SavedViewInput, ViewScope } from '../../../shared/types';
+
+let views = $state<SavedView[]>([]);
+let loaded = $state(false);
+
+async function refresh(): Promise<void> {
+  views = await api.views.list();
+  loaded = true;
+}
+
+async function save(scope: ViewScope, input: SavedViewInput): Promise<SavedView> {
+  const saved = await api.views.save(scope, input);
+  await refresh();
+  return saved;
+}
+
+async function remove(filePath: string): Promise<void> {
+  await api.views.delete(filePath);
+  await refresh();
+}
+
+async function rename(filePath: string, newName: string): Promise<void> {
+  await api.views.rename(filePath, newName);
+  await refresh();
+}
+
+async function reorder(entries: Array<{ filePath: string; order: number | null }>): Promise<void> {
+  await api.views.setOrder(entries);
+  await refresh();
+}
+
+export const savedViewsStore = {
+  get views(): SavedView[] {
+    return views;
+  },
+  get loaded(): boolean {
+    return loaded;
+  },
+  /** The saved views for one type, in stored order. */
+  forType(typeId: string): SavedView[] {
+    return views.filter((v) => v.typeId === typeId);
+  },
+  refresh,
+  save,
+  remove,
+  rename,
+  reorder,
+};

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -105,6 +105,14 @@ export const Channels = {
   /** Apply a new @order across many queries at once (#315 — drag-reorder). */
   QUERIES_SET_ORDER: 'queries:setOrder',
 
+  // Saved views (typed-object multi-view presets — #1072)
+  VIEWS_LIST: 'views:list',
+  VIEWS_SAVE: 'views:save',
+  VIEWS_DELETE: 'views:delete',
+  VIEWS_RENAME: 'views:rename',
+  /** Apply a new order across many saved views at once (drag-reorder). */
+  VIEWS_SET_ORDER: 'views:setOrder',
+
   // Search
   SEARCH_QUERY: 'search:query',
 

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -28,6 +28,8 @@ import type {
   LayoutSession,
   TabSession,
   SavedQuery,
+  SavedView,
+  SavedViewInput,
   SearchResult,
   OutgoingLink,
   Backlink,
@@ -178,6 +180,13 @@ export interface ChannelMap {
   'queries:move': (filePath: string, newScope: 'project' | 'global') => string;
   'queries:setGroup': (filePath: string, group: string | null) => void;
   'queries:setOrder': (entries: Array<{ filePath: string; order: number | null }>) => void;
+
+  // Saved views (typed-object multi-view presets — #1072)
+  'views:list': () => SavedView[];
+  'views:save': (scope: 'project' | 'global', input: SavedViewInput) => SavedView;
+  'views:delete': (filePath: string) => void;
+  'views:rename': (filePath: string, newName: string) => string;
+  'views:setOrder': (entries: Array<{ filePath: string; order: number | null }>) => void;
 
   // Search
   'search:query': (query: string) => SearchResult[];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -104,6 +104,35 @@ export interface SavedQuery {
   order: number | null;
 }
 
+/** Saved views (#1072) — named presets over a type's multi-view (#1070). The
+ *  types live here (renderer-safe, no electron) so the IPC contract + renderer
+ *  share them; the store lives in `src/main/saved-views.ts`. */
+export type ViewLayout = 'list' | 'table' | 'gallery';
+export type ViewScope = 'project' | 'global';
+
+/** The persisted config of a saved view (id/scope/filePath are derived from
+ *  where the file lives, so they're not part of the input). */
+export interface SavedViewInput {
+  name: string;
+  typeId: string;
+  layout: ViewLayout;
+  /** Sort key: a property name, `__title`, or null for the intrinsic order. */
+  sortColumn: string | null;
+  sortDir: 'asc' | 'desc';
+  /** Visible property names in table view; null = every declared column. */
+  columns: string[] | null;
+  order?: number | null;
+}
+
+export interface SavedView extends SavedViewInput {
+  /** Filename stem — stable id for rename/delete/reorder. */
+  id: string;
+  scope: ViewScope;
+  /** Absolute path (for delete/rename/reorder). */
+  filePath: string;
+  order: number | null;
+}
+
 export interface OutgoingLink {
   target: string;
   targetTitle: string;
@@ -248,6 +277,10 @@ export interface SavedTypeViewTab {
   typeId: string;
   /** Chosen projection (list/table/gallery); restored on reload. */
   layout?: 'list' | 'table' | 'gallery';
+  /** Sort + visible columns, restored on reload (#1072). */
+  sortColumn?: string | null;
+  sortDir?: 'asc' | 'desc';
+  columns?: string[] | null;
 }
 
 export type SavedTab = SavedNoteTab | SavedQueryTab | SavedSourceTab | SavedPdfTab | SavedGraphTab | SavedTypeViewTab | SavedUnsupportedTab;

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -231,6 +231,11 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "types:instances",
   "types:list",
   "types:noteProperties",
+  "views:delete",
+  "views:list",
+  "views:rename",
+  "views:save",
+  "views:setOrder",
   "youtube:thumbnail",
 ]
 `;

--- a/tests/main/saved-views.test.ts
+++ b/tests/main/saved-views.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Saved-views store (#1072): CRUD + scope + reorder, and that a saved view
+ * round-trips its full projection (mode, sort, columns). Mirrors the
+ * saved-queries persistence pattern per #1061.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const { userDataDir } = vi.hoisted(() => ({ userDataDir: { value: '' } }));
+vi.mock('electron', () => ({
+  app: { getPath: (k: string) => (k === 'userData' ? userDataDir.value : '') },
+}));
+
+import {
+  sanitizeFilename,
+  saveView,
+  listSavedViews,
+  renameView,
+  deleteView,
+  setViewOrder,
+  type SavedViewInput,
+} from '../../src/main/saved-views';
+
+let root: string;
+let userData: string;
+
+function input(over: Partial<SavedViewInput> = {}): SavedViewInput {
+  return {
+    name: 'Reading list',
+    typeId: 'book',
+    layout: 'table',
+    sortColumn: 'rating',
+    sortDir: 'desc',
+    columns: ['author', 'rating'],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-views-root-'));
+  userData = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-views-ud-'));
+  userDataDir.value = userData;
+});
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.rmSync(userData, { recursive: true, force: true });
+});
+
+describe('sanitizeFilename', () => {
+  it('lowercases and hyphenates', () => {
+    expect(sanitizeFilename('Reading List!')).toBe('reading-list');
+  });
+});
+
+describe('saved views: persistence (#1072)', () => {
+  it('saves a project view under .minerva/views and round-trips every field', () => {
+    const saved = saveView(root, 'project', input());
+    expect(saved.scope).toBe('project');
+    expect(saved.filePath).toContain(path.join('.minerva', 'views'));
+    expect(fs.existsSync(saved.filePath)).toBe(true);
+
+    const [got] = listSavedViews(root);
+    expect(got).toMatchObject({
+      name: 'Reading list',
+      typeId: 'book',
+      layout: 'table',
+      sortColumn: 'rating',
+      sortDir: 'desc',
+      columns: ['author', 'rating'],
+      scope: 'project',
+    });
+  });
+
+  it('saves a global view under userData and lists project-then-global', () => {
+    saveView(root, 'global', input({ name: 'All books' }));
+    saveView(root, 'project', input({ name: 'Reading list' }));
+    const views = listSavedViews(root);
+    expect(views.map((v) => v.scope)).toEqual(['project', 'global']); // project first
+    expect(views.find((v) => v.scope === 'global')!.filePath).toContain(userData);
+  });
+
+  it('renames a view (and moves its file)', () => {
+    const saved = saveView(root, 'project', input({ name: 'Old name' }));
+    const newPath = renameView(saved.filePath, 'New name');
+    expect(fs.existsSync(saved.filePath)).toBe(false);
+    expect(fs.existsSync(newPath)).toBe(true);
+    const [got] = listSavedViews(root);
+    expect(got!.name).toBe('New name');
+    expect(got!.typeId).toBe('book'); // other fields preserved
+  });
+
+  it('deletes a view', () => {
+    const saved = saveView(root, 'project', input());
+    deleteView(saved.filePath);
+    expect(listSavedViews(root)).toHaveLength(0);
+  });
+
+  it('reorders views by explicit order', () => {
+    const a = saveView(root, 'project', input({ name: 'Alpha' }));
+    const b = saveView(root, 'project', input({ name: 'Beta' }));
+    // Alphabetical by default: Alpha, Beta.
+    expect(listSavedViews(root).map((v) => v.name)).toEqual(['Alpha', 'Beta']);
+    // Force Beta first.
+    setViewOrder([{ filePath: b.filePath, order: 0 }, { filePath: a.filePath, order: 1 }]);
+    expect(listSavedViews(root).map((v) => v.name)).toEqual(['Beta', 'Alpha']);
+  });
+
+  it('tolerates a malformed view file (defaults, never throws)', () => {
+    const dir = path.join(root, '.minerva', 'views');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'broken.json'), '{ not json', 'utf-8');
+    const views = listSavedViews(root);
+    expect(views).toHaveLength(1);
+    expect(views[0]!.layout).toBe('table'); // default
+  });
+});

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -399,6 +399,13 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "getZoomFactor",
     "setZoomFactor",
   ],
+  "views": [
+    "delete",
+    "list",
+    "rename",
+    "save",
+    "setOrder",
+  ],
   "youtube": [
     "thumbnail",
   ],

--- a/tests/preload/preload-bridge.test.ts
+++ b/tests/preload/preload-bridge.test.ts
@@ -58,7 +58,7 @@ describe('preload contextBridge contract (#676)', () => {
       'conversations', 'csl', 'embeddings', 'export', 'files', 'formatter', 'git', 'graph',
       'images', 'links', 'menu', 'notebase', 'proposals', 'publish', 'queries',
       'refactor', 'search', 'shell', 'sites', 'skills', 'sources', 'tables',
-      'tabs', 'tags', 'templates', 'tools', 'types', 'view', 'youtube',
+      'tabs', 'tags', 'templates', 'tools', 'types', 'view', 'views', 'youtube',
     ]);
   });
 

--- a/tests/renderer/components/ObjectsPanel.test.ts
+++ b/tests/renderer/components/ObjectsPanel.test.ts
@@ -8,9 +8,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
 
-const { typesMock, queryMock } = vi.hoisted(() => ({ typesMock: vi.fn(), queryMock: vi.fn() }));
+const { typesMock, queryMock, viewsListMock } = vi.hoisted(() => ({ typesMock: vi.fn(), queryMock: vi.fn(), viewsListMock: vi.fn() }));
 vi.mock('../../../src/renderer/lib/ipc/client', () => ({
-  api: { types: { list: typesMock }, graph: { query: queryMock } },
+  api: { types: { list: typesMock }, graph: { query: queryMock }, views: { list: viewsListMock } },
 }));
 
 import ObjectsPanel from '../../../src/renderer/lib/components/ObjectsPanel.svelte';
@@ -20,6 +20,7 @@ const MEETING = { id: 'meeting', label: 'Meeting', classLocalName: 'Meeting', so
 
 beforeEach(() => {
   typesMock.mockResolvedValue({ types: [BOOK, MEETING], errors: [] });
+  viewsListMock.mockResolvedValue([]); // saved-views store refresh (#1072)
   queryMock.mockImplementation((sparql: string) => {
     if (sparql.includes('thought:Excerpt')) return Promise.resolve({ results: [{ n: '7' }], columns: [] }); // excerpt count
     if (sparql.includes('COUNT')) return Promise.resolve({ results: [{ id: 'book', n: '2' }], columns: [] });
@@ -29,7 +30,7 @@ beforeEach(() => {
     return Promise.resolve({ results: [], columns: [] });
   });
 });
-afterEach(() => { cleanup(); typesMock.mockReset(); queryMock.mockReset(); });
+afterEach(() => { cleanup(); typesMock.mockReset(); queryMock.mockReset(); viewsListMock.mockReset(); });
 
 describe('ObjectsPanel (#1068)', () => {
   it('lists types with instance counts, including a zero-instance type', async () => {

--- a/tests/renderer/components/TypeView.test.ts
+++ b/tests/renderer/components/TypeView.test.ts
@@ -34,8 +34,11 @@ function props(over: Record<string, unknown> = {}) {
   return {
     typeId: 'book',
     layout: 'list' as const,
+    sortColumn: null,
+    sortDir: 'asc' as const,
+    columns: null,
     revision: 0,
-    onLayoutChange: vi.fn(),
+    onStateChange: vi.fn(),
     onOpenNote: vi.fn(),
     ...over,
   };
@@ -60,20 +63,32 @@ describe('TypeView (#1070)', () => {
     expect(onOpenNote).toHaveBeenCalledWith('Dune.md');
   });
 
-  it('renders a column per declared property and sorts by a column', async () => {
-    const { container } = render(TypeView, props({ layout: 'table' }));
+  it('renders a column per declared property and projects the sort from props', async () => {
+    // Sort is prop-driven (the tab owns it, #1072): the projection follows
+    // sortColumn/sortDir, and clicking a header requests a change via onStateChange.
+    const onStateChange = vi.fn();
+    const { container, rerender } = render(TypeView, props({ layout: 'table', onStateChange }));
     await waitFor(() => expect(screen.getByRole('columnheader', { name: /Author/ })).toBeTruthy());
     expect(screen.getByRole('columnheader', { name: /Rating/ })).toBeTruthy();
 
     const titles = () => [...container.querySelectorAll('tbody .tv-cell-title')].map((e) => e.textContent);
-    expect(titles()).toEqual(['Dune', 'Neuromancer']); // intrinsic order
+    expect(titles()).toEqual(['Dune', 'Neuromancer']); // intrinsic order (sortColumn null)
 
-    // Sort by Rating asc: 4 (Neuromancer) before 5 (Dune).
+    // Clicking a header requests a sort — it doesn't self-sort.
     await fireEvent.click(screen.getByRole('columnheader', { name: /Rating/ }));
+    expect(onStateChange).toHaveBeenCalledWith({ sortColumn: 'rating', sortDir: 'asc' });
+
+    // Applying that sort via props reorders (Rating asc: 4 Neuromancer before 5 Dune).
+    await rerender(props({ layout: 'table', sortColumn: 'rating', sortDir: 'asc' }));
     await waitFor(() => expect(titles()).toEqual(['Neuromancer', 'Dune']));
-    // Toggle to desc.
-    await fireEvent.click(screen.getByRole('columnheader', { name: /Rating/ }));
+    await rerender(props({ layout: 'table', sortColumn: 'rating', sortDir: 'desc' }));
     await waitFor(() => expect(titles()).toEqual(['Dune', 'Neuromancer']));
+  });
+
+  it('hides a column when it is not in the visible set', async () => {
+    render(TypeView, props({ layout: 'table', columns: ['author'] })); // rating hidden
+    await waitFor(() => expect(screen.getByRole('columnheader', { name: /Author/ })).toBeTruthy());
+    expect(screen.queryByRole('columnheader', { name: /Rating/ })).toBeNull();
   });
 
   it('keys the gallery off the cover property, falling back to an icon card', async () => {
@@ -92,11 +107,11 @@ describe('TypeView (#1070)', () => {
   });
 
   it('switches views without re-querying the instance set', async () => {
-    const onLayoutChange = vi.fn();
-    render(TypeView, props({ layout: 'list', onLayoutChange }));
+    const onStateChange = vi.fn();
+    render(TypeView, props({ layout: 'list', onStateChange }));
     await waitFor(() => expect(screen.getByText('Dune')).toBeTruthy());
     await fireEvent.click(screen.getByRole('tab', { name: 'Table' }));
-    expect(onLayoutChange).toHaveBeenCalledWith('table');
+    expect(onStateChange).toHaveBeenCalledWith({ layout: 'table' });
     expect(instancesMock).toHaveBeenCalledTimes(1); // one load, not one per view
   });
 });


### PR DESCRIPTION
Closes #1072. Final piece of the Typed Objects epic (#1060) — Phase 3 complete.

## What

"Projects as a table sorted by status" becomes a **saved view** with a real home instead of ephemeral UI state. A saved view captures a type's **mode** (list/table/gallery), **sort**, and **visible columns**; reopening it restores that projection exactly. Saved views are renamable, deletable, and reorderable.

## Storage — mirrors saved-queries (the #1061 decision: "a config entry, not a note")

- `src/main/saved-views.ts` — one JSON file per view: **project** scope under `.minerva/views/` (travels with the thoughtbase) or **global** under userData. `list / save / delete / rename / setViewOrder`, malformed files degrade to defaults (never throw). The view types live in `shared/types.ts` so the IPC contract + renderer share them — no duplicate declaration (unlike the two `SavedQuery` copies).
- New `views:list/save/delete/rename/setOrder` IPC channels.

## Renderer

- **TypeView is now projection-state-driven from the tab.** Layout + sort + visible columns are props mutated via `onStateChange`, so a saved view restores them exactly and "Save view" captures them. Adds a **column-visibility popover** (table view) and a **Save view** action.
- **The tab carries it too.** `TypeViewTab` (+ `SavedTypeViewTab`) now hold `sortColumn/sortDir/columns`, so the chosen projection also survives a **session restart** (#1070's persistence, extended). `openTypeView` re-applies an incoming preset onto an already-open tab.
- **`saved-views` store** owns the `api.views.*` mutations (renderer data-flow rule #1086 — components never call them directly).
- **ObjectsPanel** lists a type's saved views as sub-rows (click opens the preset) and offers a **"Manage saved views…"** entry.
- **`EditSavedViewsDialog`** — rename / delete / reorder (per-scope up-down). Deliberately leaner than the 476-line `EditSavedQueriesDialog` (no scope-move, no groups — a saved view is a lightweight preset).

## Acceptance criteria

- [x] A configured view (type + mode + sort + columns) saves with a name.
- [x] Reopening restores mode, sort, and column selection exactly (store round-trip + tab persistence, tested).
- [x] Saved views can be renamed, deleted, and reordered.
- [x] Storage matches the #1061 decision and travels with its scope (project = `.minerva/views/`, global = userData).

## Out of scope (per the issue)

- View-level filters as first-class query objects (Notion-style). A saved view is a preset, not a query builder; a lightweight in-type filter is left for a follow-on (not in the AC).
- Sharing/sync beyond however the chosen storage already travels.

## Tests

- `tests/main/saved-views.test.ts` — CRUD, project/global scope + ordering, full field round-trip, reorder, malformed-file tolerance.
- `tests/renderer/components/TypeView.test.ts` — prop-driven sort (click requests via `onStateChange`; projection follows props), column hiding, view switch.
- Existing TypeView/ObjectsPanel tests updated for the new props + store. Preload + IPC-registration snapshots updated.

`pnpm lint` clean; 1400 store/ipc/shared/component/types tests green.

---

With this, the **Typed Objects epic (#1060) Phase 3 is complete**: multi-view (#1070) → type-keyed rendering (#1071) → saved views (#1072).