### PR TITLE
feat(ipc): type the proposals channels instead of unknown (#1632)

### DIFF
--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,6 +1,7 @@
 import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SavedView, SavedViewInput, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate, MenuEditorState } from '../../../shared/types';
 import type { ToolExecutionRequest, ToolExecutionResult, ConversationToolPayload } from '../../../shared/tools/types';
 import type { ClipperState } from '../../../shared/clipper-pairing';
+import type { Proposal } from '../../../shared/proposals';
 import type { ThemeMode } from '../../../shared/theme';
 
 export interface NotebaseApi {
@@ -672,8 +673,8 @@ export interface ConversationsApi {
 }
 
 export interface ProposalsApi {
-  list(status?: string): Promise<unknown[]>;
-  detail(uri: string): Promise<unknown>;
+  list(status?: string): Promise<Proposal[]>;
+  detail(uri: string): Promise<Proposal | null>;
   approve(uri: string): Promise<boolean>;
   reject(uri: string): Promise<boolean>;
   expire(): Promise<number>;

--- a/src/renderer/lib/stores/proposals.svelte.ts
+++ b/src/renderer/lib/stores/proposals.svelte.ts
@@ -20,16 +20,11 @@
  * the list self-updates after a mutation with no manual refresh.
  */
 import { api } from '../ipc/client';
+import type { Proposal } from '../../../shared/proposals';
 
-export interface Proposal {
-  uri: string;
-  status: string;
-  operationType: string;
-  note: string;
-  proposedBy: string;
-  proposedAt: string;
-  payloads: unknown[];
-}
+// Re-exported so existing importers keep resolving `Proposal` from the store;
+// the wire shape now lives in shared/ so the IPC contract can name it (#1632).
+export type { Proposal };
 
 let proposals = $state<Proposal[]>([]);
 /** True once the first list() has resolved — lets a surface distinguish "no
@@ -74,7 +69,7 @@ function bufferArrivals(arrived: Proposal[]): void {
  * any newly-pending proposals as arrivals.
  */
 async function refresh(opts?: { baseline?: boolean }): Promise<void> {
-  proposals = (await api.proposals.list()) as Proposal[];
+  proposals = await api.proposals.list();
   loaded = true;
   const pending = proposals.filter((p) => p.status === 'pending');
   if (!opts?.baseline) {

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -42,6 +42,7 @@ import type {
   SourceDetail,
 } from './types';
 import type { ClipperState } from './clipper-pairing';
+import type { Proposal } from './proposals';
 import type { CellResult, CellOutput, ComputeConsentSummary } from './compute/types';
 import type { AutoLinkSuggestion } from './refactor/auto-link';
 import type { AutoLinkInboundSuggestion } from './refactor/auto-link-inbound';
@@ -485,8 +486,8 @@ export interface ChannelMap {
   'collections:smartMembers': (id: string) => SourceMetadata[];
 
   // Proposals (approval engine)
-  'proposal:list': (status?: string) => unknown[];
-  'proposal:detail': (uri: string) => unknown;
+  'proposal:list': (status?: string) => Proposal[];
+  'proposal:detail': (uri: string) => Proposal | null;
   'proposal:approve': (uri: string) => boolean;
   'proposal:reject': (uri: string) => boolean;
   'proposal:expire': () => number;

--- a/src/shared/proposals.ts
+++ b/src/shared/proposals.ts
@@ -1,0 +1,22 @@
+/**
+ * The wire shape of a proposal as it crosses IPC (`proposal:list` /
+ * `proposal:detail`) and reaches the renderer — the serializable, renderer-safe
+ * subset of the main-process `Proposal` (src/main/llm/proposal-types.ts). Kept
+ * in `shared/` so the typed IPC contract, the preload bridge, and the renderer
+ * store all name one type instead of the surface being `unknown` (#1632).
+ *
+ * `payloads` stays `unknown[]` at this boundary: the payload discriminated union
+ * lives in the main process, and the review UI narrows each payload per-kind at
+ * render time. Giving the payloads a shared union is a separate, larger effort.
+ */
+export interface Proposal {
+  uri: string;
+  /** `pending` | `approved` | `rejected` | `expired` — kept as a string because
+   *  the proposals store filters on it client-side. */
+  status: string;
+  operationType: string;
+  note: string;
+  proposedBy: string;
+  proposedAt: string;
+  payloads: unknown[];
+}


### PR DESCRIPTION
Closes #1632.

## Problem
`proposal:list` / `proposal:detail` were declared `unknown[]` / `unknown` in the typed IPC contract (`ipc-contract.ts:488-489`). The API review flagged this: the one surface central to the "LLM proposes, human confirms" trust model had **no wire type**, and the proposals store papered over it with `(await api.proposals.list()) as Proposal[]`.

## Fix
Lift the renderer's existing `Proposal` interface into **`src/shared/proposals.ts`** — the serializable, renderer-safe subset of the main-process `Proposal` (`proposal-types.ts`) — and point the three layers at it:
- `ipc-contract.ts`: `proposal:list` → `Proposal[]`, `proposal:detail` → `Proposal | null`.
- `client.ts` `ProposalsApi`: `list()` → `Promise<Proposal[]>`, `detail()` → `Promise<Proposal | null>`.
- the proposals store: imports (and re-exports) the shared type; the `as Proposal[]` cast is gone.

The main handler returns its richer internal `Proposal` (typed payloads + `affectsNodeUris`/`autoExpires`), which is **structurally assignable** to the shared wire type — so `handle()` enforces the contract end-to-end at `tsc` time (a future field-type drift in the main `Proposal` would now fail the build at `register-conversation.ts`).

### Scope
`payloads` stays `unknown[]` at the boundary — the payload discriminated union lives in main and the review UI narrows per-kind at render time. Giving the payloads a shared union is a separate, larger effort (noted in the shared file's doc comment).

## Verification
Type-only change (no runtime behavior). `pnpm lint` clean (proving the assignability holds), and the existing proposals store / panel / arrival suites are green (16). No preload shape change → preload-bridge snapshot unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
