### PR TITLE
feat(objects): rdfs:subClassOf — parent-type field + materialization (#1586)

### DIFF
--- a/src/main/types/compile.ts
+++ b/src/main/types/compile.ts
@@ -13,6 +13,7 @@ import { MINERVA, RDF, RDFS, TYPES } from '../graph/state';
 import type { TypeCatalog } from '../../shared/objects/type-def';
 
 export function materializeTypeClasses(store: $rdf.IndexedFormula, catalog: TypeCatalog): void {
+  const byId = new Map(catalog.types.map((t) => [t.id, t]));
   for (const t of catalog.types) {
     const cls = TYPES(t.classLocalName);
     store.add(cls, RDF('type'), RDFS('Class'));
@@ -23,5 +24,10 @@ export function materializeTypeClasses(store: $rdf.IndexedFormula, catalog: Type
     for (const p of t.properties) {
       store.add(cls, TYPES('expectsProperty'), $rdf.lit(p.name));
     }
+    // Subclassing (#1586): a parent (validated to exist by the loader) becomes
+    // an `rdfs:subClassOf` edge, so `?x a/rdfs:subClassOf* types:Parent` returns
+    // this type's instances too.
+    const parent = t.parent ? byId.get(t.parent) : undefined;
+    if (parent) store.add(cls, RDFS('subClassOf'), TYPES(parent.classLocalName));
   }
 }

--- a/src/main/types/loader.ts
+++ b/src/main/types/loader.ts
@@ -92,5 +92,20 @@ export async function loadTypeCatalog(rootPath: string): Promise<TypeCatalog> {
     byId.set(t.id, t);
   }
 
+  // Validate parent refs now that every type id is known (#1586). An unknown or
+  // self parent is soft-flagged and cleared so nothing materializes a dangling
+  // `rdfs:subClassOf`. (Cycles are left alone — SPARQL property paths handle
+  // them; single inheritance keeps them rare.)
+  for (const t of byId.values()) {
+    if (!t.parent) continue;
+    if (t.parent === t.id) {
+      errors.push({ source: t.source, filePath: t.filePath, label: t.label, message: `a type can't be its own parent` });
+      t.parent = undefined;
+    } else if (!byId.has(t.parent)) {
+      errors.push({ source: t.source, filePath: t.filePath, label: t.label, message: `parent type "${t.parent}" does not exist` });
+      t.parent = undefined;
+    }
+  }
+
   return { types: [...byId.values()], errors };
 }

--- a/src/main/types/parse.ts
+++ b/src/main/types/parse.ts
@@ -162,6 +162,10 @@ export function parseType(content: string, source: TypeSource, filePath: string)
   // declared properties but keep the rest.
   const card = normalizeCard(fm.card, properties, errors);
   if (card.length > 0) type.card = card;
+  // `parent` (a.k.a. `extends`): the type this one specializes (#1586), stored
+  // as an id ref. Existence is validated later, in the loader (all types known).
+  const parent = asString(fm.parent) ?? asString(fm.extends);
+  if (parent) type.parent = slugify(parent);
 
   return { type, errors, label: bestLabel };
 }

--- a/src/main/types/write.ts
+++ b/src/main/types/write.ts
@@ -19,6 +19,8 @@ export interface SaveTypeInput {
   color?: string | undefined;
   cover?: string | undefined;
   card?: string[] | undefined;
+  /** Parent type id — materialized as `rdfs:subClassOf` (#1586). */
+  parent?: string | undefined;
   /** Template body (markdown after the frontmatter) — carried for a faithful
    *  duplicate; "Save Note as Object Type" leaves it empty. */
   template?: string | undefined;
@@ -37,6 +39,7 @@ export function serializeTypeFile(id: string, input: SaveTypeInput): string {
   if (input.color) fm.color = input.color;
   if (input.cover) fm.cover = input.cover;
   if (input.card && input.card.length > 0) fm.card = input.card;
+  if (input.parent) fm.parent = input.parent;
   fm.properties = input.properties.map((p) => {
     const o: Record<string, unknown> = { name: p.name, type: p.type };
     if (p.label) o.label = p.label;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -770,7 +770,7 @@ export interface TypesApi {
   /** Every instance of a type + its property values, for the multi-view (#1070). */
   instances(typeId: string): Promise<import('../../../shared/objects/type-def').TypeInstancesResult>;
   /** Save a user object type — "Save Note as Object Type" + the Type Manager. */
-  save(input: { label: string; id?: string; properties: import('../../../shared/objects/type-def').PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; template?: string }): Promise<{ id: string; filePath: string }>;
+  save(input: { label: string; id?: string; properties: import('../../../shared/objects/type-def').PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; parent?: string; template?: string }): Promise<{ id: string; filePath: string }>;
   /** Delete a user object type by id (#1584). */
   delete(id: string): Promise<void>;
 }

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -396,7 +396,7 @@ export interface ChannelMap {
   'types:list': () => TypeCatalogInfo;
   'types:noteProperties': (relativePath: string) => NoteTypedProperties;
   'types:instances': (typeId: string) => TypeInstancesResult;
-  'types:save': (input: { label: string; id?: string; properties: PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; template?: string }) => { id: string; filePath: string };
+  'types:save': (input: { label: string; id?: string; properties: PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; parent?: string; template?: string }) => { id: string; filePath: string };
   'types:delete': (id: string) => void;
 
   // Skills (markdown skill files — #622)

--- a/src/shared/objects/type-def.ts
+++ b/src/shared/objects/type-def.ts
@@ -47,6 +47,9 @@ export interface TypeDef {
    *  hovers, preview) — the card "template" (#1071). Empty/absent → a default
    *  derived from the first few declared properties. */
   card?: string[] | undefined;
+  /** Parent type id — materialized as `rdfs:subClassOf` so instances of this
+   *  type also count as the parent (#1586). Single inheritance for v1. */
+  parent?: string | undefined;
   source: TypeSource;
   /** Absolute path for user types; the glob key for stock types. */
   filePath: string;
@@ -69,6 +72,9 @@ export interface TypeInfo {
    *  hovers, preview) — the card "template" (#1071). Empty/absent → a default
    *  derived from the first few declared properties. */
   card?: string[] | undefined;
+  /** Parent type id — materialized as `rdfs:subClassOf` so instances of this
+   *  type also count as the parent (#1586). Single inheritance for v1. */
+  parent?: string | undefined;
   source: TypeSource;
 }
 
@@ -102,6 +108,7 @@ export function toTypeInfo(t: TypeDef): TypeInfo {
     color: t.color,
     cover: t.cover,
     card: t.card,
+    parent: t.parent,
     source: t.source,
   };
 }

--- a/tests/main/graph/subclassof.test.ts
+++ b/tests/main/graph/subclassof.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Type subclassing substrate (#1586): a type's `parent` materializes as an
+ * `rdfs:subClassOf` edge, and a subclass's instance is returned when querying
+ * for the parent class via a property path — the read side the Objects browser
+ * and multi-view build on (#1587).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexAllNotes, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+function writeType(id: string, frontmatter: string): void {
+  const dir = path.join(root, '.minerva', 'types');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${id}.md`), `---\n${frontmatter}\n---\n`, 'utf-8');
+}
+function writeNote(rel: string, content: string): void {
+  const fp = path.join(root, rel);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content, 'utf-8');
+}
+async function paths(sparql: string): Promise<string[]> {
+  const { results } = await queryGraph(ctx, sparql);
+  return (results as Array<{ p: string }>).map((r) => r.p).sort();
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-subclassof-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+  writeType('reference', `label: Reference`);
+  writeType('monograph', `label: Monograph
+parent: reference`);
+  writeNote('Dune.md', `---
+title: Dune
+type: monograph
+---
+`);      // a Book (⊂ Reference)
+  writeNote('Cite.md', `---\ntitle: Cite\ntype: reference\n---\n`); // a direct Reference
+  await indexAllNotes(ctx);
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('subclassing (#1586)', () => {
+  it('materializes types:Monograph rdfs:subClassOf types:Reference', async () => {
+    const { results } = await queryGraph(ctx, `SELECT ?x WHERE { types:Monograph rdfs:subClassOf types:Reference . BIND("ok" AS ?x) }`);
+    expect(results).toHaveLength(1);
+  });
+
+  it('returns a subclass instance when querying the parent via the property path', async () => {
+    // The parent's instances = direct Reference notes + subclass (Book) notes.
+    expect(await paths(
+      `SELECT ?p WHERE { ?n minerva:relativePath ?p ; rdf:type/rdfs:subClassOf* types:Reference }`,
+    )).toEqual(['Cite.md', 'Dune.md']);
+  });
+
+  it('a DIRECT type query excludes the subclass (only the path includes it)', async () => {
+    // Dune is typed Book, not directly Reference.
+    expect(await paths(`SELECT ?p WHERE { ?n minerva:relativePath ?p ; a types:Reference }`)).toEqual(['Cite.md']);
+    expect(await paths(`SELECT ?p WHERE { ?n minerva:relativePath ?p ; a types:Monograph }`)).toEqual(['Dune.md']);
+  });
+});

--- a/tests/main/types/loader.test.ts
+++ b/tests/main/types/loader.test.ts
@@ -65,6 +65,30 @@ describe('loadTypeCatalog (#1062)', () => {
     const cat = await loadTypeCatalog(root);
     expect(cat.types.length).toBeGreaterThanOrEqual(6);
   });
+
+  // Non-stock ids throughout — a user type sharing a stock id (e.g. `book`) is
+  // shadowed by stock, which carries no parent.
+  it('keeps a parent that resolves to a known type (#1586)', async () => {
+    writeUserType('reference.md', `---\nlabel: Reference\n---\n`);
+    writeUserType('monograph.md', `---\nlabel: Monograph\nparent: reference\n---\n`);
+    const cat = await loadTypeCatalog(root);
+    expect(cat.types.find((t) => t.id === 'monograph')?.parent).toBe('reference');
+    expect(cat.errors.filter((e) => /parent/.test(e.message))).toEqual([]);
+  });
+
+  it('flags + clears a parent that does not exist (#1586)', async () => {
+    writeUserType('monograph.md', `---\nlabel: Monograph\nparent: ghost\n---\n`);
+    const cat = await loadTypeCatalog(root);
+    expect(cat.types.find((t) => t.id === 'monograph')?.parent).toBeUndefined(); // cleared
+    expect(cat.errors.some((e) => /parent type "ghost" does not exist/.test(e.message))).toBe(true);
+  });
+
+  it('flags + clears a self-referential parent (#1586)', async () => {
+    writeUserType('monograph.md', `---\nlabel: Monograph\nparent: monograph\n---\n`);
+    const cat = await loadTypeCatalog(root);
+    expect(cat.types.find((t) => t.id === 'monograph')?.parent).toBeUndefined();
+    expect(cat.errors.some((e) => /can't be its own parent/.test(e.message))).toBe(true);
+  });
 });
 
 describe('parseType (#1062)', () => {
@@ -130,5 +154,11 @@ describe('parseType (#1062)', () => {
     );
     expect(r.type?.card).toEqual(['author']);
     expect(r.errors.some((e) => /"bogus".*not a declared property/.test(e))).toBe(true);
+  });
+
+  it('reads a parent type reference from `parent` or `extends`, slugified (#1586)', () => {
+    expect(parseType(`---\nlabel: Book\nparent: Reference Work\n---\n`, 'user', '/x/b.md').type?.parent).toBe('reference-work');
+    expect(parseType(`---\nlabel: Book\nextends: reference\n---\n`, 'user', '/x/b.md').type?.parent).toBe('reference');
+    expect(parseType(`---\nlabel: Book\n---\n`, 'user', '/x/b.md').type?.parent).toBeUndefined();
   });
 });

--- a/tests/main/types/write.test.ts
+++ b/tests/main/types/write.test.ts
@@ -39,6 +39,11 @@ describe('serializeTypeFile (#save-as-type)', () => {
     expect(r.type).toMatchObject({ icon: '📖', color: '#89b4fa', cover: 'author', card: ['rating'] });
     expect(r.type?.template).toContain('## Notes');
   });
+
+  it('carries a parent through the round-trip (#1586)', () => {
+    const content = serializeTypeFile('monograph', { label: 'Monograph', properties: [], parent: 'reference' });
+    expect(parseType(content, 'user', '/x/m.md').type?.parent).toBe('reference');
+  });
 });
 
 describe('saveType (#save-as-type)', () => {


### PR DESCRIPTION
Closes #1586. The subclassing **substrate** for the Type Manager epic (#1583) — a type can declare a parent, so its instances also count as the parent. (The parent *picker* + property inheritance + subclass-aware UI grouping are #1587.)

## What

- **`parent` field** on `TypeDef`/`TypeInfo`, parsed from `parent:` or `extends:` (slugified). The **loader validates** it once every id is known: an unknown or self parent is soft-flagged and **cleared**, so nothing materializes a dangling `rdfs:subClassOf`. Cycles are left alone — SPARQL property paths tolerate them and single inheritance keeps them rare.
- **`materializeTypeClasses`** emits `types:Child rdfs:subClassOf types:Parent`.
- The **write path** (`saveType`/serializer + `types:save`) carries `parent`, so it round-trips — the editor's parent picker is #1587.

## Read side (verified)

`?x rdf:type/rdfs:subClassOf* types:Parent` returns a subclass's instances (Comunica handles the property path), while a direct `?x a types:Parent` **excludes** them — exactly the capability the Objects browser (#1068) + multi-view (#1070) will adopt in #1587.

## Acceptance criteria

- [x] A type file with `parent: <id>` materializes an `rdfs:subClassOf` edge.
- [x] A subclass instance is returned when querying for the parent class (via the property path).
- [x] The Objects browser / multi-view *can* surface subclass instances under the parent (the substrate + query capability exist; the UI wiring is #1587).

## Out of scope (per the issue)

- The editor's parent picker + property inheritance → #1587.
- Multiple inheritance (single parent for v1).

## Tests

`loader.test.ts` — parse reads `parent`/`extends`; loader keeps a valid parent and flags+clears an unknown or self parent. `subclassof.test.ts` — the `subClassOf` edge materializes; a subclass instance is returned via the property path and **only** via it (direct type query excludes it). `write.test.ts` — parent round-trips through serialize↔parse.

Lint clean; 702 types/graph/component tests green.

> Note (learned in this PR): tests that create a user type must use a **non-stock id** — a user type sharing a stock id (e.g. `book`) is shadowed by stock, which carries no parent. The tests use `reference`/`monograph`.