### PR TITLE
refactor(menu): extract printFocusedWindowToPdf from buildFileMenu (#1627)

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -198,6 +198,28 @@ function buildRecentSubmenu(): Electron.MenuItemConstructorOptions[] {
     : [{ label: 'No Recent Thoughtbases', enabled: false }];
 }
 
+/**
+ * Print the focused window's rendered view to a user-chosen PDF (the File →
+ * Print to PDF… action). No-op if no window is focused or the save dialog is
+ * cancelled. Extracted from the menu entry's inline click for readability (#1627).
+ */
+async function printFocusedWindowToPdf(): Promise<void> {
+  const win = BrowserWindow.getFocusedWindow();
+  if (!win) return;
+  const result = await dialog.showSaveDialog(win, {
+    title: 'Export as PDF',
+    defaultPath: 'note.pdf',
+    filters: [{ name: 'PDF', extensions: ['pdf'] }],
+  });
+  if (result.canceled || !result.filePath) return;
+  const data = await win.webContents.printToPDF({
+    pageSize: 'Letter',
+    printBackground: true,
+  });
+  const fs = await import('node:fs/promises');
+  await fs.writeFile(result.filePath, data);
+}
+
 /** File menu — thoughtbase lifecycle, note actions, ingest/import, print, indexes. */
 function buildFileMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructorOptions {
   return {
@@ -298,23 +320,7 @@ function buildFileMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
       }, { note: true }),
       gate({
         label: 'Print to PDF…',
-        click: async () => {
-          const win = BrowserWindow.getFocusedWindow();
-          if (!win) return;
-          const result = await dialog.showSaveDialog(win, {
-            title: 'Export as PDF',
-            defaultPath: 'note.pdf',
-            filters: [{ name: 'PDF', extensions: ['pdf'] }],
-          });
-          if (!result.canceled && result.filePath) {
-            const data = await win.webContents.printToPDF({
-              pageSize: 'Letter',
-              printBackground: true,
-            });
-            const fs = await import('node:fs/promises');
-            await fs.writeFile(result.filePath, data);
-          }
-        },
+        click: printFocusedWindowToPdf,
       }, { note: true }),
       { type: 'separator' },
       {


### PR DESCRIPTION
Closes #1627.

The File → Print to PDF… menu entry embedded ~18 lines of save-dialog + `printToPDF` + file-write inside its `click`. Hoisted it to a named `printFocusedWindowToPdf()` and pointed the entry at it (`click: printFocusedWindowToPdf`).

Pure extraction — the only shape change is an early-return on the no-window / cancelled-dialog path (was a nested `if`); behaviour is identical.

## Verification
- `pnpm lint` clean.
- `menu-accelerators.test.ts` green (the menu builders' only automated coverage). The Print action itself is runtime-only; the extraction preserves it verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)