### PR TITLE
feat(objects): Type editor form — author a type without markdown (#1585)

### DIFF
--- a/src/main/types/write.ts
+++ b/src/main/types/write.ts
@@ -10,6 +10,10 @@ import type { PropertyDef } from '../../shared/objects/type-def';
 
 export interface SaveTypeInput {
   label: string;
+  /** Stable id when EDITING an existing type — keeps the file/class id fixed
+   *  while the display label changes (#1585). Omit for a new type (id is
+   *  derived from the label). */
+  id?: string | undefined;
   properties: PropertyDef[];
   icon?: string | undefined;
   color?: string | undefined;
@@ -50,7 +54,9 @@ export function serializeTypeFile(id: string, input: SaveTypeInput): string {
  * caller reloads the graph's type catalog so the new type is usable at once.
  */
 export async function saveType(rootPath: string, input: SaveTypeInput): Promise<{ id: string; filePath: string }> {
-  const id = slugify(input.label);
+  // Editing keeps the original id (label is free to change); a new type derives
+  // its id from the label.
+  const id = (input.id && slugify(input.id)) || slugify(input.label);
   if (!id) throw new Error('Type name is empty');
   const filePath = `.minerva/types/${id}.md`;
   await notebaseFs.writeFile(rootPath, filePath, serializeTypeFile(id, input));

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -60,6 +60,9 @@
   import EditSavedQueriesDialog from './lib/components/EditSavedQueriesDialog.svelte';
   import EditSavedViewsDialog from './lib/components/EditSavedViewsDialog.svelte';
   import AttachEvidenceDialog from './lib/components/AttachEvidenceDialog.svelte';
+  import TypeEditorDialog from './lib/components/TypeEditorDialog.svelte';
+  import type { TypeEditorInitial } from './lib/components/type-editor-value';
+  import { setFrontmatterProperty } from '../shared/frontmatter-edit';
   import SaveQueryDialog from './lib/components/SaveQueryDialog.svelte';
   import FindInNotesDialog from './lib/components/FindInNotesDialog.svelte';
   import GotoNoteDialog from './lib/components/GotoNoteDialog.svelte';
@@ -392,6 +395,18 @@
 
   let showEditSavedViews = $state(false);
 
+  // Type editor (#1585) opened from "Save Note as Object Type" — pre-filled from
+  // the note; on save the note is promoted to the new type (its first instance).
+  let typeEditorState = $state<{ initial: TypeEditorInitial; promoteNotePath: string } | null>(null);
+  function handleTypeEditorSaved(id: string): void {
+    const s = typeEditorState;
+    typeEditorState = null;
+    if (s && editor.activeFilePath === s.promoteNotePath) {
+      editor.setContent(setFrontmatterProperty(editor.content, 'type', id));
+    }
+    sidebar?.refreshObjects();
+  }
+
   // Attach-excerpt-as-evidence (#1073): the excerpt whose evidence dialog is open.
   let attachEvidenceExcerptId = $state<string | null>(null);
   async function handleAttachEvidence(claimPath: string, role: 'grounds' | 'supports' | 'rebuts'): Promise<void> {
@@ -680,6 +695,7 @@
     setSafeDeleteState: (s) => { safeDeleteDialogState = s; },
     setMergePickerSource: (s) => { mergePickerSource = s; },
     openTypeFields: () => { rightSidebarVisible = true; rightSidebar?.showPanel('fields'); },
+    openTypeEditor: (initial, promoteNotePath) => { typeEditorState = { initial, promoteNotePath }; },
   };
   const {
     handleNewNote, handleInlineTypeCreate, handlePromoteToType, handleSaveNoteAsObjectType, handleNewFolder, handleDelete, openFirstReferenceFromSafeDelete,
@@ -1466,6 +1482,13 @@
       excerptId={attachEvidenceExcerptId}
       onClose={() => { attachEvidenceExcerptId = null; }}
       onAttach={handleAttachEvidence}
+    />
+  {/if}
+  {#if typeEditorState}
+    <TypeEditorDialog
+      initial={typeEditorState.initial}
+      onClose={() => { typeEditorState = null; }}
+      onSaved={handleTypeEditorSaved}
     />
   {/if}
   {#if saveQueryRequest}

--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -17,7 +17,7 @@ import { describeDeleteNoun, describeDeleteMessage, offsetToLineCol, flattenNote
 import { resolveWikiLinkTarget } from '../../../shared/wiki-link-resolver';
 import { setFrontmatterProperty, getFrontmatterValues } from '../../../shared/frontmatter-edit';
 import { deriveTypeProperties } from '../../../shared/objects/derive-type';
-import type { TypeInfo } from '../../../shared/objects/type-def';
+import type { TypeInfo, PropertyDef } from '../../../shared/objects/type-def';
 import { substituteTemplate } from '../../../shared/templates';
 import { buildTypedNoteScaffold } from '../../../shared/objects/scaffold';
 import { CONFIRM_KEYS } from '../confirm-keys';
@@ -35,6 +35,9 @@ export interface NoteOpsCtx {
   setMergePickerSource: (s: string | null) => void;
   /** Reveal the right-sidebar "Fields" panel after promoting a note (#1067). */
   openTypeFields?: () => void;
+  /** Open the type editor pre-filled from a note ("Save Note as Object Type",
+   *  #1585); on save the host promotes `promoteNotePath` to the new type. */
+  openTypeEditor?: (initial: { label: string; properties: PropertyDef[] }, promoteNotePath: string) => void;
 }
 
 export function createNoteOps(ctx: NoteOpsCtx) {
@@ -161,17 +164,12 @@ export function createNoteOps(ctx: NoteOpsCtx) {
    * frontmatter (schema; the body is the separate "Save as Template" concern),
    * writes it, then promotes the seeding note to it so it's the first instance.
    */
-  async function handleSaveNoteAsObjectType() {
+  function handleSaveNoteAsObjectType() {
     if (!notebase.meta || !editor.activeFilePath) return;
     const stem = editor.activeFilePath.replace(/\.md$/i, '').split('/').pop() ?? '';
-    const label = (await showPrompt('Object type name:', { initial: stem }))?.trim();
-    if (!label) return;
-    const properties = deriveTypeProperties(getFrontmatterValues(editor.content));
-    const { id } = await api.types.save({ label, properties });
-    // Promote the seeding note to the new type — its first instance.
-    editor.setContent(setFrontmatterProperty(editor.content, 'type', id));
-    ctx.getSidebar()?.refreshObjects?.();
-    ctx.openTypeFields?.();
+    // Open the editor pre-filled with the derived properties so the user can
+    // refine before saving (#1585); the host promotes this note on save.
+    ctx.openTypeEditor?.({ label: stem, properties: deriveTypeProperties(getFrontmatterValues(editor.content)) }, editor.activeFilePath);
   }
 
   async function handleNewFolder(directory: string = '') {

--- a/src/renderer/lib/components/ObjectTypesSettings.svelte
+++ b/src/renderer/lib/components/ObjectTypesSettings.svelte
@@ -11,12 +11,28 @@
   import { api } from '../ipc/client';
   import { objectTypesStore } from '../stores/object-types.svelte';
   import { getDialogStore } from '../stores/dialogs.svelte';
+  import TypeEditorDialog from './TypeEditorDialog.svelte';
+  import type { TypeEditorInitial } from './type-editor-value';
   import type { TypeInfo } from '../../../shared/objects/type-def';
 
   const { showConfirm } = getDialogStore();
 
   let counts = $state<Record<string, number>>({});
   let busy = $state(false);
+  // The type editor (#1585): open with a blank value (New) or an existing type (Edit).
+  let editorInitial = $state<TypeEditorInitial | null>(null);
+  let editorOpen = $state(false);
+
+  function openNew(): void { editorInitial = { label: '', properties: [] }; editorOpen = true; }
+  function openEdit(t: TypeInfo): void {
+    editorInitial = {
+      id: t.id, label: t.label, properties: t.properties,
+      ...(t.icon ? { icon: t.icon } : {}), ...(t.color ? { color: t.color } : {}),
+      ...(t.cover ? { cover: t.cover } : {}), ...(t.card ? { card: t.card } : {}),
+      ...(t.template ? { template: t.template } : {}),
+    };
+    editorOpen = true;
+  }
 
   async function loadCounts(): Promise<void> {
     const { results } = await api.graph.query(
@@ -60,10 +76,13 @@
 </script>
 
 <div class="object-types">
-  <p class="hint">
-    Object types let notes act as first-class objects (Book, Person, Meeting…). Create one from any note
-    with <strong>File → Save Note as Object Type</strong>; stock types are read-only.
-  </p>
+  <div class="head">
+    <p class="hint">
+      Object types let notes act as first-class objects (Book, Person, Meeting…). Create one here or from any
+      note with <strong>File → Save Note as Object Type</strong>; stock types are read-only.
+    </p>
+    <button class="new-btn" onclick={openNew}>+ New type</button>
+  </div>
 
   {#if objectTypesStore.errors.length > 0}
     <div class="errors">
@@ -90,6 +109,7 @@
           <span class="type-src" class:user={t.source === 'user'}>{t.source}</span>
           {#if t.source === 'user'}
             <span class="type-actions">
+              <button class="link-btn" disabled={busy} onclick={() => openEdit(t)}>Edit</button>
               <button class="link-btn" disabled={busy} onclick={() => { void duplicate(t); }}>Duplicate</button>
               <button class="link-btn" disabled={busy} onclick={() => { void remove(t); }}>Delete</button>
             </span>
@@ -102,9 +122,24 @@
   {/if}
 </div>
 
+{#if editorOpen}
+  <TypeEditorDialog
+    initial={editorInitial}
+    onClose={() => { editorOpen = false; }}
+    onSaved={() => { editorOpen = false; void refresh(); }}
+  />
+{/if}
+
 <style>
   .object-types { display: flex; flex-direction: column; gap: 10px; }
-  .hint { font-size: 12.5px; color: var(--text-muted); margin: 0; line-height: 1.5; }
+  .head { display: flex; align-items: flex-start; gap: 12px; }
+  .hint { flex: 1; font-size: 12.5px; color: var(--text-muted); margin: 0; line-height: 1.5; }
+  .new-btn {
+    flex-shrink: 0; padding: 5px 12px; border: 1px solid var(--accent); border-radius: 6px;
+    background: color-mix(in oklch, var(--accent) 12%, transparent); color: var(--accent);
+    font-family: inherit; font-size: 12px; cursor: pointer;
+  }
+  .new-btn:hover { background: color-mix(in oklch, var(--accent) 20%, transparent); }
   .empty { font-size: 13px; color: var(--text-faint); }
   .errors { display: flex; flex-direction: column; gap: 2px; }
   .error-row { font-size: 11.5px; color: var(--text-muted); }

--- a/src/renderer/lib/components/TypeEditorDialog.svelte
+++ b/src/renderer/lib/components/TypeEditorDialog.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+  /**
+   * Type editor (#1585) — author an object type's fields without hand-writing
+   * markdown: label, icon, color, cover, and its property list (add / remove /
+   * reorder; per property name, type, enum options, link-to-type target, and
+   * whether it shows on the card). Saves the full `TypeDef` through the
+   * object-types store, which round-trips through parse.ts.
+   *
+   * Opened blank (New), pre-filled from an existing type (Edit), or pre-filled
+   * from a note ("Save Note as Object Type"). Editing keeps the original id.
+   */
+  import { onMount } from 'svelte';
+  import { api } from '../ipc/client';
+  import { objectTypesStore } from '../stores/object-types.svelte';
+  import { PROPERTY_TYPES, type PropertyDef, type PropertyType } from '../../../shared/objects/type-def';
+  import type { TypeEditorInitial } from './type-editor-value';
+
+  interface Props {
+    initial: TypeEditorInitial | null;
+    onClose: () => void;
+    onSaved?: (id: string) => void;
+  }
+  let { initial, onClose, onSaved }: Props = $props();
+  // The editor seeds its form from `initial` ONCE (it's a draft to edit, not a
+  // live binding); capture it so the one-time reads below aren't flagged.
+  const seed = initial;
+
+  interface Row {
+    name: string;
+    type: PropertyType;
+    options: string;   // comma-separated (enum)
+    targetType: string; // link-to-type target id
+    onCard: boolean;
+  }
+
+  let label = $state(seed?.label ?? '');
+  let icon = $state(seed?.icon ?? '');
+  let color = $state(seed?.color ?? '');
+  let cover = $state(seed?.cover ?? '');
+  let rows = $state<Row[]>(
+    (seed?.properties ?? []).map((p) => ({
+      name: p.name,
+      type: p.type,
+      options: (p.options ?? []).join(', '),
+      targetType: p.targetType ?? '',
+      onCard: (seed?.card ?? []).includes(p.name),
+    })),
+  );
+  let saving = $state(false);
+  let error = $state('');
+
+  // Existing type ids for the link-to-type target dropdown.
+  let typeIds = $state<string[]>([]);
+  onMount(async () => {
+    const cat = await api.types.list();
+    typeIds = cat.types.map((t) => t.id).filter((id) => id !== initial?.id);
+  });
+
+  const propNames = $derived(rows.map((r) => r.name.trim()).filter(Boolean));
+
+  function addRow(): void {
+    rows = [...rows, { name: '', type: 'text', options: '', targetType: '', onCard: false }];
+  }
+  function removeRow(i: number): void { rows = rows.filter((_, j) => j !== i); }
+  function move(i: number, dir: -1 | 1): void {
+    const j = i + dir;
+    if (j < 0 || j >= rows.length) return;
+    const next = [...rows];
+    [next[i], next[j]] = [next[j]!, next[i]!];
+    rows = next;
+  }
+
+  function buildProperties(): PropertyDef[] {
+    return rows
+      .filter((r) => r.name.trim())
+      .map((r) => {
+        const p: PropertyDef = { name: r.name.trim(), type: r.type };
+        if (r.type === 'enum') p.options = r.options.split(',').map((s) => s.trim()).filter(Boolean);
+        if (r.type === 'link-to-type' && r.targetType.trim()) p.targetType = r.targetType.trim();
+        return p;
+      });
+  }
+
+  async function save(): Promise<void> {
+    if (!label.trim()) { error = 'A type needs a name.'; return; }
+    saving = true;
+    error = '';
+    try {
+      const props = buildProperties();
+      const cardNames = rows.filter((r) => r.onCard && r.name.trim()).map((r) => r.name.trim());
+      const result = await objectTypesStore.save({
+        label: label.trim(),
+        ...(initial?.id ? { id: initial.id } : {}),
+        properties: props,
+        ...(icon.trim() ? { icon: icon.trim() } : {}),
+        ...(color.trim() ? { color: color.trim() } : {}),
+        ...(cover && propNames.includes(cover) ? { cover } : {}),
+        ...(cardNames.length > 0 ? { card: cardNames } : {}),
+        ...(initial?.template ? { template: initial.template } : {}),
+      });
+      onSaved?.(result.id);
+      onClose();
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+      saving = false;
+    }
+  }
+
+  function overlayKey(e: KeyboardEvent): void { if (e.key === 'Escape') onClose(); }
+</script>
+
+<div class="overlay" onkeydown={overlayKey} onmousedown={(e) => { if (e.target === e.currentTarget) onClose(); }} role="presentation">
+  <div class="dialog" role="dialog" aria-modal="true" aria-label="Edit object type">
+    <h3 class="title">{initial?.id ? 'Edit' : 'New'} object type</h3>
+
+    <div class="meta">
+      <label class="field grow"><span>Name</span>
+        <input bind:value={label} placeholder="Book" />
+      </label>
+      <label class="field narrow"><span>Icon</span>
+        <input bind:value={icon} placeholder="📖" maxlength="4" />
+      </label>
+      <label class="field narrow"><span>Color</span>
+        <input bind:value={color} placeholder="#89b4fa" />
+      </label>
+    </div>
+
+    <div class="props-head">
+      <span class="props-title">Properties</span>
+      <button class="btn small" onclick={addRow}>+ Add property</button>
+    </div>
+    {#if rows.length === 0}
+      <p class="muted">No properties yet — a type can be property-less, or add some.</p>
+    {/if}
+    <ul class="prop-list">
+      {#each rows as row, i (i)}
+        <li class="prop-row">
+          <input class="p-name" bind:value={row.name} placeholder="author" />
+          <select class="p-type" bind:value={row.type}>
+            {#each PROPERTY_TYPES as pt (pt)}<option value={pt}>{pt}</option>{/each}
+          </select>
+          {#if row.type === 'enum'}
+            <input class="p-extra" bind:value={row.options} placeholder="option, option" title="Enum options (comma-separated)" />
+          {:else if row.type === 'link-to-type'}
+            <select class="p-extra" bind:value={row.targetType} title="Target type">
+              <option value="">(any type)</option>
+              {#each typeIds as tid (tid)}<option value={tid}>{tid}</option>{/each}
+            </select>
+          {:else}
+            <span class="p-extra"></span>
+          {/if}
+          <label class="p-card" title="Show on the type-keyed card"><input type="checkbox" bind:checked={row.onCard} /> card</label>
+          <span class="p-actions">
+            <button class="icon-btn" title="Move up" aria-label="Move up" disabled={i === 0} onclick={() => move(i, -1)}>↑</button>
+            <button class="icon-btn" title="Move down" aria-label="Move down" disabled={i === rows.length - 1} onclick={() => move(i, 1)}>↓</button>
+            <button class="icon-btn" title="Remove" aria-label="Remove" onclick={() => removeRow(i)}>×</button>
+          </span>
+        </li>
+      {/each}
+    </ul>
+
+    <label class="field cover"><span>Cover (gallery image)</span>
+      <select bind:value={cover}>
+        <option value="">(none)</option>
+        {#each propNames as n (n)}<option value={n}>{n}</option>{/each}
+      </select>
+    </label>
+
+    {#if error}<p class="error">{error}</p>{/if}
+
+    <div class="actions">
+      <button class="btn" onclick={onClose}>Cancel</button>
+      <button class="btn primary" disabled={saving || !label.trim()} onclick={save}>{initial?.id ? 'Save' : 'Create'}</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.45); display: flex; align-items: center; justify-content: center; z-index: 1100; }
+  .dialog {
+    width: 640px; max-width: 92vw; max-height: 85vh; overflow-y: auto;
+    background: var(--bg); border: 1px solid var(--border); border-radius: 10px; padding: 18px 20px;
+    box-shadow: 0 12px 48px rgba(0,0,0,0.45);
+  }
+  .title { margin: 0 0 14px; font-size: 15px; color: var(--text); }
+  .meta { display: flex; gap: 10px; margin-bottom: 16px; }
+  .field { display: flex; flex-direction: column; gap: 4px; }
+  .field span { font-size: 11px; color: var(--text-muted); }
+  .field.grow { flex: 1; }
+  .field.narrow { width: 90px; }
+  .field input, .field select, .prop-row input, .prop-row select {
+    padding: 5px 8px; border: 1px solid var(--border); border-radius: 5px;
+    background: var(--bg-inset); color: var(--text); font-family: inherit; font-size: 13px;
+  }
+  .props-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
+  .props-title { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  .muted { font-size: 12px; color: var(--text-faint); margin: 2px 0 8px; }
+  .prop-list { list-style: none; margin: 0 0 12px; padding: 0; display: flex; flex-direction: column; gap: 5px; }
+  .prop-row { display: flex; align-items: center; gap: 6px; }
+  .p-name { flex: 1; min-width: 0; }
+  .p-type { width: 110px; }
+  .p-extra { width: 140px; flex-shrink: 0; }
+  .p-card { display: flex; align-items: center; gap: 3px; font-size: 11px; color: var(--text-muted); flex-shrink: 0; }
+  .p-actions { display: flex; gap: 1px; flex-shrink: 0; }
+  .icon-btn {
+    width: 22px; height: 24px; border: 1px solid var(--border); border-radius: 4px;
+    background: var(--bg-button); color: var(--text-muted); cursor: pointer; font-size: 12px;
+  }
+  .icon-btn:hover:not(:disabled) { color: var(--text); border-color: var(--accent); }
+  .icon-btn:disabled { opacity: 0.4; cursor: default; }
+  .field.cover { max-width: 260px; margin-bottom: 12px; }
+  .error { color: var(--accent); font-size: 12px; margin: 0 0 10px; }
+  .actions { display: flex; justify-content: flex-end; gap: 8px; }
+  .btn {
+    padding: 6px 16px; border: 1px solid var(--border); border-radius: 6px;
+    background: var(--bg-button); color: var(--text); font-family: inherit; font-size: 12px; cursor: pointer;
+  }
+  .btn:hover:not(:disabled) { border-color: var(--accent); }
+  .btn.small { padding: 3px 10px; font-size: 11.5px; }
+  .btn.primary { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+  .btn:disabled { opacity: 0.5; cursor: default; }
+</style>

--- a/src/renderer/lib/components/type-editor-value.ts
+++ b/src/renderer/lib/components/type-editor-value.ts
@@ -1,0 +1,18 @@
+/**
+ * The value the type editor (#1585) opens with — a blank type (New), an existing
+ * type (Edit), or a note-derived draft ("Save Note as Object Type"). Kept in a
+ * plain module so both the dialog and its hosts can import it as a type.
+ */
+import type { PropertyDef } from '../../../shared/objects/type-def';
+
+export interface TypeEditorInitial {
+  /** Set when editing — the id stays fixed while the label may change. */
+  id?: string;
+  label: string;
+  icon?: string;
+  color?: string;
+  cover?: string;
+  card?: string[];
+  properties: PropertyDef[];
+  template?: string;
+}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -770,7 +770,7 @@ export interface TypesApi {
   /** Every instance of a type + its property values, for the multi-view (#1070). */
   instances(typeId: string): Promise<import('../../../shared/objects/type-def').TypeInstancesResult>;
   /** Save a user object type — "Save Note as Object Type" + the Type Manager. */
-  save(input: { label: string; properties: import('../../../shared/objects/type-def').PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; template?: string }): Promise<{ id: string; filePath: string }>;
+  save(input: { label: string; id?: string; properties: import('../../../shared/objects/type-def').PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; template?: string }): Promise<{ id: string; filePath: string }>;
   /** Delete a user object type by id (#1584). */
   delete(id: string): Promise<void>;
 }

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -396,7 +396,7 @@ export interface ChannelMap {
   'types:list': () => TypeCatalogInfo;
   'types:noteProperties': (relativePath: string) => NoteTypedProperties;
   'types:instances': (typeId: string) => TypeInstancesResult;
-  'types:save': (input: { label: string; properties: PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; template?: string }) => { id: string; filePath: string };
+  'types:save': (input: { label: string; id?: string; properties: PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; template?: string }) => { id: string; filePath: string };
   'types:delete': (id: string) => void;
 
   // Skills (markdown skill files — #622)

--- a/tests/main/types/write.test.ts
+++ b/tests/main/types/write.test.ts
@@ -64,6 +64,19 @@ describe('saveType (#save-as-type)', () => {
     await expect(saveType(root, { label: '   ', properties: [] })).rejects.toThrow(/empty/i);
   });
 
+  it('keeps a stable id when editing, even as the label changes (#1585)', async () => {
+    // A non-stock id so the user file isn't shadowed by a bundled stock type.
+    await saveType(root, { label: 'Widget', properties: [] });
+    // Edit: new label, same id → overwrites the same file (a rename of the label,
+    // not a new type).
+    const { id, filePath } = await saveType(root, { id: 'widget', label: 'Widget (renamed)', properties: PROPS });
+    expect(id).toBe('widget');
+    expect(filePath).toBe('.minerva/types/widget.md');
+    const catalog = await loadTypeCatalog(root);
+    expect(catalog.types.filter((t) => t.id === 'widget')).toHaveLength(1); // not duplicated
+    expect(catalog.types.find((t) => t.id === 'widget')!.label).toBe('Widget (renamed)');
+  });
+
   it('deleteType removes the user type file (#1584)', async () => {
     const { filePath } = await saveType(root, { label: 'Gadget', properties: [] });
     expect(fs.existsSync(path.join(root, filePath))).toBe(true);

--- a/tests/renderer/components/TypeEditorDialog.test.ts
+++ b/tests/renderer/components/TypeEditorDialog.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Type editor form (#1585): builds a full type from the form — properties with
+ * enum options / link-to-type target / on-card flag, plus cover — saved through
+ * the object-types store; editing carries the stable id.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+
+const { saveMock, listMock } = vi.hoisted(() => ({ saveMock: vi.fn(), listMock: vi.fn() }));
+vi.mock('../../../src/renderer/lib/stores/object-types.svelte', () => ({
+  objectTypesStore: { save: saveMock },
+}));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: { types: { list: listMock } } }));
+
+import TypeEditorDialog from '../../../src/renderer/lib/components/TypeEditorDialog.svelte';
+
+beforeEach(() => {
+  saveMock.mockResolvedValue({ id: 'book', filePath: '.minerva/types/book.md' });
+  listMock.mockResolvedValue({ types: [{ id: 'person' }, { id: 'book' }], errors: [] });
+});
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe('TypeEditorDialog (#1585)', () => {
+  it('creates a new type from the form — label + added properties', async () => {
+    const onSaved = vi.fn();
+    render(TypeEditorDialog, { initial: { label: '', properties: [] }, onSaved, onClose: vi.fn() });
+
+    await fireEvent.input(screen.getByPlaceholderText('Book'), { target: { value: 'Reading' } });
+    await fireEvent.click(screen.getByText('+ Add property'));
+    await fireEvent.click(screen.getByText('+ Add property'));
+    const names = screen.getAllByPlaceholderText('author');
+    await fireEvent.input(names[0]!, { target: { value: 'rating' } });
+    await fireEvent.input(names[1]!, { target: { value: 'status' } });
+    // Blank-named rows are dropped on save (here both are named).
+
+    await fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const input = saveMock.mock.calls[0]![0];
+    expect(input.label).toBe('Reading');
+    expect(input.id).toBeUndefined(); // new type — id derived from label
+    expect(input.properties).toEqual([
+      { name: 'rating', type: 'text' },
+      { name: 'status', type: 'text' },
+    ]);
+    expect(onSaved).toHaveBeenCalledWith('book');
+  });
+
+  it('carries the stable id + link-to-type target + card flag when editing', async () => {
+    render(TypeEditorDialog, {
+      initial: { id: 'book', label: 'Book', properties: [{ name: 'author', type: 'link-to-type', targetType: 'person' }], card: ['author'] },
+      onSaved: vi.fn(), onClose: vi.fn(),
+    });
+    await waitFor(() => expect(screen.getByDisplayValue('Book')).toBeTruthy());
+    // The link-to-type target select should be pre-selected to person.
+    await fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const input = saveMock.mock.calls[0]![0];
+    expect(input.id).toBe('book');
+    expect(input.properties).toEqual([{ name: 'author', type: 'link-to-type', targetType: 'person' }]);
+    expect(input.card).toEqual(['author']); // the on-card checkbox stayed set
+  });
+
+  it('reorders properties', async () => {
+    render(TypeEditorDialog, {
+      initial: { label: 'T', properties: [{ name: 'first', type: 'text' }, { name: 'second', type: 'text' }] },
+      onSaved: vi.fn(), onClose: vi.fn(),
+    });
+    await waitFor(() => expect(screen.getByDisplayValue('first')).toBeTruthy());
+    await fireEvent.click(screen.getAllByLabelText('Move down')[0]!); // move 'first' below 'second'
+    await fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(saveMock.mock.calls[0]![0].properties.map((p: { name: string }) => p.name)).toEqual(['second', 'first']);
+  });
+
+  it('refuses to save without a name', async () => {
+    render(TypeEditorDialog, { initial: { label: '', properties: [] }, onSaved: vi.fn(), onClose: vi.fn() });
+    // The Create button is disabled with an empty name.
+    expect(screen.getByText('Create').hasAttribute('disabled')).toBe(true);
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1585. The form behind the Type Manager epic (#1583) — create and edit an object type's fields without hand-writing `.minerva/types/*.md`.

## What

**`TypeEditorDialog`** — a focused modal with:
- **label, icon, color, cover**, and
- a **property editor**: add / remove / **reorder**, and per property — `name`, `PropertyType`, **enum options**, **link-to-type target** (a dropdown of existing type ids), and an **"on card"** flag (drives the #1071 card).

It saves the full `TypeDef` through the object-types store, round-tripping via `parse.ts`.

**`saveType` now takes an optional stable `id`** — so **editing keeps the file/class id fixed** while the label changes (relabeling isn't an accidental duplicate). New types still derive their id from the label.

**One dialog, three entry points:**
- the Type Manager's **"+ New type"** (blank) and per-user-type **"Edit"** (pre-filled from the type), and
- **"Save Note as Object Type"** (#1582), which now **opens the editor pre-filled** with the note's derived properties instead of writing directly — on save, the note is promoted to the new type (its first instance).

## Acceptance criteria

- [x] A type can be created and edited entirely through the form; the written file round-trips through the parser.
- [x] Property add / remove / reorder + per-property type / options / target all persist.
- [x] "Save Note as Object Type" opens the editor pre-filled with the derived properties.

## Tests

- `TypeEditorDialog.test.ts` — build a new type (label + added properties); editing carries the stable id + link-to-type target + card flag; reorder; the Create button is disabled without a name.
- `write.test.ts` — `saveType` id-preservation (a relabel overwrites the same file, not a duplicate).

Lint clean; 1820 renderer/types tests green.

## Note

Editing a type still doesn't migrate existing instances if the *id* were to change — but the editor now keeps the id stable, so that case doesn't arise here; full rename/delete-in-use safety is #1588.