### PR TITLE
refactor(objects): extract optionalTypeFields for the Edit/Duplicate spread (#1603)

### DIFF
--- a/src/renderer/lib/components/ObjectTypesSettings.svelte
+++ b/src/renderer/lib/components/ObjectTypesSettings.svelte
@@ -13,7 +13,7 @@
   import { getDialogStore } from '../stores/dialogs.svelte';
   import { getToastStore } from '../stores/toasts.svelte';
   import TypeEditorDialog from './TypeEditorDialog.svelte';
-  import type { TypeEditorInitial } from './type-editor-value';
+  import { optionalTypeFields, type TypeEditorInitial } from './type-editor-value';
   import type { TypeInfo } from '../../../shared/objects/type-def';
 
   const { showConfirm, showPrompt } = getDialogStore();
@@ -29,10 +29,7 @@
   function openEdit(t: TypeInfo): void {
     editorInitial = {
       id: t.id, label: t.label, properties: t.properties,
-      ...(t.icon ? { icon: t.icon } : {}), ...(t.color ? { color: t.color } : {}),
-      ...(t.cover ? { cover: t.cover } : {}), ...(t.card ? { card: t.card } : {}),
-      ...(t.parent ? { parent: t.parent } : {}),
-      ...(t.template ? { template: t.template } : {}),
+      ...optionalTypeFields(t),
     };
     editorOpen = true;
   }
@@ -57,12 +54,7 @@
       await objectTypesStore.save({
         label: `${t.label} copy`,
         properties: t.properties,
-        ...(t.icon ? { icon: t.icon } : {}),
-        ...(t.color ? { color: t.color } : {}),
-        ...(t.cover ? { cover: t.cover } : {}),
-        ...(t.card ? { card: t.card } : {}),
-        ...(t.parent ? { parent: t.parent } : {}),
-        ...(t.template ? { template: t.template } : {}),
+        ...optionalTypeFields(t),
       });
     } finally { busy = false; }
   }

--- a/src/renderer/lib/components/type-editor-value.ts
+++ b/src/renderer/lib/components/type-editor-value.ts
@@ -3,7 +3,7 @@
  * type (Edit), or a note-derived draft ("Save Note as Object Type"). Kept in a
  * plain module so both the dialog and its hosts can import it as a type.
  */
-import type { PropertyDef } from '../../../shared/objects/type-def';
+import type { PropertyDef, TypeInfo } from '../../../shared/objects/type-def';
 
 export interface TypeEditorInitial {
   /** Set when editing — the id stays fixed while the label may change. */
@@ -17,4 +17,22 @@ export interface TypeEditorInitial {
   parent?: string;
   properties: PropertyDef[];
   template?: string;
+}
+
+/** A type's optional carry-over fields (icon / color / cover / card / parent /
+ *  template), spread only when set. Shared by the Type Manager's Edit and
+ *  Duplicate paths so a newly-added optional type field can't be threaded into
+ *  one and missed by the other — the exact gap `parent` nearly fell into in
+ *  #1587 (#1603). */
+export function optionalTypeFields(
+  t: TypeInfo,
+): { icon?: string; color?: string; cover?: string; card?: string[]; parent?: string; template?: string } {
+  return {
+    ...(t.icon ? { icon: t.icon } : {}),
+    ...(t.color ? { color: t.color } : {}),
+    ...(t.cover ? { cover: t.cover } : {}),
+    ...(t.card ? { card: t.card } : {}),
+    ...(t.parent ? { parent: t.parent } : {}),
+    ...(t.template ? { template: t.template } : {}),
+  };
 }


### PR DESCRIPTION
Closes #1603.

The Type Manager's **Edit** (`openEdit`) and **Duplicate** paths both spread a type's optional carry-over fields with the identical six-line cascade:

```ts
...(t.icon ? { icon: t.icon } : {}), ...(t.color ? { color: t.color } : {}),
...(t.cover ? { cover: t.cover } : {}), ...(t.card ? { card: t.card } : {}),
...(t.parent ? { parent: t.parent } : {}), ...(t.template ? { template: t.template } : {}),
```

Adding a new optional type field means remembering to thread it into **both** — the exact gap `parent` nearly fell into in #1587.

## Fix
Extract **`optionalTypeFields(t)`** into `type-editor-value.ts` and call it at both sites. The return is annotated `{ icon?: string; … }` rather than `Partial<Pick<TypeInfo, …>>`, because the latter carries `| undefined` (from `TypeInfo`) which the never-`undefined` conditional spread and the `SaveTypeInput` / `TypeEditorInitial` targets reject under `exactOptionalPropertyTypes`.

## Scope note
The issue also listed `TypeEditorDialog.save()` and `toTypeInfo`, but on inspection those are **different shapes** — `save()` spreads *form* fields with their own conditions (`trim()` / `propNames.includes` / `length > 0`), and `toTypeInfo` is an unconditional field-by-field copy. Neither shares the conditional `TypeInfo`-spread, so they're intentionally left alone; consolidating them would add indirection without removing real duplication.

## Verification
Behaviour-preserving. `ObjectTypesSettings` + `TypeEditorDialog` suites (**14**) green; `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
