### PR TITLE
build(tooling): pin pnpm via packageManager field, derive CI version from it (#1644)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,9 +34,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up pnpm
+        # Version comes from the `packageManager` field in package.json.
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Set up Node
         uses: actions/setup-node@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up pnpm
+        # Version comes from the `packageManager` field in package.json.
         uses: pnpm/action-setup@v6
-        with:
-          # Match the local dev version. Bump together with the dev's pnpm.
-          version: 10
 
       - name: Set up Node
         uses: actions/setup-node@v7
@@ -112,9 +110,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up pnpm
+        # Version comes from the `packageManager` field in package.json.
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Set up Node
         uses: actions/setup-node@v7
@@ -143,9 +140,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up pnpm
+        # Version comes from the `packageManager` field in package.json.
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Set up Node
         uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up pnpm
+        # Version comes from the `packageManager` field in package.json.
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Set up Node
         uses: actions/setup-node@v7

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "license": "MIT",
+  "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
Closes #1644.

pnpm's version was hardcoded as `version: 10` in three workflows (`ci.yml`, `bench.yml`, `release.yml`) with no single source of truth.

- Add `"packageManager": "pnpm@10.33.0"` to `package.json` (matches the local `pnpm --version`; Corepack-compatible).
- Drop the hardcoded `version:` from each `pnpm/action-setup@v6` step — the action derives the version from the `packageManager` field when none is given.

Now bumping pnpm is a one-line change in `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)