### PR TITLE
fix(sources): tear down excerpt-changed subscription on unmount (#1610)

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -427,9 +427,7 @@ contextBridge.exposeInMainWorld('api', {
       pageRange?: string | null;
       locationText?: string | null;
     }) => invoke(Channels.SOURCES_CREATE_EXCERPT, params),
-    onExcerptsChanged: (cb: () => void) => {
-      ipcRenderer.on(Channels.EXCERPTS_CHANGED, () => cb());
-    },
+    onExcerptsChanged: (cb: () => void) => subscribeIpc(Channels.EXCERPTS_CHANGED, () => cb()),
   },
   collections: {
     list: () => invoke(Channels.COLLECTIONS_LIST),

--- a/src/renderer/lib/components/PdfViewer.svelte
+++ b/src/renderer/lib/components/PdfViewer.svelte
@@ -14,6 +14,7 @@
    * whose text was OCR-altered or spans a column break. Adding
    * explicit pdfBoundingBox to excerpts is a future-work refinement.
    */
+  import { onMount } from 'svelte';
   import { api } from '../ipc/client';
   import type { SourceExcerpt } from '../../../shared/types';
   import { getEditorStore } from '../stores/editor.svelte';
@@ -148,11 +149,12 @@
     }
   }
 
-  // Listen for excerpt-changed broadcasts so newly-saved excerpts
-  // appear as highlights immediately.
-  sourceData.onExcerptsChanged(() => {
+  // Listen for excerpt-changed broadcasts so newly-saved excerpts appear as
+  // highlights immediately. Subscribe in onMount and return the unsubscribe so
+  // the listener is torn down on unmount (#1610).
+  onMount(() => sourceData.onExcerptsChanged(() => {
     void refreshExcerpts(sourceId);
-  });
+  }));
 
   // ── Render a page ─────────────────────────────────────────────────────────
 

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { api } from '../ipc/client';
   import Preview from './Preview.svelte';
   import ExcerptDensityGutter from './ExcerptDensityGutter.svelte';
@@ -305,10 +305,11 @@
 
   // Reload the source detail when the main process tells us an excerpt
   // was added/updated/removed (covers cross-window sync and any direct
-  // filesystem edits the user made to excerpt ttls).
-  sourceData.onExcerptsChanged(() => {
+  // filesystem edits the user made to excerpt ttls). Subscribe in onMount and
+  // return the unsubscribe so the listener is torn down on unmount (#1610).
+  onMount(() => sourceData.onExcerptsChanged(() => {
     if (loadedId === sourceId) void load(sourceId);
-  });
+  }));
 
   async function createNoteFromExcerpt(excerpt: SourceExcerpt): Promise<void> {
     if (!onCreateNoteFromExcerpt) return;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1091,8 +1091,9 @@ export interface SourcesApi {
     pageRange?: string | null;
     locationText?: string | null;
   }): Promise<{ excerptId: string; relativePath: string; duplicate: boolean }>;
-  /** Fires when an excerpt is added, updated, or removed. */
-  onExcerptsChanged(cb: () => void): void;
+  /** Fires when an excerpt is added, updated, or removed. Returns an unsubscribe
+   *  — call it on teardown so the listener doesn't leak across remounts (#1610). */
+  onExcerptsChanged(cb: () => void): () => void;
 }
 
 /** Source collections (#470). */

--- a/tests/renderer/components/PdfViewer.test.ts
+++ b/tests/renderer/components/PdfViewer.test.ts
@@ -149,6 +149,22 @@ describe('PdfViewer (#100)', () => {
     expect(onShowMarkdown).toHaveBeenCalledWith('doi-x');
   });
 
+  it('unsubscribes from excerpt-changed on unmount (no listener leak) (#1610)', async () => {
+    mockDoc(1);
+    readPdfMock.mockResolvedValue(new Uint8Array([0x25]));
+    sourceDetailMock.mockResolvedValue({ excerpts: [] });
+    const unsub = vi.fn();
+    onExcerptsChangedMock.mockReturnValue(unsub);
+
+    const { findByText, unmount } = renderViewer();
+    await findByText('/ 1');
+    expect(onExcerptsChangedMock).toHaveBeenCalledTimes(1);
+    expect(unsub).not.toHaveBeenCalled();
+
+    unmount();
+    expect(unsub).toHaveBeenCalledTimes(1); // teardown ran — the listener is removed
+  });
+
   it('surfaces a load error when the PDF bytes cannot be read', async () => {
     readPdfMock.mockRejectedValue(new Error('source not found'));
     const { findByText } = renderViewer();


### PR DESCRIPTION
Closes #1610.

## Problem
`SourceDetail.svelte` (and `PdfViewer.svelte`) subscribed to excerpt-changed broadcasts at **script-init** with **no teardown**. Worse, the underlying `api.sources.onExcerptsChanged` in the preload used a raw `ipcRenderer.on(...)` and **returned nothing** — so there was no unsubscribe to call even if a caller wanted one. Every remount added another listener that was never removed, and each listener's closure pinned a stale component instance.

## Fix
- **preload** (`preload.ts`): route `onExcerptsChanged` through the existing `subscribeIpc` helper (the same one every other subscription uses), so it returns an unsubscribe.
- **client type** (`client.ts`): `onExcerptsChanged(cb): () => void`.
- **SourceDetail + PdfViewer**: subscribe inside `onMount` and return the unsubscribe, so Svelte tears the listener down on unmount.

`PdfViewer` had the **identical leak** and shares the same store method + API change, so it's fixed here too rather than left as a known twin bug.

## Test
`PdfViewer.test.ts`: on unmount the unsubscribe is called exactly once — guarding the shared `store → onMount → unsubscribe` mechanism (the exact pattern `SourceDetail` uses) against regression. A dedicated `SourceDetail` render test is out of scope here and tracked separately as **#1597** (QA H2 — it has no render harness yet).

## Note / follow-up
The sibling `api.sources.onChanged` (`SOURCES_CHANGED`) still uses a raw `ipcRenderer.on` with no unsubscribe — the same latent pattern for a different subscription. Left out of this PR's scope; worth a follow-up sweep to route all remaining `on*` subscriptions through `subscribeIpc`.

`pnpm lint` clean; preload-bridge snapshot unchanged (exposed shape is the same).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
