### PR TITLE
refactor(app): extract reportBulkSummary for the bulk tag/property reporters (#1604)

### DIFF
--- a/src/renderer/lib/app/refactor-ops.svelte.ts
+++ b/src/renderer/lib/app/refactor-ops.svelte.ts
@@ -462,6 +462,17 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     }
   }
 
+  /** Show a bulk-op result dialog: the primary summary line, plus a capped
+   *  "Failed (N)" list when any note errored. Shared by the tag + property
+   *  reporters (#1604). */
+  async function reportBulkSummary(primary: string, failures: OperationFailure[], confirmKey: string): Promise<void> {
+    let msg = primary;
+    if (failures.length > 0) {
+      msg += `\n\nFailed (${failures.length}):\n${formatCappedList(failures, (f) => `• ${f.path}: ${f.error}`)}`;
+    }
+    await showConfirm(msg, confirmKey, 'OK');
+  }
+
   async function reportBulkTagSummary(
     op: 'Add' | 'Remove',
     tag: string,
@@ -470,11 +481,10 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     failures: OperationFailure[],
   ): Promise<void> {
     const verb = op === 'Add' ? 'tagged' : 'untagged';
-    let msg = `${verb} ${changed} of ${total} note${total === 1 ? '' : 's'} with "${tag}".`;
-    if (failures.length > 0) {
-      msg += `\n\nFailed (${failures.length}):\n${formatCappedList(failures, (f) => `• ${f.path}: ${f.error}`)}`;
-    }
-    await showConfirm(msg, CONFIRM_KEYS.bulkTagComplete, 'OK');
+    await reportBulkSummary(
+      `${verb} ${changed} of ${total} note${total === 1 ? '' : 's'} with "${tag}".`,
+      failures, CONFIRM_KEYS.bulkTagComplete,
+    );
   }
 
   /**
@@ -592,11 +602,10 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     failures: OperationFailure[],
   ): Promise<void> {
     const verb = op === 'Add' ? 'set' : 'removed';
-    let msg = `${verb} "${key}" on ${changed} of ${total} note${total === 1 ? '' : 's'}.`;
-    if (failures.length > 0) {
-      msg += `\n\nFailed (${failures.length}):\n${formatCappedList(failures, (f) => `• ${f.path}: ${f.error}`)}`;
-    }
-    await showConfirm(msg, CONFIRM_KEYS.bulkPropertyComplete, 'OK');
+    await reportBulkSummary(
+      `${verb} "${key}" on ${changed} of ${total} note${total === 1 ? '' : 's'}.`,
+      failures, CONFIRM_KEYS.bulkPropertyComplete,
+    );
   }
 
   /**


### PR DESCRIPTION
Closes #1604.

`reportBulkTagSummary` and `reportBulkPropertySummary` shared an identical tail — append a capped `Failed (N)` list when any note errored, then `showConfirm`. Extract **`reportBulkSummary(primary, failures, confirmKey)`**; the two reporters are now thin wrappers that build their domain-specific primary line ("tagged N of M with X" / "set X on N of M") and confirm key.

## Scope note
The issue also suggested a `runBulkFrontmatterEdit(targets, transform)` to unify the four handlers' write loops. On inspection those loops **genuinely differ**: the **Add** handlers read each file *inside the loop* (`readFile` → transform → write), while the **Remove** handlers reuse a **pre-read cache** from the union-of-keys suggestion pass and *skip* cache-misses (`if (!cache.has(path)) continue`). A shared loop would need to abstract the content source and the skip behavior, trading readability for a forced abstraction — so it's intentionally left as-is. The real shared block was the summary tail, which this removes.

## Verification
Behaviour-preserving — identical dialog output. `refactor-ops` suite (**58 tests**) green; `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
