### PR TITLE
refactor(graph): promote firstObjectValue helper in queries.ts (#1607)

### DIFF
--- a/src/main/graph/queries.ts
+++ b/src/main/graph/queries.ts
@@ -869,6 +869,19 @@ function collectSourceReferences(state: GraphState, sourceSubject: $rdf.NamedNod
   return out;
 }
 
+/**
+ * First object value for (subject, pred) in the store, or null — collapses the
+ * `store.statementsMatching(s, p)[0]?.object.value ?? null` idiom that recurs
+ * across these RDF extractors (#1607).
+ */
+function firstObjectValue(
+  store: $rdf.IndexedFormula,
+  subject: $rdf.NamedNode,
+  pred: ReturnType<typeof MINERVA>,
+): string | null {
+  return store.statementsMatching(subject, pred, undefined)[0]?.object.value ?? null;
+}
+
 function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rdf.NamedNode): SourceMetadata {
   const { store } = state;
 
@@ -890,10 +903,7 @@ function collectSourceMetadata(state: GraphState, sourceId: string, subject: $rd
     if (!creators.includes(v)) creators.push(v);
   }
 
-  const first = (pred: ReturnType<typeof MINERVA>): string | null => {
-    const stmts = store.statementsMatching(subject, pred, undefined);
-    return stmts[0]?.object.value ?? null;
-  };
+  const first = (pred: ReturnType<typeof MINERVA>): string | null => firstObjectValue(store, subject, pred);
 
   const issued = first(DC('issued'));
   const rawReadStatus = first(MINERVA('readStatus'));
@@ -1046,10 +1056,7 @@ function collectExcerptsForSource(state: GraphState, sourceSubject: $rdf.NamedNo
     if (!id || seen.has(id)) continue;
     seen.add(id);
 
-    const first = (pred: ReturnType<typeof MINERVA>): string | null => {
-      const s = store.statementsMatching(ex, pred, undefined);
-      return s[0]?.object.value ?? null;
-    };
+    const first = (pred: ReturnType<typeof MINERVA>): string | null => firstObjectValue(store, ex, pred);
 
     excerpts.push({
       excerptId: id,


### PR DESCRIPTION
Closes #1607.

`const first = (pred) => store.statementsMatching(subject, pred)[0]?.object.value ?? null` was defined identically in `collectSourceMetadata` (:893) and `collectExcerptsForSource` (:1049).

- Hoist a module-level `firstObjectValue(store, subject, pred)` (typed `pred: ReturnType<typeof MINERVA>` to match the RDF/JS `NamedNode` the namespace helpers return).
- Collapse both local `first` closures to one-line delegations, so call sites (`first(DC('title'))`, …) stay unchanged.

## Verification
- `pnpm lint` clean.
- Full `tests/main/graph/` suite green (53 files / 440 tests), including `citations-for-note`, `anchor-links`, and the parser suites the review flagged as coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)