### PR TITLE
fix(objects): make type rename/delete migration partial-failure safe (#1611)

### DIFF
--- a/src/main/types/migrate.ts
+++ b/src/main/types/migrate.ts
@@ -23,21 +23,46 @@ async function directInstancePaths(rootPath: string, classLocalName: string): Pr
   return (results as Array<{ path?: string }>).map((r) => r.path).filter((p): p is string => !!p);
 }
 
+/** A note that couldn't be re-typed (a write/index error), with the reason —
+ *  surfaced so the caller can report a partial result instead of a bare throw. */
+export interface RetypeFailure {
+  /** Project-relative note path. */
+  path: string;
+  error: string;
+}
+
+interface RetypeResult {
+  /** Notes whose `type:` was actually rewritten to disk. */
+  rewritten: string[];
+  failed: RetypeFailure[];
+}
+
 /** Rewrite `type:` on each note to `toTypeId`, or REMOVE the key when null.
- *  Reads current content (edits since aren't clobbered), writes + reindexes. */
-async function retypeNotes(rootPath: string, paths: string[], toTypeId: string | null): Promise<string[]> {
+ *  Reads current content (edits since aren't clobbered), writes + reindexes.
+ *
+ *  A single note's failure must not abort the batch or leave the returned list
+ *  lying about what persisted (#1611): each note is isolated, and only a note
+ *  that actually reached disk is reported as `rewritten` — the rest come back in
+ *  `failed` for the caller to surface. */
+async function retypeNotes(rootPath: string, paths: string[], toTypeId: string | null): Promise<RetypeResult> {
   const ctx = projectContext(rootPath);
   const rewritten: string[] = [];
+  const failed: RetypeFailure[] = [];
   for (const p of paths) {
     let content: string;
+    // A note that vanished between the query and now has nothing to migrate.
     try { content = await notebaseFs.readFile(rootPath, p); } catch { continue; }
     const { content: next, changedKeys } = patchFrontmatterProperties(content, { type: toTypeId });
     if (changedKeys.length === 0) continue;
-    await notebaseFs.writeFile(rootPath, p, next);
-    await graph.indexNote(ctx, p, next);
-    rewritten.push(p);
+    try {
+      await notebaseFs.writeFile(rootPath, p, next);
+      await graph.indexNote(ctx, p, next);
+      rewritten.push(p);
+    } catch (e) {
+      failed.push({ path: p, error: e instanceof Error ? e.message : String(e) });
+    }
   }
-  return rewritten;
+  return { rewritten, failed };
 }
 
 /** Full-fidelity save input for re-writing a type under a (possibly new) id. */
@@ -55,23 +80,30 @@ function inputFromDef(def: TypeDef, label: string, id: string): SaveTypeInput {
   };
 }
 
-export interface DeleteTypeResult { cleared: string[] }
+export interface DeleteTypeResult { cleared: string[]; failed: RetypeFailure[] }
 
 /** Delete a user type; optionally clear `type:` from its instances first so they
- *  aren't left pointing at a type that no longer resolves. */
+ *  aren't left pointing at a type that no longer resolves. The delete is the
+ *  user's explicit intent, so it proceeds even if some instances couldn't be
+ *  cleared — those come back in `failed` (they still carry the old `type:`). */
 export async function deleteTypeSafely(rootPath: string, id: string, clearInstances: boolean): Promise<DeleteTypeResult> {
   const ctx = projectContext(rootPath);
   let cleared: string[] = [];
+  let failed: RetypeFailure[] = [];
   if (clearInstances) {
     const def = (await loadTypeCatalog(rootPath)).types.find((t) => t.id === id);
-    if (def) cleared = await retypeNotes(rootPath, await directInstancePaths(rootPath, def.classLocalName), null);
+    if (def) {
+      const res = await retypeNotes(rootPath, await directInstancePaths(rootPath, def.classLocalName), null);
+      cleared = res.rewritten;
+      failed = res.failed;
+    }
   }
   await deleteType(rootPath, id);
   await graph.reloadTypeCatalog(ctx);
-  return { cleared };
+  return { cleared, failed };
 }
 
-export interface RenameTypeResult { newId: string; migrated: string[] }
+export interface RenameTypeResult { newId: string; migrated: string[]; failed: RetypeFailure[] }
 
 /** Rename a user type. A label-only change (same slug) just re-labels in place;
  *  an id change writes the new type, migrates its instances' `type:` to the new
@@ -86,7 +118,7 @@ export async function renameType(rootPath: string, oldId: string, newLabel: stri
   if (newId === oldId) {
     await saveType(rootPath, inputFromDef(def, newLabel, oldId));
     await graph.reloadTypeCatalog(ctx);
-    return { newId: oldId, migrated: [] };
+    return { newId: oldId, migrated: [], failed: [] };
   }
 
   // Capture instances BEFORE the class changes, write the new type so its class
@@ -94,8 +126,11 @@ export async function renameType(rootPath: string, oldId: string, newLabel: stri
   const paths = await directInstancePaths(rootPath, def.classLocalName);
   await saveType(rootPath, inputFromDef(def, newLabel, newId));
   await graph.reloadTypeCatalog(ctx);
-  const migrated = await retypeNotes(rootPath, paths, newId);
-  await deleteType(rootPath, oldId);
+  const { rewritten: migrated, failed } = await retypeNotes(rootPath, paths, newId);
+  // Only retire the old type once EVERY instance has moved. If any failed, the
+  // old type must stay so those notes still resolve — dropping it now would
+  // orphan them, the exact harm #1588 prevents (#1611).
+  if (failed.length === 0) await deleteType(rootPath, oldId);
   await graph.reloadTypeCatalog(ctx);
-  return { newId, migrated };
+  return { newId, migrated, failed };
 }

--- a/src/renderer/lib/components/ObjectTypesSettings.svelte
+++ b/src/renderer/lib/components/ObjectTypesSettings.svelte
@@ -84,9 +84,10 @@
     }
     busy = true;
     try {
-      const { cleared } = await objectTypesStore.removeSafely(t.id, clear);
+      const { cleared, failed } = await objectTypesStore.removeSafely(t.id, clear);
       await loadCounts();
       if (cleared.length > 0) toasts.push({ message: `Deleted “${t.label}” and cleared it from ${cleared.length} note${cleared.length === 1 ? '' : 's'}.` });
+      if (failed.length > 0) toasts.push({ message: `Deleted “${t.label}”, but ${failed.length} note${failed.length === 1 ? '' : 's'} couldn’t be cleared — ${failed.length === 1 ? 'it' : 'they'} still list this type.` });
     } finally { busy = false; }
   }
 
@@ -95,11 +96,15 @@
     if (!newName || newName === t.label) return;
     busy = true;
     try {
-      const { migrated } = await objectTypesStore.rename(t.id, newName);
+      const { migrated, failed } = await objectTypesStore.rename(t.id, newName);
       await loadCounts();
-      toasts.push({ message: migrated.length > 0
-        ? `Renamed to “${newName}” — migrated ${migrated.length} note${migrated.length === 1 ? '' : 's'}.`
-        : `Renamed to “${newName}”.` });
+      if (failed.length > 0) {
+        toasts.push({ message: `Renamed to “${newName}” — migrated ${migrated.length} note${migrated.length === 1 ? '' : 's'}, but ${failed.length} couldn’t be migrated, so the old type was kept to avoid orphaning ${failed.length === 1 ? 'it' : 'them'}.` });
+      } else {
+        toasts.push({ message: migrated.length > 0
+          ? `Renamed to “${newName}” — migrated ${migrated.length} note${migrated.length === 1 ? '' : 's'}.`
+          : `Renamed to “${newName}”.` });
+      }
     } finally { busy = false; }
   }
 </script>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -773,10 +773,13 @@ export interface TypesApi {
   save(input: { label: string; id?: string; properties: import('../../../shared/objects/type-def').PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; parent?: string; template?: string }): Promise<{ id: string; filePath: string }>;
   /** Delete a user object type by id (#1584). */
   delete(id: string): Promise<void>;
-  /** Delete a user type, optionally clearing `type:` from its instances (#1588). */
-  deleteSafely(id: string, clearInstances: boolean): Promise<{ cleared: string[] }>;
-  /** Rename a user type, migrating its instances' `type:` to the new id (#1588). */
-  rename(oldId: string, newLabel: string): Promise<{ newId: string; migrated: string[] }>;
+  /** Delete a user type, optionally clearing `type:` from its instances (#1588).
+   *  `failed` lists instances that couldn't be cleared (#1611). */
+  deleteSafely(id: string, clearInstances: boolean): Promise<{ cleared: string[]; failed: { path: string; error: string }[] }>;
+  /** Rename a user type, migrating its instances' `type:` to the new id (#1588).
+   *  `failed` lists instances that couldn't be migrated; the old type is kept
+   *  when any fail so nothing is orphaned (#1611). */
+  rename(oldId: string, newLabel: string): Promise<{ newId: string; migrated: string[]; failed: { path: string; error: string }[] }>;
 }
 
 export interface SkillsApi {

--- a/src/renderer/lib/stores/object-types.svelte.ts
+++ b/src/renderer/lib/stores/object-types.svelte.ts
@@ -31,13 +31,13 @@ async function remove(id: string): Promise<void> {
   await refresh();
 }
 
-async function removeSafely(id: string, clearInstances: boolean): Promise<{ cleared: string[] }> {
+async function removeSafely(id: string, clearInstances: boolean): Promise<{ cleared: string[]; failed: { path: string; error: string }[] }> {
   const result = await api.types.deleteSafely(id, clearInstances);
   await refresh();
   return result;
 }
 
-async function rename(oldId: string, newLabel: string): Promise<{ newId: string; migrated: string[] }> {
+async function rename(oldId: string, newLabel: string): Promise<{ newId: string; migrated: string[]; failed: { path: string; error: string }[] }> {
   const result = await api.types.rename(oldId, newLabel);
   await refresh();
   return result;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -398,8 +398,8 @@ export interface ChannelMap {
   'types:instances': (typeId: string) => TypeInstancesResult;
   'types:save': (input: { label: string; id?: string; properties: PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; parent?: string; template?: string }) => { id: string; filePath: string };
   'types:delete': (id: string) => void;
-  'types:deleteSafely': (id: string, clearInstances: boolean) => { cleared: string[] };
-  'types:rename': (oldId: string, newLabel: string) => { newId: string; migrated: string[] };
+  'types:deleteSafely': (id: string, clearInstances: boolean) => { cleared: string[]; failed: { path: string; error: string }[] };
+  'types:rename': (oldId: string, newLabel: string) => { newId: string; migrated: string[]; failed: { path: string; error: string }[] };
 
   // Skills (markdown skill files — #622)
   'skills:list': () => SkillCatalogInfo;

--- a/tests/main/types/migrate.test.ts
+++ b/tests/main/types/migrate.test.ts
@@ -3,13 +3,14 @@
  * renaming migrates instances' `type:` to the new id. Non-stock ids throughout
  * (a user type sharing a stock id is shadowed).
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexAllNotes } from '../../../src/main/graph/index';
 import { loadTypeCatalog } from '../../../src/main/types/loader';
 import { deleteTypeSafely, renameType } from '../../../src/main/types/migrate';
+import * as notebaseFs from '../../../src/main/notebase/fs';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
 let root: string;
@@ -35,7 +36,16 @@ beforeEach(async () => {
   writeNote('W2.md', `---\ntitle: W2\ntype: widget\n---\n# W2\n`);
   await indexAllNotes(ctx);
 });
-afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+afterEach(() => { vi.restoreAllMocks(); fs.rmSync(root, { recursive: true, force: true }); });
+
+/** Make `notebaseFs.writeFile` throw for one note path; write the rest for real,
+ *  so a mid-batch failure can be exercised deterministically (no fs-perm flake). */
+function failWriteFor(failPath: string): void {
+  vi.spyOn(notebaseFs, 'writeFile').mockImplementation(async (rp: string, rel: string, data: string) => {
+    if (rel === failPath) throw new Error('disk full');
+    fs.writeFileSync(path.join(rp, rel), data, 'utf-8');
+  });
+}
 
 describe('deleteTypeSafely (#1588)', () => {
   it('clears `type:` from the instances when asked, and deletes the type', async () => {
@@ -48,10 +58,22 @@ describe('deleteTypeSafely (#1588)', () => {
   });
 
   it('leaves the instances untouched when not clearing (dangling but reversible)', async () => {
-    const { cleared } = await deleteTypeSafely(root, 'widget', false);
+    const { cleared, failed } = await deleteTypeSafely(root, 'widget', false);
     expect(cleared).toEqual([]);
+    expect(failed).toEqual([]);
     expect(read('W1.md')).toContain('type: widget'); // kept
     expect(typeExists('widget')).toBe(false);
+  });
+
+  it('reports notes it could not clear, still deletes, and does not abort the batch (#1611)', async () => {
+    failWriteFor('W2.md');
+    const { cleared, failed } = await deleteTypeSafely(root, 'widget', true);
+    expect(cleared).toEqual(['W1.md']);                 // W1 cleared despite W2 failing
+    expect(failed.map((f) => f.path)).toEqual(['W2.md']);
+    expect(failed[0]!.error).toMatch(/disk full/);
+    expect(read('W1.md')).not.toContain('type:');        // W1 actually persisted
+    expect(read('W2.md')).toContain('type: widget');     // W2 unchanged (write failed)
+    expect(typeExists('widget')).toBe(false);            // delete is the user's intent — proceeds
   });
 });
 
@@ -72,12 +94,28 @@ describe('renameType (#1588)', () => {
   });
 
   it('a label-only change (same slug) re-labels in place, no migration', async () => {
-    const { newId, migrated } = await renameType(root, 'widget', 'Widget!!');
+    const { newId, migrated, failed } = await renameType(root, 'widget', 'Widget!!');
     expect(newId).toBe('widget'); // slug unchanged
     expect(migrated).toEqual([]);
+    expect(failed).toEqual([]);
     expect(read('W1.md')).toContain('type: widget'); // untouched
     expect(typeExists('widget')).toBe(true);
     expect((await loadTypeCatalog(root)).types.find((t) => t.id === 'widget')?.label).toBe('Widget!!');
+  });
+
+  it('on a partial migration failure, keeps the old type so nothing is orphaned (#1611)', async () => {
+    failWriteFor('W2.md');
+    const { newId, migrated, failed } = await renameType(root, 'widget', 'Gadget');
+    expect(newId).toBe('gadget');
+    expect(migrated).toEqual(['W1.md']);                 // W1 moved
+    expect(failed.map((f) => f.path)).toEqual(['W2.md']);
+    expect(failed[0]!.error).toMatch(/disk full/);
+    expect(read('W1.md')).toContain('type: gadget');     // W1 persisted to the new id
+    expect(read('W2.md')).toContain('type: widget');     // W2 still on the old id
+    // Both types must exist so every note still resolves — the old type is NOT
+    // dropped while an instance still references it.
+    expect(typeExists('gadget')).toBe(true);
+    expect(typeExists('widget')).toBe(true);
   });
 
   it('throws for an unknown type', async () => {

--- a/tests/renderer/components/ObjectTypesSettings.test.ts
+++ b/tests/renderer/components/ObjectTypesSettings.test.ts
@@ -31,8 +31,8 @@ beforeEach(() => {
   listMock.mockResolvedValue({ types: [BOOK, GADGET], errors: [] });
   saveMock.mockResolvedValue({ id: 'gadget-copy', filePath: '.minerva/types/gadget-copy.md' });
   deleteMock.mockResolvedValue(undefined);
-  deleteSafelyMock.mockResolvedValue({ cleared: [] });
-  renameMock.mockResolvedValue({ newId: 'widget', migrated: ['W1.md'] });
+  deleteSafelyMock.mockResolvedValue({ cleared: [], failed: [] });
+  renameMock.mockResolvedValue({ newId: 'widget', migrated: ['W1.md'], failed: [] });
   queryMock.mockResolvedValue({ results: [{ id: 'book', n: '3' }, { id: 'gadget', n: '1' }], columns: [] });
   confirmMock.mockResolvedValue(true);
   promptMock.mockResolvedValue('Widget');


### PR DESCRIPTION
Closes #1611.

## Problem
`retypeNotes` (`src/main/types/migrate.ts`) rewrote every instance of a type in a sequential loop with **no per-note error handling**. A single write/index failure mid-batch would:
- **throw**, aborting the loop — earlier notes rewritten, later ones not,
- leave the thoughtbase **half-migrated with no rollback**, and
- **discard the record** of what had already persisted (the thrown error replaced the `migrated`/`cleared` return).

Flagged independently by both the refactoring and architecture reviews — the only data-loss-shaped finding.

## Fix (option (b) from the issue — resilient + honest partial result)
- **`retypeNotes`** isolates each note in its own `try/catch`: a failure is recorded as `{ path, error }` and the batch **continues**. Only a note that actually reached disk is reported as `rewritten`, so the return can never overstate what persisted.
- **`renameType`** now retires the old type **only when every instance migrated**. If any failed, the old type file is kept so those notes still resolve — dropping it would orphan them, the exact harm #1588 was built to prevent. (Because the loop no longer throws, guarding the `deleteType(oldId)` was essential — otherwise the resilient loop would have *newly* orphaned failed notes.)
- **`deleteTypeSafely`** proceeds with the delete (the user's explicit intent) and reports any instances it couldn't clear.
- `failed: { path, error }[]` threaded through the typed IPC contract, `client.ts`, the store, and surfaced in the Type Manager toasts ("…migrated N, but M couldn't be migrated, so the old type was kept to avoid orphaning them").

Both paths remain user-initiated **direct writes** (not approval-engine paths), unchanged from #1588.

## Tests
Two new tests inject a deterministic write failure mid-batch (spy on `notebaseFs.writeFile`):
- **rename** — W1 moves to the new id, W2 fails; **both type files kept**, no orphan; `failed` reports W2.
- **delete** — W1 cleared, W2 fails; type still deleted (user intent); `failed` reports W2.

Existing success / label-only / unknown-type cases updated for the new `failed` field. `tests/main/types` + `ObjectTypesSettings` green (39); `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
