### PR TITLE
feat(objects): parent picker + subclass property inheritance + subclass-aware surfaces (#1587)

### DIFF
--- a/src/main/graph/note-properties.ts
+++ b/src/main/graph/note-properties.ts
@@ -10,15 +10,21 @@
  * empty properties come back with `value: null` so the form can show every field.
  */
 import type { ProjectContext } from '../project-context-types';
-import { getState } from './state';
+import { getState, type GraphState } from './state';
 import { noteUriFor, queryGraph } from './queries';
 import { declaredPropertyPredicate } from './indexers';
+import { effectivePropertyDefs, type TypeLike } from '../../shared/objects/inheritance';
 import {
   toTypeInfo,
   type NoteTypedProperties,
   type TypeInstancesResult,
   type TypeInstanceRow,
 } from '../../shared/objects/type-def';
+
+/** The project's types keyed by id — for resolving inheritance chains (#1587). */
+function typeCatalogById(state: GraphState): ReadonlyMap<string, TypeLike> {
+  return new Map(state.typeCatalog.types.map((t) => [t.id, t]));
+}
 
 export async function getNoteTypedProperties(
   ctx: ProjectContext,
@@ -45,7 +51,11 @@ export async function getNoteTypedProperties(
     if (r.p && r.v !== undefined && !byPredicate.has(r.p)) byPredicate.set(r.p, r.v);
   }
 
-  const properties = def.properties.map((pd) => ({
+  // Effective properties include those inherited from parent types (#1587) —
+  // the child overrides an ancestor's by name — so a subclass's form shows the
+  // full set.
+  const effective = effectivePropertyDefs(def.id, typeCatalogById(state));
+  const properties = effective.map((pd) => ({
     name: pd.name,
     type: pd.type,
     label: pd.label,
@@ -77,9 +87,9 @@ export async function getTypeInstances(
   const def = state.typeCatalog.types.find((t) => t.id === typeId);
   if (!def) return { type: null, instances: [] };
 
-  // A stable column alias per declared property (?c0, ?c1, …) avoids clashes
-  // when two properties happen to resolve to the same predicate IRI.
-  const cols = def.properties.map((pd, i) => ({
+  // Columns include inherited properties (#1587); a stable alias per column
+  // (?c0, ?c1, …) avoids clashes when two properties resolve to the same IRI.
+  const cols = effectivePropertyDefs(def.id, typeCatalogById(state)).map((pd, i) => ({
     pd,
     alias: `c${i}`,
     predicate: declaredPropertyPredicate(pd.name, pd.type).value,
@@ -89,10 +99,12 @@ export async function getTypeInstances(
     .join('\n     ');
   const selectCols = cols.map((c) => `?${c.alias}`).join(' ');
 
+  // Subclass-aware (#1587): a parent's view includes its subclasses' instances
+  // via the `rdfs:subClassOf*` path (matches the class itself + descendants).
   const { results } = await queryGraph(
     ctx,
     `SELECT ?path ?title ${selectCols} WHERE {
-       ?n a types:${def.classLocalName} ; minerva:relativePath ?path .
+       ?n a/rdfs:subClassOf* types:${def.classLocalName} ; minerva:relativePath ?path .
        OPTIONAL { ?n dc:title ?title }
        ${optionals}
      } ORDER BY LCASE(?title) ?path`,

--- a/src/renderer/lib/components/ObjectTypesSettings.svelte
+++ b/src/renderer/lib/components/ObjectTypesSettings.svelte
@@ -29,6 +29,7 @@
       id: t.id, label: t.label, properties: t.properties,
       ...(t.icon ? { icon: t.icon } : {}), ...(t.color ? { color: t.color } : {}),
       ...(t.cover ? { cover: t.cover } : {}), ...(t.card ? { card: t.card } : {}),
+      ...(t.parent ? { parent: t.parent } : {}),
       ...(t.template ? { template: t.template } : {}),
     };
     editorOpen = true;
@@ -58,6 +59,7 @@
         ...(t.color ? { color: t.color } : {}),
         ...(t.cover ? { cover: t.cover } : {}),
         ...(t.card ? { card: t.card } : {}),
+        ...(t.parent ? { parent: t.parent } : {}),
         ...(t.template ? { template: t.template } : {}),
       });
     } finally { busy = false; }

--- a/src/renderer/lib/components/ObjectsPanel.svelte
+++ b/src/renderer/lib/components/ObjectsPanel.svelte
@@ -38,8 +38,10 @@
   let excerptsOpen = $state(false);
 
   async function loadCounts(): Promise<Record<string, number>> {
+    // Subclass-aware (#1587): count each instance under its type AND every
+    // ancestor, so a parent's count includes its subclasses' instances.
     const { results } = await api.graph.query(
-      `SELECT ?id (COUNT(?x) AS ?n) WHERE { ?x a ?c . ?c minerva:typeId ?id } GROUP BY ?id`,
+      `SELECT ?id (COUNT(DISTINCT ?x) AS ?n) WHERE { ?x a ?sub . ?sub rdfs:subClassOf* ?c . ?c minerva:typeId ?id } GROUP BY ?id`,
     );
     const out: Record<string, number> = {};
     for (const r of results as Array<{ id?: string; n?: string }>) {
@@ -53,7 +55,7 @@
     if (!row) return;
     const { results } = await api.graph.query(
       `SELECT ?path ?title WHERE {
-         ?n a types:${row.type.classLocalName} ; minerva:relativePath ?path .
+         ?n a/rdfs:subClassOf* types:${row.type.classLocalName} ; minerva:relativePath ?path .
          OPTIONAL { ?n dc:title ?title }
        } ORDER BY ?title`,
     );

--- a/src/renderer/lib/components/TypeEditorDialog.svelte
+++ b/src/renderer/lib/components/TypeEditorDialog.svelte
@@ -37,6 +37,7 @@
   let icon = $state(seed?.icon ?? '');
   let color = $state(seed?.color ?? '');
   let cover = $state(seed?.cover ?? '');
+  let parent = $state(seed?.parent ?? '');
   let rows = $state<Row[]>(
     (seed?.properties ?? []).map((p) => ({
       name: p.name,
@@ -96,6 +97,7 @@
         ...(color.trim() ? { color: color.trim() } : {}),
         ...(cover && propNames.includes(cover) ? { cover } : {}),
         ...(cardNames.length > 0 ? { card: cardNames } : {}),
+        ...(parent && typeIds.includes(parent) ? { parent } : {}),
         ...(initial?.template ? { template: initial.template } : {}),
       });
       onSaved?.(result.id);
@@ -159,12 +161,20 @@
       {/each}
     </ul>
 
-    <label class="field cover"><span>Cover (gallery image)</span>
-      <select bind:value={cover}>
-        <option value="">(none)</option>
-        {#each propNames as n (n)}<option value={n}>{n}</option>{/each}
-      </select>
-    </label>
+    <div class="type-selects">
+      <label class="field cover"><span>Cover (gallery image)</span>
+        <select bind:value={cover}>
+          <option value="">(none)</option>
+          {#each propNames as n (n)}<option value={n}>{n}</option>{/each}
+        </select>
+      </label>
+      <label class="field cover"><span>Parent type (inherits its properties)</span>
+        <select bind:value={parent}>
+          <option value="">(none)</option>
+          {#each typeIds as tid (tid)}<option value={tid}>{tid}</option>{/each}
+        </select>
+      </label>
+    </div>
 
     {#if error}<p class="error">{error}</p>{/if}
 
@@ -208,7 +218,8 @@
   }
   .icon-btn:hover:not(:disabled) { color: var(--text); border-color: var(--accent); }
   .icon-btn:disabled { opacity: 0.4; cursor: default; }
-  .field.cover { max-width: 260px; margin-bottom: 12px; }
+  .type-selects { display: flex; gap: 16px; margin-bottom: 12px; }
+  .field.cover { max-width: 260px; }
   .error { color: var(--accent); font-size: 12px; margin: 0 0 10px; }
   .actions { display: flex; justify-content: flex-end; gap: 8px; }
   .btn {

--- a/src/renderer/lib/components/type-editor-value.ts
+++ b/src/renderer/lib/components/type-editor-value.ts
@@ -13,6 +13,8 @@ export interface TypeEditorInitial {
   color?: string;
   cover?: string;
   card?: string[];
+  /** Parent type id (#1587) — the type this one specializes. */
+  parent?: string;
   properties: PropertyDef[];
   template?: string;
 }

--- a/src/shared/objects/inheritance.ts
+++ b/src/shared/objects/inheritance.ts
@@ -1,0 +1,34 @@
+/**
+ * Subclass property inheritance (#1587). A type's *effective* declared
+ * properties are its ancestors' properties (root-first) plus its own, with the
+ * child overriding an ancestor's property of the same name in place. Pure +
+ * cycle-safe (a `visited` set), so the read-back (#1063), the multi-view
+ * projection (#1070), and the property form (#1066) all derive the same list.
+ */
+import type { PropertyDef } from './type-def';
+
+export interface TypeLike {
+  id: string;
+  parent?: string | undefined;
+  properties: PropertyDef[];
+}
+
+export function effectivePropertyDefs(
+  typeId: string,
+  byId: ReadonlyMap<string, TypeLike>,
+): PropertyDef[] {
+  // Walk parent → root, collecting the chain root-first; stop on a cycle.
+  const chain: TypeLike[] = [];
+  const visited = new Set<string>();
+  let cur = byId.get(typeId);
+  while (cur && !visited.has(cur.id)) {
+    visited.add(cur.id);
+    chain.unshift(cur);
+    cur = cur.parent ? byId.get(cur.parent) : undefined;
+  }
+  // Insertion order = ancestor props first; a same-name child prop overrides the
+  // value while keeping the ancestor's position; genuinely new child props append.
+  const byName = new Map<string, PropertyDef>();
+  for (const t of chain) for (const p of t.properties) byName.set(p.name, p);
+  return [...byName.values()];
+}

--- a/tests/main/graph/subclassof.test.ts
+++ b/tests/main/graph/subclassof.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { initGraph, indexAllNotes, queryGraph } from '../../../src/main/graph/index';
+import { initGraph, indexAllNotes, queryGraph, getNoteTypedProperties, getTypeInstances } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 let root: string;
@@ -33,15 +33,10 @@ beforeEach(async () => {
   root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-subclassof-'));
   ctx = projectContext(root);
   await initGraph(ctx);
-  writeType('reference', `label: Reference`);
-  writeType('monograph', `label: Monograph
-parent: reference`);
-  writeNote('Dune.md', `---
-title: Dune
-type: monograph
----
-`);      // a Book (⊂ Reference)
-  writeNote('Cite.md', `---\ntitle: Cite\ntype: reference\n---\n`); // a direct Reference
+  writeType('reference', `label: Reference\nproperties:\n  - name: citation\n    type: text`);
+  writeType('monograph', `label: Monograph\nparent: reference\nproperties:\n  - name: isbn\n    type: text`);
+  writeNote('Dune.md', `---\ntitle: Dune\ntype: monograph\ncitation: Herbert 1965\nisbn: "9780441172719"\n---\n`); // a Monograph (⊂ Reference)
+  writeNote('Cite.md', `---\ntitle: Cite\ntype: reference\ncitation: Smith 2020\n---\n`); // a direct Reference
   await indexAllNotes(ctx);
 });
 afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
@@ -60,8 +55,29 @@ describe('subclassing (#1586)', () => {
   });
 
   it('a DIRECT type query excludes the subclass (only the path includes it)', async () => {
-    // Dune is typed Book, not directly Reference.
+    // Dune is typed Monograph, not directly Reference.
     expect(await paths(`SELECT ?p WHERE { ?n minerva:relativePath ?p ; a types:Reference }`)).toEqual(['Cite.md']);
     expect(await paths(`SELECT ?p WHERE { ?n minerva:relativePath ?p ; a types:Monograph }`)).toEqual(['Dune.md']);
+  });
+
+  it('the read-back inherits the parent\'s properties (#1587)', async () => {
+    const rb = await getNoteTypedProperties(ctx, 'Dune.md');
+    expect(rb.type?.id).toBe('monograph');
+    // citation is inherited from Reference; isbn is the Monograph's own.
+    const byName = new Map(rb.properties.map((p) => [p.name, p]));
+    expect([...byName.keys()]).toEqual(['citation', 'isbn']); // ancestor-first
+    expect(byName.get('citation')!.value).toBe('Herbert 1965');
+    expect(byName.get('isbn')!.value).toContain('9780441172719');
+  });
+
+  it('the multi-view is subclass-aware and inherits columns (#1587)', async () => {
+    // The parent's view shows the parent's columns and INCLUDES subclass instances.
+    const ref = await getTypeInstances(ctx, 'reference');
+    expect(ref.instances.map((i) => i.path).sort()).toEqual(['Cite.md', 'Dune.md']);
+    // The subclass's view carries inherited + own columns.
+    const mono = await getTypeInstances(ctx, 'monograph');
+    const dune = mono.instances.find((i) => i.path === 'Dune.md')!;
+    expect(Object.keys(dune.values).sort()).toEqual(['citation', 'isbn']);
+    expect(dune.values.citation).toBe('Herbert 1965');
   });
 });

--- a/tests/renderer/components/TypeEditorDialog.test.ts
+++ b/tests/renderer/components/TypeEditorDialog.test.ts
@@ -62,6 +62,18 @@ describe('TypeEditorDialog (#1585)', () => {
     expect(input.card).toEqual(['author']); // the on-card checkbox stayed set
   });
 
+  it('carries the parent type through save (#1587)', async () => {
+    render(TypeEditorDialog, {
+      initial: { id: 'monograph', label: 'Monograph', parent: 'book', properties: [] },
+      onSaved: vi.fn(), onClose: vi.fn(),
+    });
+    // Wait for the type list to load (populates the parent dropdown).
+    await waitFor(() => expect(document.querySelector('option[value="book"]')).toBeTruthy());
+    await fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(saveMock.mock.calls[0]![0].parent).toBe('book');
+  });
+
   it('reorders properties', async () => {
     render(TypeEditorDialog, {
       initial: { label: 'T', properties: [{ name: 'first', type: 'text' }, { name: 'second', type: 'text' }] },

--- a/tests/shared/objects/inheritance.test.ts
+++ b/tests/shared/objects/inheritance.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Subclass property inheritance (#1587): effective properties = ancestors' props
+ * (root-first) + own, child overriding by name; cycle-safe.
+ */
+import { describe, it, expect } from 'vitest';
+import { effectivePropertyDefs, type TypeLike } from '../../../src/shared/objects/inheritance';
+import type { PropertyDef } from '../../../src/shared/objects/type-def';
+
+const p = (name: string, type: PropertyDef['type'] = 'text'): PropertyDef => ({ name, type });
+function map(...types: TypeLike[]): Map<string, TypeLike> {
+  return new Map(types.map((t) => [t.id, t]));
+}
+
+describe('effectivePropertyDefs (#1587)', () => {
+  it('returns a parentless type\'s own properties', () => {
+    const m = map({ id: 'book', properties: [p('author'), p('rating')] });
+    expect(effectivePropertyDefs('book', m).map((x) => x.name)).toEqual(['author', 'rating']);
+  });
+
+  it('inherits the parent\'s properties, ancestor-first, child appends its own', () => {
+    const m = map(
+      { id: 'reference', properties: [p('citation'), p('year')] },
+      { id: 'monograph', parent: 'reference', properties: [p('isbn')] },
+    );
+    expect(effectivePropertyDefs('monograph', m).map((x) => x.name)).toEqual(['citation', 'year', 'isbn']);
+  });
+
+  it('lets the child override an inherited property in place (by name)', () => {
+    const m = map(
+      { id: 'reference', properties: [p('year', 'text')] },
+      { id: 'monograph', parent: 'reference', properties: [p('year', 'number'), p('isbn')] },
+    );
+    const eff = effectivePropertyDefs('monograph', m);
+    expect(eff.map((x) => x.name)).toEqual(['year', 'isbn']); // year kept its position
+    expect(eff.find((x) => x.name === 'year')!.type).toBe('number'); // child's type wins
+  });
+
+  it('walks a multi-level chain root-first', () => {
+    const m = map(
+      { id: 'a', properties: [p('a1')] },
+      { id: 'b', parent: 'a', properties: [p('b1')] },
+      { id: 'c', parent: 'b', properties: [p('c1')] },
+    );
+    expect(effectivePropertyDefs('c', m).map((x) => x.name)).toEqual(['a1', 'b1', 'c1']);
+  });
+
+  it('is cycle-safe', () => {
+    const m = map(
+      { id: 'x', parent: 'y', properties: [p('x1')] },
+      { id: 'y', parent: 'x', properties: [p('y1')] },
+    );
+    // Terminates; each type's props appear once.
+    expect(effectivePropertyDefs('x', m).map((x) => x.name).sort()).toEqual(['x1', 'y1']);
+  });
+
+  it('stops at an unknown parent (dangling ref)', () => {
+    const m = map({ id: 'monograph', parent: 'ghost', properties: [p('isbn')] });
+    expect(effectivePropertyDefs('monograph', m).map((x) => x.name)).toEqual(['isbn']);
+  });
+});


### PR DESCRIPTION
Closes #1587. Makes the subclassing substrate (#1586) user-visible — pick a parent, inherit its properties, and see subclass instances under the parent.

## What

- **Parent picker** in the type editor — a "Parent type" select that writes the `parent` field (the id list already excludes self). It seeds from + round-trips the value, and duplicate/edit carry it.
- **Property inheritance** — `effectivePropertyDefs` (shared, pure, **cycle-safe**) merges a type's ancestors' properties (root-first) with its own, the child overriding an inherited property **by name, in place**. The #1063 read-back and the #1070 projection both derive their property lists through it, so a subclass's **property form** (#1066) and **multi-view columns** include inherited properties.
- **Subclass-aware surfaces** —
  - `getTypeInstances` + the Objects browser's **expand** query match `?n a/rdfs:subClassOf* types:Class`, so a parent's multi-view / expansion **includes its subclasses' instances**;
  - the Objects browser **count** query counts each instance under every ancestor, so a parent's count **includes descendants**.

  All three are consistent: a `Monograph` (⊂ `Reference`) appears under both, and `Reference`'s count includes it.

## Acceptance criteria

- [x] The editor can set/clear a parent type.
- [x] A subclass's property form + read-back include the parent's declared properties.
- [x] The Objects browser / multi-view reflect subclassing consistently (parent count includes descendants; parent view/expand includes subclass instances).

## Tests

- `inheritance.test.ts` — inherit / override-in-place / multi-level chain / cycle-safe / dangling-parent.
- `subclassof.test.ts` — the read-back inherits the parent's properties (with values); the multi-view is subclass-aware and carries inherited columns.
- `TypeEditorDialog.test.ts` — the parent is carried through save.

Lint clean; 704 graph/types/shared/component tests green.

---

With this the epic's substantive work is done — only **#1588** (rename/delete-in-use safety) remains, which the editor's stable-id design already sidesteps for the common case.