### PR TITLE
fix(notes): route paste/move rename through applyRenameTransitions (#1595)

### DIFF
--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -375,14 +375,9 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       }
       try {
         await api.notebase.rename(t.relativePath, destPath);
-        const tabIdx = editor.tabs.findIndex((tab) => tab.type === 'note' && tab.relativePath === t.relativePath);
-        if (tabIdx !== -1) {
-          const tab = editor.tabs[tabIdx]!;
-          if (tab.type === 'note') {
-            tab.relativePath = destPath;
-            tab.fileName = name;
-          }
-        }
+        // Retarget any open tab through the store so it also fixes an
+        // unsupported-file tab's ext and re-persists the session (#1595).
+        editor.applyRenameTransitions([{ old: t.relativePath, new: destPath }]);
       } catch (err) {
         failures.push({ path: t.relativePath, error: err instanceof Error ? err.message : String(err) });
       }
@@ -420,14 +415,9 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       try {
         if (mode === 'cut') {
           await api.notebase.rename(item.relativePath, destPath);
-          const tabIdx = editor.tabs.findIndex((t) => t.type === 'note' && t.relativePath === item.relativePath);
-          if (tabIdx !== -1) {
-            const tab = editor.tabs[tabIdx]!;
-            if (tab.type === 'note') {
-              tab.relativePath = destPath;
-              tab.fileName = name;
-            }
-          }
+          // Retarget any open tab through the store so it also fixes an
+          // unsupported-file tab's ext and re-persists the session (#1595).
+          editor.applyRenameTransitions([{ old: item.relativePath, new: destPath }]);
         } else {
           await api.notebase.copy(item.relativePath, destPath);
         }

--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -22,6 +22,7 @@ const h = vi.hoisted(() => {
   const editor = {
     openFile: vi.fn(), tabs: [] as unknown[], closeTabsForDeletedPath: vi.fn(), flushAutoSave: vi.fn(),
     activeFilePath: 'Note.md' as string | null, content: '', setContent: vi.fn(),
+    applyRenameTransitions: vi.fn(),
   };
   const dialog = {
     showPrompt: vi.fn(), showConfirm: vi.fn(), showNewNoteDialog: vi.fn(), showSnippetPicker: vi.fn(),
@@ -461,12 +462,13 @@ describe('handleCut / handleCopy', () => {
 });
 
 describe('handleMove (drag-move)', () => {
-  it('moves a single dragged file and retargets its open tab', async () => {
+  it('moves a single dragged file and retargets its open tab via the store', async () => {
     h.notebase.files = [file('a.md')];
-    h.editor.tabs = [{ type: 'note', relativePath: 'a.md', fileName: 'a.md' }];
     await ops.handleMove('a.md', 'dest');
     expect(h.api.notebase.rename).toHaveBeenCalledWith('a.md', 'dest/a.md');
-    expect(h.editor.tabs[0]).toMatchObject({ relativePath: 'dest/a.md', fileName: 'a.md' });
+    // Retarget goes through the store (fixes unsupported-file ext + re-persists
+    // the session), not a direct editor.tabs mutation (#1595).
+    expect(h.editor.applyRenameTransitions).toHaveBeenCalledWith([{ old: 'a.md', new: 'dest/a.md' }]);
     expect(sidebar.clearSelection).toHaveBeenCalled();
   });
 
@@ -521,12 +523,12 @@ describe('handleMove (drag-move)', () => {
 });
 
 describe('handlePaste — collisions, failures, tab retarget', () => {
-  it('cut+paste retargets an open tab for the moved item', async () => {
-    h.editor.tabs = [{ type: 'note', relativePath: 'a.md', fileName: 'a.md' }];
+  it('cut+paste retargets an open tab for the moved item via the store', async () => {
     getClipboardStore().set({ items: [{ relativePath: 'a.md', isDirectory: false }], mode: 'cut' });
     await ops.handlePaste('dest');
     expect(h.api.notebase.rename).toHaveBeenCalledWith('a.md', 'dest/a.md');
-    expect(h.editor.tabs[0]).toMatchObject({ relativePath: 'dest/a.md', fileName: 'a.md' });
+    // Retarget goes through the store, not a direct editor.tabs mutation (#1595).
+    expect(h.editor.applyRenameTransitions).toHaveBeenCalledWith([{ old: 'a.md', new: 'dest/a.md' }]);
   });
 
   it('skips a collision and reports the Copy summary', async () => {


### PR DESCRIPTION
Closes #1595.

## Problem
`handleMove` and `handlePaste` (`note-ops.ts`) retargeted an open tab by mutating `editor.tabs[i]` directly. That bypassed the editor store's own `applyRenameTransitions`, so the retarget:
- only scanned `editor.tabs` — **missed tabs in split groups**;
- only handled note tabs — **missed unsupported-file tabs**;
- didn't fix an unsupported-file tab's `ext`; and
- **didn't re-persist the session**, so a rename-via-paste/move was lost on restart.

## Fix
Replace both inline mutations with `editor.applyRenameTransitions([{ old, new }])`, which already:
- walks **all** tabs across **all** groups,
- retargets both note and unsupported-file tabs,
- fixes the unsupported-file tab's `ext` (`extensionOf(newPath)`), and
- calls `schedulePersistTabs()`.

Net: the store is now the single path for rename-driven tab retargeting (the #1086 data-flow rule), and it's applied only after a successful `api.notebase.rename` (a rejected rename skips it and is reported as a failure, unchanged).

## Tests
The move and cut/paste retarget cases now assert `applyRenameTransitions` is called with the transition (`[{ old, new }]`) rather than checking a direct `editor.tabs` mutation. `tests/renderer/app/note-ops.test.ts` green (62); `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
