### PR TITLE
feat(objects): migrate untyped notes — approval-gated type inference (#1075)

### DIFF
--- a/src/main/llm/infer-types.ts
+++ b/src/main/llm/infer-types.ts
@@ -1,0 +1,94 @@
+/**
+ * Type-inference apply helper (#1075) — the migration answer to "a thoughtbase
+ * built before types is all untyped notes." Given the LLM's inferred typings
+ * (`{ relativePath, typeId }`), files ONE pending `thought:Proposal` per note
+ * that sets `type:` in its frontmatter — the same reversible promotion as the
+ * single-note "treat this as a Book" command (#1067). The user reviews each in
+ * the diff view and approves/rejects per note; nothing is applied silently.
+ *
+ * Trust Principle: this is LLM-originated, so the whole pass runs inside
+ * `withLLMContext` — any graph write that skips the approval engine trips the
+ * write guard under test. It mirrors `applyAutoTag` exactly, minus the immediate
+ * `approveProposal` (auto-tag's card was pre-reviewed; these land pending).
+ *
+ * Electron-free: returns plain data for the tool layer, no `app`/IPC imports.
+ */
+import * as notebaseFs from '../notebase/fs';
+import * as graph from '../graph/index';
+import { projectContext } from '../project-context-types';
+import { proposeWrite } from './approval';
+import { loadTypeCatalog } from '../types/loader';
+import { getFrontmatterValues, setFrontmatterProperty } from '../../shared/frontmatter-edit';
+
+export interface TypingAssignment {
+  relativePath: string;
+  typeId: string;
+}
+export interface TypingProposalResult {
+  /** Notes for which a pending type proposal was filed. */
+  proposed: Array<{ relativePath: string; typeId: string }>;
+  /** Notes skipped, with a short reason (unknown type, missing note, already that type). */
+  skipped: Array<{ relativePath: string; reason: string }>;
+}
+
+/**
+ * File a pending `type:` proposal for each assignment. `note` is the reviewer-
+ * facing rationale carried on every proposal. `conversationId` sets provenance.
+ */
+export async function proposeNoteTypings(
+  rootPath: string,
+  conversationId: string,
+  assignments: TypingAssignment[],
+  note: string,
+): Promise<TypingProposalResult> {
+  const catalog = await loadTypeCatalog(rootPath);
+  const knownTypeIds = new Set(catalog.types.map((t) => t.id));
+
+  // Armed with the trust guard (#944): LLM-originated, so a graph write that
+  // bypasses the approval engine here throws under test.
+  return graph.withLLMContext(async () => {
+    const ctx = projectContext(rootPath);
+    const proposed: TypingProposalResult['proposed'] = [];
+    const skipped: TypingProposalResult['skipped'] = [];
+
+    for (const { relativePath, typeId } of assignments) {
+      if (!knownTypeIds.has(typeId)) {
+        // Never invent types not in the registry (out of scope per #1075).
+        skipped.push({ relativePath, reason: `unknown type "${typeId}"` });
+        continue;
+      }
+      let content: string;
+      try {
+        content = await notebaseFs.readFile(rootPath, relativePath);
+      } catch {
+        skipped.push({ relativePath, reason: 'note not found' });
+        continue;
+      }
+      if (getFrontmatterValues(content).type === typeId) {
+        skipped.push({ relativePath, reason: `already type "${typeId}"` });
+        continue;
+      }
+
+      // The whole promotion: set `type:`, leaving body + existing keys untouched
+      // (reversible — remove `type:` → plain note). Frontmatter keys that match
+      // the type's declared properties become its property values via the #1063
+      // read-back, so no key rewriting is needed.
+      const next = setFrontmatterProperty(content, 'type', typeId);
+      if (next === content) {
+        skipped.push({ relativePath, reason: 'frontmatter could not be edited' });
+        continue;
+      }
+
+      const proposal = await proposeWrite(ctx, {
+        operationType: 'note_rewrite',
+        payloads: [{ kind: 'note-rewrite', path: relativePath, content: next }],
+        note: `${note} — type ${typeId} for ${relativePath}`,
+        conversationUri: `https://minerva.dev/ontology/thought#conversation/${conversationId}`,
+        proposedBy: `llm:conversation:${conversationId}`,
+      });
+      if (proposal) proposed.push({ relativePath, typeId });
+    }
+
+    return { proposed, skipped };
+  });
+}

--- a/src/main/llm/tools/propose-note-types.ts
+++ b/src/main/llm/tools/propose-note-types.ts
@@ -1,0 +1,112 @@
+import { proposeNoteTypings, type TypingAssignment } from '../infer-types';
+import type { NotebaseTool, ToolContext, ToolCallbacks } from './types';
+
+/**
+ * `propose_note_types` (#1075) — migrate untyped notes to registry types. Unlike
+ * the inline-card tools, this files pending `thought:Proposal` nodes DIRECTLY
+ * (one per note) that land in the Proposals panel's diff view for per-note
+ * approval. Approving sets `type:`; rejecting leaves the note untyped. It only
+ * assigns EXISTING stock/user types — never invents one.
+ */
+async function runProposeNoteTypes(
+  ctx: ToolContext,
+  input: unknown,
+): Promise<{ content: string; isError: boolean }> {
+  if (!ctx.conversationId) {
+    return { content: 'propose_note_types requires a bound conversation id.', isError: true };
+  }
+  const parsed = parseInput(input);
+  if ('error' in parsed) return { content: parsed.error, isError: true };
+
+  const { proposed, skipped } = await proposeNoteTypings(
+    ctx.rootPath,
+    ctx.conversationId,
+    parsed.assignments,
+    parsed.note,
+  );
+
+  if (proposed.length === 0) {
+    const why = skipped.length > 0 ? ` (${skipped.length} skipped: ${skipped.slice(0, 5).map((s) => `${s.relativePath} — ${s.reason}`).join('; ')})` : '';
+    return { content: `No type proposals were filed${why}.`, isError: true };
+  }
+
+  return {
+    content: JSON.stringify({
+      status: 'proposed',
+      proposedCount: proposed.length,
+      proposed: proposed.map((p) => ({ relativePath: p.relativePath, type: p.typeId })),
+      skipped,
+      hint:
+        'STOP. Each note now has a PENDING type proposal the user reviews and ' +
+        'approves per note in the Proposals panel — nothing has been typed yet. ' +
+        `End the turn with ONE short sentence ("Proposed types for ${proposed.length} ` +
+        'note(s) — review them in Proposals.") and DO NOT call propose_note_types ' +
+        'again this turn.',
+    }),
+    isError: false,
+  };
+}
+
+function parseInput(
+  input: unknown,
+): { note: string; assignments: TypingAssignment[] } | { error: string } {
+  if (!input || typeof input !== 'object') return { error: 'input must be an object.' };
+  const obj = input as Record<string, unknown>;
+  const note = typeof obj.note === 'string' && obj.note.trim() ? obj.note.trim() : 'Inferred type';
+  if (!Array.isArray(obj.assignments) || obj.assignments.length === 0) {
+    return { error: '`assignments` must be a non-empty array of { relativePath, typeId }.' };
+  }
+  const assignments: TypingAssignment[] = [];
+  for (const raw of obj.assignments) {
+    if (!raw || typeof raw !== 'object') return { error: 'each assignment must be an object.' };
+    const a = raw as Record<string, unknown>;
+    const relativePath = typeof a.relativePath === 'string' ? a.relativePath.trim() : '';
+    const typeId = typeof a.typeId === 'string' ? a.typeId.trim() : '';
+    if (!relativePath) return { error: 'each assignment needs a non-empty `relativePath`.' };
+    if (relativePath.includes('..')) return { error: `relativePath must not contain '..': ${relativePath}` };
+    if (!typeId) return { error: `assignment for ${relativePath} needs a non-empty \`typeId\`.` };
+    assignments.push({ relativePath, typeId });
+  }
+  return { note, assignments };
+}
+
+export const proposeNoteTypes: NotebaseTool = {
+  definition: {
+    name: 'propose_note_types',
+    description:
+      'Migrate untyped notes to types: propose a type for one or more notes, ' +
+      'filed as pending proposals the user reviews per note in the Proposals ' +
+      'panel (Approve sets `type:` in the note\'s frontmatter; Reject leaves it ' +
+      'untyped). Infer each note\'s type from its frontmatter keys, tags, and ' +
+      'content — e.g. a note with `author:`/`isbn:` is a Book. Assign ONLY types ' +
+      'that already exist in the registry (call list_notes / query_graph and the ' +
+      'type registry to see them) — never invent a type. Setting `type:` is ' +
+      'reversible and leaves the body + existing keys untouched; keys that match ' +
+      'the type\'s declared properties become its values automatically.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        note: {
+          type: 'string',
+          description: 'A short rationale shown to the user on each proposal.',
+        },
+        assignments: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 100,
+          description: 'One entry per note to type.',
+          items: {
+            type: 'object',
+            properties: {
+              relativePath: { type: 'string', description: 'Project-relative path to the note (include `.md`). Must already exist.' },
+              typeId: { type: 'string', description: 'An existing registry type id (e.g. `book`, `person`).' },
+            },
+            required: ['relativePath', 'typeId'],
+          },
+        },
+      },
+      required: ['assignments'],
+    },
+  },
+  run: (ctx: ToolContext, input: unknown, _callbacks: ToolCallbacks) => runProposeNoteTypes(ctx, input),
+};

--- a/src/main/llm/tools/registry.ts
+++ b/src/main/llm/tools/registry.ts
@@ -24,6 +24,7 @@ import { proposeSources } from './propose-sources';
 import { fetchProperties } from './fetch-properties';
 import { setProperties } from './set-properties';
 import { proposeSourceProperties } from './propose-source-properties';
+import { proposeNoteTypes } from './propose-note-types';
 import { proposeClaims } from './propose-claims';
 import { proposeCompute } from './propose-compute';
 import { askUser } from './ask-user';
@@ -56,6 +57,7 @@ const DEFAULT_TOOLS: NotebaseTool[] = [
   fetchProperties,
   setProperties,
   proposeSourceProperties,
+  proposeNoteTypes,
   proposeClaims,
   proposeCompute,
 ];

--- a/src/main/skills/stock/infer-types.md
+++ b/src/main/skills/stock/infer-types.md
@@ -1,0 +1,55 @@
+---
+id: analysis.infer-types
+name: Infer Types for Notes
+description: Propose a type for untyped notes, reviewed and approved per note
+menu: Analysis
+group: Organization
+outputMode: openConversation
+model: claude-opus-5
+web: false
+firstMessage: "Look over the untyped notes in this thoughtbase and propose a type for the ones that clearly fit an existing type. Show them to me to approve per note."
+longDescription: >-
+  Opens a conversation that scans this thoughtbase for untyped notes and proposes
+  a type for each one that clearly matches an existing type — a note with
+  author/isbn is a Book, one with role/affiliation is a Person, and so on. Each
+  proposal is filed for you to review in the Proposals panel and approve or reject
+  per note; approving just sets `type:` in the note's frontmatter (reversible,
+  nothing else changes) and its matching keys become the type's properties. The
+  agent proposes only — it never types a note itself, and it only assigns types
+  that already exist in your registry.
+---
+You are migrating an existing thoughtbase to **typed objects**: find untyped notes and propose a type for each one that clearly fits an **existing** type. You **propose only** — every proposal is reviewed and approved by the human per note; you never type a note yourself, and you never invent a type.
+
+## Procedure
+
+1. **Learn the available types.** Call `query_graph` to list the registry's types and what each expects:
+   ```sparql
+   SELECT ?id ?label ?prop WHERE {
+     ?c minerva:typeId ?id .
+     OPTIONAL { ?c rdfs:label ?label }
+     OPTIONAL { ?c types:expectsProperty ?p . ?p rdfs:label ?prop }
+   } ORDER BY ?id
+   ```
+   These `id`s (e.g. `book`, `person`) are the ONLY types you may assign. If there are none, tell the user there are no types to assign yet and stop.
+
+2. **Find the untyped notes.** Call `query_graph` for notes that have no type class:
+   ```sparql
+   SELECT ?path WHERE {
+     ?n minerva:relativePath ?path .
+     FILTER NOT EXISTS { ?n a ?c . ?c minerva:typeId ?tid }
+   } ORDER BY ?path
+   ```
+   `list_notes` gives you titles alongside. Work only from this untyped set — never re-type a note that already has one.
+
+3. **Infer a type per note — from real signal.** For each untyped note, judge its type from its **frontmatter keys**, **tags**, and **content**. Read titles first; call `read_note` on a note when the title alone is ambiguous (don't read the whole vault). Match on the type's expected properties: `author`/`isbn`/`publisher` → Book; `role`/`affiliation`/`email` → Person; `date`/`attendees` → Meeting. **Assign a type only when the fit is clear.** A note that doesn't clearly match any existing type stays untyped — leave it out rather than guessing.
+
+4. **Propose the typings.** Call `propose_note_types` ONCE with every confident assignment: `{ note: "<why, in a few words>", assignments: [{ relativePath, typeId }, …] }`. Each becomes a pending proposal the user reviews in the Proposals panel and approves or rejects per note. Approving sets `type:` (leaving the body and existing keys untouched); the note's keys that match the type's declared properties become its values automatically.
+
+5. **Explain briefly, then stop.** After proposing, end the turn with one or two sentences: how many notes you proposed types for, and which types dominated. Say plainly that ambiguous notes were left untyped. Do NOT call the tool again this turn, and do NOT claim any note has been typed — nothing changes until the user approves.
+
+## Constraints
+
+- **Propose, never apply.** Your only mutation tool is `propose_note_types`, which queues per-note proposals for review. You cannot type a note yourself.
+- **Only existing types.** Assign only the `typeId`s from step 1. Never invent a type or suggest the user create one mid-migration.
+- **Confidence over coverage.** A half-typed thoughtbase the user trusts beats a fully-typed one full of wrong guesses. When a note doesn't clearly fit, leave it untyped.
+- **One `propose_note_types` call** with the full batch — the user reviews and approves per note, so put every confident assignment in the single call rather than holding some back.

--- a/tests/main/llm/propose-note-types-tool.test.ts
+++ b/tests/main/llm/propose-note-types-tool.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Type-inference migration (#1075): the `propose_note_types` tool files a PENDING
+ * type proposal per untyped note (never a direct write — the trust guard would
+ * trip under test), and approving it promotes the note by setting `type:`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
+import { approveProposal } from '../../../src/main/llm/approval';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { proposeNoteTypings } from '../../../src/main/llm/infer-types';
+import { proposeNoteTypes } from '../../../src/main/llm/tools/propose-note-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+async function plant(rel: string, content: string): Promise<void> {
+  const full = path.join(root, rel);
+  await fsp.mkdir(path.dirname(full), { recursive: true });
+  await fsp.writeFile(full, content, 'utf-8');
+  await indexNote(ctx, rel, content);
+}
+function read(rel: string): string {
+  return fs.readFileSync(path.join(root, rel), 'utf-8');
+}
+async function pendingCount(): Promise<number> {
+  const r = await queryGraph(ctx, `SELECT (COUNT(?p) AS ?n) WHERE { ?p a thought:Proposal ; thought:proposalStatus thought:pending }`);
+  return Number((r.results as Array<{ n: string }>)[0]!.n);
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-infer-types-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+  // `book` is a stock type (author/isbn/…). Plant an untyped note that looks like one.
+  await plant('Dune.md', `---\ntitle: Dune\nauthor: Frank Herbert\nisbn: "9780441172719"\n---\n# Dune\n`);
+});
+afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+describe('proposeNoteTypings (#1075)', () => {
+  it('files a pending proposal and does NOT write the note (proposes, never applies)', async () => {
+    const before = read('Dune.md');
+    const result = await proposeNoteTypings(root, 'conv1', [{ relativePath: 'Dune.md', typeId: 'book' }], 'Inferred');
+    expect(result.proposed).toEqual([{ relativePath: 'Dune.md', typeId: 'book' }]);
+    expect(await pendingCount()).toBe(1);
+    // Trust: nothing applied until approval — the file is untouched.
+    expect(read('Dune.md')).toBe(before);
+    expect(read('Dune.md')).not.toContain('type: book');
+  });
+
+  it('approving the proposal promotes the note (sets type:), leaving the body + keys intact', async () => {
+    await proposeNoteTypings(root, 'conv1', [{ relativePath: 'Dune.md', typeId: 'book' }], 'Inferred');
+    const { results } = await queryGraph(ctx, `SELECT ?p WHERE { ?p a thought:Proposal ; thought:proposalStatus thought:pending }`);
+    const uri = (results as Array<{ p: string }>)[0]!.p;
+
+    expect((await approveProposal(ctx, uri)).ok).toBe(true);
+    const after = read('Dune.md');
+    expect(after).toContain('type: book');
+    expect(after).toContain('author: Frank Herbert'); // existing keys preserved
+    expect(after).toContain('# Dune'); // body preserved
+  });
+
+  it('skips an unknown type — never invents one', async () => {
+    const result = await proposeNoteTypings(root, 'conv1', [{ relativePath: 'Dune.md', typeId: 'wizard' }], 'x');
+    expect(result.proposed).toEqual([]);
+    expect(result.skipped[0]).toMatchObject({ relativePath: 'Dune.md', reason: expect.stringContaining('unknown type') });
+    expect(await pendingCount()).toBe(0);
+  });
+
+  it('skips a missing note and a note already of that type', async () => {
+    await plant('Typed.md', `---\ntitle: Typed\ntype: book\n---\n`);
+    const result = await proposeNoteTypings(root, 'conv1', [
+      { relativePath: 'Ghost.md', typeId: 'book' },
+      { relativePath: 'Typed.md', typeId: 'book' },
+    ], 'x');
+    expect(result.proposed).toEqual([]);
+    expect(result.skipped.map((s) => s.reason).join('|')).toMatch(/not found/);
+    expect(result.skipped.map((s) => s.reason).join('|')).toMatch(/already type/);
+  });
+});
+
+describe('propose_note_types tool (#1075)', () => {
+  const convCtx = () => ({ rootPath: root, conversationId: 'conv1' });
+
+  it('proposes via the tool and reports the count', async () => {
+    const res = await proposeNoteTypes.run(convCtx(), { note: 'Migrate', assignments: [{ relativePath: 'Dune.md', typeId: 'book' }] }, {});
+    expect(res.isError).toBe(false);
+    const payload = JSON.parse(res.content);
+    expect(payload.status).toBe('proposed');
+    expect(payload.proposedCount).toBe(1);
+    expect(await pendingCount()).toBe(1);
+  });
+
+  it('requires a bound conversation id', async () => {
+    const res = await proposeNoteTypes.run({ rootPath: root }, { assignments: [{ relativePath: 'Dune.md', typeId: 'book' }] }, {});
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/conversation id/);
+  });
+
+  it('rejects a malformed bundle', async () => {
+    const res = await proposeNoteTypes.run(convCtx(), { assignments: [] }, {});
+    expect(res.isError).toBe(true);
+  });
+
+  it('is an error result when nothing could be proposed', async () => {
+    const res = await proposeNoteTypes.run(convCtx(), { assignments: [{ relativePath: 'Dune.md', typeId: 'nope' }] }, {});
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/skipped/);
+  });
+});

--- a/tests/skills-eval/add-term-to-glossary/output/request.json
+++ b/tests/skills-eval/add-term-to-glossary/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/antithesize-essential-complexity/output/request.json
+++ b/tests/skills-eval/antithesize-essential-complexity/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/antithesize/output/request.json
+++ b/tests/skills-eval/antithesize/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/aversionfactor/output/request.json
+++ b/tests/skills-eval/aversionfactor/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/check-facts/output/request.json
+++ b/tests/skills-eval/check-facts/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/create-learning-journey/output/request.json
+++ b/tests/skills-eval/create-learning-journey/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/create-overview/output/request.json
+++ b/tests/skills-eval/create-overview/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute",
     "ask_user"

--- a/tests/skills-eval/crystallize/output/request.json
+++ b/tests/skills-eval/crystallize/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/date-scope-check/output/request.json
+++ b/tests/skills-eval/date-scope-check/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/decompose-into-claims/output/request.json
+++ b/tests/skills-eval/decompose-into-claims/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/decompose/output/request.json
+++ b/tests/skills-eval/decompose/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute",
     "ask_user"

--- a/tests/skills-eval/deep-dive/output/request.json
+++ b/tests/skills-eval/deep-dive/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/describe-current-controversies/output/request.json
+++ b/tests/skills-eval/describe-current-controversies/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/describe-historical-background-ask/output/request.json
+++ b/tests/skills-eval/describe-historical-background-ask/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/describe-historical-background/output/request.json
+++ b/tests/skills-eval/describe-historical-background/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/dimensionalize/output/request.json
+++ b/tests/skills-eval/dimensionalize/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/doublecrux/output/request.json
+++ b/tests/skills-eval/doublecrux/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/explain-like-im/output/request.json
+++ b/tests/skills-eval/explain-like-im/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/extract-key-claims/output/request.json
+++ b/tests/skills-eval/extract-key-claims/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/fill-out-note/output/request.json
+++ b/tests/skills-eval/fill-out-note/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/find-correlations/output/request.json
+++ b/tests/skills-eval/find-correlations/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/find-counterexamples/output/request.json
+++ b/tests/skills-eval/find-counterexamples/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/find-opposing-arguments/output/request.json
+++ b/tests/skills-eval/find-opposing-arguments/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/find-outliers/output/request.json
+++ b/tests/skills-eval/find-outliers/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/find-prerequisites/output/request.json
+++ b/tests/skills-eval/find-prerequisites/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/find-primary-sources/output/request.json
+++ b/tests/skills-eval/find-primary-sources/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/find-sources/output/request.json
+++ b/tests/skills-eval/find-sources/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/find-supporting-arguments/output/request.json
+++ b/tests/skills-eval/find-supporting-arguments/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/find-tensions/output/request.json
+++ b/tests/skills-eval/find-tensions/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/generate-glossary/output/request.json
+++ b/tests/skills-eval/generate-glossary/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/generate-visualizations/output/request.json
+++ b/tests/skills-eval/generate-visualizations/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/give-examples/output/request.json
+++ b/tests/skills-eval/give-examples/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/goalfactor/output/request.json
+++ b/tests/skills-eval/goalfactor/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/hamming/output/request.json
+++ b/tests/skills-eval/hamming/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/handlize/output/request.json
+++ b/tests/skills-eval/handlize/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/inductify/output/request.json
+++ b/tests/skills-eval/inductify/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/innerloop/output/request.json
+++ b/tests/skills-eval/innerloop/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/load-bearing-claim/output/request.json
+++ b/tests/skills-eval/load-bearing-claim/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/metaphorize/output/request.json
+++ b/tests/skills-eval/metaphorize/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/negspace/output/request.json
+++ b/tests/skills-eval/negspace/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/noticing/output/request.json
+++ b/tests/skills-eval/noticing/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/organize-by-topic/output/request.json
+++ b/tests/skills-eval/organize-by-topic/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/propose-flashcards/output/request.json
+++ b/tests/skills-eval/propose-flashcards/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/propose-source-summary/output/request.json
+++ b/tests/skills-eval/propose-source-summary/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/quiz-me/output/request.json
+++ b/tests/skills-eval/quiz-me/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/referenceclass/output/request.json
+++ b/tests/skills-eval/referenceclass/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/rhetoricize/output/request.json
+++ b/tests/skills-eval/rhetoricize/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/rhyme/output/request.json
+++ b/tests/skills-eval/rhyme/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/summarize/output/request.json
+++ b/tests/skills-eval/summarize/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/synthesize/output/request.json
+++ b/tests/skills-eval/synthesize/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/tidy-filenames/output/request.json
+++ b/tests/skills-eval/tidy-filenames/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]

--- a/tests/skills-eval/translate-magnitude/output/request.json
+++ b/tests/skills-eval/translate-magnitude/output/request.json
@@ -33,6 +33,7 @@
     "fetch_properties",
     "set_properties",
     "propose_source_properties",
+    "propose_note_types",
     "propose_claims",
     "propose_compute"
   ]


### PR DESCRIPTION
Closes #1075. The migration story for the Typed Objects epic (#1060) — and the trust-critical one.

## What

A stock skill that **proposes** a type for untyped notes; the human confirms. "A thoughtbase built before types is all untyped notes" → run the skill, review the per-note proposals in the diff view, approve the ones that are right. **The LLM never types a note directly.**

## How — Pattern B (direct pending proposals)

Unlike the inline-card propose tools (`set_properties`, `propose_claims`), this files **pending `thought:Proposal` nodes directly** through the approval engine — exactly what the issue asks for ("filed as pending, approved via the diff view"). They land in the **Proposals panel** for per-note approve/reject.

- **`propose_note_types`** tool (`src/main/llm/tools/`) — input `{ note, assignments: [{ relativePath, typeId }] }`. Only assigns types that already exist in the registry; never invents one. Added to `DEFAULT_TOOLS`, so every conversation can call it (no per-skill allow-list needed).
- **`infer-types.ts`** apply helper — electron-free, **mirrors `applyAutoTag` exactly** (the proven trust-safe pattern): the whole pass runs inside `graph.withLLMContext(...)`, and files one `note_rewrite` proposal per note whose content is `setFrontmatterProperty(content, 'type', typeId)` — the **same reversible promotion as the single-note #1067 command**. Body and existing keys are untouched; keys that match the type's declared properties become its values via the #1063 read-back, so no key-rewriting is needed. Skips unknown types, missing notes, and already-typed notes. **No approval-engine changes** — `note_rewrite`/`note-rewrite` are already wired end-to-end (file → approve → write → reindex → rollback).
- **`infer-types.md`** stock skill — whole-vault `openConversation` (modeled on `organize-by-topic.md`). Discovers the registry's types and the untyped notes via `query_graph`/`list_notes`/`read_note`, infers a type from frontmatter/tags/content (`author`/`isbn` → Book), and calls `propose_note_types` once. Propose-only; leaves ambiguous notes untyped ("confidence over coverage").

## Trust

Filing runs in LLM context, so a graph write that **bypassed** the approval engine would trip the write guard under test. The tests prove the honest path:
- the note is **not written** until approval (proposes, never applies);
- **approving** promotes it — `type:` set, body + `author:` etc. intact;
- unknown / missing / already-typed assignments are **skipped**.

The canonical trust-integrity gate (CLAUDE.md) stays green.

## Acceptance criteria

- [x] Running the skill produces per-note type proposals as **pending** `thought:Proposal` nodes.
- [x] Approving sets `type:` (matching keys become properties via read-back) through the promotion path; rejecting leaves the note untyped.
- [x] No typing is applied without approval; the integrity query finds no unreviewed LLM writes.
- [x] The approval-bypass write guard trips under test if the skill writes directly (the pass is wrapped in `withLLMContext`; tests assert no direct write).

## Out of scope (per the issue)

- Auto-applying types without review; inventing new types not in the registry (the tool rejects unknown `typeId`s).

## Tests

`tests/main/llm/propose-note-types-tool.test.ts` — pending-proposal filing + no-write-until-approval, approve-promotes, skip unknown/missing/already-typed, tool-level validation.

Adding the default tool re-packages every conversation skill's request, so the **52 skill-eval goldens** were regenerated (`pnpm cli eval --all` — one `propose_note_types` line each, verified). Lint clean; trust-integrity + LLM/skills/tools/eval suites green.