### PR TITLE
test(sources): make the due-date test helper timezone-independent (#1665)

### DIFF
--- a/tests/renderer/source-display.test.ts
+++ b/tests/renderer/source-display.test.ts
@@ -11,11 +11,18 @@ import {
 // helpers depend on "today", so those cases use offsets from the current date
 // rather than hard-coded strings.
 
+// Formats the *local* calendar date, deliberately not `toISOString()`: that
+// serializes in UTC, so a local-midnight Date in any zone east of UTC renders
+// as the previous day (in UTC+2, `isoDaysFromNow(0)` yielded yesterday and the
+// "due today" case below asserted the opposite of what it meant to). The
+// helpers under test parse `${iso}T00:00:00` — local midnight — so the offsets
+// have to be local too.
 const isoDaysFromNow = (days: number): string => {
   const d = new Date();
   d.setHours(0, 0, 0, 0);
   d.setDate(d.getDate() + days);
-  return d.toISOString().slice(0, 10);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 };
 
 describe('formatCreators', () => {


### PR DESCRIPTION
Closes #1665

`isoDaysFromNow` in `tests/renderer/source-display.test.ts` normalizes to **local** midnight with `setHours(0, 0, 0, 0)`, then serializes with `toISOString()`, which renders in **UTC**. In any zone east of UTC that lands on the previous day:

```
d.setHours(0,0,0,0)          → 2026-08-02T00:00:00+02:00   (local midnight, CEST)
d.toISOString().slice(0,10)  → "2026-08-01"                (UTC — yesterday)
```

So `isoDaysFromNow(0)` — meant to be "today" — produces yesterday, and this case asserts the opposite of what it says:

```ts
expect(isOverdue(isoDaysFromNow(0))).toBe(false); // due today is not overdue
```

It fails for every contributor east of Greenwich. CI runs UTC, where local midnight serializes to the same date, so `main` is green while `pnpm test` fails locally across Europe, Africa east of GMT, Asia and Australia.

### Fix

Format the local calendar date instead of round-tripping through UTC. This matches the helpers under test — `isOverdue` and `formatDueStamp` both parse `${iso}T00:00:00`, i.e. local midnight — so the fixture and the code now agree on one frame.

`isOverdue` itself is unchanged and was never wrong; the bug is entirely in the test fixture.

### Verification

`tests/renderer/source-display.test.ts` under `TZ=…`:

| Zone | Offset | Before | After |
|---|---|---|---|
| `UTC` | ±0 | 7/7 | 7/7 |
| `Europe/Berlin` | +2 | **1 failed** | 7/7 |
| `Pacific/Kiritimati` | +14 | **1 failed** | 7/7 |
| `Asia/Kolkata` | +5:30 | — | 7/7 |
| `America/Los_Angeles` | −7 | 7/7 | 7/7 |
| `Pacific/Midway` | −11 | 7/7 | 7/7 |

`pnpm lint` clean. `pnpm coverage` — the gate CI runs — exits 0: 543 files, 5387 tests, all thresholds met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
