### PR TITLE
refactor(app): extract a shared capped-list formatter (#1618)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -83,6 +83,7 @@
   import {
     flattenNotePaths,
     lineBookmarkName,
+    formatCappedList,
   } from './lib/app/text-helpers';
   import { initAppearance } from './lib/appearance/settings';
   import { applyStoredZoom } from './lib/appearance/zoom';
@@ -1593,12 +1594,9 @@
       onCancel={() => { exportDialogGroup = null; }}
       onExported={async (result) => {
         exportDialogGroup = null;
-        const pathPreview = result.writtenPaths.slice(0, 5).map((p) => `  • ${p}`).join('\n');
-        const more = result.writtenPaths.length > 5
-          ? `\n  …and ${result.writtenPaths.length - 5} more`
-          : '';
+        const pathPreview = formatCappedList(result.writtenPaths, (p: string) => `  • ${p}`, { moreIndent: '  ' });
         await showConfirm(
-          `${result.summary}\n\nFiles written:\n${pathPreview}${more}`,
+          `${result.summary}\n\nFiles written:\n${pathPreview}`,
           CONFIRM_KEYS.exportComplete,
           'OK',
         );

--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -13,7 +13,7 @@ import { getDialogStore } from '../stores/dialogs.svelte';
 import { getBusyStore } from '../stores/busy.svelte';
 import { getClipboardStore } from '../stores/clipboard.svelte';
 import { resolveSelectionTargets, expandSelectionToNoteFiles, pathExistsInTree } from '../sidebar-tree-utils';
-import { describeDeleteNoun, describeDeleteMessage, offsetToLineCol, flattenNotePaths } from './text-helpers';
+import { describeDeleteNoun, describeDeleteMessage, offsetToLineCol, flattenNotePaths, formatCappedList, type OperationFailure } from './text-helpers';
 import { resolveWikiLinkTarget } from '../../../shared/wiki-link-resolver';
 import { setFrontmatterProperty, getFrontmatterValues } from '../../../shared/frontmatter-edit';
 import { deriveTypeProperties } from '../../../shared/objects/derive-type';
@@ -251,7 +251,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
   async function executeDeletes(
     targets: Array<{ relativePath: string; isDirectory: boolean }>,
   ): Promise<void> {
-    const failures: Array<{ path: string; error: string }> = [];
+    const failures: OperationFailure[] = [];
     for (const t of targets) {
       try {
         if (t.isDirectory) {
@@ -274,10 +274,9 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     ctx.getSidebar()?.clearSelection();
 
     if (failures.length > 0) {
-      const head = failures.slice(0, 5).map((f) => `• ${f.path}: ${f.error}`).join('\n');
-      const tail = failures.length > 5 ? `\n…and ${failures.length - 5} more` : '';
+      const body = formatCappedList(failures, (f) => `• ${f.path}: ${f.error}`);
       await showConfirm(
-        `Failed to delete ${failures.length} of ${targets.length} item${targets.length === 1 ? '' : 's'}:\n${head}${tail}`,
+        `Failed to delete ${failures.length} of ${targets.length} item${targets.length === 1 ? '' : 's'}:\n${body}`,
         CONFIRM_KEYS.deletePartialFailure,
         'OK',
       );
@@ -364,7 +363,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     if (targets.length === 0) return;
 
     const collisions: string[] = [];
-    const failures: Array<{ path: string; error: string }> = [];
+    const failures: OperationFailure[] = [];
     for (const t of targets) {
       const name = t.relativePath.split('/').pop()!;
       const destPath = destDirectory ? `${destDirectory}/${name}` : name;
@@ -403,7 +402,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     const { items, mode } = entry;
 
     const collisions: string[] = [];
-    const failures: Array<{ path: string; error: string }> = [];
+    const failures: OperationFailure[] = [];
     for (const item of items) {
       const name = item.relativePath.split('/').pop()!;
       const destPath = destDirectory ? `${destDirectory}/${name}` : name;
@@ -439,18 +438,16 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     label: 'Move' | 'Copy',
     total: number,
     collisions: string[],
-    failures: Array<{ path: string; error: string }>,
+    failures: OperationFailure[],
   ): Promise<void> {
     const lines: string[] = [];
     if (collisions.length > 0) {
-      const head = collisions.slice(0, 5).map((p) => `• ${p}`).join('\n');
-      const tail = collisions.length > 5 ? `\n…and ${collisions.length - 5} more` : '';
-      lines.push(`Skipped ${collisions.length} (destination already exists):\n${head}${tail}`);
+      const body = formatCappedList(collisions, (p) => `• ${p}`);
+      lines.push(`Skipped ${collisions.length} (destination already exists):\n${body}`);
     }
     if (failures.length > 0) {
-      const head = failures.slice(0, 5).map((f) => `• ${f.path}: ${f.error}`).join('\n');
-      const tail = failures.length > 5 ? `\n…and ${failures.length - 5} more` : '';
-      lines.push(`Failed (${failures.length}):\n${head}${tail}`);
+      const body = formatCappedList(failures, (f) => `• ${f.path}: ${f.error}`);
+      lines.push(`Failed (${failures.length}):\n${body}`);
     }
     const skipped = collisions.length + failures.length;
     const completed = total - skipped;

--- a/src/renderer/lib/app/refactor-ops.svelte.ts
+++ b/src/renderer/lib/app/refactor-ops.svelte.ts
@@ -16,6 +16,7 @@ import { getEditorStore } from '../stores/editor.svelte';
 import { getDialogStore } from '../stores/dialogs.svelte';
 import { getBusyStore } from '../stores/busy.svelte';
 import { getRefactorFlowStore } from '../stores/refactor-flow.svelte';
+import { formatCappedList, type OperationFailure } from './text-helpers';
 import {
   planExtract,
   planSplitHere,
@@ -338,7 +339,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     if (!tag) return;
 
     const changedPaths: string[] = [];
-    const failures: Array<{ path: string; error: string }> = [];
+    const failures: OperationFailure[] = [];
     for (const path of targets) {
       try {
         const content = await api.notebase.readFile(path);
@@ -379,7 +380,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     // file contents anyway for the writes that follow, but the
     // prompt has to come first — so do a read pass up-front.
     const tagSet = new Set<string>();
-    const readFailures: Array<{ path: string; error: string }> = [];
+    const readFailures: OperationFailure[] = [];
     const cache = new Map<string, string>();
     for (const path of targets) {
       try {
@@ -408,7 +409,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     if (!tag) return;
 
     const changedPaths: string[] = [];
-    const failures: Array<{ path: string; error: string }> = [...readFailures];
+    const failures: OperationFailure[] = [...readFailures];
     for (const path of targets) {
       // Skip files that already errored on read — we don't have
       // content to operate on and re-reading would just re-fail.
@@ -466,14 +467,12 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     tag: string,
     total: number,
     changed: number,
-    failures: Array<{ path: string; error: string }>,
+    failures: OperationFailure[],
   ): Promise<void> {
     const verb = op === 'Add' ? 'tagged' : 'untagged';
     let msg = `${verb} ${changed} of ${total} note${total === 1 ? '' : 's'} with "${tag}".`;
     if (failures.length > 0) {
-      const head = failures.slice(0, 5).map((f) => `• ${f.path}: ${f.error}`).join('\n');
-      const tail = failures.length > 5 ? `\n…and ${failures.length - 5} more` : '';
-      msg += `\n\nFailed (${failures.length}):\n${head}${tail}`;
+      msg += `\n\nFailed (${failures.length}):\n${formatCappedList(failures, (f) => `• ${f.path}: ${f.error}`)}`;
     }
     await showConfirm(msg, CONFIRM_KEYS.bulkTagComplete, 'OK');
   }
@@ -509,7 +508,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     const value = entered.value;
 
     const changedPaths: string[] = [];
-    const failures: Array<{ path: string; error: string }> = [];
+    const failures: OperationFailure[] = [];
     for (const path of targets) {
       try {
         const content = await api.notebase.readFile(path);
@@ -541,7 +540,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     }
 
     const keySet = new Set<string>();
-    const readFailures: Array<{ path: string; error: string }> = [];
+    const readFailures: OperationFailure[] = [];
     const cache = new Map<string, string>();
     for (const path of targets) {
       try {
@@ -567,7 +566,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     if (!key) return;
 
     const changedPaths: string[] = [];
-    const failures: Array<{ path: string; error: string }> = [...readFailures];
+    const failures: OperationFailure[] = [...readFailures];
     for (const path of targets) {
       if (!cache.has(path)) continue;
       try {
@@ -590,14 +589,12 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     key: string,
     total: number,
     changed: number,
-    failures: Array<{ path: string; error: string }>,
+    failures: OperationFailure[],
   ): Promise<void> {
     const verb = op === 'Add' ? 'set' : 'removed';
     let msg = `${verb} "${key}" on ${changed} of ${total} note${total === 1 ? '' : 's'}.`;
     if (failures.length > 0) {
-      const head = failures.slice(0, 5).map((f) => `• ${f.path}: ${f.error}`).join('\n');
-      const tail = failures.length > 5 ? `\n…and ${failures.length - 5} more` : '';
-      msg += `\n\nFailed (${failures.length}):\n${head}${tail}`;
+      msg += `\n\nFailed (${failures.length}):\n${formatCappedList(failures, (f) => `• ${f.path}: ${f.error}`)}`;
     }
     await showConfirm(msg, CONFIRM_KEYS.bulkPropertyComplete, 'OK');
   }

--- a/src/renderer/lib/app/text-helpers.ts
+++ b/src/renderer/lib/app/text-helpers.ts
@@ -88,6 +88,28 @@ export function countNotes(files: NoteFile[]): number {
   return n;
 }
 
+/** A per-item failure in a batch op (move / paste / delete / bulk tag /
+ *  bulk property): the note path that failed and why. */
+export interface OperationFailure {
+  path: string;
+  error: string;
+}
+
+/** Join up to `cap` items (one per line via `render`), appending
+ *  "…and N more" when the list is longer — the shared shape behind the
+ *  move / paste / delete / bulk-refactor / export summary dialogs. `moreIndent`
+ *  prefixes the overflow line for callers that indent their bullets. */
+export function formatCappedList<T>(
+  items: T[],
+  render: (item: T) => string,
+  opts: { cap?: number; moreIndent?: string } = {},
+): string {
+  const { cap = 5, moreIndent = '' } = opts;
+  const head = items.slice(0, cap).map(render).join('\n');
+  const extra = items.length - cap;
+  return extra > 0 ? `${head}\n${moreIndent}…and ${extra} more` : head;
+}
+
 /** Singular/plural noun for a delete confirmation over a set of targets. */
 export function describeDeleteNoun(targets: Array<{ isDirectory: boolean }>): string {
   if (targets.length === 1) return targets[0]!.isDirectory ? 'folder' : 'note';

--- a/tests/renderer/app/text-helpers.test.ts
+++ b/tests/renderer/app/text-helpers.test.ts
@@ -12,6 +12,7 @@ import {
   countNotes,
   describeDeleteNoun,
   describeDeleteMessage,
+  formatCappedList,
 } from '../../../src/renderer/lib/app/text-helpers';
 import type { NoteFile } from '../../../src/shared/types';
 
@@ -143,5 +144,33 @@ describe('describeDeleteMessage', () => {
   it('summarizes multiple with a sample and overflow', () => {
     const targets = ['a.md', 'b.md', 'c.md', 'd.md'].map((p) => ({ relativePath: p, isDirectory: false }));
     expect(describeDeleteMessage(targets, 'notes')).toBe('Delete 4 notes (a.md, b.md, c.md, …)?');
+  });
+});
+
+describe('formatCappedList', () => {
+  const fails = (n: number) => Array.from({ length: n }, (_, i) => ({ path: `n${i}.md`, error: 'x' }));
+
+  it('renders every item when at or under the cap, no overflow line', () => {
+    expect(formatCappedList(fails(2), (f) => `• ${f.path}: ${f.error}`))
+      .toBe('• n0.md: x\n• n1.md: x');
+  });
+
+  it('caps at 5 and appends "…and N more"', () => {
+    const out = formatCappedList(fails(7), (f) => `• ${f.path}`);
+    expect(out).toBe('• n0.md\n• n1.md\n• n2.md\n• n3.md\n• n4.md\n…and 2 more');
+  });
+
+  it('honors a custom cap', () => {
+    expect(formatCappedList(['a', 'b', 'c'], (s) => `• ${s}`, { cap: 2 }))
+      .toBe('• a\n• b\n…and 1 more');
+  });
+
+  it('indents the overflow line with moreIndent (App export summary)', () => {
+    const out = formatCappedList(['a', 'b', 'c', 'd', 'e', 'f'], (p) => `  • ${p}`, { moreIndent: '  ' });
+    expect(out.endsWith('\n  …and 1 more')).toBe(true);
+  });
+
+  it('returns an empty string for no items', () => {
+    expect(formatCappedList([], (s: string) => s)).toBe('');
   });
 });


### PR DESCRIPTION
Closes #1618.

The `slice(0,5).map(render) + "…and N more"` summary was copy-pasted at 6 sites:
- `note-ops.ts` delete-failures + the clipboard-summary collisions/failures,
- two `refactor-ops.svelte.ts` bulk reporters,
- the `App.svelte` export summary.

## Fix
Extract `formatCappedList(items, render, { cap = 5, moreIndent = '' })` into `text-helpers.ts` and call it from all six. `moreIndent` preserves the export summary's 2-space-indented overflow line (`  …and N more`), so **all output is byte-for-byte unchanged**.

Also promote the repeated `{ path; error }` failure shape to a shared `OperationFailure` type (12 annotations across note-ops + refactor-ops), as the report suggested.

## Verification
Behavior-preserving. New unit tests cover the formatter (cap, overflow, custom cap, `moreIndent`, empty). `text-helpers` / `note-ops` / `refactor-ops` suites green (142), `pnpm lint` clean.

Note: the App export callback's `result` isn't fully contextually typed through the Svelte prop, so the render param is annotated `(p: string)` to keep the generic from widening to `unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
