### PR TITLE
docs: fix dev-doc lint-description drift + document the svelte-check gotcha (#1646)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Pre-push lint gate (#690).
 #
-# Runs the fast `pnpm lint` (tsc + svelte-check + eslint, ~30s) before a push so
+# Runs the fast `pnpm lint` (tsc + svelte-check + eslint, ~50s) before a push so
 # an obvious type/template/lint failure is caught locally instead of burning a
 # slow macos-latest CI run. Pre-push (not pre-commit) keeps commits frictionless.
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Minerva is a desktop markdown IDE built with Electron + Svelte 5 + TypeScript. I
 ## Commands
 
 - `pnpm dev` — Start the dev server (electron-forge + Vite HMR)
-- `pnpm lint` — Type check: `tsc --noEmit` for `.ts` files, then `svelte-check --threshold error` for `.svelte` files (script/template drift, undefined references, wrong prop types). Warnings (a11y, state-referenced-locally) are not fatal.
+- `pnpm lint` — Full static-check gate: `tsc --noEmit` (`.ts` type errors), then `svelte-check --threshold error` (`.svelte` script/template drift, undefined references, wrong prop types), then `eslint .` (lint rules, incl. the renderer data-flow rule). Note `svelte-check` — not `tsc` or `eslint` — is what catches script↔template drift in `.svelte` files. Warnings (a11y, state-referenced-locally) are not fatal.
 - `pnpm test` — Run tests once (vitest run). Use `pnpm test:watch` for the file-watcher loop.
 - `pnpm build` — Build distributable (electron-forge make)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,11 @@ lint gate before each push so obvious failures are caught locally instead of in
 CI. Bypass a single push with `git push --no-verify` (or `SKIP_HOOKS=1 git push`)
 if you need to.
 
+> **Gotcha:** in a `.svelte` file it's `svelte-check` — not `tsc` or `eslint` —
+> that catches script↔template drift (a template referencing a renamed/removed
+> binding, a wrong prop type). If a `.svelte` change looks fine but `pnpm lint`
+> still fails, read the `svelte-check` section of the output.
+
 ## Architecture in one screen
 
 Three processes with strict context isolation:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ pnpm install
 # Start dev server
 pnpm dev
 
-# Type check
+# Lint gate: tsc + svelte-check + eslint
 pnpm lint
 
 # Run tests


### PR DESCRIPTION
Closes #1646.

- **CLAUDE.md** described `pnpm lint` as a "Type check" (`tsc` + `svelte-check`) — it's now `tsc` + `svelte-check` + `eslint`. Rewritten to name all three passes.
- **README** labeled the same command `# Type check`; relabeled to the full gate.
- **.githooks/pre-push** comment said `~30s`; measured ~50s.
- Added a **contributor gotcha** (CLAUDE.md + CONTRIBUTING.md): in `.svelte` files it's `svelte-check` — not `tsc` or `eslint` — that catches script↔template drift.

Doc/comment-only; `CONTRIBUTING.md:53` was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)