### PR TITLE
feat(objects): Type Manager panel — Settings → Object Types (#1584)

### DIFF
--- a/src/main/ipc/register-types.ts
+++ b/src/main/ipc/register-types.ts
@@ -7,7 +7,7 @@
  */
 import { Channels } from '../../shared/channels';
 import { loadTypeCatalog } from '../types/loader';
-import { saveType, type SaveTypeInput } from '../types/write';
+import { saveType, deleteType, type SaveTypeInput } from '../types/write';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import { toTypeInfo, type TypeCatalogInfo, type NoteTypedProperties, type TypeInstancesResult } from '../../shared/objects/type-def';
@@ -50,5 +50,10 @@ export function registerTypes(): void {
     const result = await saveType(rootPath, input);
     await graph.reloadTypeCatalog(projectContext(rootPath));
     return result;
+  }));
+
+  handle(Channels.TYPES_DELETE, withRootPath(async (rootPath, id: string) => {
+    await deleteType(rootPath, id);
+    await graph.reloadTypeCatalog(projectContext(rootPath));
   }));
 }

--- a/src/main/types/write.ts
+++ b/src/main/types/write.ts
@@ -13,6 +13,11 @@ export interface SaveTypeInput {
   properties: PropertyDef[];
   icon?: string | undefined;
   color?: string | undefined;
+  cover?: string | undefined;
+  card?: string[] | undefined;
+  /** Template body (markdown after the frontmatter) — carried for a faithful
+   *  duplicate; "Save Note as Object Type" leaves it empty. */
+  template?: string | undefined;
 }
 
 function slugify(s: string): string {
@@ -26,6 +31,8 @@ export function serializeTypeFile(id: string, input: SaveTypeInput): string {
   const fm: Record<string, unknown> = { label: input.label, id };
   if (input.icon) fm.icon = input.icon;
   if (input.color) fm.color = input.color;
+  if (input.cover) fm.cover = input.cover;
+  if (input.card && input.card.length > 0) fm.card = input.card;
   fm.properties = input.properties.map((p) => {
     const o: Record<string, unknown> = { name: p.name, type: p.type };
     if (p.label) o.label = p.label;
@@ -33,7 +40,8 @@ export function serializeTypeFile(id: string, input: SaveTypeInput): string {
     if (p.targetType) o.targetType = p.targetType;
     return o;
   });
-  return `---\n${YAML.stringify(fm)}---\n`;
+  const body = input.template?.trim();
+  return `---\n${YAML.stringify(fm)}---\n${body ? `\n${body}\n` : ''}`;
 }
 
 /**
@@ -47,4 +55,12 @@ export async function saveType(rootPath: string, input: SaveTypeInput): Promise<
   const filePath = `.minerva/types/${id}.md`;
   await notebaseFs.writeFile(rootPath, filePath, serializeTypeFile(id, input));
   return { id, filePath };
+}
+
+/** Delete a USER type by id (removes `.minerva/types/<id>.md`). A no-op for a
+ *  stock-only id (stock types live in the bundle, not the thoughtbase). */
+export async function deleteType(rootPath: string, id: string): Promise<void> {
+  const cleaned = slugify(id);
+  if (!cleaned) return;
+  await notebaseFs.deleteFile(rootPath, `.minerva/types/${cleaned}.md`).catch(() => { /* already gone / stock-only */ });
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -483,6 +483,7 @@ contextBridge.exposeInMainWorld('api', {
     noteProperties: (relativePath: string) => invoke(Channels.TYPES_NOTE_PROPERTIES, relativePath),
     instances: (typeId: string) => invoke(Channels.TYPES_INSTANCES, typeId),
     save: (input: Parameters<ChannelMap['types:save']>[0]) => invoke(Channels.TYPES_SAVE, input),
+    delete: (id: string) => invoke(Channels.TYPES_DELETE, id),
   },
   skills: {
     list: () => invoke(Channels.SKILLS_LIST),

--- a/src/renderer/lib/components/ObjectTypesSettings.svelte
+++ b/src/renderer/lib/components/ObjectTypesSettings.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  /**
+   * Object Types settings panel (#1584) — an in-app home to see and manage
+   * object types, so a user no longer hand-authors `.minerva/types/*.md`. Lists
+   * stock (read-only) + user types with their icon, property count, and live
+   * instance count; user types can be duplicated or deleted. Mutations route
+   * through the object-types store (renderer data-flow rule); editing a type's
+   * fields lands with the type editor (#1585).
+   */
+  import { onMount } from 'svelte';
+  import { api } from '../ipc/client';
+  import { objectTypesStore } from '../stores/object-types.svelte';
+  import { getDialogStore } from '../stores/dialogs.svelte';
+  import type { TypeInfo } from '../../../shared/objects/type-def';
+
+  const { showConfirm } = getDialogStore();
+
+  let counts = $state<Record<string, number>>({});
+  let busy = $state(false);
+
+  async function loadCounts(): Promise<void> {
+    const { results } = await api.graph.query(
+      `SELECT ?id (COUNT(?x) AS ?n) WHERE { ?x a ?c . ?c minerva:typeId ?id } GROUP BY ?id`,
+    );
+    const out: Record<string, number> = {};
+    for (const r of results as Array<{ id?: string; n?: string }>) if (r.id) out[r.id] = Number(r.n ?? 0);
+    counts = out;
+  }
+
+  async function refresh(): Promise<void> {
+    await Promise.all([objectTypesStore.refresh(), loadCounts()]);
+  }
+  onMount(refresh);
+
+  async function duplicate(t: TypeInfo): Promise<void> {
+    busy = true;
+    try {
+      await objectTypesStore.save({
+        label: `${t.label} copy`,
+        properties: t.properties,
+        ...(t.icon ? { icon: t.icon } : {}),
+        ...(t.color ? { color: t.color } : {}),
+        ...(t.cover ? { cover: t.cover } : {}),
+        ...(t.card ? { card: t.card } : {}),
+        ...(t.template ? { template: t.template } : {}),
+      });
+    } finally { busy = false; }
+  }
+
+  async function remove(t: TypeInfo): Promise<void> {
+    const n = counts[t.id] ?? 0;
+    const msg = n > 0
+      ? `Delete the “${t.label}” type? ${n} note${n === 1 ? '' : 's'} still reference${n === 1 ? 's' : ''} it — they keep their frontmatter but will no longer resolve to a type (reversible: recreate the type or re-type the notes).`
+      : `Delete the “${t.label}” type?`;
+    if (!(await showConfirm(msg, 'delete-object-type', 'Delete'))) return;
+    busy = true;
+    try { await objectTypesStore.remove(t.id); await loadCounts(); }
+    finally { busy = false; }
+  }
+</script>
+
+<div class="object-types">
+  <p class="hint">
+    Object types let notes act as first-class objects (Book, Person, Meeting…). Create one from any note
+    with <strong>File → Save Note as Object Type</strong>; stock types are read-only.
+  </p>
+
+  {#if objectTypesStore.errors.length > 0}
+    <div class="errors">
+      {#each objectTypesStore.errors as e (e.filePath)}
+        <div class="error-row"><span class="error-label">{e.label}</span> — {e.message}</div>
+      {/each}
+    </div>
+  {/if}
+
+  {#if objectTypesStore.types.length === 0}
+    <p class="empty">No object types yet.</p>
+  {:else}
+    <ul class="type-list">
+      {#each objectTypesStore.types as t (t.id)}
+        <li class="type-row">
+          <span class="type-icon" style={t.color ? `color:${t.color}` : undefined}>{t.icon ?? '◆'}</span>
+          <span class="type-main">
+            <span class="type-label">{t.label}</span>
+            <span class="type-meta">
+              {t.properties.length} propert{t.properties.length === 1 ? 'y' : 'ies'}
+              · {counts[t.id] ?? 0} instance{(counts[t.id] ?? 0) === 1 ? '' : 's'}
+            </span>
+          </span>
+          <span class="type-src" class:user={t.source === 'user'}>{t.source}</span>
+          {#if t.source === 'user'}
+            <span class="type-actions">
+              <button class="link-btn" disabled={busy} onclick={() => { void duplicate(t); }}>Duplicate</button>
+              <button class="link-btn" disabled={busy} onclick={() => { void remove(t); }}>Delete</button>
+            </span>
+          {:else}
+            <span class="type-actions muted">read-only</span>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .object-types { display: flex; flex-direction: column; gap: 10px; }
+  .hint { font-size: 12.5px; color: var(--text-muted); margin: 0; line-height: 1.5; }
+  .empty { font-size: 13px; color: var(--text-faint); }
+  .errors { display: flex; flex-direction: column; gap: 2px; }
+  .error-row { font-size: 11.5px; color: var(--text-muted); }
+  .error-label { font-family: var(--font-mono); }
+  .type-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+  .type-row { display: flex; align-items: center; gap: 10px; padding: 7px 8px; border-radius: 6px; }
+  .type-row:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  .type-icon { font-size: 16px; width: 20px; text-align: center; flex-shrink: 0; }
+  .type-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+  .type-label { font-size: 13px; font-weight: 500; color: var(--text); }
+  .type-meta { font-size: 11px; color: var(--text-faint); }
+  .type-src {
+    font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em;
+    padding: 1px 6px; border-radius: 3px; color: var(--text-faint);
+    background: color-mix(in oklch, var(--text) 6%, transparent);
+  }
+  .type-src.user { color: var(--accent); background: color-mix(in oklch, var(--accent) 12%, transparent); }
+  .type-actions { display: flex; gap: 8px; flex-shrink: 0; }
+  .type-actions.muted { color: var(--text-faint); font-size: 11px; }
+  .link-btn {
+    border: none; background: none; color: var(--accent); font-family: inherit; font-size: 12px; cursor: pointer; padding: 0;
+  }
+  .link-btn:hover:not(:disabled) { text-decoration: underline; }
+  .link-btn:disabled { opacity: 0.5; cursor: default; }
+</style>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -51,6 +51,7 @@
   import SitesSettings from './SitesSettings.svelte';
   import ComputeSettings from './ComputeSettings.svelte';
   import SkillsSettings from './SkillsSettings.svelte';
+  import ObjectTypesSettings from './ObjectTypesSettings.svelte';
   import BibliographySettings from './BibliographySettings.svelte';
   import AiSettings from './AiSettings.svelte';
   import { DEFAULT_MODEL } from '../../../shared/tools/models';
@@ -82,7 +83,7 @@
 
   let { onApplyEditor, onApplyFontSize, onThemeChanged, onClose, initialTab }: Props = $props();
 
-  type TabId = 'editor' | 'appearance' | 'behaviors' | 'notes' | 'formatter' | 'web' | 'sources' | 'clipper' | 'bibliography' | 'compute' | 'ai' | 'skills';
+  type TabId = 'editor' | 'appearance' | 'behaviors' | 'notes' | 'formatter' | 'objectTypes' | 'web' | 'sources' | 'clipper' | 'bibliography' | 'compute' | 'ai' | 'skills';
 
   /** Restructure per IMPLEMENTATION.md §10.4 — 10 flat tabs become 4
    *  semantic groups. Group labels render in mono-uppercase above each
@@ -110,6 +111,7 @@
       items: [
         { id: 'notes',        label: 'Notes',        sub: 'Refactoring · excerpt destinations' },
         { id: 'formatter',    label: 'Formatter',    sub: 'House style · format rules' },
+        { id: 'objectTypes',  label: 'Object Types', sub: 'Create · delete · duplicate types' },
         { id: 'bibliography', label: 'Bibliography', sub: 'Citation style · locale' },
       ],
     },
@@ -991,6 +993,9 @@
               </p>
             {/if}
           {/if}
+
+        {:else if activeTab === 'objectTypes'}
+          <ObjectTypesSettings />
 
         {:else if activeTab === 'bibliography'}
           <BibliographySettings />

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -769,8 +769,10 @@ export interface TypesApi {
   noteProperties(relativePath: string): Promise<import('../../../shared/objects/type-def').NoteTypedProperties>;
   /** Every instance of a type + its property values, for the multi-view (#1070). */
   instances(typeId: string): Promise<import('../../../shared/objects/type-def').TypeInstancesResult>;
-  /** Save a new user object type derived from a note ("Save Note as Object Type"). */
-  save(input: { label: string; properties: import('../../../shared/objects/type-def').PropertyDef[]; icon?: string; color?: string }): Promise<{ id: string; filePath: string }>;
+  /** Save a user object type — "Save Note as Object Type" + the Type Manager. */
+  save(input: { label: string; properties: import('../../../shared/objects/type-def').PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; template?: string }): Promise<{ id: string; filePath: string }>;
+  /** Delete a user object type by id (#1584). */
+  delete(id: string): Promise<void>;
 }
 
 export interface SkillsApi {

--- a/src/renderer/lib/stores/object-types.svelte.ts
+++ b/src/renderer/lib/stores/object-types.svelte.ts
@@ -1,0 +1,41 @@
+/**
+ * Object-types store (#1584). Owns the `api.types.save`/`delete` mutations + the
+ * catalog list, so the Type Manager panel never calls them directly (renderer
+ * data-flow rule #1086). Every mutation re-lists, and re-lists refresh the
+ * reactive view the panel + pickers read.
+ */
+import { api } from '../ipc/client';
+import type { TypeInfo, TypeLoadError } from '../../../shared/objects/type-def';
+
+type SaveInput = Parameters<typeof api.types.save>[0];
+
+let types = $state<TypeInfo[]>([]);
+let errors = $state<TypeLoadError[]>([]);
+let loaded = $state(false);
+
+async function refresh(): Promise<void> {
+  const catalog = await api.types.list();
+  types = catalog.types;
+  errors = catalog.errors;
+  loaded = true;
+}
+
+async function save(input: SaveInput): Promise<{ id: string; filePath: string }> {
+  const result = await api.types.save(input);
+  await refresh();
+  return result;
+}
+
+async function remove(id: string): Promise<void> {
+  await api.types.delete(id);
+  await refresh();
+}
+
+export const objectTypesStore = {
+  get types(): TypeInfo[] { return types; },
+  get errors(): TypeLoadError[] { return errors; },
+  get loaded(): boolean { return loaded; },
+  refresh,
+  save,
+  remove,
+};

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -449,6 +449,8 @@ export const Channels = {
   TYPES_INSTANCES: 'types:instances',
   /** Save a new user object type derived from a note ("Save Note as Object Type"). */
   TYPES_SAVE: 'types:save',
+  /** Delete a user object type by id (#1584). */
+  TYPES_DELETE: 'types:delete',
 
   // Skills (markdown skill files — #622)
   /** List the loaded skill catalog (metadata + load errors). */

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -396,7 +396,8 @@ export interface ChannelMap {
   'types:list': () => TypeCatalogInfo;
   'types:noteProperties': (relativePath: string) => NoteTypedProperties;
   'types:instances': (typeId: string) => TypeInstancesResult;
-  'types:save': (input: { label: string; properties: PropertyDef[]; icon?: string; color?: string }) => { id: string; filePath: string };
+  'types:save': (input: { label: string; properties: PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; template?: string }) => { id: string; filePath: string };
+  'types:delete': (id: string) => void;
 
   // Skills (markdown skill files — #622)
   'skills:list': () => SkillCatalogInfo;

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -230,6 +230,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "tool:getSettings",
   "tool:prepareConversation",
   "tool:setSettings",
+  "types:delete",
   "types:instances",
   "types:list",
   "types:noteProperties",

--- a/tests/main/types/write.test.ts
+++ b/tests/main/types/write.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { serializeTypeFile, saveType } from '../../../src/main/types/write';
+import { serializeTypeFile, saveType, deleteType } from '../../../src/main/types/write';
 import { parseType } from '../../../src/main/types/parse';
 import { loadTypeCatalog } from '../../../src/main/types/loader';
 import type { PropertyDef } from '../../../src/shared/objects/type-def';
@@ -28,6 +28,16 @@ describe('serializeTypeFile (#save-as-type)', () => {
     expect(byName.get('author')).toMatchObject({ type: 'link-to-type', targetType: 'person' });
     expect(byName.get('rating')).toMatchObject({ type: 'number' });
     expect(byName.get('status')).toMatchObject({ type: 'enum', options: ['reading', 'read'] });
+  });
+
+  it('carries icon/color/cover/card + a template body through the round-trip (#1584)', () => {
+    const content = serializeTypeFile('book', {
+      label: 'Book', properties: PROPS, icon: '📖', color: '#89b4fa', cover: 'author', card: ['rating'],
+      template: '## Notes\n',
+    });
+    const r = parseType(content, 'user', '/x/book.md');
+    expect(r.type).toMatchObject({ icon: '📖', color: '#89b4fa', cover: 'author', card: ['rating'] });
+    expect(r.type?.template).toContain('## Notes');
   });
 });
 
@@ -52,5 +62,14 @@ describe('saveType (#save-as-type)', () => {
 
   it('rejects an empty name', async () => {
     await expect(saveType(root, { label: '   ', properties: [] })).rejects.toThrow(/empty/i);
+  });
+
+  it('deleteType removes the user type file (#1584)', async () => {
+    const { filePath } = await saveType(root, { label: 'Gadget', properties: [] });
+    expect(fs.existsSync(path.join(root, filePath))).toBe(true);
+    await deleteType(root, 'gadget');
+    expect(fs.existsSync(path.join(root, filePath))).toBe(false);
+    // Idempotent — deleting a stock-only / missing id is a no-op, not an error.
+    await expect(deleteType(root, 'nonexistent')).resolves.toBeUndefined();
   });
 });

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -394,6 +394,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "setSettings",
   ],
   "types": [
+    "delete",
     "instances",
     "list",
     "noteProperties",

--- a/tests/renderer/components/ObjectTypesSettings.test.ts
+++ b/tests/renderer/components/ObjectTypesSettings.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Object Types settings panel (#1584): lists stock (read-only) + user types with
+ * property + instance counts; user types can be duplicated and deleted (with a
+ * confirm), routed through the object-types store. Stock types show no actions.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+
+const { listMock, saveMock, deleteMock, queryMock, confirmMock } = vi.hoisted(() => ({
+  listMock: vi.fn(), saveMock: vi.fn(), deleteMock: vi.fn(), queryMock: vi.fn(), confirmMock: vi.fn(),
+}));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { types: { list: listMock, save: saveMock, delete: deleteMock }, graph: { query: queryMock } },
+}));
+vi.mock('../../../src/renderer/lib/stores/dialogs.svelte', () => ({
+  getDialogStore: () => ({ showConfirm: confirmMock }),
+}));
+
+import ObjectTypesSettings from '../../../src/renderer/lib/components/ObjectTypesSettings.svelte';
+
+const BOOK = { id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock', icon: '📖', properties: [{ name: 'author', type: 'text' }] };
+const GADGET = { id: 'gadget', label: 'Gadget', classLocalName: 'Gadget', source: 'user', icon: '🔧', properties: [{ name: 'maker', type: 'text' }, { name: 'model', type: 'text' }] };
+
+beforeEach(() => {
+  listMock.mockResolvedValue({ types: [BOOK, GADGET], errors: [] });
+  saveMock.mockResolvedValue({ id: 'gadget-copy', filePath: '.minerva/types/gadget-copy.md' });
+  deleteMock.mockResolvedValue(undefined);
+  queryMock.mockResolvedValue({ results: [{ id: 'book', n: '3' }, { id: 'gadget', n: '1' }], columns: [] });
+  confirmMock.mockResolvedValue(true);
+});
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe('ObjectTypesSettings (#1584)', () => {
+  it('lists types with property + instance counts', async () => {
+    render(ObjectTypesSettings);
+    await waitFor(() => expect(screen.getByText('Book')).toBeTruthy());
+    expect(screen.getByText('Gadget')).toBeTruthy();
+    expect(screen.getByText(/1 property · 3 instances/)).toBeTruthy();   // Book
+    expect(screen.getByText(/2 properties · 1 instance/)).toBeTruthy();  // Gadget
+  });
+
+  it('shows actions only on user types (stock is read-only)', async () => {
+    render(ObjectTypesSettings);
+    await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
+    expect(screen.getAllByText('Delete')).toHaveLength(1); // only the user type
+    expect(screen.getByText('read-only')).toBeTruthy();    // the stock type
+  });
+
+  it('duplicate saves a copy of the user type', async () => {
+    render(ObjectTypesSettings);
+    await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
+    await fireEvent.click(screen.getByText('Duplicate'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(saveMock.mock.calls[0]![0]).toMatchObject({ label: 'Gadget copy', icon: '🔧' });
+  });
+
+  it('delete asks for confirmation and removes on confirm', async () => {
+    render(ObjectTypesSettings);
+    await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
+    await fireEvent.click(screen.getByText('Delete'));
+    await waitFor(() => expect(confirmMock).toHaveBeenCalled());
+    expect(confirmMock.mock.calls[0]![0]).toMatch(/1 note still references it/); // instance-count warning
+    expect(deleteMock).toHaveBeenCalledWith('gadget');
+  });
+
+  it('delete does nothing when the confirm is dismissed', async () => {
+    confirmMock.mockResolvedValue(false);
+    render(ObjectTypesSettings);
+    await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
+    await fireEvent.click(screen.getByText('Delete'));
+    await waitFor(() => expect(confirmMock).toHaveBeenCalled());
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1584. First child of the Type Manager epic (#1583) — an in-app home to see and manage object types, so a user no longer hand-authors `.minerva/types/*.md`.

## What

**Settings → Object Types** lists every type (stock + user) with its icon, **property count**, and **live instance count** (a graph `COUNT` per class). User types get **Duplicate** and **Delete**; stock types are read-only.

- **`types:delete` IPC** — `deleteType` removes `.minerva/types/<id>.md` (idempotent: a no-op for a stock-only / missing id), then `reloadTypeCatalog` so the change lands immediately (no rebuild).
- **`saveType` extended** to carry `icon`/`color`/`cover`/`card` + a **template body**, so Duplicate copies a type faithfully (and sets up the #1585 editor). The serializer still round-trips through `parse.ts`.
- Mutations route through a new **object-types store** (renderer data-flow rule #1086); Delete confirms with an **instance-count warning** framed reversibly ("they keep their frontmatter but no longer resolve to a type").

Editing a type's fields (not just create/delete/duplicate) lands with the **type editor (#1585)** — this PR is list + delete + duplicate per the issue's acceptance criteria.

## Acceptance criteria

- [x] The panel lists stock (read-only) + user types with icon / label / property count (+ instance count).
- [x] A user type can be deleted (with an instance-count warning) and duplicated.
- [x] Changes reflect immediately — the store re-lists, and pickers/`api.types.list` surfaces pick it up (the Objects browser refreshes on next open).

## Tests

- `write.test.ts` — serialize↔`parseType` round-trip incl. cover/card/template body; `deleteType` removes the file (idempotent on a missing id).
- `ObjectTypesSettings.test.ts` — lists with property + instance counts, gates actions to user types (stock read-only), Duplicate saves a copy, Delete confirms + removes (and no-ops when the confirm is dismissed).

Lint clean; preload + IPC snapshots updated; 689 types/graph/component tests green.