### PR TITLE
docs(reports): 2026-08 code-quality review reports

### DIFF
--- a/reports/api-review-entire-project-2026-08-02-073151.md
+++ b/reports/api-review-entire-project-2026-08-02-073151.md
@@ -1,0 +1,427 @@
+# API Design Review — Minerva
+
+**Date:** 2026-08-02
+**Scope:** Entire project — the Electron IPC contract as Minerva's real "API surface"
+**Reviewer lens:** API/interface design (naming, shape, contract completeness, developer experience)
+
+---
+
+## Critical Framing
+
+Minerva is a **desktop Electron application, not a web service.** There is no
+HTTP server, no REST/GraphQL endpoints, no OpenAPI document, no OAuth, no rate
+limiting, no CORS, no public API consumers, and no SDK. The generic web-API
+review template (status codes, HATEOAS, pagination, SLAs, developer portals,
+versioning strategy) is therefore **mostly Not Applicable**, and this report
+says so explicitly rather than inventing findings.
+
+The genuine API of this codebase is the **Electron IPC contract** — the typed
+boundary between the renderer (Svelte UI) and the main (Node.js) process,
+surfaced to UI code as `window.api.*`. That boundary is a real, versioned,
+consumed interface with request/response shapes, an error convention, a naming
+scheme, and a wiring workflow. This review assesses **that** surface, mapping
+each template heading onto the IPC reality.
+
+Files reviewed:
+- `src/shared/channels.ts` — 333 channel-name constants (the "endpoints")
+- `src/shared/ipc-contract.ts` — `ChannelMap`, 235 typed invoke signatures (#981)
+- `src/shared/ipc-validators.ts` — runtime return-payload validators (#983)
+- `src/main/ipc/typed-ipc.ts` + `helpers.ts` — typed `handle()` + guards
+- `src/main/ipc/register-*.ts` — 21 domain registrars
+- `src/preload/preload.ts` + `typed-invoke.ts` — the single `contextBridge` surface
+- `src/renderer/lib/ipc/client.ts` — the renderer-facing `IdeApi` (1118 lines)
+
+---
+
+## Executive Summary
+
+The IPC surface is **large, mature, and unusually well-governed for an internal
+API.** With 333 channel constants across ~37 client namespaces, this is a big
+interface, yet it is held together by real contract machinery: a typed
+`ChannelMap` (#981) that makes wrong argument/return types fail `tsc`, a typed
+`handle()`/`invoke()` wrapper pair that derives its signatures from that map,
+zero raw `ipcMain.handle` calls anywhere in the codebase, a runtime
+return-payload validator (#983) that is fatal under test, and a preload snapshot
+test that catches an unexposed method. This is genuinely good interface
+discipline and materially better than the "half-stringly channels" the
+architecture review recalled.
+
+The prior architecture review's P2 flag — "`ipc-contract.ts` may be scoped to
+the notebase domain, confirm coverage" — is **resolved and can be closed for the
+type contract**: `ChannelMap` now spans ~40 domains and 235 invoke channels, not
+just notebase. However, the concern is **half-true at the runtime layer**: the
+runtime validators in `ipc-validators.ts` cover only ~19 channels, all
+notebase. So the *type* contract is universal; the *runtime* shape guard is
+still notebase-only.
+
+The three highest-value API-design issues are: (1) **three competing error
+conventions** across the surface (throw vs. `{ok,error}` union vs. `null`
+sentinel vs. in-band `error` field) with no documented rule for which to use;
+(2) **event (one-way) channels have no single source of truth** — `ChannelMap`
+covers only invoke channels, so the ~98 `send`-style channels are typed
+independently in three places that can silently drift; and (3) **naming drift
+between channel domains and client namespaces** (e.g. `excerpt:*` and `ingest:*`
+channels surfaced under `api.sources.*`, client verb `remove` mapping to channel
+`delete`). None are severe; all are the kind of consistency debt that
+accumulates on a fast-growing surface.
+
+---
+
+## API Design Findings
+
+### High
+
+#### H1 — Three (arguably four) competing error conventions across the surface
+`src/shared/ipc-contract.ts`, multiple registrars
+
+The same conceptual outcome ("this operation failed") is modeled four different
+ways depending on which channel you call, with no documented rule:
+
+1. **Throw** — the dominant path. `withRootPath` throws `'No project open'`
+   (`src/main/ipc/helpers.ts:35`); `notebase:*` fs errors propagate as thrown
+   exceptions that reject the renderer promise. Most `notebase:*`, `tags:*`,
+   `links:*` channels behave this way.
+2. **Result union `{ ok: false; error: string }`** —
+   `graph:setBaseUri` (`ipc-contract.ts:212`), `tables:query` (`:230`),
+   `publish:toGit` (`:300`), `publish:checkS3`/`checkGitHub` (`:314`,`:322`),
+   `graph:attachExcerptEvidence` (`:217`).
+3. **Discriminated status union other than ok/error** —
+   `compute:interruptPython` returns `{ ok:false; reason: ... }` (`:328`);
+   `compute:saveCellOutput` returns `{ status:'written' } | { status:'needs-confirm' }` (`:340`).
+4. **`null` sentinel** — `templates:get` (`:139`), `graph:sourceDetail` (`:215`),
+   `graph:excerptSource` (`:216`), `csl:importStyle` (`:362`),
+   `sources:ingestFile` (`:414`). Note `null` is overloaded: for pickers it
+   means "user cancelled," for lookups it means "not found."
+5. **In-band `error` field** — `graph:query` returns
+   `{ results; columns; error? }` (`:209`): a SPARQL error is neither thrown nor
+   an `ok:false` union, it is an optional string field the caller must remember
+   to check.
+
+**Failure scenario:** a developer adding a store method assumes the dominant
+throw convention and wraps a call to `graph:query` in try/catch. A malformed
+SPARQL query never throws — it resolves with `{ results: [], error: '...' }` —
+so the error is silently swallowed and the UI shows an empty result set instead
+of the parse error. The inverse also bites: code that checks
+`if (!result.ok)` against a channel that actually throws never runs.
+
+**Recommendation:** document a single decision rule in CLAUDE.md (suggested:
+throw for programmer errors / unexpected failures; `{ ok:false; error }` for
+*expected, user-surfaceable* failures where the raw message must reach the UI;
+`null` reserved exclusively for "picker cancelled"). Do not attempt a big-bang
+migration — annotate each channel's chosen convention in `ChannelMap` comments
+and converge opportunistically.
+
+#### H2 — Event (one-way) channels have no single source of truth; payloads typed in three places
+`src/shared/channels.ts`, `src/preload/preload.ts`, `src/renderer/lib/ipc/client.ts`
+
+`ChannelMap` (#981) is explicitly and correctly *invoke-only* — 235 entries. But
+`channels.ts` defines 333 channels; the ~98-channel gap is the one-way `send`
+surface: `menu:*` dispatch, `*:changed` broadcasts (`sources:changed`,
+`collections:changed`, `tables:changed`, `excerpts:changed`,
+`proposals:changed`), `*:progress` streams, `conversation:*Draft` events,
+`tool:stream`, `notebase:rewritten`, etc.
+
+These payloads have **no contract**. Each is typed independently at three sites:
+the main-process `webContents.send(...)` call, the preload `subscribeIpc<T>` /
+callback signature, and the `client.ts` `on*` method signature. In preload,
+every draft subscription erases the type entirely — e.g.
+`onDraft: (cb: (draft: unknown) => void)` (`preload.ts:274`), repeated for
+`onSourceDraft`, `onPropertyDraft`, `onClaimsDraft`, `onComputeDraft`,
+`onRefactorDraft`, `onReorgDraft`, `onDeleteDraft`, `onNoteBodyDraft` — then
+`client.ts` re-adds the proper `ConversationDraft` etc. types (`client.ts:589`+).
+Nothing enforces that the main-side `send` payload actually matches what the
+client claims to receive.
+
+**Failure scenario:** a change to `ConversationDraft`'s shape on the main side
+(the `send` producer) compiles cleanly; the `client.ts` consumer still declares
+the old shape; the renderer reads a field that is now `undefined` at runtime with
+no type error at any of the three sites.
+
+**Recommendation:** introduce an `EventMap` (sibling to `ChannelMap`) keying each
+one-way channel to its payload type, and a typed `subscribe<K>()` / `broadcast<K>()`
+wrapper pair mirroring `handle`/`invoke`. This closes the last untyped seam and
+makes the event surface as safe as the invoke surface.
+
+#### H3 — The proposals surface — central to the trust model — is fully untyped (`unknown`)
+`src/shared/ipc-contract.ts:486-487`, `client.ts:675-677`
+
+```ts
+'proposal:list': (status?: string) => unknown[];
+'proposal:detail': (uri: string) => unknown;
+```
+
+Proposals are *the* core abstraction of Minerva's "LLM proposes, human confirms"
+trust principle (CLAUDE.md). Every LLM-originated graph mutation flows through a
+`thought:Proposal`. Yet the entire read side of that surface is typed `unknown[]`
+/ `unknown` — the one domain where a strong, documented wire type would most
+help reviewers verify the trust invariant is exactly the one with no type at all.
+The renderer's proposals store must hand-cast every field.
+
+**Recommendation:** define a `ProposalView` / `ProposalDetailView` type in
+`shared/` and use it in `ChannelMap`. Low effort, high clarity payoff, and it
+directly supports the "Code Review Checklist for LLM/Graph PRs" in CLAUDE.md.
+(Lesser instances: `git:status.files: unknown[]` at `:143`; `graph:query.results`
+is inherently `unknown[]` and acceptable for SPARQL.)
+
+### Medium
+
+#### M1 — Runtime validators cover ~8% of channels, all notebase
+`src/shared/ipc-validators.ts`
+
+The runtime shape-validation layer (#983) — the analogue of "validate the
+response against its schema" — is excellent in design (fatal under test,
+`console.error` in prod, never crashes the user's app; `typed-invoke.ts:6-13`).
+But `CHANNEL_VALIDATORS` covers only ~19 channels, and they are all
+`notebase:*`. The other ~216 invoke channels resolve unvalidated. This is the
+kernel of truth behind the architecture review's "scoped to notebase" note: it
+is the *runtime validators* that are notebase-scoped, not the type contract.
+
+**Recommendation:** this is intentionally opt-in and expanding it is real work,
+but the highest-value additions are the channels with union/`ok` return shapes
+(H1) and the proposals surface (H3) — exactly the shapes most likely to drift.
+Prioritize validators there rather than aiming for 100%.
+
+#### M2 — Channel-domain ↔ client-namespace drift
+`src/shared/channels.ts`, `src/preload/preload.ts`
+
+The channel string's domain prefix and the `window.api` namespace it lands under
+disagree in several places, hurting discoverability (a developer grepping for
+`excerpt:` won't find it under `api.excerpt`):
+
+- `excerpt:getNoteFolder` / `excerpt:setNoteFolder` → `api.sources.getExcerptNoteFolder` / `setExcerptNoteFolder` (`preload.ts:378`)
+- `ingest:getSettings` / `ingest:setSettings` → `api.sources.getIngestSettings` / `setIngestSettings` (`preload.ts:407`)
+- `inspections:list` / `inspections:run` → `api.graph.inspections()` / `api.graph.runInspections()` (`preload.ts:134`)
+- `images:cacheExternal` and `youtube:thumbnail` are their own top-level namespaces (`api.images`, `api.youtube`) despite being small offline-cache helpers that could sit under a shared namespace.
+
+Singular/plural is also mixed: `api.conversations` → `conversation:*`,
+`api.tools` → `tool:*`, `api.proposals` → `proposal:*`, while `api.queries` →
+`queries:*` and `api.views` → `views:*` agree.
+
+#### M3 — Client verb ↔ channel verb drift
+`src/preload/preload.ts`, `src/renderer/lib/ipc/client.ts`
+
+The client method name and the channel action disagree for several operations,
+so the "same" concept is named two ways:
+
+- `api.collections.remove(id)` → `collections:delete` (`preload.ts:440`), yet `api.types.delete(id)` → `types:delete`. Pick one of remove/delete.
+- `api.refactor.autoTag(...)` → `refactor:autoTagSuggest` (`preload.ts:357`), but `api.refactor.autoLinkSuggest(...)` → `refactor:autoLinkSuggest`. One drops the "Suggest" suffix, its sibling keeps it.
+- `api.compute.interruptPythonKernel()` → `compute:interruptPython` (`preload.ts:197`).
+
+These are cosmetic but they are precisely the kind of inconsistency that makes a
+large surface feel arbitrary to a new contributor.
+
+#### M4 — `client.ts` `IdeApi` is a second hand-maintained contract parallel to `ChannelMap`
+`src/renderer/lib/ipc/client.ts` (1118 lines) vs `src/shared/ipc-contract.ts` (548 lines)
+
+`ChannelMap` and the renderer-facing `IdeApi` interface describe substantially
+the same signatures, but `IdeApi` is authored and maintained by hand rather than
+derived from `ChannelMap`. The preload `invoke()` call ties argument/return
+*through* `ChannelMap`, so a mismatch is caught where preload assigns — but
+`IdeApi` itself can carry return types that differ in shape from `ChannelMap`
+(e.g. richer JSDoc, re-declared object literals) and no test asserts the two
+agree. This is effectively a **6th wiring site** on top of the documented five
+(channel → module → register → preload → client) and doubles the surface a
+signature change must touch.
+
+**Recommendation:** medium-term, generate the renderer-facing type from
+`ChannelMap` (a mapped type `{ [K in ...]: (...args) => Promise<Return> }`
+grouped by namespace) so `IdeApi` becomes derived, not authored. This would
+collapse ~1100 lines of duplication and remove a whole drift class.
+
+### Low / Positive
+
+- **Zero raw `ipcMain.handle`.** Every handler goes through the typed `handle()`
+  wrapper (`typed-ipc.ts`); a grep across `src/main` finds no bypass. Excellent.
+- **`withRootPath` / `withRootPathOr` / `withRootPathWin`** (`helpers.ts:29-72`)
+  collapse the "is a project open?" guard that was hand-rolled 86× (#990) into a
+  single, tested combinator — a genuinely good bit of API-guard design.
+- **The `graph:query` SPARQL surface** auto-injects standard prefixes
+  (`src/main/graph/state.ts`, `queries.ts`) so callers write terse queries — a
+  nice secondary-API affordance, though its in-band `error` field feeds H1.
+
+---
+
+## Current API Assessment (Inventory)
+
+| Dimension | Value |
+|---|---|
+| Channel constants (`channels.ts`) | **333** |
+| Typed invoke signatures (`ChannelMap`) | **235** |
+| One-way event channels (no `ChannelMap` entry) | **~98** (menu dispatch, `*:changed`, `*:progress`, drafts, streams) |
+| Client namespaces (`window.api.*`) | **~37** |
+| Domain registrars (`register-*.ts`) | **21** |
+| Runtime validators (`ipc-validators.ts`) | **~19** (notebase only, ~8% of invoke channels) |
+| Raw `ipcMain.handle` bypasses | **0** |
+
+**Namespaces** (representative): `notebase`, `links`, `queries`, `views`,
+`search`, `git`, `graph`, `embeddings`, `tables`, `tags`, `templates`, `export`,
+`files`, `compute`, `publish`, `app`, `images`, `youtube`, `view`, `shell`,
+`conversations`, `proposals`, `bookmarks`, `clipper`, `tabs`, `refactor`,
+`sources`, `collections`, `formatter`, `tools`, `types`, `skills`, `sites`,
+`bibliography`, `csl`, `citations`, `menu`.
+
+**Dominant patterns (good):** channels follow `domain:verbNoun` in camelCase
+(`notebase:readFile`, `sources:setReadStatus`, `collections:createSmart`);
+constants are `SCREAMING_SNAKE`; the largest domains (notebase, conversation,
+sources) are richly documented inline. The convention is real and mostly
+adhered to — the findings above are the exceptions, not the rule.
+
+---
+
+## Improvement Plan
+
+Ordered by value/effort. Estimates assume one engineer familiar with the codebase.
+
+| # | Item | Finding | Effort |
+|---|---|---|---|
+| 1 | Type the proposals surface (`ProposalView`/`ProposalDetailView`) | H3 | **0.5 day** |
+| 2 | Document the error-convention decision rule in CLAUDE.md; annotate each channel's chosen shape in `ChannelMap` comments | H1 | **1 day** (doc + annotation; no code migration) |
+| 3 | Introduce `EventMap` + typed `subscribe`/`broadcast` wrappers; migrate the draft/`*:changed`/`*:progress` channels | H2 | **2-3 days** |
+| 4 | Fix the stale `ipc-contract.ts` header comment ("for the notebase domain") to reflect the ~40-domain reality; close the arch-review P2 | doc | **15 min** |
+| 5 | Expand runtime validators to the union/`ok`-return and proposals channels | M1 | **1-2 days** |
+| 6 | Reconcile channel-domain vs namespace names and client-verb drift (deprecate-and-alias, don't hard-rename) | M2, M3 | **1 day** |
+| 7 | Derive `IdeApi` from `ChannelMap` via a mapped type; delete the hand-maintained duplicate | M4 | **2-3 days** (careful, touches every store) |
+
+---
+
+## Consistency Enhancements
+
+- **One error shape rule, written down** (H1) — the single highest-leverage
+  consistency win.
+- **One delete verb** (`delete` vs `remove`) and a **suffix rule for
+  suggest/apply pairs** (M3).
+- **Namespace = domain-prefix invariant** — either rename the outlier channels
+  (`excerpt:*`, `ingest:*`, `inspections:*`) or document why they intentionally
+  fold into `sources`/`graph`. A lint rule asserting `Channels.X`'s prefix
+  matches its preload namespace would prevent regressions.
+- **Singular/plural** — settle `conversation` vs `conversations`, `tool` vs
+  `tools`, `proposal` vs `proposals` (channels are singular, namespaces plural;
+  either is fine, but be uniform).
+
+---
+
+## Error Handling (how IPC errors actually propagate today)
+
+- **Thrown errors** cross the boundary via Electron's `invoke`/`handle`
+  serialization and **reject the renderer promise**; the message survives, the
+  stack does not. This is the default for `notebase:*` fs failures and the
+  `withRootPath` "No project open" guard.
+- **Result unions** (`{ ok:false; error }`) are used where the raw underlying
+  message must reach the UI verbatim — notably `publish:toGit` (git auth /
+  non-fast-forward messages) and the connection checks. This is the right choice
+  for those cases; the problem (H1) is only that the rule for *when* to use it
+  isn't written down or uniformly applied.
+- **`null`** doubles as "not found" and "picker cancelled," which is ambiguous
+  at call sites (M-adjacent to H1).
+- **Runtime payload validation** (`typed-invoke.ts` + `ipc-validators.ts`) is a
+  distinct, well-designed guard: a return that fails its validator throws under
+  test (fails CI) and logs in prod (never crashes the app) — but only for the
+  ~19 validated channels (M1).
+- **Error-message quality to the UI:** good where the result-union pattern is
+  used (raw messages preserved); weaker on thrown paths where the renderer often
+  only sees a generic message. No user-facing error taxonomy/codes exist — and
+  for a single-consumer desktop app, none is needed.
+
+---
+
+## Versioning — mostly N/A
+
+**N/A — desktop Electron app; the IPC contract is internal and ships versioned
+with the app binary.** Renderer and main are always built and released together
+from one repo, so there is no independent client to break, no need for URL/header
+API versioning, no deprecation window, and no backward-compatibility guarantee
+across app versions.
+
+The one place a versioning-adjacent concern is *real* is **persisted-data shape
+compatibility**, and the codebase already handles it correctly: `tabs:load`
+returns `LayoutSession | TabSession | null` and the renderer migrates the legacy
+flat `TabSession` written by older builds on load (`ipc-contract.ts:173`,
+`client.ts:692`). That is the appropriate analogue of backward compatibility for
+this architecture — schema evolution of on-disk `.minerva/*.json` and the graph,
+not wire versioning. No action needed; noted as a well-handled case.
+
+---
+
+## Developer Experience
+
+**The 5-point wiring pattern** (CLAUDE.md): adding a channel means touching
+(1) `channels.ts`, (2) the fs/module, (3) a `register-*.ts`, (4) `preload.ts`,
+(5) `client.ts`. This is inherently more ceremony than a single-file REST route,
+but the drift risk is now well-mitigated:
+
+- **Type-enforced sites (2 of 5):** `handle()` and `invoke()` both derive their
+  arg/return types from `ChannelMap`, so a wrong type in the registrar or preload
+  fails `tsc`. This is the big #981 win and it works.
+- **Snapshot-guarded site:** `tests/preload/preload-bridge.test.ts` catches a
+  method added to `client.ts`/`ChannelMap` but *not* exposed in the preload
+  bridge — the classic silent-failure this architecture is prone to. (Per the
+  team's own memory: adding a `window.api` method requires updating this
+  snapshot with `-u`.) Credit where due — this is exactly the right guardrail.
+- **Validation test:** `tests/preload/typed-invoke-validation.test.ts` exercises
+  the runtime validator path.
+- **Remaining manual drift:** `ChannelMap` ↔ hand-authored `IdeApi` (M4), and
+  the entire event surface (H2). These are the two seams a signature change can
+  still slip through.
+
+**The renderer data-flow rule** (components call `api.*` for reads only;
+mutations route through stores/ops) is enforced by a `no-restricted-syntax`
+denylist in `eslint.config.mjs:244` that enumerates mutation method names
+(`writeFile|writeBinary|createFile|...`). As the architecture review noted (P1),
+this is a **denylist that fails open**: a new mutation channel is *not* caught
+until someone remembers to add its method name to the regex. This is an
+API-governance DX gap — the rule protects the contract only as well as the
+manually-maintained list. An allowlist (components may call only names ending in
+read-ish patterns, or only names on an explicit read list) would fail closed, but
+that is a larger change and is already tracked by the architecture review; noted
+here only because it is genuinely an interface-governance concern.
+
+**Discoverability** for the renderer consumer is otherwise strong: `window.api`
+is one flat, namespaced, fully-typed object with rich JSDoc; autocomplete makes
+the surface browsable without docs. The naming drift (M2/M3) is the main friction.
+
+---
+
+## Not Applicable (web-only template sections)
+
+Each is genuinely inapplicable to a desktop Electron app; the IPC analogue (where
+one exists) is named.
+
+- **RESTful resource modeling / HTTP verbs / status codes** — N/A. No HTTP. The
+  analogue is the `domain:verbNoun` channel convention (assessed above).
+- **HATEOAS / hypermedia** — N/A. No hypertext API; the UI is the client and
+  ships with the server.
+- **Pagination for collections** — N/A. Local in-process calls return full
+  result sets (e.g. `sources:listAll`, `tags:list`); the data lives on the same
+  machine and is bounded by the thoughtbase size.
+- **Authentication / authorization / OAuth** — N/A for the IPC boundary itself
+  (context isolation + a fixed local peer is the boundary). Credential handling
+  *does* exist but for outbound integrations only: `tool:getKeyStorage` /
+  `tool:checkConnection` (LLM keys), `publish:checkGitHub` / `publish:checkS3`,
+  and `sites:*` (privileged-site session cookies). Those are outbound-client
+  concerns, not an inbound API auth surface.
+- **Rate limiting / throttling / quotas** — N/A. No untrusted callers.
+- **CORS / content negotiation** — N/A. No cross-origin requests; a strict CSP
+  governs the renderer instead.
+- **API gateway / SDK / developer portal / public docs** — N/A. Single internal
+  consumer. `docs/authoring-skills.md` documents the *skills* extensibility
+  surface, which is the closest thing to a public extension API.
+- **Formal API versioning / deprecation policy** — N/A (see Versioning).
+- **GraphQL** — N/A as a transport. The **SPARQL** surface (`graph:query`, with
+  auto-injected prefixes) is the codebase's actual query-language interface and
+  is assessed as a secondary internal API above.
+
+---
+
+## Secondary Internal APIs (briefly)
+
+- **SPARQL (`api.graph.query`)** — standard prefixes auto-injected
+  (`src/main/graph/state.ts`), so callers write terse queries; results are
+  `{ results: unknown[]; columns: string[]; error? }`. The `unknown[]` results
+  are inherent to SPARQL and acceptable; the in-band `error` field is the H1
+  outlier. A good, discoverable internal query API.
+- **Skills / tools registry (`src/shared/tools/`, `api.skills.*`)** — the real
+  user-facing *extensibility* API: markdown skill files with YAML frontmatter,
+  loaded from `~/.minerva/skills/`, documented in `docs/authoring-skills.md`.
+  This is the one Minerva surface that behaves like a public API (third parties
+  author against it), and it is appropriately file-based, additive (user skills
+  can't shadow stock), and documented. No findings.

--- a/reports/architecture-review-entire-project-2026-08-01-212629.md
+++ b/reports/architecture-review-entire-project-2026-08-01-212629.md
@@ -1,0 +1,391 @@
+# Architecture Review
+
+Generated: 2026-08-01 21:26:29
+Scope: entire project (/Users/davegriffith/minerva)
+Prior review: reports/architecture-review-entire-project-2026-06-10-114911.md
+
+## Executive Summary
+
+Minerva remains a mature, unusually well-layered Electron + Svelte 5 + TypeScript
+desktop markdown IDE (~120k LOC across ~700 source files). The headline of this
+review is not new problems — it is that **the June review's entire High-Priority
+plan has been executed**, and the codebase is materially healthier for it.
+
+Specifically, every top-3 structural fix from June is done:
+
+- **C3 (main→renderer layer violation) is fixed.** `grep` for `renderer/` imports
+  under `src/main` now returns nothing.
+- **Enforced import boundaries exist** (`eslint.config.mjs:192-232`, #668):
+  `shared` may not import main/renderer/preload/`node:*`; main may not import
+  renderer; renderer may not import main. The clean topology is now machine-frozen,
+  not convention.
+- **`ipc.ts` (was 2,717 lines, one mega-function) is gone.** It is now 21
+  domain-sliced `src/main/ipc/register-*.ts` modules plus a typed dispatch layer
+  (`typed-ipc.ts`, `helpers.ts`) and a single typed contract
+  (`src/shared/ipc-contract.ts`, #981). Only the wrapper itself calls raw
+  `ipcMain.handle`; all 21 registrars go through the typed `handle`.
+- **`graph/index.ts` (was 2,717 lines) is 226 lines**, a thin facade over
+  extracted modules: `indexers.ts`, `queries.ts`, `state.ts`, `write-guard.ts`,
+  `health-checks.ts`, `integrity.ts`, `neighborhood.ts`, `parser.ts`.
+- **The write guard is its own module** (`graph/write-guard.ts`, 102 lines) with
+  dedicated tests (`write-guard.test.ts`, `write-guard-wired.test.ts`,
+  `trust-integrity.test.ts`) — closing June's D2 gap ("no integrity test asserting
+  the gate cannot be skipped").
+
+The renderer story changed just as much. June counted **two** stores; there are
+now **24 rune stores** plus **10 App-ops modules**, and the renderer data-flow
+rule (#1086) is enforced by an eslint `no-restricted-syntax` block
+(`eslint.config.mjs:241-279`) with **zero `eslint-disable` escapes** anywhere in
+the tree. `App.svelte` shrank from 3,764 to 2,011 lines (script portion ends at
+line 956; the rest is template).
+
+The new object-type editor work (#1584-1588) is a model of seam adherence: it
+mirrors the skills pipeline exactly (`src/main/types/` = parse/loader/compile/
+write/migrate + `stock/*.md`), keeps its domain logic pure in `src/shared/objects/`,
+exposes a typed `register-types.ts`, and fronts all mutations through a proper
+`object-types.svelte.ts` store.
+
+What remains is a **shorter, milder** list than June's: one residual god-module
+(`graph/indexers.ts`, 1,665 lines), a cluster of oversized Svelte components
+(`Preview` 2,185, `Editor` 1,475, `SettingsDialog` 1,423, `SourceDetail` 1,365,
+`SourcesPanel` 1,297, `PropertiesPanel` 1,127), the largest IPC registrar
+(`register-conversation.ts`, 967), a fragility in the data-flow rule's denylist
+design, and one genuinely new correctness finding: the type rename/delete batch
+rewrite (`types/migrate.ts`) is non-atomic.
+
+**No Critical issues remain.** The architecture is in the best shape this review
+series has recorded.
+
+## Current Architecture
+
+### Overview
+
+**Style:** Three-process Electron app (Main / Preload / Renderer) with strict
+`contextBridge` isolation, plus a fourth conceptual layer — a genuinely pure
+`shared` domain library imported by both ends. All four boundaries are now
+eslint-enforced.
+
+**Key components:**
+
+- **Main** (`src/main/`) — Node. File I/O behind `notebase/fs.ts`
+  (`assertSafePath` traversal guard); the RDF graph as a thin facade
+  (`graph/index.ts`, 226 lines) over `indexers.ts`/`queries.ts`/`state.ts`/
+  `write-guard.ts`; SPARQL via Comunica over an N3.Store; the LLM/approval engine
+  (`llm/`, with `approval.ts` now 163 lines + `apply-dispatch.ts` 482 +
+  `proposal-persistence.ts` + a `tools/` folder of per-tool proposers); the skills
+  pipeline (`skills/`); the **new type system** (`types/`); sources (`sources/`);
+  compute kernels (`compute/`); publish/export (`publish/`); a new `substrate/`
+  app-server (MCP epic #1145) and `search/` (minisearch provider); IPC registrars
+  (`ipc/register-*.ts`).
+- **Preload** (`src/preload/preload.ts`, 721 lines) — the single `contextBridge`
+  surface exposing `window.api`.
+- **Renderer** (`src/renderer/`) — Svelte 5 runes UI. **24 singleton stores**
+  (`lib/stores/*.svelte.ts`) own `api.*` mutations + event subscriptions; **10 App
+  ops modules** (`lib/app/*`) provide top-level orchestration clusters wired by
+  `App.svelte` as the composition root; `lib/ipc/client.ts` (1,122 lines) is the
+  typed `api` wrapper.
+- **Shared** (`src/shared/`) — channel constants, types, the typed IPC contract
+  (`ipc-contract.ts`), the thought ontology, and pure logic: skills menu-config,
+  tool registry/grouping, formatter rules, markdown/refactor helpers, and the new
+  `objects/` type-definition domain. Verified pure (no fs/path/electron/`node:`,
+  no main/renderer imports) both by grep and by the eslint boundary rule.
+
+**Design patterns observed:**
+
+- **Proposal / approval (command + memento):** the Trust Principle. `llm/`
+  proposes; the human confirms; `apply-dispatch.ts` applies per-payload with
+  reverse-order rollback. Now split out of the old monolith into `approval.ts` +
+  `apply-dispatch.ts` + `proposal-persistence.ts`.
+- **Pipeline, applied twice:** skills (`parse → loader → compile → register`) and
+  now **types** (`types/parse.ts → loader.ts → compile.ts → write.ts / migrate.ts`),
+  both fed by bundled `stock/*.md`. The type system deliberately reuses the exact
+  shape of the skills subsystem.
+- **Typed IPC contract (#981):** `shared/ipc-contract.ts` is one source of truth
+  linking channel ↔ handler ↔ preload ↔ client signatures; the typed
+  `handle`/`invoke` wrappers derive arg/return types from it, so a wrong
+  param/return fails `tsc`. This resolves June's P1 (half-typed/half-stringly
+  channels).
+- **Store-owns-mutation (#1086):** every state write and every main→renderer
+  subscription lives in a store or ops module; components read reactive state and
+  call store methods. Enforced by lint.
+- **Context object:** `ProjectContext` brand type threaded through main APIs.
+- **Named-graph-per-note indexing:** incremental re-index per note; unchanged and
+  still strong.
+
+### Architecture Diagram (real 3-process + store/ops + graph)
+
+```
+        ┌────────────────────────────────────────────────────────────────┐
+        │  src/shared  (PURE — eslint-enforced: no fs/electron/node/main)  │
+        │  channels • types • ipc-contract(#981) • ontology •              │
+        │  objects/ (type-def, inheritance, card) • tools/registry+group • │
+        │  skills/menu-config • formatter rules • markdown/refactor        │
+        └───────▲──────────────────────────────────────────────▲─────────┘
+                │ imports (typed)                                │ imports (typed)
+   ┌────────────┴───────────────┐   contextBridge   ┌───────────┴──────────────────┐
+   │        RENDERER             │  window.api       │            MAIN               │
+   │                             │  (preload 721)    │                               │
+   │  App.svelte (2011)          │                   │  ipc/register-*.ts  (21 files)│
+   │   = composition root        │── invoke/handle ─▶│  typed-ipc.ts + helpers.ts    │
+   │   wires 10 ops modules      │◀── events ────────│  register-conversation (967)  │
+   │                             │                   │        │                      │
+   │  24 stores (own api.* +     │                   │        ▼                      │
+   │   subscriptions):           │                   │  ┌──────────────────────────┐ │
+   │   notebase editor           │                   │  │ graph/index.ts (226 facade)│ │
+   │   conversations proposals   │                   │  │  indexers.ts (1665) ◀─OCP  │ │
+   │   object-types source-data  │                   │  │  queries.ts(1267) state.ts │ │
+   │   settings … (+16)          │                   │  │  write-guard.ts (tested)   │ │
+   │                             │                   │  │  N3.Store + Comunica       │ │
+   │  components/ (read-only api;│                   │  └────────────▲───────────────┘ │
+   │   mutations via stores —    │                   │  ┌────────────┴──────────────┐ │
+   │   lint-enforced #1086)      │                   │  │ llm/ approval.ts (163) +   │ │
+   │  Preview(2185) Editor(1475) │                   │  │  apply-dispatch.ts (482) + │ │
+   │  SettingsDialog(1423) …     │                   │  │  tools/ proposers          │ │
+   │                             │                   │  └────────────────────────────┘ │
+   │  Type editor (#1584-88):    │                   │  types/ (parse→loader→compile→  │
+   │   ObjectTypesSettings →     │                   │   write/migrate) + stock/*.md   │
+   │   object-types store →──────┼── api.types.* ───▶│  register-types.ts (typed)      │
+   │   TypeEditorDialog TypeView │                   │  skills/ sources/ compute/      │
+   │                             │                   │  publish/ substrate/ search/    │
+   └─────────────────────────────┘                   └───────────────────────────────┘
+        NO main→renderer imports (C3 fixed) · NO circular deps (madge, 703 files)
+```
+
+## Architectural Issues
+
+### Critical Issues
+
+**None.** June's three Critical items (C1 `ipc.ts` god-module, C2 `App.svelte`
+size, C3 main→renderer import) are all resolved. C1 and C3 are fully closed; C2 is
+substantially reduced (3,764 → 2,011, with orchestration extracted to 10 ops
+modules) and downgraded to a Design Flaw below.
+
+### Design Flaws
+
+**D1 — `graph/indexers.ts` (1,665 lines) is the last real god-module.** The graph
+decomposition extracted the store, queries, write-guard, health-checks and parser,
+but concentrated *all* per-format indexing plus several unrelated concerns into one
+file: note indexing (`indexNote`, `indexers.ts:565`), CSV tables
+(`indexCsvTable`, `:889`), markdown tables (`indexMarkdownTable`, `:981`), sources
+(`indexSource`, `:1222`), excerpts (`indexExcerpt`, `:1341`), the type catalog
+(`reloadTypeCatalog`, `:268`), ontology bootstrap (`addOntologyToStore`, `:518`),
+and frontmatter-predicate resolution (`resolveFrontmatterPredicate`, `:275`). It is
+the single file most future graph features will have to touch. Splitting per-format
+indexers into `graph/indexers/{note,tables,source,excerpt}.ts` would mirror what was
+already done to `ipc.ts`.
+
+**D2 — Non-atomic batch rewrite in type rename/delete (NEW, #1588).**
+`types/migrate.ts:28-41` (`retypeNotes`) loops over every instance of a type,
+reading, `writeFile`-ing, and `indexNote`-ing each note in sequence. If any
+iteration throws (a read/write error, a reindex failure), earlier notes are already
+rewritten and later ones are not — leaving the thoughtbase in a half-migrated state
+with **no rollback**, and the returned `migrated`/`cleared` list will not reflect
+what actually persisted vs. what the caller believes. For a type with many
+instances this is also O(n) sequential disk writes + full per-note reindex. This is
+correctly *outside* the approval engine (it is a user-initiated frontmatter rewrite,
+like the promote flow, not an LLM write — the header documents this and it is the
+right call), but it should either be made resumable/idempotent or at minimum
+surface partial-failure to the caller instead of propagating a bare throw.
+
+**D3 — Oversized Svelte components persist below `App.svelte`.** `Preview.svelte`
+(2,185), `Editor.svelte` (1,475), `SettingsDialog.svelte` (1,423),
+`SourceDetail.svelte` (1,365), `SourcesPanel.svelte` (1,297), and
+`PropertiesPanel.svelte` (1,127) still mix rendering, local state, and orchestration.
+`SettingsDialog.svelte` in particular is a container for many unrelated settings
+panes and is a natural split candidate. These are less risky than the old god-modules
+(they don't concentrate cross-feature wiring), but they remain the renderer's biggest
+SRP offenders. Note `Preview` and `SettingsDialog` actually shrank slightly since
+June (2,585→2,185; 2,205→1,423), so the trend is right.
+
+**D4 — `register-conversation.ts` (967 lines) is the outlier registrar.** The IPC
+split produced 20 small, single-domain registrars and one large one: the
+conversation registrar carries ~36 handler/function sites and concentrates the
+LLM conversation lifecycle, proposal wiring, and tool-callback surface. Because this
+is an LLM/graph write path, it is also the highest-stakes registrar. It would
+benefit from the same slicing the other domains received (e.g. splitting proposal
+handling from conversation lifecycle).
+
+### Pattern Inconsistencies
+
+**P1 — The data-flow rule is a hand-maintained denylist, not an allowlist.** The
+`no-restricted-syntax` selector (`eslint.config.mjs:247-272`) matches a long regex
+of specific mutation method names plus a set of generic verbs
+(`merge|rename|remove|create|add|delete|save|move|import|reload|execute|cancel`).
+This is enforced and currently has zero bypasses, but a **newly added mutation
+channel whose verb is not in the list** (and isn't one of the generic verbs) will
+silently pass lint from inside a component — the rule is only as complete as the
+regex, and CLAUDE.md itself flags the manual step ("When you add a new mutation
+channel, add its method name to the regex below"). An allowlist model (components
+may only call a known set of read/`shell`/`export`/`view` methods) would fail
+*closed* instead of *open*. Reviewers of new IPC PRs must remember this coupling.
+
+**P2 — Typed IPC contract is scoped, not universal.** `ipc-contract.ts` is
+documented as the contract "for the notebase domain (#981)". Most channels flow
+through it and the typed `handle`, which is a large improvement over June, but the
+contract's name/scope suggests not every domain's signatures are yet centralized in
+one `ChannelMap`. Worth confirming that skills/types/sources/publish signatures are
+all represented so no channel falls back to `unknown` args.
+
+**P3 — Tool/type registries carry module-level mutable state in `shared/`.**
+Unchanged from June P3: `shared/tools/registry.ts` (and the analogous type catalog
+handling) hold module-global `Map`/state instantiated independently per process.
+This is intentional (renderer gets serializable info), but module-global mutable
+state in a *pure* layer remains a subtle pattern that can surprise tests importing
+the registry. Still just worth a documented note at the top of the file.
+
+## SOLID Principles Assessment
+
+**Single Responsibility — 3/5** (up from 2/5). The two worst offenders (`ipc.ts`,
+`graph/index.ts`) were decomposed into cohesive modules; `App.svelte` lost its
+orchestration to 10 ops modules and 24 stores. The score is held below 4 by the
+residual `graph/indexers.ts` (1,665, D1) and the oversized-component cluster (D3).
+The new `types/` and `objects/` modules are exemplary — each file does one thing.
+
+**Open/Closed — 4/5** (unchanged, now doubly demonstrated). The skills system made
+Tools-for-Thought extensible without code; the **new type system extends the same
+pattern** — a user drops `.minerva/types/<id>.md` and it is picked up without a
+rebuild (`register-types.ts:5-6`). The one closure leak persists: per-format
+indexers in `indexers.ts` are extended by adding a branch/function rather than
+registering a handler (OCP), which is exactly what D1 would fix.
+
+**Liskov Substitution — 4/5** (unchanged). Still a largely functional codebase with
+few hierarchies; discriminated unions (`ProposalPayload`, exporters, `PropertyType`)
+and the `ProjectContext` brand are used substitutably. No violations found.
+
+**Interface Segregation — 4/5** (up from 3/5). The typed `ipc-contract.ts` plus the
+namespaced `api.*` surface plus **24 focused stores** mean consumers now depend on
+narrow slices (`objectTypesStore`, `sourceData`, `proposals`) rather than one
+monolithic `api`. The remaining drag is that `lib/ipc/client.ts` (1,122 lines) and
+the preload bridge are still single large surfaces, but the *consumption* is well
+segregated.
+
+**Dependency Inversion — 3/5** (unchanged). Concrete coupling still dominates:
+`types/migrate.ts` imports `graph` and `notebaseFs` concretely (`migrate.ts:8-9`),
+registrars call subsystem modules directly, and the approval engine imports graph
+concretely. The typed contract and `ProjectContext` are good DIP instincts, and the
+enforced boundaries prevent *cross-layer* inversion, but there is still no
+abstraction seam between IPC and the domain modules. This is an acceptable,
+deliberate trade-off for a functional single-developer codebase — not a defect to
+fix, just a ceiling on the score.
+
+**Overall SOLID: ~3.6/5** (up from ~3.2). The gain is almost entirely SRP + ISP,
+earned by executing June's decomposition plan.
+
+## Improvement Plan
+
+### High Priority
+
+1. **Make the type migrate batch safe (D2).** In `types/migrate.ts`, either (a)
+   collect all rewrites, apply them, and on any failure roll back the notes already
+   written, or (b) make `retypeNotes` return per-note success/failure and have the
+   caller report a partial result to the UI instead of throwing. At minimum, wrap
+   the loop so a mid-batch failure does not leave the returned list lying about what
+   persisted. Add a test with a forced write failure on the k-th instance.
+
+2. **Split `graph/indexers.ts` (D1).** Extract per-format indexers into
+   `graph/indexers/{note,tables,source,excerpt}.ts` behind the existing
+   `graph/index.ts` facade. Mechanical and low-risk (the functions are already
+   independent exports); do one format per PR. Optionally introduce a small
+   registered-indexer map to close the OCP leak.
+
+### Medium Priority
+
+3. **Harden the data-flow rule (P1).** Convert the `no-restricted-syntax` denylist
+   to an allowlist of permitted read/OS methods, or add a lint/test that asserts
+   every mutation channel name in `channels.ts` appears in the rule's regex, so a
+   new mutation channel can't be called from a component by omission.
+
+4. **Slice `register-conversation.ts` (D4)** into conversation-lifecycle vs.
+   proposal/tool-callback registrars, mirroring the other 20 domains.
+
+5. **Confirm/complete typed-contract coverage (P2).** Ensure every domain's channel
+   signatures live in `ipc-contract.ts` (or a per-domain contract) so no handler
+   falls back to `unknown`.
+
+### Low Priority
+
+6. **Split the oversized components (D3):** `SettingsDialog.svelte` into per-pane
+   children; extract local orchestration from `Preview`, `Editor`, `SourceDetail`,
+   `SourcesPanel`, `PropertiesPanel` into stores/sub-components.
+
+7. **Document the module-global registry pattern (P3)** at the top of
+   `shared/tools/registry.ts` and the type catalog loader.
+
+## Migration Strategy
+
+### Phase 1: Correctness (do first)
+- Fix the type-migrate atomicity bug (#1) and add its failure-path test. This is the
+  only finding with user-visible data-loss potential (silent half-migration), so it
+  leads regardless of size.
+
+### Phase 2: Decomposition (mechanical, one PR each)
+- Split `graph/indexers.ts` by format (#2), one format per PR, leaning on the strong
+  existing graph test suite (`csv-indexing`, `markdown-table-indexing`,
+  `python-indexing`, `sources-index`, `excerpt-index`, etc.) as the regression net.
+- Slice `register-conversation.ts` (#4).
+
+### Phase 3: Guardrails & polish
+- Convert the data-flow rule to an allowlist or add the channel-coverage assertion
+  (#3); confirm typed-contract completeness (#5).
+- Split the oversized components (#6); document the registry pattern (#7).
+
+## Impact Analysis
+
+- **Risk concentration has genuinely dropped.** The three files every feature used
+  to touch (`ipc.ts`, `graph/index.ts`, `App.svelte`) are decomposed; blast radius
+  and merge-conflict surface are far smaller than in June. The remaining
+  concentration points are `graph/indexers.ts` (graph features) and the oversized
+  components (their own features) — narrower, domain-local hotspots.
+- **Trust Principle integrity is now tested, not just observed.** June's D2 gap is
+  closed: `write-guard.ts` is isolated with `write-guard.test.ts`,
+  `write-guard-wired.test.ts`, and `trust-integrity.test.ts` asserting the honest
+  path is empty and bypass/pending-only paths are flagged. The
+  `findUnreviewedLLMWrites` integrity gate (CLAUDE.md) runs on every PR. This is the
+  single most important improvement since June.
+- **Layering is frozen.** The eslint boundary rules (#668) plus verified-clean grep
+  plus zero data-flow-rule bypasses mean the topology can no longer erode silently —
+  exactly the durability June asked for.
+- **The type system fits the existing seams with zero new architecture.** It reuses
+  the skills pipeline shape, the pure-shared discipline, the typed-IPC pattern, and
+  the store/ops rule. This is the strongest signal that the architecture is
+  self-consistent enough that new subsystems land cheaply.
+- **Performance:** incremental named-graph-per-note indexing is unchanged and still
+  strong. The one new perf note is the O(n) sequential write+reindex in type
+  migration (D2), which is bounded by a type's instance count and only runs on an
+  explicit rename/delete.
+
+## Recommendations
+
+1. **Ship the type-migrate atomicity fix first** — it is the only finding with a
+   data-loss shape, and it is small.
+2. **Finish the decomposition arc you started:** `graph/indexers.ts` and
+   `register-conversation.ts` are the last two files that carry the old god-module
+   smell. The pattern for fixing them already exists in this repo.
+3. **Make the data-flow guard fail closed.** The rule is excellent policy but its
+   denylist implementation can be defeated by omission; an allowlist or a
+   channel-coverage test removes the one manual step in an otherwise-enforced system.
+4. **Keep doing exactly what produced this delta.** The June plan was executed
+   almost verbatim and the codebase is measurably better; the pure-shared discipline,
+   the store/ops rule, and the typed IPC contract are the load-bearing structural
+   wins — protect them.
+5. **Resist new abstraction.** DIP sits at 3/5 by choice; the functional,
+   registry-driven, contract-typed style is working. The remaining work is
+   extraction and one bug fix, not re-architecture.
+
+## Estimated Effort
+
+| Item | Effort |
+|------|--------|
+| Type-migrate atomicity + failure test (#1) | 0.5–1 day |
+| Split `graph/indexers.ts` by format (#2) | 2–3 days (incremental) |
+| Data-flow rule → allowlist / coverage test (#3) | 0.5–1 day |
+| Slice `register-conversation.ts` (#4) | 1 day |
+| Confirm typed-contract coverage (#5) | 0.5 day |
+| Split oversized components (#6) | 4–5 days |
+| Document registry pattern (#7) | 0.25 day |
+| **Total** | **~9–12 days**, sequenceable one PR at a time |
+
+Net: the remaining debt is roughly two-thirds the size of June's, and none of it is
+Critical. The June review's "treat the four mega-modules as the primary debt"
+directive was followed — three are gone and the fourth (`indexers.ts`, spun out of
+the old `graph/index.ts`) is the main structural item left.

--- a/reports/configuration-review-entire-project-2026-08-02-074205.md
+++ b/reports/configuration-review-entire-project-2026-08-02-074205.md
@@ -1,0 +1,304 @@
+# Configuration Management Review — Minerva
+
+**Scope:** Entire project (`/Users/davegriffith/minerva`)
+**Date:** 2026-08-02
+**Reviewer:** Configuration management review (analysis-only; no files modified except this report)
+**Subject:** Minerva — local, single-user desktop app (Electron + Svelte 5 + TypeScript)
+
+---
+
+## Executive Summary
+
+Minerva is a **local, single-user desktop application**, not a deployed multi-environment
+service. There is no dev/staging/prod topology, no `.env` deployment files, no cloud secret
+vault, and no config server. Accordingly, most of a conventional "environment configuration"
+audit is **Not Applicable** (see the dedicated block near the end). The meaningful
+configuration surface is: (1) per-machine + per-project **app settings**, (2) **secrets
+handling** for the user's LLM API keys and publish credentials, (3) **build/tooling config**,
+and (4) **defaults / feature toggles** (model defaults, skills menu enable/disable).
+
+**Headline finding — secrets are handled well.** The user's Anthropic/LLM API key is
+**encrypted at rest** via Electron `safeStorage` (OS Keychain / DPAPI / libsecret), stored in
+`~/Library/Application Support/<app>/llm-settings.json`, **decrypted only on the API-call path
+in the main process, and never crosses IPC to the renderer, never logged, and never written
+into the graph or notes.** Publish credentials (S3 secret access key, GitHub token) are
+encrypted into a **gitignored** `.minerva/secrets.json` that is deliberately split from the
+shareable `.minerva/config.json`. Build/release secrets in `.github/workflows/release.yml` use
+GitHub Actions secrets, a throwaway keychain, files never echoed, and always-on cleanup. No
+hardcoded secret literals exist anywhere in the tree. This is a strong posture.
+
+**No Critical or High findings.** The residual items are Medium/Low maturity gaps: there is no
+formal config **schema** (validation is hand-rolled per file) and no config **version field**
+(migrations are ad-hoc shape-sniffing). Both work correctly today but will not scale gracefully
+as config shapes evolve.
+
+**Overall configuration risk: LOW.**
+
+---
+
+## Configuration Findings
+
+### Critical
+None.
+
+### High
+None. (Specifically: the user's LLM API key is encrypted at rest, not plaintext — the one
+finding that would have been High if present is absent.)
+
+### Medium
+
+**M1 — No centralized configuration schema / validation; each config file re-implements its own tolerant reader.**
+Every config module hand-rolls validation with `resolve*` helpers and `typeof` guards rather
+than a shared schema (e.g. zod/valibot). Examples: `src/main/llm/settings.ts:28-80`
+(`resolveModel`, `resolveWeb`, `resolveEffortSetting`, `resolveCustomModels`,
+`resolveToolModelOverrides`), `src/main/clipper/clipper-config.ts:38-52`,
+`src/main/project-config.ts:124-133`, `src/shared/skills/menu-config.ts:39` (`normalizeMenuConfig`).
+The behavior is individually correct and defensively coded (corrupt/missing files fall back to
+defaults instead of crashing — good), but the pattern is duplicated across ~10 files, inviting
+drift and making "what is the valid shape of this file?" impossible to answer in one place.
+**Impact:** maintainability, not security. **Effort to consolidate:** ~1–2 days.
+
+**M2 — No config version field anywhere; schema migrations rely on ad-hoc shape-sniffing.**
+None of `llm-settings.json`, `clipper-config.json`, `menu-config.json`, or project
+`config.json` carry a `configVersion`/`schemaVersion`. Migrations are currently inferred from
+the data shape: legacy top-level `apiKey` → `providers.anthropic.apiKey`
+(`src/main/llm/settings.ts:132-136`), inline `secretAccessKeyEnc`/`githubTokenEnc` →
+`secrets.json` (`src/main/project-config.ts:246-266`), plaintext → `enc:v1:` on next write
+(`src/main/secret-storage.ts:73-82`). These specific migrations are well done, but the general
+approach doesn't scale: a future ambiguous shape change (two migrations keying off the same
+field) has no version to disambiguate. **Impact:** future maintainability. **Effort:** ~1 day
+to introduce a version field + a small migration runner; low urgency.
+
+### Low
+
+**L1 — Silent degradation to plaintext when `safeStorage` is unavailable.**
+`src/main/secret-storage.ts:54-64` returns plaintext when OS encryption is unavailable (e.g.
+Linux with no keyring). This is a **deliberate, documented** trade-off ("encryption at rest is
+a hardening measure, not a boundary that should ever cost the user their API key") and the app
+**does** surface the true state to the UI via `secretEncryptionAvailable()` and
+`getApiKeyStorage()` (`src/main/secret-storage.ts:45-47`, `src/main/llm/settings.ts:275-284`),
+so the settings panel can tell the user the truth. Acceptable as designed; flagged only so it's
+a conscious posture. **No action required.**
+
+**L2 — Legacy plaintext secrets re-encrypt lazily, only on the next write.**
+A pre-#1326 plaintext key/secret in `llm-settings.json` or `clipper-config.json` is returned
+verbatim and stays plaintext on disk until its config is next saved
+(`src/main/secret-storage.ts:9-11,73-76`; `src/main/clipper/clipper-config.ts:46-48`).
+Backward-compatible and intentional, but a user who set their key long ago and never re-saves
+retains a plaintext key indefinitely. **Optional hardening:** opportunistically re-encrypt on
+read. **Effort:** ~1–2 hours. Low priority.
+
+**L3 — `patchProjectConfig` shallow-merges: top-level keys are replaced wholesale.**
+`src/main/project-config.ts:140-145` documents this as intentional ("none of the current
+consumers want a deep merge"). Correct today, but a footgun for a future writer that patches a
+nested object expecting a deep merge (it would clobber sibling keys). Each nested writer
+currently guards this by reading-then-spreading the existing sub-object (e.g.
+`setOnboardingDismissed` at `:181-184`). Flag for awareness; **no action required** while the
+convention holds.
+
+**L4 — Per-machine config files are scattered across three roots with bespoke helpers.**
+Config lives under (a) `app.getPath('userData')` — `llm-settings.json`, `clipper-config.json`,
+`python-settings.json`, `ingest-settings.json`, `recent-projects.json`, `privileged-sites.json`,
+`session.json`, `compute-audit.jsonl`, plus `queries/` and `views/` dirs; (b) `~/.minerva/` —
+`menu-config.json`, `skills/`; (c) `<project>/.minerva/` — `config.json`, `secrets.json`,
+`graph.ttl`. Each has its own read/write helper. This is coherent (per-machine vs per-project
+is a real distinction) but there's no single registry documenting the full inventory. **Impact:**
+discoverability. Consider a short `docs/configuration.md` inventory. **Effort:** ~2 hours.
+
+---
+
+## Current State Analysis
+
+### Configuration file inventory
+
+**Per-machine app settings — `app.getPath('userData')`** (macOS: `~/Library/Application Support/<app>/`):
+
+| File | Purpose | Module | Secrets? |
+|------|---------|--------|----------|
+| `llm-settings.json` | LLM provider keys (encrypted), model, effort, web settings, custom models, per-skill overrides | `src/main/llm/settings.ts:82-83` | **Yes — encrypted** |
+| `clipper-config.json` | Browser-clipper enable flag + shared secret (encrypted) | `src/main/clipper/clipper-config.ts:30-31` | **Yes — encrypted** |
+| `python-settings.json` | Compute: python path, allow-network | `src/main/compute/python-settings.ts:52` | No |
+| `ingest-settings.json` | Source ingest prefs | `src/main/sources/ingest-settings.ts:25` | No |
+| `recent-projects.json` | MRU project paths | `src/main/recent-projects.ts:6` | No |
+| `privileged-sites.json` | Per-site login config | `src/main/privileged-sites.ts:23` | Session-scoped |
+| `session.json` | Window/session restore | `src/main/session.ts:13` | No |
+| `compute-audit.jsonl` | Compute consent audit log | `src/main/compute/audit.ts:52` | No |
+| `queries/`, `views/` | Saved SPARQL queries / views | `src/main/saved-queries.ts:22`, `saved-views.ts:17` | No |
+
+**Per-machine, home dir — `~/.minerva/`:**
+- `menu-config.json` — skills menu enable/disable/reassign/order (`src/main/skills/menu-config-store.ts:19-21`). Loaded once into a module cache; missing/corrupt → defaults, non-fatal (`:31-46`). Validated by `normalizeMenuConfig` on read and write (`:53`).
+- `skills/` — user-authored skill `.md` files (additive; cannot shadow stock skills).
+
+**Per-project — `<thoughtbase>/.minerva/`:**
+- `config.json` — `baseUri`, `displayName`, `bibliography.styleId`, onboarding state, excerpt note folder, **non-secret** publish target fields (`src/main/project-config.ts:14-47`). Travels with the thoughtbase.
+- `secrets.json` — **encrypted** publish credentials (S3 secret, GitHub token), keyed by target id (`src/main/project-config.ts:205-239`). **Gitignored** via a Minerva-owned `.minerva/.gitignore` written automatically (`:218-228,236`) so it never rides along in a git-backed/shared thoughtbase.
+- `graph.ttl` + indexes — derived, regenerated on open.
+
+### Secrets-management assessment (the crux)
+
+**Mechanism — Electron `safeStorage` with a versioned prefix.** `src/main/secret-storage.ts`
+is the single at-rest encryption chokepoint. Values are wrapped with `safeStorage`
+(Keychain/DPAPI/libsecret) and tagged `enc:v1:` (`:25,54-64`). Decrypt transparently handles
+both encrypted and legacy-plaintext forms (`:73-82`). If OS encryption is unavailable it
+degrades to plaintext rather than losing the key (`:56`, see L1).
+
+**LLM/Anthropic API key — ENCRYPTED at rest, and never leaves main:**
+- Stored encrypted in `llm-settings.json`; written via `encryptSecret` in `applyCredsUpdate` (`src/main/llm/settings.ts:226`).
+- Decrypted **only** on the API-call path (`getSettings` → `decryptProviders`, `src/main/llm/settings.ts:147-158,177-190`).
+- The renderer/settings UI path is a **separate** function `getSettingsForDisplay` that **never decrypts** — it returns model/effort and boolean presence flags only (`src/main/llm/settings.ts:200-218`). The IPC handlers confirm this: `TOOL_GET_SETTINGS → getSettingsForDisplay()` and `TOOL_GET_KEY_STORAGE → getApiKeyStorage()` (`src/main/ipc/register-tools.ts:95,99`). **The plaintext key never crosses the IPC bridge to the renderer.**
+- **Never logged:** a grep for `console.*` with key/secret/token found only one hit — an error log that prints an exception, not a secret (`src/renderer/lib/components/SettingsDialog.svelte:377`).
+- **Never in localStorage:** grep for `localStorage` + secret terms found none.
+- **Never in the graph/notes:** keys live only in `userData` JSON, not in `graph.ttl` or note bodies.
+- Env fallback (`ANTHROPIC_API_KEY` etc.) applies only when no key field is stored (`src/main/llm/settings.ts:139-142,151`).
+
+**Publish credentials (S3 secret access key, GitHub token) — ENCRYPTED, split, write-only over the wire:**
+- Encrypted into gitignored `.minerva/secrets.json`, never in the shareable `config.json` (`src/main/project-config.ts:49-56,205-239`).
+- Wire contract is **write-only + tri-state**: a string sets (encrypted), `''` clears, omitted keeps; the read path returns only `hasSecret`/`hasToken` presence flags, never the credential (`src/main/project-config.ts:268-273,313-333`). Decrypted only main-side at push time (`getS3Credentials` `:289-298`, `getGitCredentials` `:305-311`).
+- Git token precedence: stored encrypted token → `gh auth token` CLI → `GH_TOKEN`/`GITHUB_TOKEN` env (`src/main/git/publish-git.ts:52-66,89`). Sent as an `Authorization: Bearer` header to GitHub only (`:95`).
+
+**Clipper shared secret — ENCRYPTED at rest:** 64-hex secret generated via `crypto.randomBytes`,
+encrypted on disk, held plaintext in memory only for the loopback constant-time compare
+(`src/main/clipper/clipper-config.ts:34,54-59`).
+
+**No hardcoded secret literals:** grep for `sk-ant-…`, `ghp_…`, `AKIA…`, and PEM private-key
+headers across `src/`, `scripts/`, and root configs returned **nothing**.
+
+**Build/release secrets (cross-check of the deployment review — CONFIRMED clean):**
+`.github/workflows/release.yml` — Apple signing/notarization creds are GitHub Actions secrets
+(`APPLE_CERTIFICATE_P12_BASE64`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_API_KEY_BASE64`,
+`APPLE_API_KEY_ID`, `APPLE_API_ISSUER`), presence-gated via a hoisted `HAS_SIGNING` env flag
+(secretless forks build unsigned). Secrets are base64-decoded to files under `$RUNNER_TEMP`,
+**never echoed**; the cert file is `rm`'d immediately after import; a throwaway keychain holds
+the identity and is deleted in an `if: always()` cleanup step so material never lingers on a
+reused runner. `ci.yml` uses `CODECOV_TOKEN` via `secrets`. This matches the prior deployment
+review's conclusion — verified independently, confirmed clean.
+
+**`.gitignore` — the `.minerva/` dotdir trap is handled correctly.** The global `.minerva/`
+ignore is present, and the negation patterns re-include exactly the bundled thoughtbase payloads
+that must ship (`tests/fixtures/sample-project/.minerva/sources|excerpts`,
+`tests/skills-eval/thoughtbase/.minerva/sources|excerpts`,
+`resources/tutorial-thoughtbase/.minerva/config.json|sources|excerpts`) while keeping
+regenerated indexes and `graph.ttl` ignored. No user `userData` path or key material is at risk
+of being committed; no `.env` files are tracked. This addresses the known dotdir-gitignore trap.
+
+### Environment strategy
+
+**N/A — local desktop app.** There is no dev/staging/prod environment matrix. The nearest
+analogue is the Vite/Electron dev-vs-packaged distinction (HMR dev server vs. built bundle,
+handled by electron-forge + `MAIN_WINDOW_VITE_DEV_SERVER_URL`), and per-machine vs per-project
+config scoping — both already cleanly separated.
+
+### Build / tooling configuration
+
+Organized and consistent: `forge.config.ts` (packaging/signing), `vite.main.config.ts` /
+`vite.preload.config.ts` / `vite.renderer.config.mts` / `vite.cli.config.ts` (per-target
+builds), `vitest.config.mts` / `vitest.bench.config.ts`, `eslint.config.mjs` (which enforces the
+renderer data-flow rule via `no-restricted-syntax`), `tsconfig*.json`, `.nvmrc`, `.npmrc`. The
+CSP is centralized (`src/main/security.ts:46-52`, `buildCsp` in `security-helpers.ts`) and
+applied via `onHeadersReceived`. Renderer hardening is correct: `contextIsolation: true`,
+`nodeIntegration: false`, `sandbox: true` (`src/main/security.ts:40-42`). No secrets or
+environment-specific literals in build configs.
+
+---
+
+## Configuration Security Issues
+
+1. **At-rest encryption of user secrets:** PRESENT and correct (`safeStorage`, `enc:v1:` tag). No issue.
+2. **Secret exposure across the IPC boundary:** NONE — display path never decrypts; call path is main-only.
+3. **Secret leakage to logs / graph / notes / localStorage:** NONE found.
+4. **Secrets in a shareable/committed file:** MITIGATED — publish creds split into gitignored `secrets.json`; `.gitignore` negation patterns verified; no `.env` tracked; no hardcoded literals.
+5. **Build/release secret handling:** CLEAN — GitHub secrets, throwaway keychain, no echo, always-on cleanup.
+6. **Residual:** plaintext fallback when OS keyring absent (L1, surfaced to UI) and lazy re-encryption of legacy plaintext (L2). Neither is a live exposure.
+
+---
+
+## Improvement Plan
+
+| ID | Item | Priority | Effort | Type |
+|----|------|----------|--------|------|
+| M1 | Centralize config validation behind a shared schema layer (zod/valibot), replacing per-file `resolve*` guards | Medium | 1–2 days | Maintainability |
+| M2 | Introduce a `configVersion` field + a small migration runner for the JSON config files | Medium | ~1 day | Maintainability |
+| L2 | Opportunistically re-encrypt legacy plaintext secrets on read | Low | 1–2 hrs | Hardening |
+| L4 | Add `docs/configuration.md` inventorying all config file locations, shapes, and defaults | Low | ~2 hrs | Docs |
+| L1/L3 | No action — documented, conscious trade-offs; keep as-is | — | — | — |
+
+---
+
+## Environment Management Recommendations
+
+- **Secrets:** No change to the storage mechanism — `safeStorage` + versioned prefix is the
+  right call for a desktop app. Optionally implement L2 (lazy re-encrypt on read) and consider
+  a one-line note in the settings UI when `secretEncryptionAvailable()` is false (the data is
+  already exposed via `getApiKeyStorage`; ensure the panel actually renders it).
+- **Organization:** The per-machine (`userData` + `~/.minerva`) vs per-project (`.minerva/`)
+  split is sound. The only gap is discoverability — address with L4.
+- **Validation:** Adopt a single schema library and route every config read through it (M1).
+  This also gives you free, uniform migration hooks, which pairs naturally with M2.
+
+---
+
+## Risk Assessment
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Secret storage at rest | **Low risk** | Encrypted via OS keychain; graceful, surfaced degradation |
+| Secret exposure (IPC / logs / graph / VCS) | **Low risk** | Verified no leakage; display path never decrypts |
+| Build/release secret handling | **Low risk** | GitHub secrets, throwaway keychain, cleanup on always |
+| Config validation robustness | **Low–Medium risk** | Tolerant readers prevent crashes, but no shared schema |
+| Config migration/versioning | **Medium risk (future)** | Ad-hoc today; no version field to disambiguate future changes |
+| Config organization/discoverability | **Low risk** | Coherent scoping; lacks a central inventory doc |
+| **Overall** | **LOW** | Strong secrets posture; residual items are maturity, not exposure |
+
+---
+
+## Implementation Roadmap
+
+- **Now (optional, small):** L2 re-encrypt-on-read (1–2 hrs); L4 config inventory doc (2 hrs);
+  verify the settings panel surfaces the `available:false` state.
+- **Next quarter (as config churns):** M1 shared schema layer (1–2 days), landing per config
+  module behind the existing `resolve*` call sites so behavior is preserved test-by-test.
+- **Alongside M1:** M2 config version field + migration runner (~1 day) — cheapest to add while
+  touching the readers for M1.
+- **No action:** L1, L3 (documented intentional trade-offs).
+
+Total discretionary effort to close every non-"no-action" item: **~3–4 days.**
+
+---
+
+## Compliance Checklist (checked against reality)
+
+- [x] **Secrets stored securely (never in code):** Encrypted via `safeStorage`; no hardcoded literals; build secrets via GitHub Actions secrets.
+- [x] **Secrets never logged / exposed:** No secret in logs, graph, notes, localStorage, or over IPC.
+- [x] **Environment-specific settings separated:** Per-machine vs per-project scoping is clean. (Dev/staging/prod: N/A — desktop app.)
+- [x] **Configuration validated on load:** Yes — tolerant `resolve*`/`normalize*` readers with default fallbacks; corrupt files don't crash startup.
+- [~] **Configuration schema:** Hand-rolled per file; no shared/formal schema (M1).
+- [x] **Feature flags / toggles implemented:** Model defaults (`DEFAULT_MODEL = 'claude-opus-5'`, `src/shared/tools/models.ts:19`; `DEFAULT_EFFORT = 'medium'`, `effort.ts:37`), skills menu-config enable/disable, web-tools enable, clipper enable, compute allow-network.
+- [x] **Sensible defaults:** Yes — every config module ships explicit defaults (e.g. `DEFAULT_CLIPPER_CONFIG`, `DEFAULT_WEB_SETTINGS`, `emptyMenuConfig()`).
+- [~] **Migration path clear:** Specific migrations exist and are well done; no general version field (M2).
+- [x] **Rollback / no-lockout on secrets:** Encryption failures degrade to plaintext rather than losing the key; corrupt config → defaults.
+- [~] **Documentation comprehensive:** Modules are well-commented, but no single config inventory doc (L4).
+- [x] **Config files versioned in VCS where appropriate:** Build/tooling configs tracked; user secrets/`userData` correctly gitignored; bundled thoughtbase payloads allowlisted via negation patterns.
+- [x] **Hot reload where sensible:** Menu-config reloads into cache on save; skills reloadable; dev HMR via Vite. (Server-config hot reload: N/A.)
+
+Legend: [x] met · [~] partially met / improvement identified.
+
+---
+
+## Not Applicable (server / multi-environment template sections)
+
+Minerva is a local single-user Electron desktop app. The following standard configuration-review
+sections do not apply; each notes the desktop analogue actually reviewed above:
+
+- **Dev/staging/prod environment matrix & parity** — N/A. Analogue: dev (Vite HMR) vs packaged build; per-machine vs per-project config scoping.
+- **`.env` / dotenv deployment files** — N/A. Analogue: `userData` JSON configs; env vars used only as optional fallbacks (`ANTHROPIC_API_KEY`, `GH_TOKEN`).
+- **Cloud secret vault / secret manager (AWS Secrets Manager, Vault, etc.)** — N/A. Analogue: OS keychain via Electron `safeStorage`.
+- **Config server / centralized dynamic config (Consul, Spring Cloud Config, feature-flag service)** — N/A. Analogue: local JSON + menu-config.
+- **12-factor server configuration** — N/A for a desktop binary.
+- **Horizontal-scaling / multi-instance config consistency** — N/A (single local process).
+- **Server config hot-reload / rolling restarts** — N/A. Analogue: menu-config/skills reload, Vite HMR.
+- **Multi-region / infra-as-code config (Terraform, Helm, k8s ConfigMaps)** — N/A.
+- **CDN / load-balancer / TLS-cert config** — N/A (the app is not a served endpoint; the only server-ish surface is the opt-in loopback clipper, which uses a shared-secret compare and is off by default).
+
+---
+
+*Analysis-only review. No source or configuration files were modified. All findings cite `file_path:line`.*

--- a/reports/deployment-review-entire-project-2026-08-02-073721.md
+++ b/reports/deployment-review-entire-project-2026-08-02-073721.md
@@ -1,0 +1,416 @@
+# Deployment / Release-Engineering Review — Minerva
+
+**Date:** 2026-08-02
+**Scope:** Entire project — build → sign → notarize → package → publish → auto-update pipeline
+**Reviewer:** Deployment specialist (analysis-only; no source or config modified)
+
+---
+
+## Critical framing: this is a distributed desktop app, not a service
+
+Minerva is an Electron + electron-forge **desktop application** shipped to end
+users' machines. There is **no server, no environments (dev/staging/prod), no
+load balancer, no orchestrator, no database migrations, no uptime/SLA.** The
+entire "zero-downtime / blue-green / canary / rolling / DR-failover" apparatus of
+the generic deployment template is **Not Applicable** here — see the explicitly
+labeled N/A block at the end of this report rather than fabricated content.
+
+For a desktop app, "deployment" means:
+
+> **build → code-sign → notarize/staple → package (DMG/ZIP) → publish a release
+> artifact → ship an auto-update to users' machines.**
+
+The desktop analogues of the template's concepts:
+
+| Template concept | Desktop analogue in Minerva |
+|---|---|
+| Environments (dev/staging/prod) | OS/arch build matrix (macOS/Win/Linux × x64/arm64) |
+| Zero-downtime deploy | Background auto-update that installs on next restart |
+| Rollback | Publish a follow-up patch; auto-update rolls users forward |
+| Health checks | Post-build signature verification + packaged-app e2e smoke |
+| Progressive rollout / canary | Poll-interval trickle; draft→publish human gate |
+| Deploy frequency / MTTR / CFR (DORA) | N/A — releases are tag-triggered, not continuous |
+
+---
+
+## Executive Summary
+
+Minerva's release engineering is **mature and, for a solo/small-team desktop
+app, well above average.** The single most important question this review was
+asked to settle:
+
+> **Is auto-update wired, or still the "Road to 1.0" gap?**
+> **It is fully wired and shipped.** `src/main/auto-update.ts` drives
+> `update-electron-app` against the hosted `update.electronjs.org` Squirrel.Mac
+> feed, is initialized on launch (`src/main/main.ts:67`), has a custom
+> non-hijacking UX (#963), a "Check for Updates…" menu item, and a test suite
+> (`tests/main/auto-update.test.ts`). #662 is **done**, not pending.
+
+The pipeline is a clean **tag → signed/notarized draft release → manual publish**
+loop, with genuinely good secret hygiene (throwaway keychain, always-cleanup),
+a blocking supply-chain audit gate on shipped deps, and a written runbook
+(`docs/releasing.md`). The correctness invariants that matter for a desktop
+updater — tag must equal `package.json` version, unsigned builds can't
+auto-update, only *published* releases reach users — are all understood and
+guarded.
+
+The real, honest gaps are about **breadth and post-build verification**, not
+about a missing core:
+
+1. **Single-platform, single-arch.** The release workflow builds **macOS arm64
+   only**, despite `forge.config.ts` declaring ZIP makers for `win32`/`linux`.
+   No Windows/Linux/Intel artifacts are ever produced by CI. (High — but a
+   deliberate, documented scope choice, #962.)
+2. **No automated verification of the *signed* artifact before drafting.**
+   The e2e smoke runs in `ci.yml` against an *unsigned, in-tree* package;
+   `release.yml` never boots the DMG/ZIP it just signed, and the
+   signature/notarization sanity check is a **manual** runbook step, not an
+   automated gate. (High.)
+3. **Release build re-installs deps uncached and doesn't re-run the CI gates.**
+   Minor cost/robustness issues (Medium).
+
+Bottom line: the core deploy machine is **boring, predictable, and reversible —
+exactly the goal — on macOS arm64.** The improvement work is widening the matrix
+and moving the "did the signed thing actually launch?" check from a human's eyes
+into the workflow.
+
+---
+
+## Current Deployment Assessment (what the machinery actually does)
+
+### Triggers
+
+- **`ci.yml`** — on `push` to `main` and on every `pull_request`
+  (`.github/workflows/ci.yml:15-18`). Concurrency-cancels superseded runs.
+- **`release.yml`** — on `push` of a `v*` tag **or** `workflow_dispatch`
+  (`.github/workflows/release.yml:32-35`). `workflow_dispatch` exercises the
+  `make` path and uploads artifacts *without* cutting a release; a tag push
+  *additionally* drafts a GitHub Release. Concurrency group keyed on the ref
+  with `cancel-in-progress: false` (`:41-43`) — correct; you never want to
+  cancel a release build midway.
+- **`bench.yml`** — `workflow_dispatch` + weekly cron (`Mondays 06:00 UTC`),
+  deliberately **not** on PR/push because micro-benchmarks flap on shared
+  runners (`.github/workflows/bench.yml:19-27`).
+
+### CI gates (`ci.yml`) — credit where due
+
+- `lint-and-test` (macos-latest): `pnpm lint` (tsc + svelte-check + eslint) then
+  `pnpm coverage` with **per-area coverage floors** enforced in vitest config
+  for the trust/security paths (`ci.yml:62-71`).
+- `e2e` (macos-latest, parallel): `electron-forge package` + Playwright smoke
+  against the built app (`ci.yml:169-174`).
+- `audit` (ubuntu): **`audit:prod` is blocking** (high+critical on shipped deps,
+  `ci.yml:126-127`), `audit:all` visibility-only. Paired with Dependabot.
+- `node_modules` caching keyed on lockfile+Node+OS/arch shared across jobs
+  (`ci.yml:51-56`).
+
+These are strong; the QA review covered test gates in depth, so this report does
+not re-litigate them.
+
+### Release pipeline (`release.yml`) — stage by stage
+
+1. **Checkout + toolchain** — pnpm 10, Node from `.nvmrc`, `pnpm install
+   --frozen-lockfile` (`:59-73`). Note: **no `node_modules` cache** here (unlike
+   `ci.yml`), so every release re-installs cold.
+2. **Prepare macOS signing** (`:81-119`) — only when `HAS_SIGNING` (the cert
+   secret is present; the flag is hoisted to env because `secrets` can't be used
+   in a step `if:`, `:56`). Decodes the P12 + App Store Connect `.p8` to files
+   under `$RUNNER_TEMP`, imports the Developer ID identity into a **throwaway
+   keychain**, sets the partition list, and exports `APPLE_API_KEY/_KEY_ID/
+   _ISSUER` + `SIGNING_KEYCHAIN` via `$GITHUB_ENV`. Secrets are decoded to files,
+   never echoed; the cert file is `rm`'d immediately after import.
+3. **Build** — `pnpm build` = `electron-forge make` (`:121-122`), with
+   `NODE_OPTIONS=--max-old-space-size=4096` to avoid OOM bundling the renderer +
+   native deps. `forge.config.ts` then, per the env presence:
+   - **signs** the `.app` with the hardened runtime + entitlements
+     (`forge.config.ts:129-136`, `build/entitlements.mac.plist`),
+   - **notarizes** via `osxNotarize` App Store Connect key (`:137-144`),
+   - a **`postMake` hook notarizes + staples each produced DMG** (`:213-231`)
+     — because the DMG maker wraps an already-stapled app but leaves the DMG
+     wrapper itself un-stapled (would fail to open **offline** otherwise). This
+     is a subtle, correct detail.
+   - `afterPrune` ships the transitive closure of unbundleable native deps
+     (DuckDB binding, domino, vega, sql.js, onnxruntime-web) and stages the
+     headless CLI bundle (`forge.config.ts:25-102`).
+4. **Collect artifacts** (`:124-141`) — copies `*.dmg`/`*.zip` out of
+   `out/make`, and makes a **stable-named `Minerva-mac-arm64.dmg`** copy so the
+   website can link to `releases/latest/download/Minerva-mac-arm64.dmg` (a URL
+   that survives across releases). Clever and correct.
+5. **Upload build artifacts** (`:143-148`) — `if-no-files-found: error` (good;
+   a silent empty upload can't slip through).
+6. **Publish draft Release** (`:153-159`) — **tag pushes only**;
+   `softprops/action-gh-release` with `draft: true` and
+   `generate_release_notes: true`. The draft is reviewed and published **by
+   hand** (`gh release edit vX.Y.Z --draft=false --latest`).
+7. **Clean up signing material** (`:163-167`) — `if: always()`; deletes the
+   keychain + staged API key even on failure.
+
+### Publish target & update feed
+
+- **Publish target:** GitHub Releases (draft, then manually published).
+- **Update feed:** `update.electronjs.org` (hosted Squirrel.Mac), inferred from
+  `package.json` `repository`. There is **no self-generated `latest.yml`/
+  `RELEASES` file** — that's correct for this stack; the hosted feed derives the
+  feed from the published GitHub Release's `.zip` asset. **The `.zip` is the
+  auto-update payload** (the DMG is the human download); the runbook explicitly
+  warns not to remove it (`docs/releasing.md:77-78`).
+
+### Versioning & release management
+
+- `package.json` `version` (`1.0.0`) is the single source of truth for both the
+  DMG name and the updater's version comparison.
+- `pnpm release:tag` (`scripts/tag-release.mjs`) enforces: version is semver,
+  branch is `main`, working tree clean, tag doesn't already exist, and `vX.Y.Z`
+  equals `package.json` version — because a tag↔version mismatch means the
+  updater never offers the build.
+- Release notes: `generate_release_notes: true` (commit/PR-derived). **No
+  hand-maintained `CHANGELOG.md`** — a deliberate choice documented at
+  `docs/releasing.md:125-128`.
+- Existing tags: `v0.1.1, v0.1.2, v0.3.0, v1.0.0`.
+
+---
+
+## Deployment Process Findings
+
+### Critical
+
+*None.* No finding rises to release-blocking. The core sign/notarize/publish/
+update loop is present, correct, and documented.
+
+### High
+
+**H-1 — macOS-arm64-only distribution; declared Win/Linux makers never fire.**
+`forge.config.ts:173` declares `new MakerZIP({}, ['darwin','linux','win32'])`,
+but `release.yml` has a single `build-macos` job on `runs-on: macos-latest`
+(`release.yml:47`) with no build matrix. `electron-forge make` on a macOS runner
+produces **only the host platform**, so Windows and Linux ZIPs are never built,
+and there is **no Windows `MakerSquirrel`** (grep confirms none) — meaning even
+if a Windows build were produced, there'd be no Windows auto-update channel.
+Effect: Minerva ships to **macOS Apple Silicon only**. Intel/universal is
+explicitly deferred (`docs/releasing.md:29-30`, #962). This is a scope decision,
+not a bug — but the *declared-vs-built* gap is a latent trap: the config implies
+three platforms while CI delivers one. **Recommendation:** either (a) narrow the
+maker list to `['darwin']` to match reality, or (b) add a build matrix
+(`macos-latest` arm64/x64 + `windows-latest` + `ubuntu-latest`) with a
+`MakerSquirrel` for Windows auto-update, if cross-platform is on the roadmap.
+Until then, keep the divergence documented.
+
+**H-2 — The *signed* release artifact is never smoke-tested by the workflow.**
+The Playwright e2e (`ci.yml:169-174`) runs against `electron-forge package` —
+an **unsigned, in-tree** bundle — on PRs. `release.yml` builds, signs,
+notarizes, staples, uploads, and drafts **without ever launching the DMG/ZIP it
+produced.** The signature/notarization sanity check (`spctl -a`, `codesign -dv`)
+is a **manual** step in the runbook (`docs/releasing.md:79-84`). A signing/
+notarization/stapling regression, or a packaging breakage that only manifests in
+the *signed* artifact, would reach the draft and rely entirely on a human
+remembering to run `spctl`. **Recommendation:** add a post-make gate to
+`release.yml` that (1) runs `spctl -a -t open --context context:primary-signature`
+and `codesign --verify --deep --strict` on the DMG and fails the job on
+rejection, and (2) mounts/launches the packaged app for a headless smoke boot
+(or at least `xcrun stapler validate`). This is the desktop equivalent of a
+post-deploy health check.
+
+### Medium
+
+**M-1 — Release build re-installs deps cold and skips the CI gates.**
+`release.yml` has no `node_modules` cache (contrast `ci.yml:51-56`), so each
+release pays a full cold `pnpm install`. More importantly, the release job runs
+**no lint/test/audit** — it trusts that the tagged commit already passed CI on
+`main`. That trust is *mostly* sound (`tag-release.mjs` requires a clean `main`),
+but a tag can be pushed to any commit, and `main`'s CI could have been bypassed.
+**Recommendation:** either make `release.yml` `needs:` a reusable CI job, or add
+a lightweight `pnpm lint && pnpm audit --prod --audit-level=high` pre-flight step
+before the expensive build. Add the same `node_modules` cache key as `ci.yml`.
+
+**M-2 — Update delivery has a single hosted dependency with no integrity check
+on the published asset.** Auto-update relies wholly on `update.electronjs.org`
+being reachable; if it's down, updates silently stall (non-fatal — handled by the
+`error` state, `auto-update.ts:122-132`). Separately, nothing in `release.yml`
+asserts that the **`.zip` asset** (the auto-update payload) is actually attached
+before/after publish — the runbook asks a human to eyeball it
+(`docs/releasing.md:77`, `:107-109`). A DMG-only release would silently break
+auto-update. **Recommendation:** add a workflow assertion that both a `.dmg` and
+a `.zip` are present in `dist-artifacts` (the `find` already runs; just fail if
+either is missing), mirroring the existing `if-no-files-found: error`.
+
+**M-3 — No published checksums for the website (stable-named) download.**
+Auto-update integrity is covered by Squirrel signature verification, but the
+website's `Minerva-mac-arm64.dmg` direct download has no published SHA-256 for
+manual verification. Low-severity for a notarized DMG (Gatekeeper covers
+tampering), but a `shasum -a 256` artifact is cheap defense-in-depth.
+
+### Low
+
+- **L-1** — `draft: true` is hardcoded with a comment to "flip to `false` once
+  trusted" (`release.yml:151-158`). Keeping the human publish gate is *correct*
+  for a desktop app (it's the last line of defense before users, per
+  `docs/releasing.md:16`); recommend **keeping it draft** and treating the
+  comment as stale guidance rather than a to-do.
+- **L-2** — `upload-artifact@v7` in `release.yml` vs `@v4` in `bench.yml`
+  (`bench.yml:65`) — harmless version drift worth aligning.
+- **L-3** — No SBOM generation. Optional for a desktop app; `pnpm audit`
+  substitutes for the runtime-CVE need.
+
+---
+
+## Improvement Plan (prioritized, with real estimates)
+
+| # | Item | Effort | Priority |
+|---|---|---|---|
+| H-2 | Automated signature/notarization verification gate in `release.yml` (`spctl` + `codesign --verify` + `stapler validate`, fail on reject) | **0.5 day** | Highest ROI — catches the failure the whole pipeline exists to prevent |
+| M-2 | Assert `.dmg` **and** `.zip` present before drafting (fail otherwise) | **1–2 hrs** | High — protects the update channel |
+| M-1 | Add `node_modules` cache + a lint/audit pre-flight (or `needs: ci`) to `release.yml` | **0.5 day** | Medium |
+| H-2b | Headless smoke-boot of the packaged app in `release.yml` (reuse the Playwright e2e harness against the *made* artifact) | **1–2 days** | Medium |
+| H-1 | Decide cross-platform posture: either narrow makers to `['darwin']` (30 min) **or** add a full build matrix + Windows `MakerSquirrel` + auto-update channel | **30 min** _or_ **3–5 days** | Medium — scope decision |
+| M-3 | Publish `SHA-256` alongside the stable DMG | **1 hr** | Low |
+| L-2 | Align `upload-artifact` versions | **10 min** | Low |
+
+---
+
+## Automation Opportunities
+
+- **Build caching (M-1):** the release job is the one place *without* the shared
+  `node_modules` cache; adding it saves minutes per release.
+- **Build matrix (H-1):** the cleanest lever if multi-platform is desired — one
+  `strategy.matrix` over `{os, arch}` replaces the single `build-macos` job and
+  naturally fans artifacts into the same draft.
+- **Version bump automation:** currently a hand-edit of `package.json` in a
+  release PR (`docs/releasing.md:44-50`). A `release-please`-style bot or a
+  `pnpm version` script could automate the bump + tag + changelog, though the
+  current manual-bump-then-`pnpm release:tag` flow is already low-friction and
+  well-guarded. Marginal ROI for a low release cadence.
+- **Changelog:** `generate_release_notes: true` already auto-derives per-release
+  notes; a curated top-section is manual by design. Adequate.
+- **Publish assertion:** the `find` in "Collect artifacts" can double as an
+  automated invariant (M-2) instead of a runbook eyeball.
+
+---
+
+## Release Management (what exists vs. gaps)
+
+**Exists (strong):**
+- Semver single-source-of-truth in `package.json`, guarded tag creation
+  (`scripts/tag-release.mjs`) enforcing tag↔version parity, clean-`main`,
+  no-duplicate-tag.
+- Auto-generated GitHub release notes.
+- A written, accurate runbook (`docs/releasing.md`) covering the full loop,
+  verification commands, rollout timing, and the "if something's wrong" path;
+  plus `docs/packaging.md` for one-time secret setup.
+- Stable-named artifact for a durable website download URL.
+
+**Gaps:**
+- No `CHANGELOG.md` (deliberate; acceptable).
+- Draft→publish is fully manual (deliberate and correct; it's the human review
+  gate — the runbook calls Publish "the load-bearing step").
+- DORA-style metrics (deploy frequency, lead time, MTTR, change-failure-rate)
+  are **N/A/unknown** — a desktop app releases on tags, not continuously; the
+  meaningful signal is "did the signed artifact launch on a clean machine," not
+  a deploy-frequency dashboard.
+
+---
+
+## Security Integration
+
+**Strong, and a highlight of the pipeline:**
+
+- **Code signing** — Developer ID Application, hardened runtime, entitlements
+  scoped to real needs (JIT for V8, library-validation-off *only* because
+  third-party DuckDB `.node` binaries aren't team-signed, mic for dictation)
+  — `build/entitlements.mac.plist`, `forge.config.ts:129-136`.
+- **Notarization + stapling** — app via `osxNotarize` (`:137-144`) **and** the
+  DMG wrapper via the `postMake` hook (`:213-231`), closing the offline-open gap.
+- **Secret handling in CI** — throwaway keychain with a random password, secrets
+  decoded to `$RUNNER_TEMP` files and **never echoed**, cert file deleted right
+  after import, and an `if: always()` cleanup step that removes the keychain +
+  key material even on failure (`release.yml:81-119`, `:163-167`). Presence-gated
+  so forks build unsigned rather than erroring. This is textbook.
+- **Supply-chain gate** — `audit:prod` **blocking** on shipped deps (`ci.yml:
+  126-127`) with a documented remediation history via `pnpm.overrides`; Dependabot
+  paired. `audit:all` visibility-only with a clear promotion path.
+- **Fallback safety** — a secretless build produces an *unsigned* app rather than
+  failing, and the runbook correctly notes an unsigned build **can't**
+  auto-update (Squirrel.Mac rejects it) — so there's no risk of shipping an
+  unverifiable auto-update.
+
+**Minor:** no published artifact checksums (M-3); the release build doesn't
+re-run the audit gate (M-1). Neither is a real exposure given notarization.
+
+---
+
+## Risk Mitigation (bad-release recovery / rollback)
+
+Rollback for a desktop app is fundamentally **forward-only**, and Minerva's
+strategy is the right one and is documented (`docs/releasing.md:130-136`):
+
+- **Before users are affected:** the release is a **draft**; a bad draft is
+  deleted (and the tag with `git push origin :vX.Y.Z`), fixed, re-tagged.
+  **Nothing reached users.** The draft review (step 4, incl. signature check) is
+  the primary safety gate.
+- **After publish:** there is **no un-ship** — the recovery is a **follow-up
+  patch release**, and auto-update rolls users forward within the poll interval
+  (hourly + on launch, `auto-update.ts:76`). This is the correct and only real
+  model for Squirrel-based desktop auto-update.
+- **Update-apply safety:** `quitAndInstall` triggers app quit → the `before-quit`
+  flush in `main.ts` → Squirrel swaps the bundle and relaunches
+  (`auto-update.ts:180-184`), so in-flight work is saved before the swap.
+- **Updater robustness:** the updater is inert in dev (`!app.isPackaged`), and
+  **any** setup/runtime error is swallowed with a warning — "a broken updater
+  must never crash the user's app on launch" (`auto-update.ts:68-82`,
+  `:122-132`). End-to-end apply was verified across two real releases (#961).
+
+**Residual risks & mitigations:**
+- A bad *published* build has a blast radius bounded only by how fast a patch can
+  be cut and by the manual draft-review discipline — **strengthening H-2
+  (automated signed-artifact verification) is the highest-value mitigation**,
+  because it prevents the class of "the signed thing was broken" bugs that the
+  manual `spctl` step is meant to catch.
+- No staged/percentage rollout — every published release goes to 100% of pollers.
+  For this app's scale that's acceptable; if the user base grows, a
+  percentage-gated feed (self-hosted) would be the canary analogue.
+
+---
+
+## Not Applicable (web-service template sections)
+
+These template sections assume a server/service and have **no meaning** for a
+distributed desktop app. Listed honestly with the desktop analogue rather than
+fabricated content:
+
+- **Zero-downtime deployment** — N/A. Analogue: background auto-update that
+  applies on next app restart; user's work is flushed on quit.
+- **Blue-green deployment** — N/A. There is no running fleet to swap between.
+- **Canary deployment / progressive rollout** — N/A. Analogue: hourly poll
+  trickle + the draft→publish human gate; no percentage-gated feed today.
+- **Environments (dev/staging/prod)** — N/A. Analogue: the OS/arch build matrix
+  (currently macOS arm64 only).
+- **Load balancer / traffic shifting** — N/A. No inbound traffic.
+- **Disaster recovery / failover site** — N/A. Analogue: forward-only recovery
+  via a follow-up patch release; user data lives on the user's disk (backup is a
+  user concern, not a deploy concern).
+- **Database migrations** — N/A. The knowledge graph is a local `.minerva/
+  graph.ttl` re-indexed on write; there is no shared server DB to migrate on
+  deploy.
+- **GitOps / cluster reconciliation / container image scanning** — N/A. No
+  containers, no cluster. Analogue for image scanning: `pnpm audit` on the
+  shipped dependency tree.
+- **Uptime/SLA/DORA metrics** — N/A. Releases are tag-triggered, not continuous;
+  deploy-frequency/MTTR/CFR don't apply. The meaningful signal is
+  "signed artifact launches cleanly + auto-update applies."
+
+---
+
+## Appendix — Files reviewed
+
+- `/Users/davegriffith/minerva/.github/workflows/ci.yml`
+- `/Users/davegriffith/minerva/.github/workflows/release.yml`
+- `/Users/davegriffith/minerva/.github/workflows/bench.yml`
+- `/Users/davegriffith/minerva/.github/dependabot.yml` (referenced)
+- `/Users/davegriffith/minerva/forge.config.ts`
+- `/Users/davegriffith/minerva/build/entitlements.mac.plist`
+- `/Users/davegriffith/minerva/.githooks/pre-push`
+- `/Users/davegriffith/minerva/package.json`
+- `/Users/davegriffith/minerva/scripts/tag-release.mjs`
+- `/Users/davegriffith/minerva/src/main/auto-update.ts`
+- `/Users/davegriffith/minerva/src/main/main.ts` (init site)
+- `/Users/davegriffith/minerva/docs/releasing.md`
+- `/Users/davegriffith/minerva/docs/packaging.md` (referenced)

--- a/reports/quality-review-entire-project-2026-08-01-212217.md
+++ b/reports/quality-review-entire-project-2026-08-01-212217.md
@@ -1,0 +1,202 @@
+# Quality Assurance Review — Minerva (whole project)
+
+**Date:** 2026-08-01
+**Scope:** Entire codebase (`/Users/davegriffith/minerva`)
+**Reviewer:** QA review (analysis-only; no source or test files were modified)
+**Stack:** Electron + Svelte 5 (runes) + TypeScript; RDF/SPARQL graph; **vitest** for unit/integration, **Playwright + Electron** for e2e. Not Jest/JUnit/pytest, not Selenium/Cypress.
+
+---
+
+## Executive Summary
+
+Minerva has a **mature, above-average QA posture for a solo/desktop project**. The test suite is large and real (542 `*.test.ts` files across a well-organized `tests/` tree), CI enforces meaningful gates rather than rubber-stamping, and the most important architectural invariant — the LLM "propose, human confirms" trust model — is protected by a *purpose-built automated integrity gate* and a *fatal-under-test write guard*. This is genuinely strong; several mechanisms a generic QA review would recommend building **already exist and work well**.
+
+The quality risk is not the tested core — it is **concentrated in a few large, recently-grown UI/orchestration files that carry high blast radius and thin or zero direct tests**:
+
+1. **`src/main/ipc/register-conversation.ts`** (967 lines, the `CONVERSATION_SEND` LLM orchestration + streaming/abort/retry/`ask_user` handler) has **no main-process test**, and `src/main/ipc/**` has **no coverage floor** in `vitest.config.mts`. This is the single highest-value gap: it is the entry point where LLM output meets the approval engine and the write guard.
+2. **`src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte`** (1127 lines) contains a **YAML frontmatter round-trip engine** (parse → rows → rewrite) with **zero tests** — a data-loss-shaped surface.
+3. **`src/renderer/lib/components/SourceDetail.svelte`** (1365 lines) has **no component render test** (only its extracted `source-actions` logic is covered).
+
+Good news on the recent object-type work (#1584–#1588): the dialogs a prior refactoring review flagged as untested — `TypeEditorDialog.svelte`, and the type settings/panels — **now have real behavioral tests** (`TypeEditorDialog.test.ts`, `TypePropertiesPanel.test.ts`, `ObjectTypesSettings.test.ts`, `TypeView.test.ts`, plus `tests/main/types/{loader,migrate,write}.test.ts` and `tests/shared/objects/*`). That flag is substantially closed. The one genuinely still-open item from that list is the **note** `PropertiesPanel` YAML engine (distinct from `TypePropertiesPanel`) and the `CONVERSATION_SEND` handler.
+
+---
+
+## QA Findings by Priority
+
+### Critical
+
+**C1 — `CONVERSATION_SEND` LLM orchestration is untested and ungated.**
+- File: `/Users/davegriffith/minerva/src/main/ipc/register-conversation.ts` (967 lines).
+- The handler owns LLM streaming callbacks, abort handling (`controller.signal`, in-flight `ask_user` prompt rejection on abort, lines ~233–254, 419), a 400-error string-match retry path (~320–386), and it dispatches conversation-draft/refactor/set-properties writes through `approval.proposeWrite` + `approveProposal` (~430–562), including the `graph.withLLMContext` wrap that arms the write guard.
+- **No test file targets it.** `grep` for `register-conversation` / `CONVERSATION_SEND` across `tests/main` returns nothing. The renderer-side `tests/renderer/stores/conversations-store.test.ts` exercises the *store*, not this handler.
+- `vitest.config.mts` has **no threshold for `src/main/ipc/**`**, so this code has no coverage floor at all — it can regress silently.
+- **Why critical:** this is exactly the "LLM meets graph" boundary the CLAUDE.md trust checklist governs. The trust-integrity gate (C-credit below) proves the *approval engine* is honest, but it does not prove *this handler routes through it* on the streaming/abort/retry paths. A regression that dropped a `withLLMContext` wrap or auto-approved the wrong bundle would not be caught by an existing test.
+- **Failure scenario:** an edit to the abort path leaves an `ask_user` promise unresolved on a cancelled send → renderer conversation hangs; no test fails.
+
+### High
+
+**H1 — `PropertiesPanel.svelte` YAML round-trip engine has zero tests.**
+- File: `/Users/davegriffith/minerva/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte` (1127 lines).
+- Header comment describes the exact risk: *"Edits round-trip through the YAML parser … editor buffer ─parsed→ rows ─UI edits→ rewritten YAML."* It uses `YAML.parseDocument`, handles scalars/seqs/maps, and slices the frontmatter block back into `content` by computed offsets (lines ~89–210).
+- **No test imports this file.** `TypePropertiesPanel.test.ts` covers a *different* component (`right-sidebar/TypePropertiesPanel.svelte`).
+- **Why high:** frontmatter rewriting is a data-loss surface — a mis-serialized seq, a dropped comment, or a wrong fence offset corrupts the user's note metadata on save. The parse/rewrite logic is pure-ish and highly testable (round-trip property assertions), yet has nothing.
+- **Recommended:** extract the pure parse/serialize/offset logic into a `*.ts` module and unit-test round-trips (scalar, list, nested map, comment preservation, empty/malformed frontmatter, non-map document → the `!YAML.isMap` guard at line 140).
+
+**H2 — `SourceDetail.svelte` (1365 lines) has no component render test.**
+- File: `/Users/davegriffith/minerva/src/renderer/lib/components/SourceDetail.svelte`.
+- Coverage today is indirect only: `tests/renderer/sources/source-actions.test.ts` tests extracted `renameSource`/`deleteSource` logic, and `tests/main/graph/source-detail.test.ts` covers the graph side. The largest source-viewer component itself is unrendered by any test.
+- **Why high:** it is the second-largest renderer file, hosts the source Tools menu / `propose_source_properties` surface (a gated LLM write path per CLAUDE.md), and metadata edits here feed `meta.ttl`. Regressions surface only via manual use or the thin e2e smoke.
+
+### Medium
+
+**M1 — No global coverage floor; several trees are ungated.**
+- `vitest.config.mts` sets thresholds per glob only (`src/shared`, `src/main/llm`, `src/main/notebase`, `src/main/publish`, `src/main/sources`, `src/main/graph`, `src/main/compute`, three `src/main/security*` files, `src/main/auto-update.ts`, `src/renderer`). There is **no fallback/global threshold**.
+- Consequence: `src/main/ipc/**` (C1), `src/main/types/**` (the new object-type compile/parse pipeline), `src/main/git/**` (0% at baseline), and `src/main/formatter/**` land new code with **no floor**. A brand-new untested main module cannot fail the gate unless it happens to sit under a gated glob.
+- **Recommended:** add a modest global floor (e.g. lines/functions 30–40%) as a backstop so *new ungated trees* can't ship at 0%, keeping the tuned per-area floors as the real gates.
+
+**M2 — Renderer coverage floor is low (42% L / 34% B) against the largest defect surface.**
+- `src/renderer/**` is 110 `.svelte` + 161 `.ts` files and, per the baseline, the biggest and most volatile user-facing surface. The floor is deliberately set below measured (documented as ratcheting: bucket A done #1451, bucket B pending #1452). This is a *reasonable* strategy, but H1/H2 show large individual components slipping under the aggregate floor. Per-file floors on the few 1000+-line components would catch that better than the aggregate alone.
+
+**M3 — Coverage baseline report is stale (2026-04-26, ~3 months old).**
+- `/Users/davegriffith/minerva/reports/coverage-baseline-2026-04-26.md` predates a large amount of work (object types, more renderer tests). Its headline (34.67% stmts) understates the current picture and its `src/main/git 0%` / `src/main/llm ~85%` rows may no longer hold. The *live* gate is `vitest.config.mts`; the report should be regenerated (`pnpm coverage`) so the committed narrative matches reality.
+
+### Low / Observations
+
+- **L1 — `src/main/git/**` was 0% at baseline.** Not re-verified live here; if still uncovered it underpins the publish story (#254). Worth a targeted check.
+- **L2 — e2e is single-platform (macOS only), by explicit design** (ci.yml comments: fsevents watcher semantics, darwin Electron bundle). Acceptable for a macOS-first app; note it as a known coverage boundary if Windows/Linux ship later.
+- **L3 — Test-quality spot-check is positive.** `TypeEditorDialog.test.ts` drives the real form (input, add/reorder/remove property rows, disabled-Create guard) and asserts the exact save payload — behavioral, not shallow. `trust-integrity.test.ts` drives the real approval engine across honest/bypass/pending/human/mixed cases. No evidence of assertion-free "it renders" filler in the sampled files.
+
+---
+
+## Current Quality Assessment
+
+**What's genuinely strong (credit where due — do NOT rebuild these):**
+
+- **Trust-model integrity gate** — `tests/main/graph/trust-integrity.test.ts` promotes the CLAUDE.md "unreviewed LLM writes" SPARQL into an executable gate (`findUnreviewedLLMWrites` in `src/main/graph/integrity.ts`), asserted on every PR with honest-path, bypass, pending-only, human-authored, and mixed-graph cases. Exemplary defect-prevention.
+- **Write guard, fatal under test** — `enterLLMContext`/`withLLMContext` + `checkLLMWriteGuard` throw under vitest so an approval-engine bypass fails CI (non-fatal warn in prod). Enforced invariant, not aspiration.
+- **Preload contract test** — `tests/preload/preload-bridge.test.ts` snapshots the full `window.api` surface; the config even documents *why* preload gets a snapshot gate instead of a line floor. Correct instinct.
+- **Skills-eval golden files** — `tests/skills-eval/*/output/request.json` snapshot each skill's compiled prompt (CI diff catches prompt drift) — ~70 skills covered.
+- **Tuned per-area coverage floors** — `vitest.config.mts` gates the trust (`llm`), security (`notebase`, `security*.ts`), and feature trees with headroom-below-measured floors, enforced via `pnpm coverage` on every PR (ci.yml). This is well beyond a single blunt global number.
+- **Blocking supply-chain gate** — `audit:prod` (shipped deps, high+critical) is blocking (#1455); `audit:all` visibility-only, with a documented promotion path and `pnpm.overrides` remediation.
+- **e2e beyond smoke** — `tests/e2e/` has `smoke`, `happy-paths`, `journeys`, plus `a11y.spec.ts` (axe-core), `focus-trap.spec.ts`, and `bundle-budget.spec.ts` (a size regression gate).
+- **Local fast feedback** — pre-push hook runs `lint:fonts` + `pnpm lint` (tsc + svelte-check + eslint) so drift is caught before CI.
+
+**Quality metrics (substantiated only):**
+
+| Metric | Value | Source |
+|---|---|---|
+| Test files | **542** `*.test.ts` | `find tests -name '*.test.ts'` |
+| Test count (baseline) | ~1587 across 162 files | coverage-baseline-2026-04-26.md (now higher) |
+| Statement/line coverage (baseline) | 34.67% (skewed low by untested Svelte bodies) | baseline report |
+| Branch / function coverage (baseline) | 81.5% / 78.9% | baseline report |
+| Live coverage % (current) | **Unknown — baseline is stale; regenerate** | — |
+| CI gates | lint, `pnpm coverage` (per-area floors), `audit:prod`, e2e | ci.yml |
+
+---
+
+## Improvement Plan
+
+Ordered by value-to-effort:
+
+1. **(C1) Add a main-process test for `register-conversation.ts`.** Mock the LLM client; assert: (a) a conversation-draft send files a proposal via `proposeWrite` and auto-approves it, (b) the send runs inside `withLLMContext` so a direct-write regression trips the guard, (c) abort resolves/rejects pending `ask_user` prompts, (d) the 400-retry path is taken once. Then add `src/main/ipc/**` to `vitest.config.mts` thresholds.
+2. **(H1) Extract + unit-test the PropertiesPanel YAML engine.** Move parse/serialize/offset logic to a pure `*.ts`; assert round-trips and edge cases (non-map doc, comments, empty frontmatter).
+3. **(H2) Add a `SourceDetail.svelte` render test** covering metadata display, the read-status/rename/delete actions wired to the store, and the source Tools/propose-properties entry point.
+4. **(M1) Add a global coverage floor backstop** so new ungated trees can't ship at 0%.
+5. **(M3) Regenerate `pnpm coverage` and refresh the baseline report** to today's tree.
+6. **(M2/L1) Per-file floors on the 1000+-line components** and a live check of `src/main/git/**`.
+
+---
+
+## Testing Strategy
+
+- **Shift-left:** already strong — pre-push lint, per-area floors, write-guard-under-test. Extend by *requiring a test with each new `register-*` IPC handler* (add to the LLM/graph PR checklist in CLAUDE.md).
+- **Risk-based prioritization:** target the three large high-blast-radius files above before chasing aggregate %. They concentrate data-loss (YAML) and trust-boundary (CONVERSATION_SEND) risk.
+- **Golden/snapshot** for prompt + preload contracts is the right tool and is in place; keep it.
+- **Continuous testing:** CI runs full `pnpm coverage` + e2e on every PR/push with in-flight cancellation.
+
+### Testing Pyramid — what CI ACTUALLY enforces
+
+- **Static/lint (base):** `pnpm lint` = `tsc --noEmit` + `svelte-check --threshold error` + `eslint .` — run locally (pre-push) and in CI. Also `lint:fonts`.
+- **Unit + integration (bulk):** `pnpm coverage` = `vitest run --coverage` with per-area v8 thresholds. 542 test files spanning `tests/{shared,main,renderer,preload,cli,clipper,skills-eval}`.
+- **e2e (thin, by design):** `pnpm test:e2e` = electron-forge package + Playwright, macOS-only, 6 specs incl. a11y/focus-trap/bundle-budget.
+- **Perf:** `pnpm bench` (vitest bench) with `scripts/bench-check.mjs` baseline comparison (separate `bench.yml`).
+- **Supply chain:** `pnpm audit --prod` (blocking) + full-tree audit (visibility).
+- **Missing rung:** no global coverage backstop (M1); no main-process test at the IPC-handler layer for the conversation path (C1).
+
+---
+
+## Quality Gates
+
+| Gate | Enforced? | Where |
+|---|---|---|
+| Type check (tsc) | ✅ blocking | pre-push + ci.yml |
+| svelte-check (errors) | ✅ blocking | pre-push + ci.yml |
+| eslint (incl. renderer `api.*` mutation rule) | ✅ blocking | pre-push + ci.yml |
+| Font-literal lint | ✅ blocking | pre-push |
+| Unit/integration tests | ✅ blocking | ci.yml (`pnpm coverage`) |
+| Per-area coverage floors | ✅ blocking (llm/notebase/graph/sources/publish/compute/security/renderer/shared) | vitest.config.mts |
+| **Global coverage floor** | ❌ **absent** | — (M1) |
+| **`src/main/ipc` coverage floor** | ❌ **absent** | — (C1) |
+| Preload surface contract | ✅ blocking | preload-bridge snapshot |
+| Trust-integrity (LLM writes) | ✅ blocking | trust-integrity.test.ts |
+| Prompt drift (skills) | ✅ blocking | skills-eval golden files |
+| e2e smoke + a11y + bundle budget | ✅ blocking | ci.yml e2e job |
+| Prod dependency CVEs | ✅ blocking | ci.yml audit:prod |
+| Codecov upload | ⚠️ non-fatal trend-only | ci.yml |
+
+---
+
+## Defect Prevention
+
+- **Approval engine + write guard + integrity query** form a three-layer defense on the highest-consequence invariant (LLM never writes the graph directly). This is the model to emulate elsewhere.
+- **Extend the same discipline to C1:** the guard only fires if the offending write runs in LLM context — so the *test* that proves `CONVERSATION_SEND` enters LLM context is what makes the guard meaningful for that path. That test is the missing prevention control.
+- **Encode the "new IPC handler ⇒ test + threshold" rule** into the LLM/Graph PR checklist so ungated handlers stop appearing.
+
+---
+
+## Risk-Based Testing
+
+| Area | Blast radius | Current coverage | Priority |
+|---|---|---|---|
+| `register-conversation.ts` (CONVERSATION_SEND) | Very high (LLM↔graph, streaming, abort) | None (ungated) | **C1** |
+| `PropertiesPanel.svelte` YAML engine | High (note metadata data-loss) | None | **H1** |
+| `SourceDetail.svelte` | High (source meta.ttl, gated LLM path) | Indirect only | **H2** |
+| Approval engine / graph / notebase / security | High | Strong (gated + integrity) | maintain |
+| Object types (#1584–88) | Medium | Now covered (dialogs + main pipeline) | maintain |
+| `src/main/git` (publish) | Medium | 0% at baseline; re-verify | L1 |
+
+---
+
+## Template Sections — Not Applicable (honest N/A)
+
+- **Cross-browser matrix (Chrome/Firefox/Safari/Edge):** N/A — desktop Electron app, single Chromium runtime; no browser matrix exists or is needed.
+- **JMeter / k6 / Gatling load & throughput targets:** N/A — local single-user desktop app, no server request surface. Perf is covered by `vitest bench` + `bench-check.mjs` instead.
+- **Postman / REST API contract collections:** N/A — no HTTP API; the equivalent contract surface is IPC channels, gated by the preload snapshot test.
+- **DAST / penetration testing / WAF:** N/A — no exposed web endpoint. The relevant security controls are the fs path-traversal sandbox (`assertSafePath`), the remote-content trust boundary (`src/main/security*.ts`, well-tested), and `audit:prod`.
+- **Mobile / responsive device testing:** N/A — desktop only.
+- **Selenium/Cypress:** N/A — Playwright-Electron is the e2e tool.
+
+---
+
+## Estimated Impact
+
+- **C1 + H1 + H2** close the three concentrated high-blast-radius gaps for roughly a handful of focused test files — the highest defect-prevention ROI available, disproportionate to effort because the surrounding infrastructure (happy-dom, approval-engine fixtures, testing-library) already exists.
+- **M1** (global floor) is a one-line-config backstop that prevents whole new trees from shipping untested.
+- Together these convert the current "strong core, a few soft giants" shape into uniformly-gated coverage without chasing the (misleading) aggregate percentage.
+
+---
+
+## Roadmap
+
+- **Now (this sprint):** C1 (conversation handler test + `src/main/ipc` floor), M3 (regenerate coverage baseline).
+- **Next:** H1 (extract + test YAML engine), H2 (SourceDetail render test).
+- **Then:** M1 (global backstop floor), M2 (per-file floors on 1000+-line components), L1 (git coverage check), continue the documented renderer ratchet (bucket B, #1452).
+
+## Success Metrics
+
+- `src/main/ipc/**` gated with a passing floor; a deliberately-introduced `withLLMContext` regression in `CONVERSATION_SEND` fails a test.
+- `PropertiesPanel` YAML round-trip covered by unit tests incl. malformed/empty/comment cases.
+- `SourceDetail.svelte` exercised by a render test.
+- A global coverage floor exists; no source tree sits at 0% unintentionally.
+- Committed coverage baseline reflects the current tree (regenerated).
+- Zero regressions in the trust-integrity, write-guard, and preload-contract gates (maintain green).

--- a/reports/refactor-review-entire-project-2026-08-01-211553.md
+++ b/reports/refactor-review-entire-project-2026-08-01-211553.md
@@ -1,0 +1,329 @@
+# Refactoring Review Plan
+Generated: 2026-08-01-211553
+Scope: entire project (/Users/davegriffith/minerva)
+
+## Executive Summary
+
+Minerva is a large, mature Electron + Svelte 5 + TypeScript codebase (~120k lines of
+`.ts`/`.svelte` under `src/`). Overall quality is high: type escapes are almost
+nonexistent (2 `as any`, 7 `@ts-ignore`, 5 `eslint-disable` in all of `src/`), the
+renderer data-flow rule from CLAUDE.md is respected (no direct mutation `api.*` calls
+found in components, no banned native `confirm`/`alert`/`prompt`), factory patterns are
+used well (e.g. `formatting.ts` builds its 40+ editor commands from `makeInlineToggle` /
+`makeLinePrefixToggle` / `makeInsertFence` helpers), and App.svelte has already been
+decomposed into ops clusters (#1084). Test coverage is broad — 557 test files, including
+~30 graph-index suites and dedicated `health-checks`, `write-guard`, and `trust-integrity`
+tests.
+
+The refactoring opportunities are therefore not systemic rot but concentrated hotspots:
+a handful of oversized files where a single function or component accreted many
+responsibilities, and recurring copy-paste in fan-out code (per-draft-kind handlers,
+per-check inspection builders, per-frontmatter-field patch helpers). Two findings are
+**latent correctness bugs surfaced by the review**, not style issues:
+
+1. **`TypeEditorDialog` silently drops every property's `label`** on save (data loss for
+   the object-type editor, #1585) — verified.
+2. **A source-detail excerpt subscription is never torn down** (listener leak on remount).
+
+Additionally, `note-ops` bypasses the editor store's own rename method, so a paste/move
+rename does not re-persist the session.
+
+Prioritized below are ~24 concrete opportunities. The highest-leverage, lowest-risk wins
+are consolidating duplicated literals/helpers (tab runtime, failure-list formatter,
+inspection builder) and extracting the two clear god-components (`Editor.svelte`
+context-menu + 40-prop surface; `SettingsDialog.svelte`'s 8 inline panels).
+
+## Code Quality Metrics
+
+**Largest source files (lines):**
+- `src/renderer/lib/components/Preview.svelte` — 2185 (script ends at 980; ~1100 lines are CSS)
+- `src/renderer/App.svelte` — 2011 (already decomposed; mostly template/wiring)
+- `src/main/graph/indexers.ts` — 1665
+- `src/renderer/lib/components/Editor.svelte` — 1475
+- `src/renderer/lib/components/SettingsDialog.svelte` — 1423
+- `src/renderer/lib/components/SourceDetail.svelte` — 1365
+- `src/main/graph/queries.ts` — 1267
+- `src/renderer/lib/stores/editor.svelte.ts` — 1155
+- `src/renderer/lib/stores/conversations.svelte.ts` — 1132
+- `src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte` — 1127
+- `src/main/ipc/register-conversation.ts` — 967
+
+**Very long functions found (>~100 lines, single responsibility violated):**
+- `CONVERSATION_SEND` handler — `register-conversation.ts:233-413` (~180 lines, untested)
+- `indexNote` — `indexers.ts:565-741` (~176 lines)
+- `buildFileMenu` — `menu.ts:202-408` (~206 lines)
+- `citationsForNote` — `queries.ts:1152-1253` (~101 lines)
+- `findExternalInboundLinks` — `queries.ts:731-826` (~95 lines)
+- Editor context menu template — `Editor.svelte:1091-1315` (~225 lines)
+- SettingsDialog inline panels — `SettingsDialog.svelte:505-1019` (~500 lines)
+
+**Notable duplication (counts verified):**
+- `TabRuntime` literal (~24 fields) inlined at 3 sites despite `blankTabRuntime` helper (only 2 of 5 sites use it) — `conversations.svelte.ts`
+- 9 byte-identical `discard*Draft` functions — `conversations.svelte.ts:766-966`
+- `slice(0,5).map(...) + "…and N more"` failure formatter copied 6× across `note-ops.ts`, `refactor-ops.svelte.ts`, `App.svelte`
+- Query→`Inspection` `.map((r,i)=>({...}))` builder repeated across 10 checks — `health-checks.ts`
+- Conversation provenance URI string `https://minerva.dev/ontology/thought#conversation/…` hardcoded 6× — `register-conversation.ts` (verified)
+- `const first = (pred) => store.statementsMatching(...)[0]?.object.value` defined twice — `queries.ts:893` and `:1049` (verified)
+- Day-in-ms literal `86400000` hardcoded at 3 sites while `DAY_MS = 86_400_000` already exists in `queries.ts:940`
+- 8 inline SPARQL `PREFIX` blocks in `health-checks.ts` that `queryGraph`'s auto-injection (`injectSparqlPrefixes`, `queries.ts:225`) makes redundant
+
+**Key issues:** 2 latent bugs (label drop, listener leak) + 1 state-sync bug (rename not
+re-persisted) + ~21 pure-cleanliness refactors. Dead/commented-out code is negligible
+(the 65 `TODO`s are almost all inside bundled CSL citation-style XML, not app code).
+
+## Refactoring Opportunities
+
+### High Priority (Quick Wins)
+
+1. **Fix the property-`label` drop in `TypeEditorDialog` (data loss).**
+   `src/renderer/lib/components/TypeEditorDialog.svelte:28-34` (`Row` type), `:41-49`
+   (seed), `:74-83` (`buildProperties`). `PropertyDef.label` is a real persisted field
+   (`type-def.ts:22-23`, written by `write.ts:12/45`, read by `card.ts` as
+   `pd.label ?? pd.name`), but `Row` has no `label`, rows aren't seeded from `p.label`,
+   and `buildProperties()` never emits it. Editing any type — or "Save Note as Object
+   Type" — strips all per-property labels. **Action:** thread `label` through `Row`, the
+   seed map, and `buildProperties`. Add a round-trip test (none exists; the existing
+   `TypeEditorDialog.test.ts:52` edits a label-less `book`).
+
+2. **Route paste/move rename through the store's own method.**
+   `src/renderer/lib/app/note-ops.ts:378-385` (`handleMove`) and `:423-430`
+   (`handlePaste`) mutate `editor.tabs[i].relativePath`/`fileName` directly instead of
+   calling `editor.applyRenameTransitions([{old,new}])` (`editor.svelte.ts:540`). The
+   store method also fixes the tab `ext` for unsupported files and calls
+   `schedulePersistTabs()`, so today a rename-via-paste/move does not re-persist the
+   session. **Action:** replace both inline mutations with `applyRenameTransitions`.
+
+3. **Use `blankTabRuntime` at all 5 tab-construction sites.**
+   `src/renderer/lib/stores/conversations.svelte.ts` — the helper (`:663`) is called at
+   only `:595` and `:723`; `init()` (`:315-340`), `openFreeform()` (`:411-436`), and
+   `openConversationTab()` (`:479-504`) still inline the full ~24-field literal. Its own
+   doc-comment claims it backs all sites. With 18 `…Drafts`/`…DraftResults`/`…DraftState`
+   fields per tab, drift is expensive (the `parent` field in #1587 was just such a risk).
+   **Action:** replace the 3 inline literals with `blankTabRuntime(conv, extraTools)`.
+
+4. **Extract a shared failure-list formatter.**
+   `slice(0,5).map(...) + "…and N more"` is copy-pasted at `note-ops.ts:277-278`,
+   `:456-458`, `:461-463`; `refactor-ops.svelte.ts:474-476`, `:598-600`; `App.svelte:1596`.
+   **Action:** add `formatFailureList(items, render, cap=5)` to
+   `src/renderer/lib/*/text-helpers.ts` and call from all six; promote the repeated
+   `{path,error}` failure shape to a shared type.
+
+5. **De-duplicate the conversation-provenance strings.**
+   `register-conversation.ts` builds `conversationUri` and `proposedBy` from the literal
+   `https://minerva.dev/ontology/thought#conversation/${convId}` in 6 draft-file handlers
+   (verified count 6). A namespace change means 6 edits today. **Action:** extract
+   `conversationProvenance(convId): { conversationUri, proposedBy }` and a
+   `fileAndAutoApprove(ctx, {operationType, payloads, note, convId})` helper.
+
+6. **Introduce a `DAY_MS` import and a `MAX_FRONTMATTER_DEPTH` constant.**
+   `DAY_MS = 86_400_000` already exists at `queries.ts:940` but the literal `86400000` is
+   re-hardcoded at `health-checks.ts:82`, `:271`, and `approval.ts:74`. Export it and
+   reuse. Likewise replace the bare `if (depth > 8)` recursion guard at `indexers.ts:234`
+   with a named `MAX_FRONTMATTER_DEPTH`.
+
+7. **Collapse the 9 identical `discard*Draft` functions.**
+   `conversations.svelte.ts:766-966` — each is `findTab(tabId)` then
+   `tab.X = tab.X.filter(d => d.draftId !== draftId)`, differing only by array name.
+   **Action:** `discardFrom(tabId, key: keyof TabRuntime, draftId)` reduces 9 functions to
+   one-liners.
+
+8. **Hoist the two duplicated CodeMirror themes / font-size logic in Editor.**
+   `Editor.svelte:315-319` and `:523-527` define the identical hidden-line-numbers
+   `EditorView.theme(...)` (a comment at :524 even flags the repeat) — hoist to a
+   module-level const. `getFontSize`/`changeFontSize`/`resetFontSize`/`setFontSize`
+   (`:270-303`) each repeat the `localStorage.setItem` + `reconfigure` pair — extract one
+   `applyFontSize(px)` and make the exports thin wrappers.
+
+### Medium Priority (Structural Improvements)
+
+9. **Split the `CONVERSATION_SEND` god handler.**
+   `register-conversation.ts:233-413` (~180 lines, no unit coverage) does abort wiring,
+   message mapping, system-prompt assembly, a ~35-line `streamCallbacks` object, web
+   overrides, and two near-identical `completeWithTools({...})` calls (`:346-361` and
+   `:378-387`, the retry only swaps `messages` and drops `initialContainerId`).
+   **Action:** extract `buildStreamCallbacks(win, convId, controller)` and
+   `runCompletionWithContainerRecovery(...)`; move `stripCodeExecutionTurns` /
+   `CONTAINER_REQUIRED_MARKER` to module scope. Add a unit test before/with this.
+
+10. **Decompose `indexNote`.**
+    `indexers.ts:565-741` — extract the cohesive blocks the comments already delimit:
+    `indexNoteCoreTriples` (title/filename/paths/modified/folder/project, `:626-646`),
+    `indexTags` (`:648-662`), `indexDomainType` returning `declaredProps` (`:664-681`),
+    `indexAliases` (`:683-698`), `indexWikiLinks` (`:700-709`), leaving `indexNote` an
+    orchestrator. Well-tested → safe.
+
+11. **Extract `Editor.svelte`'s context menu and shrink its prop surface.**
+    The hand-built nested menu at `Editor.svelte:1091-1315` (~225 lines) should become an
+    `EditorContextMenu.svelte` taking a menu model + single `onAction` dispatch. It exists
+    only to fan out ~40 one-shot callback props declared at `:75-178` and re-guarded as
+    `{#if onX}<button onclick={() => handleMenuAction(() => onX?.())}>`. **Action:** group
+    the refactor/metadata/bookmark forwarders into one ops object (or route through the
+    existing App ops cluster) so the surface is a handful of props.
+
+12. **Extract the 8 remaining inline panels in `SettingsDialog`.**
+    `SettingsDialog.svelte:505-1019` (~500 lines) still inlines `editor`, `appearance`,
+    `behaviors`, `notes`, `formatter`, `web`, `sources`, `clipper` — while 6 siblings are
+    already extracted + tested (`AiSettings`, `ComputeSettings`, …, imported `:51-56`).
+    Follow the established pattern; also collapse the 4 byte-identical `patch*` helpers
+    (`:146-167`) into a `makePatch(get, set)` factory (or fold into each panel).
+
+13. **Move `Preview.svelte`'s rendered-markdown CSS into an imported stylesheet.**
+    `Preview.svelte:1094-2185` is CSS; the ~1000 lines of `.preview :global(...)`
+    content styles (h1/code/blockquote/wiki-link/transclusion/object-card/typed-link) are
+    not component chrome. The file already imports `styles/hljs-minerva.css`. **Action:**
+    move to `styles/preview-content.css`; keep only tooltip/menu chrome scoped. Halves the
+    file.
+
+14. **Extract + test PropertiesPanel's YAML round-trip engine.**
+    `PropertiesPanel.svelte:124-346` (~220 lines: `parseFrontmatter`, `detectShape`,
+    `mutate`, `keyToString`, `commit*`/`setKeyValue*`) is pure, edge-case-heavy (CRLF,
+    date coercion, wiki-link detection, empty-map deletion) and **has no test**. **Action:**
+    move to `src/renderer/lib/refactor/frontmatter-rows.ts` (beside the already-tested
+    `property-shape.ts` it imports) and add a unit suite.
+
+15. **Consolidate the 10 `Inspection`-builder maps in `health-checks.ts`.**
+    Ten checks repeat `query → (results.results as Record<string,string>[]).map((r,i)=>({id,type,severity,nodeUri,nodeLabel,message,suggestedAction}))`.
+    **Action:** extract `toInspections(results, buildFn)` (or a small builder) and a
+    `queryRows(ctx, sparql)` helper that owns the repeated
+    `as Record<string,string>[]` cast (appears 11× in this file alone). Also drop the 8
+    redundant inline `PREFIX` blocks — `queryGraph` auto-injects. Well-tested → safe.
+
+16. **Parameterize the object-type "spread every optional field" pattern.**
+    The `...(t.icon ? {icon:t.icon} : {})` cascade over icon/color/cover/card/parent/
+    template appears in `ObjectTypesSettings.svelte:30-37` (`openEdit`) and `:57-66`
+    (`duplicate`), `TypeEditorDialog.svelte:92-102` (`save`), and `type-def.ts:100-114`
+    (`toTypeInfo`). **Action:** add `typeInfoToSaveInput(t)` in `type-editor-value.ts`
+    (or shared/objects) and reuse — this is exactly where the `parent` field would have
+    been missed in #1587.
+
+17. **Fold the two bulk-summary reporters and share the bulk-frontmatter loop.**
+    `refactor-ops.svelte.ts:464-479` (`reportBulkTagSummary`) and `:588-603`
+    (`reportBulkPropertySummary`) differ only by noun/confirm-key. The four handlers
+    (`handleAddTag`/`handleRemoveTag`/`handleAddProperty`/`handleRemoveProperty`) share the
+    guard→targets→confirm→read/transform/write→sync→summary skeleton (remove-variants also
+    share the union-of-keys pre-pass `:381-401` vs `:543-562`). **Action:**
+    `reportBulkSummary({verb,subject,key})` + `runBulkFrontmatterEdit(targets, transform)`.
+
+18. **Thread a `RollbackData` type param through the apply-dispatch handlers.**
+    `apply-dispatch.ts` re-asserts the rollback payload with `const data = rollbackData as {…}`
+    at 9 sites — a real type hole (an apply/rollback shape mismatch is invisible today).
+    **Action:** give `PayloadHandler<K>` a second `RollbackData` type param so `apply`'s
+    return type flows into `rollback`. Extract the duplicated
+    `try { deleteFile } catch {}` (note + excerpt handlers, `:148` & `:173`) into
+    `safeDeleteFile(ctx, path)`. (The `register<K>` registry itself is a clean design — do
+    not disturb it.) Thin coverage here → add an `applyBundle`/rollback test first.
+
+### Low Priority (Nice-to-Have)
+
+19. **Promote `firstObjectValue` in `queries.ts`.** The local
+    `const first = (pred) => store.statementsMatching(subject, pred)[0]?.object.value ?? null`
+    is defined identically at `:893` and `:1049`; the bare
+    `statementsMatching(x,p)[0]?.object.value` idiom recurs dozens of times. A module-level
+    `firstObjectValue(store, subject, pred)` removes the noise and repeated casts.
+
+20. **De-duplicate `indexers.ts` frontmatter-edge helpers.**
+    `frontmatterValueToEdge` (`:325-374`) and `coerceDeclared` (`:384-430`) both re-declare
+    `type Term`, `const plain`, the whole-value-wikilink block (`:347-364` vs `:417-426`),
+    and the date-shape regexes. **Action:** extract `resolveWholeWikiLink(...)`; lift
+    `ISO_DATE_RE`/`ISO_DATETIME_RE`/`YEAR_RE` to named constants.
+
+21. **Split `citationsForNote` / extract inline-citation counting.**
+    `queries.ts:1152-1253` does four jobs; extract `countCitationOccurrences(content)`
+    (the `RE`/bibliography-strip block `:1187-1199`) and `buildCitedSourceSet(...)`; give
+    the `` `${kind}:${id}` `` occurrence-key scheme a tiny helper.
+
+22. **Extract `buildFileMenu`'s inline Print-to-PDF handler.**
+    `menu.ts:301-340` embeds ~40 lines of dialog + `printToPDF` + file-write inside a menu
+    entry's `click`. **Action:** `printFocusedWindowToPdf()` named function. (`buildViewMenu`
+    `:467-568` and `buildQueryMenu` `:689-801` are similarly long — same extraction shape;
+    menu builders are lightly tested, so refactor cautiously.)
+
+23. **SourceDetail list rows + Editor small dups.**
+    `SourceDetail.svelte` renders 4 near-identical clickable lists — aboutNotes (`:693-703`),
+    references (`:709-720`), backlinks (`:729-744`) share one "title+meta, click-to-navigate"
+    row; extract `<NavList>`/`<SourceLinkRow>`. Minor.
+
+24. **Standardize IPC snapshotting + remove leftover debug log.**
+    `conversations.svelte.ts` mixes `$state.snapshot(x)` (`:753`, `:856`) and
+    `JSON.parse(JSON.stringify(x))` (`:899`, `:932`, `:957`, `:997`). Standardize on one
+    `plainSnapshot(x)` helper (the JSON round-trip is the safe one for dynamic-key
+    payloads — see MEMORY: structured-clone rejects reactive Proxies). Remove the
+    `console.log('[conv] approvePropertyDraft sending', …)` diagnostic at `:900-907`. Also
+    the two `getXStore()`-convention outliers (`objectTypesStore`, `savedViewsStore`) may be
+    aligned for consistency.
+
+## Risk Assessment
+
+### Safe Refactorings (Low Risk)
+Backed by tests, or pure mechanical extraction with no behavior change:
+- #3 `blankTabRuntime` (covered by `conversations-store.test.ts`, 642L)
+- #4 failure-list formatter, #5 provenance helper, #6 constants, #7 `discardFrom`, #8 Editor theme/font hoists
+- #10 `indexNote` decomposition (~30 graph-index suites incl. `frontmatter-indexing`, `sources-index`, `heading-rename`)
+- #15 `health-checks` builder (covered by `health-checks.test.ts`, `source-health-checks.test.ts`)
+- #19–#21 query/index helper extractions (covered by `citations-for-note`, `anchor-links`, `parser` suites)
+
+### Moderate Risk
+Behavior-adjacent or in files whose *component shell* is untested (logic helpers are tested):
+- #1 label fix — corrects behavior; **add the round-trip test with the change** (current tests can't catch it)
+- #2 rename routing — changes persistence/`ext` side-effects; verify against `note-ops.test.ts` (663L) and session-persist
+- #9 `CONVERSATION_SEND` split — ~180 lines with **no unit coverage**; add a test first
+- #11/#12/#14 component extractions — no direct component tests (helper modules are tested); rely on `pnpm lint` (svelte-check) + manual verify
+- #16 type-info helper — touches the object-type save path (#1584-1588); covered by `ObjectTypesSettings.test.ts`/`typed-objects.test.ts`
+- #17 bulk-edit consolidation — `refactor-ops.test.ts` (653L) covers, but confirm-key/summary text assertions may need updating
+
+### High Risk
+- #13 Preview CSS move — `:global` selector scope + specificity can shift; visual regression risk, no visual tests. Move in one commit, verify rendered notes (headings, callouts, wiki-links, object cards, typed links, transclusions) manually.
+- #18 apply-dispatch typing + `safeDeleteFile` — sits on the LLM approval/rollback path (the Trust Principle). Thin coverage; a rollback-ordering test is required first, and any change must keep the write-guard/approval invariants (`write-guard.test.ts`, `trust-integrity.test.ts`) green.
+- #22 menu builders — `menu.ts` construction is largely untested (only `menu-accelerators.test.ts`); regressions surface only at runtime.
+
+## Implementation Strategy
+
+Sequence to front-load value and de-risk:
+
+1. **Correctness pass first (own PR).** Fix #1 (label drop, with a new round-trip test), #2
+   (rename routing), and remove the SourceDetail listener leak (move
+   `sourceData.onExcerptsChanged` at `SourceDetail.svelte:309-311` into `onMount` and
+   return the unsubscribe). Small, high-value, each with a test.
+2. **Mechanical duplication cleanup (one PR per cluster).** #3, #7, #24 in the
+   conversations store; #4 + #5 + #6 as a "shared helpers/constants" PR; #15 in
+   health-checks; #19/#20/#21 in queries/indexers. All test-backed, low review cost.
+3. **God-function decomposition (one PR each, test-first where uncovered).** #10 `indexNote`
+   (safe), then #9 `CONVERSATION_SEND` (add test first). Keep each behavior-preserving with
+   the suite green.
+4. **Component extractions (one PR each).** #12 `SettingsDialog` panels (lowest risk,
+   established pattern), #11 `EditorContextMenu` + prop-surface reduction, #14
+   PropertiesPanel engine (+ new test), then #13 Preview CSS (isolated, manual visual
+   verify).
+5. **Approval-path typing last (#18), gated on a rollback test** and green write-guard /
+   trust-integrity suites.
+
+Per CLAUDE.md: every change ships as its own PR off a fresh branch (never commit to
+`main`); run `pnpm lint` (pre-push hook) and the relevant `tests/` suites; use `verify` /
+`run` to drive UI-affecting changes (#11-14) in the real app; and preserve the approval
+engine + write-guard invariants on any LLM/graph path (#18).
+
+## Estimated Effort
+
+| Item | Effort |
+|------|--------|
+| #1 label fix + test | 1-2 h |
+| #2 rename routing + verify | 1-2 h |
+| SourceDetail listener-leak fix | 0.5 h |
+| #3, #7, #24 conversations cleanup | 2-3 h |
+| #4, #5, #6 shared helpers/constants | 2-3 h |
+| #8 Editor theme/font hoists | 1 h |
+| #15 health-checks builder + prefix drop | 2 h |
+| #19, #20, #21 query/index helpers | 3-4 h |
+| #10 `indexNote` decomposition | 3-4 h |
+| #9 `CONVERSATION_SEND` split (+ test) | 4-6 h |
+| #12 SettingsDialog panel extraction | 4-6 h |
+| #11 EditorContextMenu + prop reduction | 4-6 h |
+| #14 PropertiesPanel engine extract + test | 3-5 h |
+| #16, #17 object-type / bulk-edit helpers | 3-4 h |
+| #13 Preview CSS move (+ visual verify) | 2-3 h |
+| #18 apply-dispatch typing (+ rollback test) | 3-5 h |
+| #22, #23 menu + list-row extractions | 3-4 h |
+
+**Totals:** Quick wins (High Priority #1-8 + leak fix) ≈ 1-1.5 days. Medium structural
+(#9-18) ≈ 4-6 days. Low priority (#19-24) ≈ 2 days. Full program ≈ 7-9 engineer-days,
+best delivered as ~12-15 small PRs so each stays independently reviewable and revertible.

--- a/reports/tooling-review-entire-project-2026-08-02-074702.md
+++ b/reports/tooling-review-entire-project-2026-08-02-074702.md
@@ -1,0 +1,244 @@
+# Developer Experience / Tooling Review — Minerva
+
+**Date:** 2026-08-02
+**Scope:** Entire project — developer ergonomics (onboarding, inner loop, IDE
+setup, custom scripts/CLI, contributor docs). Analysis-only; no source or config
+files were modified.
+**Repo root:** `/Users/davegriffith/minerva`
+
+> **Framing.** Minerva is a **single-developer, local-first desktop app**
+> (Electron + Svelte 5 + TypeScript, pnpm + electron-forge + Vite, Vitest,
+> Playwright-Electron). This review deliberately ignores large-team/server DX
+> tropes (containers, monorepo tooling, developer portals, metrics dashboards)
+> except to mark them Not Applicable at the end. Test coverage/gates, release/
+> signing, and architecture were covered by prior reviews (QA, deployment,
+> architecture) and are referenced, not re-derived.
+
+---
+
+## Executive summary
+
+Minerva's DX is **strong and unusually deliberate for a solo project.** The
+setup story is genuinely one-command (`pnpm install` → `pnpm dev`), the inner
+loop is fast, and there is real, purpose-built custom tooling: a headless
+`pnpm cli` (SPARQL/SQL/search/MCP), a golden-file skills-eval harness, a
+benchmark regression gate (`bench-check.mjs`), a font-literal lint guard
+(`lint:fonts`), and an auto-fetch of the embedding model + help corpus so first
+run "just works." Documentation (`README.md`, `CONTRIBUTING.md`, `CLAUDE.md`,
+`docs/`) is thorough and honest.
+
+The gaps are small and mostly **quick wins**: no shared editor config for a
+project that lives or dies on Svelte-5-runes + strict-TS tooling (there is a
+gitignored `.idea/`, but nothing shared — no `.vscode/`, no `.editorconfig`), no
+single-source pin for the pnpm version (three copies of `version: 10` in CI, a
+prose "pnpm 10" in docs, and no `packageManager` field), and a couple of small
+doc-drift items (`CLAUDE.md` still describes `lint` as tsc+svelte-check when it
+is now tsc+svelte-check+**eslint**; the pre-push hook comment says "~30s" but it
+measures ~50s here). None of these are urgent; all are cheap.
+
+---
+
+## Tooling Inventory (real, from `package.json`)
+
+### Runtimes / package manager
+| Item | Value | Source |
+|---|---|---|
+| Node | `>=24` (`engines`), pinned to `24` | `package.json:6-8`, `.nvmrc` |
+| Package manager | pnpm 10 (by convention; **not** pinned in `packageManager`) | `CONTRIBUTING.md:34`, `.github/workflows/ci.yml:38` |
+| node linker | `node-linker=hoisted` (flat `node_modules`, cacheable directly) | `.npmrc` |
+
+### Scripts (actual, `package.json:18-47`)
+| Script | Command | Purpose |
+|---|---|---|
+| `dev` | `electron-forge start` | Dev server, Vite HMR |
+| `predev` / `prebuild` / `prebuild:e2e` | fetch embedding model + build help corpus | first-run bootstrap (auto) |
+| `lint` | `tsc --noEmit && svelte-check --threshold error && eslint .` | **3-stage** type + template + lint gate |
+| `lint:eslint` / `:fix` | `eslint .` / `--fix` | eslint alone |
+| `lint:fonts` | `! grep -rnE "SF Mono|Fira Code|…" src/renderer …` | guard against hardcoded mono-font literals |
+| `test` / `test:watch` | `vitest run` / `vitest` | unit/integration |
+| `coverage` | `vitest run --coverage --test-timeout=30000` | the CI gate (per-area floors) |
+| `bench` / `bench:json` | `vitest bench …` | microbenchmarks |
+| `bench:check` / `bench:baseline` | `bench-check.mjs` compare / `--update` | perf regression gate |
+| `build:e2e` / `test:e2e` | forge package + `playwright test` | Electron e2e |
+| `build` / `package` | `electron-forge make` / `package` | distributable / unpackaged |
+| `cli:build` / `cli` | build `.vite/build/cli.js` then run | headless thoughtbase CLI |
+| `release:tag` | `scripts/tag-release.mjs` | release tagging |
+| `build:clipper` / `package:clipper` / `typecheck:clipper` | `clipper/*.mjs`, tsc | browser clipper build |
+| `fetch:model` / `fetch:help-corpus` | `scripts/*` | manual bootstrap steps |
+| `prepare` | `git config core.hooksPath .githooks \|\| true` | installs the pre-push hook |
+
+### Build / test / lint toolchain (devDependencies)
+- **Build:** electron-forge 7 (`@electron-forge/*`), Vite 8, `@sveltejs/vite-plugin-svelte` 7, esbuild 0.28. Separate Vite configs per process (`vite.main.config.ts`, `vite.preload.config.ts`, `vite.renderer.config.mts`, `vite.cli.config.ts`).
+- **Type/lint:** TypeScript 6, svelte-check 4, ESLint 10 + `typescript-eslint` 8 + `eslint-plugin-svelte` 3 (`eslint.config.mjs`, flat config, 14 KB — includes the renderer `no-restricted-syntax` data-flow rule).
+- **Test:** Vitest 4 + `@vitest/coverage-v8`, `@testing-library/svelte`, happy-dom + jsdom, Playwright 1.62 (`@playwright/test`), axe-core.
+
+### Custom scripts (`scripts/`)
+`bench-check.mjs` (perf gate), `build-help-corpus.mjs`, `fetch-embedding-model.mjs`, `deploy-to-gh-pages.sh`, `tag-release.mjs`, plus `scripts/lib/`.
+
+### CI (`.github/`)
+`ci.yml` (lint-and-test + audit + e2e, macos-latest), `bench.yml`, `release.yml`, `dependabot.yml`. (Release/deploy covered by the deployment review — not re-reviewed here.)
+
+---
+
+## Measured speed (real numbers)
+
+| Task | Result | How measured |
+|---|---|---|
+| `pnpm lint` (tsc + svelte-check + eslint) | **~50s** real (49.99s wall, 77.95s user) | `/usr/bin/time -p pnpm lint`, warm caches |
+| svelte-check pass | 3536 files, **0 errors**, 20 warnings, 6 files with problems | lint output |
+| single test file (`tests/main/auto-update.test.ts`, 10 tests) | **~1.3s** real (651ms Vitest duration) | `/usr/bin/time -p pnpm vitest run <file>` |
+| Full `pnpm test` / `pnpm coverage` | **not measured** (541 test files — see below) | avoided to keep this review fast |
+| `pnpm dev` cold start / HMR | **not measured** (would require booting Electron + the predev model/corpus fetch) | — |
+| `pnpm build` / `test:e2e` | **not measured** (long; covered conceptually by deployment review) | — |
+
+- **Test surface:** `find tests -name '*.test.ts'` = **541** files; e2e is small (**7** `.ts` files under `tests/*e2e*`, one real Playwright smoke journey). The single-file loop being ~1.3s means the watch loop (`pnpm test:watch`) is snappy per-file even though the whole suite is large — a good property for the inner loop.
+- **Lint is the slow step of the inner loop at ~50s.** It runs three tools sequentially (`&&`). tsc and eslint both re-parse the whole tree; that's the tax for catching script/template drift that eslint alone misses.
+
+---
+
+## Findings & recommendations (quick wins first)
+
+### QW1 — No shared editor configuration (Effort: S, ~1-2h)
+There is **no `.vscode/`** and **no `.editorconfig`**. There *is* a `.idea/`
+(JetBrains/WebStorm — `miranda.iml`, committed `codeStyles/`), but `.idea/` is
+gitignored (`.gitignore:11`), so **nothing editor-related is shared with a
+contributor.** For a project whose whole lint story depends on the Svelte
+language server and strict TS, this is the highest-value cheap win:
+- Add `.vscode/extensions.json` recommending `svelte.svelte-vscode`,
+  `dbaeumer.vscode-eslint`, and `EditorConfig.EditorConfig` so a fresh clone
+  prompts the contributor to install the Svelte 5 language server (without it,
+  the runes-based components look broken in-editor).
+- Add `.vscode/settings.json` enabling ESLint flat-config + format-on-save
+  scoping, and pointing the TS SDK at the workspace `typescript` (v6).
+- Add `.vscode/launch.json` with an Electron main-process debug config — today
+  there is **no shared debugger setup** for either editor.
+- Add a root `.editorconfig` (indentation, EOL, final newline) so formatting is
+  consistent regardless of editor.
+
+This is additive and editor-agnostic; it does not disturb the maintainer's
+JetBrains setup.
+
+### QW2 — Pin the pnpm version in one place (Effort: S, ~30m)
+The pnpm version lives in **prose** (`CONTRIBUTING.md:34-35` "pnpm 10") and is
+**hardcoded three times** in CI (`ci.yml:38`, `:117`, `:148`), but there is **no
+`packageManager` field** in `package.json` and no corepack pin. A `.nvmrc`
+pins Node but nothing pins pnpm for a fresh contributor. Add
+`"packageManager": "pnpm@10.x.y"` (exact) to `package.json` so corepack
+provisions the right pnpm automatically and CI can read `packageManager` instead
+of repeating `version: 10`. Single source of truth; removes a "works on my
+machine" class of drift.
+
+### QW3 — Document the two real DX gotchas contributors will hit (Effort: S, ~30m)
+`CONTRIBUTING.md:178-181` already flags the **preload snapshot** gotcha (adding a
+`window.api` method needs `pnpm test tests/preload/preload-bridge.test.ts -u`),
+which is excellent — lint won't catch it. Two more worth surfacing in the same
+spot:
+- **`pnpm lint` is three tools, and svelte-check is the one that catches
+  script↔template drift** that tsc and eslint miss. A contributor who only runs
+  `tsc` locally will be surprised by CI. Say so explicitly.
+- The renderer **`no-restricted-syntax`** rule (mutation `api.*` in a component
+  fails lint) is documented in `CLAUDE.md`/`CONTRIBUTING.md:93-97` — good; just
+  make sure the error message points at the rule so a first-timer knows *why*.
+
+### QW4 — Fix small doc drift (Effort: XS, ~15m)
+- `CLAUDE.md` still describes `pnpm lint` as "`tsc --noEmit` … then
+  `svelte-check`" — it is now **tsc → svelte-check → eslint** (`package.json:26`;
+  `CONTRIBUTING.md:53` is already correct). Update `CLAUDE.md`'s Commands section.
+- `.githooks/pre-push:4` comment says the lint gate is "~30s"; measured here it's
+  **~50s**. Minor, but the comment is a promise to the next contributor.
+- `README.md:154` labels `pnpm lint` as "Type check" — it now also runs eslint;
+  a one-word tweak ("Type-check + lint") keeps it honest.
+
+### QW5 — Consider a `pnpm doctor` / `setup` verification step (Effort: S-M, optional)
+Setup is already effectively one command (`pnpm install` → `pnpm dev`, with
+`predev` auto-fetching the model + corpus). The one place a fresh clone can fail
+silently is the **runtime model/corpus fetch** (network-dependent, and the first
+`dev`/`build` is "slower than later ones" per `CONTRIBUTING.md:44-46`). A tiny
+`scripts/doctor.mjs` (`pnpm doctor`) that checks Node ≥24, pnpm present, the
+embedding model downloaded, and native `@duckdb/node-api` loading would turn a
+confusing first-run stall into a clear message. Low priority given how good the
+current story is — call it a nice-to-have.
+
+---
+
+## What's already good (credit where due)
+
+- **One-command onboarding.** `pnpm install` activates the pre-push hook via the
+  `prepare` script (`package.json:19`), and `predev` (`:44`) bootstraps the
+  embedding model + help corpus so `pnpm dev` needs no manual fetch step. Node is
+  pinned (`.nvmrc`, `engines`), and `CONTRIBUTING.md`'s "Getting set up" +
+  "Everyday commands" table is accurate and copy-pasteable.
+- **Fast, honest inner loop.** Single-file test ~1.3s; `test:watch` for the loop;
+  `pnpm test <path>` documented for one-file runs. The 541-file suite is kept out
+  of the inner loop by design.
+- **Pre-push, not pre-commit** (`.githooks/pre-push`). Commits stay frictionless;
+  the lint gate runs once at push, with real escape hatches (`--no-verify`,
+  `SKIP_HOOKS=1`). This is the right call for a solo maintainer and is documented
+  in three places consistently.
+- **Real custom tooling — the standout DX asset:**
+  - **`pnpm cli`** (`src/cli/`, `docs/cli.md`) — a headless, Electron-free
+    thoughtbase interface: `query`/`sql`/`search`/`semantic`/`read`/`context`/
+    `propose-note` + a stdio **MCP server** (`mcp.ts`), reusing the app's core.
+    Proposals still route through the approval gate. Excellent leverage.
+  - **Skills-eval golden-file harness** (`tests/skills-eval/`, `src/cli/eval*.ts`)
+    — packages skill prompts exactly as the app does and snapshots
+    `output/request.json`; CI catches prompt drift without a live LLM call.
+  - **`bench-check.mjs`** — a committed-baseline perf regression gate
+    (`bench:check` / `bench:baseline`), so hot paths can't silently regress.
+  - **`lint:fonts`** — a one-line grep guard wired into the pre-push hook that
+    blocks hardcoded mono-font literals in favor of `var(--font-mono)`. Small,
+    specific, effective.
+  - **Skill authoring flow** — contributors can add a Learning/Research/Analysis
+    tool by dropping a markdown file, no TypeScript (`docs/authoring-skills.md`,
+    `CONTRIBUTING.md:25-27`).
+- **CI is thoughtful** (`ci.yml`): parallel lint-and-test / audit / e2e,
+  `node_modules` cached against the lockfile+Node (valid because
+  `node-linker=hoisted`), in-flight-run cancellation, and a documented,
+  partially-blocking `pnpm audit` supply-chain gate. (Deployment/release detail
+  deferred to the deployment review.)
+- **Documentation depth.** `CLAUDE.md` is a genuine architecture map; `docs/`
+  has `cli.md`, `authoring-skills.md`, `releasing.md`, `packaging.md`, plus
+  `docs/architecture/` deep-dives. For a solo project this is well above average.
+
+---
+
+## Not Applicable / Not Recommended for a solo desktop app
+
+These generic-template items were considered and **deliberately declined** — they
+solve large-team/server problems Minerva doesn't have:
+
+- **Containerize the dev environment (Docker/devcontainer).** N/A. Minerva builds
+  a native macOS Electron app and depends on macOS fsevents + a darwin app bundle
+  (the CI comment at `ci.yml:6-11` explains why even CI is macos-only). A
+  container would fight the platform, not help.
+- **Monorepo tooling (Nx/Turborepo/workspaces).** N/A. Single package; the
+  clipper is a self-contained sub-build (`clipper/*.mjs`). Multi-package
+  orchestration would be pure overhead.
+- **Developer portal / internal docs site.** N/A. The existing website/docs +
+  `docs/` + `CLAUDE.md` are sufficient for one maintainer plus occasional
+  contributors.
+- **Video walkthroughs / training materials / onboarding curriculum.** N/A at
+  this scale; `CONTRIBUTING.md` + `CLAUDE.md` do the job.
+- **Metrics/analytics dashboard for DX** (build-time trends, DORA, etc.). Not
+  recommended. `bench.yml` + `bench-check.mjs` already track the one metric that
+  matters (perf). A dashboard would be ceremony.
+- **Error-tracking / telemetry service (Sentry etc.).** Explicitly out of scope —
+  `CONTRIBUTING.md:146-152` makes privacy/no-telemetry a hard non-negotiable.
+- **CI/CD-as-deployment review.** Out of scope here by design; `release.yml` and
+  signing/notarization are the deployment review's territory.
+
+---
+
+## Prioritized action list
+
+| # | Action | Effort | Value |
+|---|---|---|---|
+| QW1 | Add shared editor config: `.vscode/{extensions,settings,launch}.json` + `.editorconfig` | S (1-2h) | High — Svelte LS + Electron debug for any new contributor |
+| QW2 | Add `packageManager: pnpm@10.x.y` (corepack pin); collapse the 3 CI copies | S (30m) | Med-High — one source of truth for pnpm |
+| QW3 | Document "lint = 3 tools; svelte-check catches drift" alongside the preload-snapshot note | S (30m) | Med — prevents CI surprises |
+| QW4 | Fix doc drift: `CLAUDE.md` lint desc, pre-push "~30s"→~50s, README "Type check" label | XS (15m) | Low-Med — accuracy |
+| QW5 | Optional `pnpm doctor` (Node/pnpm/model/native-dep check) | S-M | Low — first-run failure clarity |
+
+**Bottom line:** the inner loop, custom CLI/eval/bench tooling, and docs are
+already excellent. The only real gaps are shared editor config and a single pnpm
+pin — a few hours of work, not a project.


### PR DESCRIPTION
## What

Adds seven analysis-only review reports for the whole project, produced this session by the review agents. **No source changes** — reports only.

| Report | Focus | Headline |
|---|---|---|
| `refactor-review` | Code-quality hotspots, duplication | 2 latent bugs + ~22 cleanups; high overall quality |
| `quality-review` | QA / test coverage | Strong core; `CONVERSATION_SEND` untested (Critical); no global coverage floor |
| `architecture-review` | Layering & structural debt | June's High-Priority plan executed; no Critical issues remain; SOLID ~3.6/5 |
| `api-review` | The Electron IPC contract | 333 channels; 3-4 competing error conventions; proposals surface untyped |
| `deployment-review` | Build → sign → notarize → publish → auto-update | Auto-update SHIPPED; signed artifact never smoke-tested (High) |
| `configuration-review` | App settings & secrets | LLM key encrypted at rest via `safeStorage`; risk LOW, no High findings |
| `tooling-review` | Developer experience | Good one-command setup; no shared `.vscode/`/`.editorconfig`; `pnpm lint` ~50s |

## Notable cross-review signal

The **non-atomic type rename/delete migration** (`src/main/types/migrate.ts`) was independently flagged by both the refactoring and architecture reviews — the only finding with a data-loss shape.

## Tracking

Findings are filed as GitHub issues **#1594–#1646**, all labelled `generated-from-plan`. Each report's findings link back from the corresponding issues.

```
gh issue list --label generated-from-plan --state open
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
