### PR TITLE
docs: require a test + coverage threshold for new IPC handlers (#1616)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,7 @@ When reviewing PRs that touch LLM integration or graph write paths:
 - [ ] Does the code create `thought:Proposal` nodes for operations that require approval?
 - [ ] Is there a SPARQL integrity check that could detect if this write bypassed approval?
 - [ ] Are there tests that verify the approval gate cannot be skipped?
+- [ ] Does every new `register-*` IPC handler ship with a main-process test, and is its module covered by a `vitest.config.mts` threshold? An untested handler is how the `CONVERSATION_SEND` gap slipped in (#1612) — a new handler needs both a test and threshold enrollment so it can't silently regress.
 
 ### Write Guard
 


### PR DESCRIPTION
Closes #1616.

Adds a line to the *Code Review Checklist for LLM/Graph PRs* in `CLAUDE.md` requiring that every new `register-*` IPC handler ship with a main-process test and be covered by a `vitest.config.mts` threshold — encoding the "new handler ⇒ test + threshold" rule so ungated handlers (like the `CONVERSATION_SEND` gap that motivated #1612) stop appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)