### PR TITLE
refactor(graph): extract the excerpt indexer + shared index helpers (#1624)

### DIFF
--- a/src/main/graph/index-helpers.ts
+++ b/src/main/graph/index-helpers.ts
@@ -1,0 +1,45 @@
+/**
+ * Low-level graph-indexing helpers shared across the per-format indexers
+ * (note / source / excerpt / tables). Extracted from indexers.ts (#1624) so the
+ * per-format modules can import them without depending on the large indexers.ts
+ * — keeping the split acyclic. Depends only on `./state` (a leaf).
+ */
+import fsSync from 'node:fs';
+import path from 'node:path';
+import { STANDARD_PREFIXES, type GraphState } from './state';
+
+/** Disk mtime of a note/source/excerpt file as an ISO string; falls back to
+ *  `now()` when the file can't be stat'd (#336). */
+export function fileMtimeIso(state: GraphState, relativePath: string): string {
+  try {
+    return fsSync.statSync(path.join(state.rootPath, relativePath)).mtime.toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+/** Prepend any missing standard + project-scoped (`sources:` / `excerpts:` /
+ *  `this:`) `@prefix` declarations to a turtle block before it's parsed. */
+export function injectPrefixes(state: GraphState, turtle: string, noteIri: string): string {
+  const lines: string[] = [];
+  for (const [prefix, iri] of STANDARD_PREFIXES) {
+    if (!turtle.includes(`@prefix ${prefix}:`)) {
+      lines.push(`@prefix ${prefix}: <${iri}> .`);
+    }
+  }
+  // Project-scoped shortcuts for referring to other sources/excerpts in
+  // this thoughtbase by bare id: `sources:smith-2023`, `excerpts:p42`.
+  if (state.baseUri) {
+    if (!turtle.includes('@prefix sources:')) {
+      lines.push(`@prefix sources: <${state.baseUri}source/> .`);
+    }
+    if (!turtle.includes('@prefix excerpts:')) {
+      lines.push(`@prefix excerpts: <${state.baseUri}excerpt/> .`);
+    }
+  }
+  if (!turtle.includes('@prefix this:')) {
+    lines.push(`@prefix this: <${noteIri}> .`);
+  }
+  lines.push('');
+  return lines.join('\n') + turtle;
+}

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -46,9 +46,12 @@ export {
   indexNote, indexCsvTable, unindexCsvTable, unindexAllCsvTables,
   indexMarkdownTable, unindexMarkdownTable, unindexAllNoteTables,
   removeNote, indexSource, removeSource, parseSourceIdFromPath,
-  indexExcerpt, removeExcerpt, excerptIdsForSource, parseExcerptIdFromPath,
   indexAllNotes, reloadTypeCatalog,
 } from './indexers';
+// Per-format indexers extracted from ./indexers (#1624):
+export {
+  indexExcerpt, removeExcerpt, excerptIdsForSource, parseExcerptIdFromPath,
+} from './indexers/excerpt';
 export type { CsvTableColumn, CsvTableShape, MarkdownTableShape, HeadingRenameCandidate } from './indexers';
 import { addOntologyToStore } from './indexers';
 

--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -15,7 +15,6 @@
 
 import * as $rdf from 'rdflib';
 import fs from 'node:fs/promises';
-import fsSync from 'node:fs';
 import path from 'node:path';
 import { parseMarkdown, type ParsedTable, type FrontmatterValue, type FrontmatterMap } from './parser';
 import { getLinkType, type LinkType } from '../../shared/link-types';
@@ -37,7 +36,6 @@ import {
   type GraphState, type HeadingSnapshot,
   getState, invalidate, resetN3Mirror, instrumentStoreMirror,
   MINERVA, DC, RDF, RDFS, XSD, CSVW, OWL, BIBO, SCHEMA, PROV, THOUGHT, TYPES,
-  STANDARD_PREFIXES,
   noteUri, tagUri, folderUri, sourceUri, excerptUri, tableUri, projectUri,
   linkPredicate, dateLit,
 } from './state';
@@ -46,6 +44,8 @@ import { materializeTypeClasses } from '../types/compile';
 import type { PropertyType } from '../../shared/objects/type-def';
 
 import { checkLLMWriteGuard } from './write-guard';
+import { fileMtimeIso, injectPrefixes } from './index-helpers';
+import { walkAndIndexExcerpts } from './indexers/excerpt';
 
 // `findNotesLinkingToAnchorImpl` is a queries-layer helper; detectHeadingRename
 // (an indexer-only helper below) reuses it.
@@ -440,38 +440,6 @@ function coerceDeclared(
  * `now` only when the file is gone (mid-rename race) so the triple is
  * still well-formed.
  */
-function fileMtimeIso(state: GraphState, relativePath: string): string {
-  try {
-    return fsSync.statSync(path.join(state.rootPath, relativePath)).mtime.toISOString();
-  } catch {
-    return new Date().toISOString();
-  }
-}
-
-function injectPrefixes(state: GraphState, turtle: string, noteIri: string): string {
-  const lines: string[] = [];
-  for (const [prefix, iri] of STANDARD_PREFIXES) {
-    if (!turtle.includes(`@prefix ${prefix}:`)) {
-      lines.push(`@prefix ${prefix}: <${iri}> .`);
-    }
-  }
-  // Project-scoped shortcuts for referring to other sources/excerpts in
-  // this thoughtbase by bare id: `sources:smith-2023`, `excerpts:p42`.
-  if (state.baseUri) {
-    if (!turtle.includes('@prefix sources:')) {
-      lines.push(`@prefix sources: <${state.baseUri}source/> .`);
-    }
-    if (!turtle.includes('@prefix excerpts:')) {
-      lines.push(`@prefix excerpts: <${state.baseUri}excerpt/> .`);
-    }
-  }
-  if (!turtle.includes('@prefix this:')) {
-    lines.push(`@prefix this: <${noteIri}> .`);
-  }
-  lines.push('');
-  return lines.join('\n') + turtle;
-}
-
 // ── Heading snapshots ──────────────────────────────────────────────────────
 // HeadingSnapshot moved up into per-project state (#333). Snapshots live
 // on `state.headingsPerNote` — used by indexNote to spot the case where
@@ -561,11 +529,6 @@ export interface IndexNoteOptions {
   linkCtx?: LinkResolveCtx;
 }
 
-// indexNote is an async-by-contract public API: callers `await` it across
-// the project (ipc, write-pipeline, watchers, rename), and we want the
-// freedom to add real async work later without rippling out a signature
-// change. The current body happens to be sync.
-// eslint-disable-next-line @typescript-eslint/require-await
 type ParsedNote = ReturnType<typeof parseMarkdown>;
 
 /** Note type + title + filename/path + disk mtime + folder + project membership
@@ -1361,85 +1324,6 @@ export function parseSourceIdFromPath(relativePath: string): string | null {
   return id;
 }
 
-// ── Excerpt indexing ────────────────────────────────────────────────────────
-// An "excerpt" is a verbatim quotation lifted from a Source, stored at
-// .minerva/excerpts/<id>.ttl. The excerpt node's URI is `${baseUri}excerpt/<id>`.
-// Inside the .ttl file, `this:` resolves to that URI, and `sources:` resolves
-// to `${baseUri}source/`, so users can write:
-//   this: a thought:Excerpt ;
-//       thought:fromSource sources:smith-2023 ;
-//       thought:citedText "..." ;
-//       thought:page 42 .
-
-export function indexExcerpt(ctx: ProjectContext, excerptId: string, metaTtl: string): void {
-  checkLLMWriteGuard('indexExcerpt');
-  const state = getState(ctx);
-  if (!state) return;
-  invalidate(state);
-  const { store } = state;
-
-  const subject = excerptUri(state, excerptId);
-  const graph = subject;
-  const relativePath = `${uriHelpers.EXCERPTS_DIR}/${excerptId}.ttl`;
-
-  store.removeMatches(undefined, undefined, undefined, graph);
-  store.removeMatches(subject, undefined, undefined);
-
-  store.add(subject, MINERVA('excerptId'), $rdf.lit(excerptId), graph);
-  store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
-  store.add(subject, DC('modified'), dateLit(fileMtimeIso(state, relativePath)), graph);
-  store.add(projectUri(state), MINERVA('containsExcerpt'), subject, graph);
-
-  try {
-    const prefixed = injectPrefixes(state, metaTtl, subject.value);
-    $rdf.parse(prefixed, store, graph.value, 'text/turtle');
-  } catch (e) {
-    console.error(`[minerva] Failed to parse excerpt ttl for ${excerptId}:`, e instanceof Error ? e.message : e);
-  }
-}
-
-export function removeExcerpt(ctx: ProjectContext, excerptId: string): void {
-  checkLLMWriteGuard('removeExcerpt');
-  const state = getState(ctx);
-  if (!state) return;
-  invalidate(state);
-  const { store } = state;
-  const subject = excerptUri(state, excerptId);
-  store.removeMatches(undefined, undefined, undefined, subject);
-  store.removeMatches(subject, undefined, undefined);
-}
-
-/**
- * Every excerpt-id with thought:fromSource pointing at the given source.
- * Used by the source-delete path to cascade-remove orphaned excerpts.
- */
-export function excerptIdsForSource(ctx: ProjectContext, sourceId: string): string[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  const { store } = state;
-  const subject = sourceUri(state, sourceId);
-  const stmts = store.statementsMatching(undefined, THOUGHT('fromSource'), subject);
-  const ids: string[] = [];
-  const seen = new Set<string>();
-  for (const st of stmts) {
-    const idStmts = store.statementsMatching(st.subject, MINERVA('excerptId'), undefined);
-    const id = idStmts[0]?.object.value;
-    if (id && !seen.has(id)) { seen.add(id); ids.push(id); }
-  }
-  return ids;
-}
-
-/** Parse `<id>` out of `.minerva/excerpts/<id>.ttl`. Returns null for other paths. */
-export function parseExcerptIdFromPath(relativePath: string): string | null {
-  const normalized = relativePath.replace(/\\/g, '/');
-  const prefix = `${uriHelpers.EXCERPTS_DIR}/`;
-  if (!normalized.startsWith(prefix)) return null;
-  if (!normalized.endsWith('.ttl')) return null;
-  const id = normalized.slice(prefix.length, -'.ttl'.length);
-  if (!id || id.includes('/')) return null;
-  return id;
-}
-
 function ensureTag(state: GraphState, tagNode: $rdf.NamedNode, tagName: string): void {
   const { store } = state;
   const existing = store.statementsMatching(tagNode, RDF('type'), MINERVA('Tag'));
@@ -1673,26 +1557,3 @@ async function walkAndIndexSources(ctx: ProjectContext, rootPath: string): Promi
   return count;
 }
 
-async function walkAndIndexExcerpts(ctx: ProjectContext, rootPath: string): Promise<number> {
-  const excerptsRoot = path.join(rootPath, uriHelpers.EXCERPTS_DIR);
-  let count = 0;
-  let entries: import('node:fs').Dirent[];
-  try {
-    entries = await fs.readdir(excerptsRoot, { withFileTypes: true });
-  } catch {
-    return 0;
-  }
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith('.ttl')) continue;
-    const excerptId = entry.name.slice(0, -'.ttl'.length);
-    const filePath = path.join(excerptsRoot, entry.name);
-    try {
-      const content = await fs.readFile(filePath, 'utf-8');
-      indexExcerpt(ctx, excerptId, content);
-      count++;
-    } catch {
-      // Couldn't read — skip
-    }
-  }
-  return count;
-}

--- a/src/main/graph/indexers/excerpt.ts
+++ b/src/main/graph/indexers/excerpt.ts
@@ -1,0 +1,119 @@
+/**
+ * Excerpt indexing (#1624 — split by format out of indexers.ts).
+ *
+ * An "excerpt" is a verbatim quotation lifted from a Source, stored at
+ * `.minerva/excerpts/<id>.ttl`. The excerpt node's URI is `${baseUri}excerpt/<id>`.
+ * Inside the .ttl file, `this:` resolves to that URI and `sources:` resolves to
+ * `${baseUri}source/`, so users can write:
+ *   this: a thought:Excerpt ;
+ *       thought:fromSource sources:smith-2023 ;
+ *       thought:citedText "..." ;
+ *       thought:page 42 .
+ */
+import * as $rdf from 'rdflib';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as uriHelpers from '../uri-helpers';
+import type { ProjectContext } from '../../project-context-types';
+import {
+  getState, invalidate,
+  MINERVA, DC, THOUGHT,
+  projectUri, sourceUri, excerptUri, dateLit,
+} from '../state';
+import { checkLLMWriteGuard } from '../write-guard';
+import { fileMtimeIso, injectPrefixes } from '../index-helpers';
+
+export function indexExcerpt(ctx: ProjectContext, excerptId: string, metaTtl: string): void {
+  checkLLMWriteGuard('indexExcerpt');
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const { store } = state;
+
+  const subject = excerptUri(state, excerptId);
+  const graph = subject;
+  const relativePath = `${uriHelpers.EXCERPTS_DIR}/${excerptId}.ttl`;
+
+  store.removeMatches(undefined, undefined, undefined, graph);
+  store.removeMatches(subject, undefined, undefined);
+
+  store.add(subject, MINERVA('excerptId'), $rdf.lit(excerptId), graph);
+  store.add(subject, MINERVA('relativePath'), $rdf.lit(relativePath), graph);
+  store.add(subject, DC('modified'), dateLit(fileMtimeIso(state, relativePath)), graph);
+  store.add(projectUri(state), MINERVA('containsExcerpt'), subject, graph);
+
+  try {
+    const prefixed = injectPrefixes(state, metaTtl, subject.value);
+    $rdf.parse(prefixed, store, graph.value, 'text/turtle');
+  } catch (e) {
+    console.error(`[minerva] Failed to parse excerpt ttl for ${excerptId}:`, e instanceof Error ? e.message : e);
+  }
+}
+
+export function removeExcerpt(ctx: ProjectContext, excerptId: string): void {
+  checkLLMWriteGuard('removeExcerpt');
+  const state = getState(ctx);
+  if (!state) return;
+  invalidate(state);
+  const { store } = state;
+  const subject = excerptUri(state, excerptId);
+  store.removeMatches(undefined, undefined, undefined, subject);
+  store.removeMatches(subject, undefined, undefined);
+}
+
+/**
+ * Every excerpt-id with thought:fromSource pointing at the given source.
+ * Used by the source-delete path to cascade-remove orphaned excerpts.
+ */
+export function excerptIdsForSource(ctx: ProjectContext, sourceId: string): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+  const subject = sourceUri(state, sourceId);
+  const stmts = store.statementsMatching(undefined, THOUGHT('fromSource'), subject);
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const st of stmts) {
+    const idStmts = store.statementsMatching(st.subject, MINERVA('excerptId'), undefined);
+    const id = idStmts[0]?.object.value;
+    if (id && !seen.has(id)) { seen.add(id); ids.push(id); }
+  }
+  return ids;
+}
+
+/** Parse `<id>` out of `.minerva/excerpts/<id>.ttl`. Returns null for other paths. */
+export function parseExcerptIdFromPath(relativePath: string): string | null {
+  const normalized = relativePath.replace(/\\/g, '/');
+  const prefix = `${uriHelpers.EXCERPTS_DIR}/`;
+  if (!normalized.startsWith(prefix)) return null;
+  if (!normalized.endsWith('.ttl')) return null;
+  const id = normalized.slice(prefix.length, -'.ttl'.length);
+  if (!id || id.includes('/')) return null;
+  return id;
+}
+
+/** Walk `.minerva/excerpts/*.ttl` and index each — the excerpt half of a full
+ *  `indexAllNotes` pass. Returns the count indexed. */
+export async function walkAndIndexExcerpts(ctx: ProjectContext, rootPath: string): Promise<number> {
+  const excerptsRoot = path.join(rootPath, uriHelpers.EXCERPTS_DIR);
+  let count = 0;
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(excerptsRoot, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.ttl')) continue;
+    const excerptId = entry.name.slice(0, -'.ttl'.length);
+    const filePath = path.join(excerptsRoot, entry.name);
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      indexExcerpt(ctx, excerptId, content);
+      count++;
+    } catch {
+      // Couldn't read — skip
+    }
+  }
+  return count;
+}


### PR DESCRIPTION
Part of #1624 — the **first** of the per-format `indexers.ts` splits (arch D1, "one format per PR").

## What
- **New `graph/index-helpers.ts`** (leaf module): the two low-level helpers every format indexer needs — `fileMtimeIso` + `injectPrefixes` — moved out of `indexers.ts`. It depends only on `./state`, so the format modules can import from it without depending back on the big `indexers.ts` — keeping the split **acyclic**.
- **New `graph/indexers/excerpt.ts`**: the excerpt cluster (`indexExcerpt`, `removeExcerpt`, `excerptIdsForSource`, `parseExcerptIdFromPath`) plus its `walkAndIndexExcerpts` walker. The walker moves **with** the format so `indexAllNotes` imports it (one direction) rather than the excerpt module importing back into `indexers.ts` (which would cycle).
- `indexers.ts` imports the two helpers + the walker; the **graph facade** re-exports the excerpt functions from the new module, so every external caller (which goes through `graph/index`) is unchanged.

`indexers.ts`: **1669 → 1559 lines**.

## Why this shape
Every format is reachable from inside `indexers.ts` (via `indexNote` or an `indexAllNotes` walker), so a clean split needs the shared low-level helpers in a leaf. `index-helpers.ts` is that leaf; subsequent format extractions (source, tables, note-file-types) will follow the same pattern.

## Verification
Pure relocation. Full graph suite (**440 tests / 53 files**) green; `pnpm lint` clean; no direct `./indexers` imports of the moved functions (all via the facade).

Incidentally: removing the excerpt code made the (type-aware, flaky) `require-await` stop firing on `indexNote`, so the misplaced `#1624` disable directive is dropped here.

## Follow-ups
`source`, `tables`, and note-file-type (`.ttl`/`.csv`/`.py`) indexers, each as its own PR on this same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
