### PR TITLE
refactor(graph): reuse DAY_MS + name the frontmatter-depth cap (#1620)

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -1,6 +1,7 @@
 import { queryGraph, headingsFor } from './index';
 import type { ProjectContext } from '../project-context-types';
 import { LINK_TYPES } from '../../shared/link-types';
+import { DAY_MS } from './queries';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -79,7 +80,7 @@ async function checkUnsupportedClaims(ctx: ProjectContext): Promise<Inspection[]
 }
 
 async function checkStaleness(ctx: ProjectContext, thresholdDays: number): Promise<Inspection[]> {
-  const cutoff = new Date(Date.now() - thresholdDays * 86400000).toISOString();
+  const cutoff = new Date(Date.now() - thresholdDays * DAY_MS).toISOString();
 
   const results = await queryGraph(ctx, `
     PREFIX dc: <http://purl.org/dc/terms/>
@@ -268,7 +269,7 @@ async function checkSourcesMissingMetadata(ctx: ProjectContext): Promise<Inspect
  * (#107) or hand-fix the stub.
  */
 async function checkLongUnresolvedStubs(ctx: ProjectContext, thresholdDays: number): Promise<Inspection[]> {
-  const cutoff = new Date(Date.now() - thresholdDays * 86400000).toISOString();
+  const cutoff = new Date(Date.now() - thresholdDays * DAY_MS).toISOString();
   const results = await queryGraph(ctx, `
     PREFIX minerva: <https://minerva.dev/ontology#>
     PREFIX thought: <https://minerva.dev/ontology/thought#>

--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -216,6 +216,10 @@ function isFrontmatterMap(value: FrontmatterValue): value is FrontmatterMap {
  *
  * `depth` caps recursion (matches the parser's own sanitise cap).
  */
+/** Recursion cap for nested frontmatter values — matches the parser's own
+ *  sanitise cap. */
+const MAX_FRONTMATTER_DEPTH = 8;
+
 function emitFrontmatterValue(
   state: GraphState,
   store: $rdf.IndexedFormula,
@@ -231,7 +235,7 @@ function emitFrontmatterValue(
   // xsd:integer, etc. Undefined for untyped notes / undeclared keys (unchanged).
   declaredType?: PropertyType,
 ): void {
-  if (depth > 8) return;
+  if (depth > MAX_FRONTMATTER_DEPTH) return;
   const recovered = recoverYamlEatenWikiLink(value);
   if (recovered === null || recovered === undefined) return;
   if (Array.isArray(recovered)) {

--- a/src/main/graph/queries.ts
+++ b/src/main/graph/queries.ts
@@ -937,7 +937,7 @@ function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rd
  */
 export type ReadingQueueView = 'unread' | 'reading' | 'dueThisWeek' | 'recentlyFinished';
 
-const DAY_MS = 86_400_000;
+export const DAY_MS = 86_400_000;
 
 /**
  * Source ids matching the given queue view. `now` is injectable for

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -11,6 +11,7 @@
 // existing `import … from './llm/approval'` sites keep working unchanged.
 
 import * as graph from '../graph/index';
+import { DAY_MS } from '../graph/queries';
 import type { ProjectContext } from '../project-context-types';
 import type {
   ApproveResult,
@@ -71,7 +72,7 @@ function assertWiredPayloads(payloads: ProposalPayload[]): void {
 export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): Promise<Proposal> {
   assertWiredPayloads(write.payloads);
   const now = new Date().toISOString();
-  const expiryDate = new Date(Date.now() + (write.expiryDays ?? 7) * 86400000).toISOString();
+  const expiryDate = new Date(Date.now() + (write.expiryDays ?? 7) * DAY_MS).toISOString();
 
   const proposal: Proposal = {
     uri: proposalUri(),


### PR DESCRIPTION
Closes #1620.

Small constants cleanup, behavior-preserving:

- `DAY_MS = 86_400_000` already lived in `queries.ts` but `86400000` was re-hardcoded in `health-checks.ts:82,271` and `approval.ts:74` — export `DAY_MS` and reuse it (no import cycle: `queries.ts` imports neither, and both consumers already load the graph).
- Replace the bare `if (depth > 8)` recursion guard in `indexers.ts` with a named `MAX_FRONTMATTER_DEPTH` (documented as matching the parser's sanitise cap).

Graph + LLM suites green (313), `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
