### PR TITLE
fix(objects): preserve per-property label in the type editor (#1594)

### DIFF
--- a/src/main/types/parse.ts
+++ b/src/main/types/parse.ts
@@ -8,6 +8,7 @@ import YAML from 'yaml';
 import {
   PROPERTY_TYPES,
   pascalCase,
+  titleCase,
   type PropertyDef,
   type PropertyType,
   type TypeDef,
@@ -29,10 +30,6 @@ function slugify(s: string): string {
 
 function asString(v: unknown): string | undefined {
   return typeof v === 'string' ? v.trim() || undefined : undefined;
-}
-
-function titleCase(s: string): string {
-  return s.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 /** Normalize the `properties:` list; skips (with an error) any malformed entry. */

--- a/src/renderer/lib/components/TypeEditorDialog.svelte
+++ b/src/renderer/lib/components/TypeEditorDialog.svelte
@@ -12,7 +12,7 @@
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
   import { objectTypesStore } from '../stores/object-types.svelte';
-  import { PROPERTY_TYPES, type PropertyDef, type PropertyType } from '../../../shared/objects/type-def';
+  import { PROPERTY_TYPES, titleCase, type PropertyDef, type PropertyType } from '../../../shared/objects/type-def';
   import type { TypeEditorInitial } from './type-editor-value';
 
   interface Props {
@@ -31,6 +31,11 @@
     options: string;   // comma-separated (enum)
     targetType: string; // link-to-type target id
     onCard: boolean;
+    /** A property's explicit human label (#1594). Carried through the edit so a
+     *  hand-authored `label:` survives a dialog round-trip; the form doesn't
+     *  expose it, so only a genuine custom label (≠ the title-cased default) is
+     *  seeded, and defaults are never written back. */
+    label: string;
   }
 
   let label = $state(seed?.label ?? '');
@@ -45,6 +50,9 @@
       options: (p.options ?? []).join(', '),
       targetType: p.targetType ?? '',
       onCard: (seed?.card ?? []).includes(p.name),
+      // Keep only a real custom label; a default (== title-cased name, which the
+      // parser materializes) seeds blank so it isn't re-written on save.
+      label: p.label && p.label !== titleCase(p.name) ? p.label : '',
     })),
   );
   let saving = $state(false);
@@ -60,7 +68,7 @@
   const propNames = $derived(rows.map((r) => r.name.trim()).filter(Boolean));
 
   function addRow(): void {
-    rows = [...rows, { name: '', type: 'text', options: '', targetType: '', onCard: false }];
+    rows = [...rows, { name: '', type: 'text', options: '', targetType: '', onCard: false, label: '' }];
   }
   function removeRow(i: number): void { rows = rows.filter((_, j) => j !== i); }
   function move(i: number, dir: -1 | 1): void {
@@ -76,6 +84,7 @@
       .filter((r) => r.name.trim())
       .map((r) => {
         const p: PropertyDef = { name: r.name.trim(), type: r.type };
+        if (r.label.trim()) p.label = r.label.trim();
         if (r.type === 'enum') p.options = r.options.split(',').map((s) => s.trim()).filter(Boolean);
         if (r.type === 'link-to-type' && r.targetType.trim()) p.targetType = r.targetType.trim();
         return p;

--- a/src/shared/objects/type-def.ts
+++ b/src/shared/objects/type-def.ts
@@ -167,3 +167,10 @@ export function pascalCase(id: string): string {
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join('');
 }
+
+/** `first_name` → `First Name`. The default human label for a property whose
+ *  definition omits an explicit `label:` — shared so the parser's default and
+ *  the type editor's "is this label a real custom value?" check can't diverge. */
+export function titleCase(s: string): string {
+  return s.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/tests/renderer/components/TypeEditorDialog.test.ts
+++ b/tests/renderer/components/TypeEditorDialog.test.ts
@@ -62,6 +62,26 @@ describe('TypeEditorDialog (#1585)', () => {
     expect(input.card).toEqual(['author']); // the on-card checkbox stayed set
   });
 
+  it('preserves an explicit per-property label, without materializing defaults (#1594)', async () => {
+    render(TypeEditorDialog, {
+      initial: {
+        id: 'book', label: 'Book',
+        properties: [
+          { name: 'author', type: 'text', label: 'Auteur' },          // real custom label — keep
+          { name: 'page_count', type: 'number', label: 'Page Count' }, // == title-cased default — drop
+        ],
+      },
+      onSaved: vi.fn(), onClose: vi.fn(),
+    });
+    await waitFor(() => expect(screen.getByDisplayValue('Book')).toBeTruthy());
+    await fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(saveMock.mock.calls[0]![0].properties).toEqual([
+      { name: 'author', type: 'text', label: 'Auteur' },
+      { name: 'page_count', type: 'number' }, // default label not written back
+    ]);
+  });
+
   it('carries the parent type through save (#1587)', async () => {
     render(TypeEditorDialog, {
       initial: { id: 'monograph', label: 'Monograph', parent: 'book', properties: [] },


### PR DESCRIPTION
Closes #1594.

## Problem
The type editor's `Row` interface had no `label` field, so it was dropped at three points — the `Row` type, the seed map, and `buildProperties`. Editing any type (or "Save Note as Object Type") silently stripped every property's hand-authored `label:`. Verified against `type-def.ts` (`PropertyDef.label`), `write.ts:45` (persists it), and `parse.ts:63-64` (reads it, defaulting to a title-cased name).

## Fix
Thread `label` through `Row`, the seed map, and `buildProperties`.

A subtlety: `parse.ts` materializes a title-cased default into **every** property's `label`, so naively carrying it would write `label:` lines back into files for properties that never had one. So:
- **Seed** a row's label only when it's a genuine custom value (`p.label !== titleCase(p.name)`); a defaulted label seeds blank.
- **Emit** on save only when non-blank.

Net effect: hand-authored labels survive a dialog round-trip; title-cased defaults are never written back; renaming a defaulted property re-defaults correctly.

Also shares one `titleCase` from `shared/objects/type-def.ts` (it was duplicated in `parse.ts`) so the parser's default and the editor's custom-label check can't drift.

The form does not yet expose an editable label input — carrying it invisibly fixes the data loss; an editable per-property label field is a reasonable follow-up.

## Tests
- New round-trip test: a custom label (`Auteur`) survives; a default-equal label (`Page Count` for `page_count`) is not re-materialized.
- Existing `TypeEditorDialog` + `tests/main/types` suites green (30 tests). `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
