### PR TITLE
refactor(editor): hoist duplicated line-number theme + font-size apply (#1622)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -7,7 +7,7 @@
   import { markdown } from '@codemirror/lang-markdown';
   import { languages } from '@codemirror/language-data';
   import { EditorState, Prec, Compartment } from '@codemirror/state';
-  import { cmTheme, minervaEditorTheme, fontSizeTheme } from '../editor/editor-theme';
+  import { cmTheme, minervaEditorTheme, fontSizeTheme, hiddenLineNumbersTheme } from '../editor/editor-theme';
   import { getEditorSettings, saveEditorSettings, type EditorSettings } from '../editor/settings';
   import { indentUnit, foldEffect, unfoldEffect, foldedRanges, foldService } from '@codemirror/language';
   import { highlightWhitespace } from '@codemirror/view';
@@ -271,32 +271,23 @@
     return parseStoredFontSize(localStorage.getItem('editorFontSize'));
   }
 
-  export function changeFontSize(delta: number) {
-    const current = getFontSize();
-    const next = clampFontSize(current + delta);
-    localStorage.setItem('editorFontSize', String(next));
-    if (view) {
-      view.dispatch({ effects: fontSizeCompartment.reconfigure(fontSizeTheme(next)) });
-    }
-  }
-
-  export function resetFontSize() {
-    localStorage.setItem('editorFontSize', String(DEFAULT_FONT));
-    if (view) {
-      view.dispatch({ effects: fontSizeCompartment.reconfigure(fontSizeTheme(DEFAULT_FONT)) });
-    }
-  }
-
-  /** Set the editor font size to an absolute px value (clamped) — the Settings
-   *  panel's numeric control (#...). Persists + reconfigures like the
-   *  increment/decrement commands, just to a specific size. */
-  export function setFontSize(px: number) {
+  /** Clamp, persist, and reconfigure the editor to `px` — the one place font
+   *  size is applied; the exports below are thin wrappers over it. */
+  function applyFontSize(px: number): void {
     const next = clampFontSize(px);
     localStorage.setItem('editorFontSize', String(next));
     if (view) {
       view.dispatch({ effects: fontSizeCompartment.reconfigure(fontSizeTheme(next)) });
     }
   }
+
+  export function changeFontSize(delta: number) { applyFontSize(getFontSize() + delta); }
+
+  export function resetFontSize() { applyFontSize(DEFAULT_FONT); }
+
+  /** Set the editor font size to an absolute px value (clamped) — the Settings
+   *  panel's numeric control. */
+  export function setFontSize(px: number) { applyFontSize(px); }
 
   export function currentFontSize(): number {
     return getFontSize();
@@ -312,11 +303,7 @@
           indentUnit.of(' '.repeat(settings.tabSize)),
         ]),
         wrapCompartment.reconfigure(settings.wordWrap ? EditorView.lineWrapping : []),
-        lineNumbersCompartment.reconfigure(settings.lineNumbers ? [] : EditorView.theme({
-          // Must win against @codemirror/view's built-in theme which
-          // declares `.cm-gutter { display: flex !important }`.
-          '.cm-gutter.cm-lineNumbers': { display: 'none !important' },
-        })),
+        lineNumbersCompartment.reconfigure(settings.lineNumbers ? [] : hiddenLineNumbersTheme()),
         whitespaceCompartment.reconfigure(settings.showWhitespace ? highlightWhitespace() : []),
       ],
     });
@@ -520,11 +507,7 @@
       indentUnit.of(' '.repeat(initSettings.tabSize)),
     ]),
     wrapCompartment.of(initSettings.wordWrap ? EditorView.lineWrapping : []),
-    lineNumbersCompartment.of(initSettings.lineNumbers ? [] : EditorView.theme({
-      // See applySettings — overriding the default theme's !important
-      // flex rule needs our own !important.
-      '.cm-gutter.cm-lineNumbers': { display: 'none !important' },
-    })),
+    lineNumbersCompartment.of(initSettings.lineNumbers ? [] : hiddenLineNumbersTheme()),
     whitespaceCompartment.of(initSettings.showWhitespace ? highlightWhitespace() : []),
     // Markdown-only rendering layers (#1130): wiki-link/URL decorations,
     // bookmark gutter, runnable compute cells, footnote + highlight decorations.

--- a/src/renderer/lib/editor/editor-theme.ts
+++ b/src/renderer/lib/editor/editor-theme.ts
@@ -58,3 +58,13 @@ export function fontSizeTheme(size: number): Extension {
     '.cm-gutters': { fontSize: `${size}px` },
   });
 }
+
+/** Hides the line-number gutter (when the `lineNumbers` setting is off). The
+ *  `!important` is required to beat @codemirror/view's built-in
+ *  `.cm-gutter { display: flex !important }`. Swapped in via the line-numbers
+ *  compartment at init and in applySettings. */
+export function hiddenLineNumbersTheme(): Extension {
+  return EditorView.theme({
+    '.cm-gutter.cm-lineNumbers': { display: 'none !important' },
+  });
+}


### PR DESCRIPTION
Closes #1622.

Two behavior-preserving dedups in `Editor.svelte`:

## Hidden-line-numbers theme
`EditorView.theme({ '.cm-gutter.cm-lineNumbers': { display: 'none !important' } })` was inlined identically at the init compartment **and** in `applySettings` (an existing comment flagged the repeat). Moved to `hiddenLineNumbersTheme()` in `editor-theme.ts` — the home of the other CM theme builders (`cmTheme`, `minervaEditorTheme`, `fontSizeTheme`) — and both sites call it.

## Font-size apply
`changeFontSize` / `resetFontSize` / `setFontSize` each repeated the clamp + `localStorage.setItem('editorFontSize', …)` + `fontSizeCompartment.reconfigure(fontSizeTheme(next))` trio. Extracted one `applyFontSize(px)`; the three exports are now one-line wrappers (`changeFontSize` = `applyFontSize(getFontSize() + delta)`, `resetFontSize` = `applyFontSize(DEFAULT_FONT)`, `setFontSize` = `applyFontSize(px)`).

## Verification
Pure extraction, identical output. `svelte-check` passes; editor suites green (323 tests across 26 files); `pnpm lint` clean.

Note: I verified the actual current code before implementing — the review's line refs were accurate, but the pure font-size helpers/themes were already partly extracted (to `font-size.ts` / `editor-theme.ts`), so this PR finishes the job at the two remaining inline-duplication sites rather than re-extracting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
