### PR TITLE
test(ipc): cover the conversation LLM↔graph handlers + gate src/main/ipc (#1612)

### DIFF
--- a/tests/main/ipc/register-conversation.test.ts
+++ b/tests/main/ipc/register-conversation.test.ts
@@ -1,0 +1,236 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for the conversation IPC handlers (#1612 / QA C1).
+ *
+ * `register-conversation.ts` is the LLM↔graph boundary the trust model governs
+ * (CLAUDE.md), yet had NO main-process test: the `CONVERSATION_SEND` streaming /
+ * abort / 400-retry path and the draft-filing handlers were unverified. This
+ * drives the real handlers against mocked collaborators (the LLM client, the
+ * conversation store, the approval engine, the graph LLM-context guard) and
+ * asserts the trust-critical behavior:
+ *
+ *   - SEND runs inside the graph LLM context (enter/exit), and exits even on error;
+ *   - SEND retries once on the API's `container_id is required` 400;
+ *   - aborting a send rejects a pending `ask_user` prompt;
+ *   - a conversation draft is filed via `proposeWrite` and auto-approved.
+ *
+ * A regression that dropped the `enterLLMContext` wrap, the retry, or the
+ * proposeWrite/approve dispatch now fails here instead of silently at runtime.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Channels } from '../../../src/shared/channels';
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => {
+  const handlers = new Map<string, Handler>();
+  const fakeWin = { id: 1, isDestroyed: () => false, webContents: { send: vi.fn() } };
+  return {
+    handlers,
+    fakeWin,
+    enterLLMContext: vi.fn(),
+    exitLLMContext: vi.fn(),
+    completeWithTools: vi.fn(),
+    appendMessage: vi.fn(),
+    setContainerId: vi.fn(),
+    proposeWrite: vi.fn(),
+    approveProposal: vi.fn(),
+  };
+});
+
+// electron: capture every handler; hand back a fake window.
+vi.mock('electron', () => {
+  const noop = (): undefined => undefined;
+  class FakeWindow {
+    static fromWebContents() { return h.fakeWin; }
+    static fromId() { return h.fakeWin; }
+    static getFocusedWindow() { return null; }
+    static getAllWindows() { return []; }
+  }
+  return {
+    ipcMain: {
+      handle: (c: string, fn: Handler) => { h.handlers.set(c, fn); },
+      on: (c: string, fn: Handler) => { h.handlers.set(c, fn); },
+      removeHandler: noop,
+    },
+    Notification: class { show(): void {} },
+    app: { getPath: () => '/tmp', getName: () => 'minerva', getVersion: () => '0.0.0', on: noop },
+    BrowserWindow: FakeWindow,
+    dialog: {}, Menu: {}, shell: {}, nativeTheme: { on: noop }, clipboard: {}, net: {},
+  };
+});
+
+// helpers: give the raw handlers a window + rootPath, and make the withRootPath*
+// wrappers inject a fixed rootPath so the wrapped handlers run.
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  winFromEvent: () => h.fakeWin,
+  rootPathFromEvent: () => '/root',
+  withRootPath: (fn: (rp: string, ...a: unknown[]) => unknown) => (_e: unknown, ...a: unknown[]) => fn('/root', ...a),
+  withRootPathOr: (_fallback: unknown, fn: (rp: string, ...a: unknown[]) => unknown) => (_e: unknown, ...a: unknown[]) => fn('/root', ...a),
+  withRootPathWin: (fn: (rp: string, win: unknown, ...a: unknown[]) => unknown) => (_e: unknown, ...a: unknown[]) => fn('/root', h.fakeWin, ...a),
+  reindexFile: vi.fn(),
+  persistIndexes: vi.fn(),
+  hooks: {},
+}));
+
+// graph: only the LLM-context guard is exercised here.
+vi.mock('../../../src/main/graph/index', () => ({
+  enterLLMContext: h.enterLLMContext,
+  exitLLMContext: h.exitLLMContext,
+  withLLMContext: (fn: () => unknown) => fn(),
+}));
+
+// The LLM client (dynamically imported inside the handler).
+vi.mock('../../../src/main/llm/index', () => ({ completeWithTools: h.completeWithTools }));
+
+// Conversation persistence.
+vi.mock('../../../src/main/llm/conversation', () => ({
+  appendMessage: h.appendMessage,
+  setContainerId: h.setContainerId,
+}));
+
+// Approval engine — the trust gate.
+vi.mock('../../../src/main/llm/approval', () => ({
+  proposeWrite: h.proposeWrite,
+  approveProposal: h.approveProposal,
+}));
+
+// The thoughtbase-doc prompt block reads from disk — stub it out.
+vi.mock('../../../src/main/llm/thoughtbase-doc', () => ({
+  readThoughtbaseDoc: async () => null,
+  thoughtbaseDocPromptBlock: () => '',
+}));
+
+import { registerConversation } from '../../../src/main/ipc/register-conversation';
+
+registerConversation();
+
+const evt = { sender: {} };
+const send = h.handlers.get(Channels.CONVERSATION_SEND)!;
+const cancel = h.handlers.get(Channels.CONVERSATION_CANCEL)!;
+const fileDraft = h.handlers.get(Channels.CONVERSATION_FILE_DRAFT)!;
+
+function seedConversation(): void {
+  h.appendMessage.mockResolvedValue({
+    id: 'conv-1',
+    messages: [{ role: 'user', content: 'hello' }],
+    systemPrompt: undefined,
+    contextBundle: {},
+    model: 'claude-x',
+    effort: 'medium',
+    webEnabled: undefined,
+    containerId: undefined,
+  });
+}
+
+const completion = (text: string) => ({ text, citations: [], usage: { input: 1, output: 1 }, usageModel: 'claude-x' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  seedConversation();
+});
+
+describe('CONVERSATION_SEND (#1612)', () => {
+  it('registers the handler', () => {
+    expect(send).toBeDefined();
+    expect(cancel).toBeDefined();
+    expect(fileDraft).toBeDefined();
+  });
+
+  it('runs inside the graph LLM context, calls the LLM once, and appends the assistant reply', async () => {
+    h.completeWithTools.mockResolvedValue(completion('assistant reply'));
+
+    await send(evt, 'conv-1', 'hello');
+
+    expect(h.enterLLMContext).toHaveBeenCalledTimes(1);
+    expect(h.completeWithTools).toHaveBeenCalledTimes(1);
+    expect(h.completeWithTools.mock.calls[0]![0]).toMatchObject({
+      toolContext: { rootPath: '/root', conversationId: 'conv-1' },
+    });
+    // The assistant turn is persisted with the LLM result.
+    expect(h.appendMessage).toHaveBeenCalledWith(
+      'conv-1', 'assistant', 'assistant reply',
+      expect.objectContaining({ usageModel: 'claude-x' }),
+    );
+    // Context released in the finally.
+    expect(h.exitLLMContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once, stripping the container id, on the API container_id 400', async () => {
+    h.completeWithTools
+      .mockRejectedValueOnce(new Error('400 {"error":"container_id is required when there are pending tool uses"}'))
+      .mockResolvedValueOnce(completion('recovered'));
+
+    await send(evt, 'conv-1', 'hello');
+
+    expect(h.completeWithTools).toHaveBeenCalledTimes(2);
+    // The stale/absent container id is cleared before the retry.
+    expect(h.setContainerId).toHaveBeenCalledWith('conv-1', undefined, undefined);
+    expect(h.exitLLMContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-throws a non-container error but still exits the LLM context', async () => {
+    h.completeWithTools.mockRejectedValue(new Error('some other API failure'));
+
+    await expect(send(evt, 'conv-1', 'hello')).rejects.toThrow('some other API failure');
+
+    expect(h.completeWithTools).toHaveBeenCalledTimes(1); // no retry for a non-container error
+    expect(h.exitLLMContext).toHaveBeenCalledTimes(1);    // finally still ran
+  });
+
+  it('rejects a pending ask_user prompt when the send is aborted', async () => {
+    // The model calls ask_user, then a cancel arrives before the user answers.
+    h.completeWithTools.mockImplementation(async ({ callbacks }: { callbacks: { askUser: (q: { question: string }) => Promise<string> } }) => {
+      const answer = callbacks.askUser({ question: 'pick one?' });
+      cancel(evt); // abort mid-question
+      await expect(answer).rejects.toThrow('aborted');
+      return completion('unwound');
+    });
+
+    await expect(send(evt, 'conv-1', 'hello')).resolves.toBeDefined();
+  });
+});
+
+describe('CONVERSATION_FILE_DRAFT — propose + auto-approve (#1612)', () => {
+  it('files the draft through the approval engine and auto-approves it', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'proposal:abc' });
+    h.approveProposal.mockResolvedValue({ filedPaths: ['Filed.md'], rewrittenPaths: [] });
+
+    const draft = {
+      draftId: 'd1',
+      conversationId: 'conv-1',
+      payloads: [{ kind: 'note', relativePath: 'x.md', content: 'c' }],
+      note: 'a note',
+    };
+    const res = await fileDraft(evt, draft);
+
+    // Filed via proposeWrite with the conversation provenance…
+    expect(h.proposeWrite).toHaveBeenCalledTimes(1);
+    expect(h.proposeWrite.mock.calls[0]![1]).toMatchObject({
+      operationType: 'component_creation',
+      payloads: draft.payloads,
+      note: 'a note',
+      conversationUri: 'https://minerva.dev/ontology/thought#conversation/conv-1',
+      proposedBy: 'llm:conversation:conv-1',
+    });
+    // …then auto-approved (the user already accepted the inline card).
+    expect(h.approveProposal).toHaveBeenCalledWith(expect.anything(), 'proposal:abc');
+    expect(res).toEqual({ proposalUri: 'proposal:abc', applied: true, filedPaths: ['Filed.md'] });
+  });
+
+  it('does not approve when proposeWrite files nothing (empty bundle)', async () => {
+    h.proposeWrite.mockResolvedValue(null);
+
+    const draft = {
+      draftId: 'd2',
+      conversationId: 'conv-1',
+      payloads: [{ kind: 'note', relativePath: 'y.md', content: 'c' }],
+      note: 'n',
+    };
+    const res = await fileDraft(evt, draft);
+
+    expect(h.approveProposal).not.toHaveBeenCalled();
+    expect(res).toEqual({ proposalUri: null, applied: true, filedPaths: [] });
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -99,6 +99,19 @@ export default defineConfig({
           statements: 74,
           branches: 60,
         },
+        // IPC registrars — mostly thin channel→module glue that was entirely
+        // unfenced (QA C1 / #1612). The layer is deliberately low-covered (the
+        // underlying modules carry the real tests), so this is a BACKSTOP, not a
+        // target: it locks in the conversation-handler coverage (#1612) and
+        // stops a new registrar shipping at 0%. Measured ~27.6 L / 12.5 F /
+        // 25.3 S / 7.3 B; floors sit a few points below so a small change
+        // won't flap. Ratchet up as more handlers get direct tests.
+        'src/main/ipc/**': {
+          lines: 24,
+          functions: 10,
+          statements: 22,
+          branches: 5,
+        },
         // Neglected top-level main modules — previously unfenced (#1100 / QA
         // H1). These sit at `src/main/*.ts` (no directory of their own), so
         // each gets its own per-file floor set ~10pts below the measured-at-


### PR DESCRIPTION
Closes #1612.

`register-conversation.ts` is the LLM↔graph boundary the trust model governs, yet had **no main-process test**, and `src/main/ipc/**` had **no coverage floor** — the QA review's single Critical gap (C1).

## Test
New `tests/main/ipc/register-conversation.test.ts` captures the real handlers (via a mocked `electron` `ipcMain.handle`, following `registration.test.ts`) and drives them against mocked collaborators — the LLM client (`completeWithTools`), the conversation store, the approval engine, and the graph LLM-context guard:

- **`CONVERSATION_SEND` runs inside the graph LLM context** (`enterLLMContext` → `exitLLMContext`), the LLM is called once, and the assistant turn is persisted — and the context is **still released when the LLM call throws** (finally).
- **400-retry:** on the API's `container_id is required` error it clears the container id and retries **once**; a non-container error is re-thrown with **no** retry.
- **Abort:** cancelling a send **rejects a pending `ask_user` prompt** (the agent loop unwinds instead of hanging).
- **`CONVERSATION_FILE_DRAFT`:** files via `approval.proposeWrite` with the conversation provenance and **auto-approves** it; skips approve when `proposeWrite` files nothing.

A regression that drops the `enterLLMContext` wrap, the retry, or the propose/approve dispatch now fails here instead of silently at runtime.

## Coverage floor
Added a `src/main/ipc/**` threshold (**24 L / 10 F / 22 S / 5 B**). The IPC layer is deliberately low-covered (the underlying modules carry the real tests), so this is an honest **backstop** a few points below the measured ~27.6 / 12.5 / 25.3 / 7.3 — it locks in this PR's coverage and stops a new registrar shipping at 0%. Comment invites ratcheting up as more handlers get direct tests.

## Verification
`pnpm coverage` green (exit 0, the new floor passes); `pnpm lint` clean; the new suite passes (7 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
