### PR TITLE
docs: document the type-catalog loader's process/test scoping (#1630)

### DIFF
--- a/src/main/types/loader.ts
+++ b/src/main/types/loader.ts
@@ -7,6 +7,15 @@
  *
  * Loading is additive and stock wins id collisions: a user type can't shadow a
  * stock type.
+ *
+ * Process / test note (#1630): the stock set is a build-time module-global — the
+ * `?raw` glob below, one immutable copy per process. Crucially, unlike the tool
+ * registry's *mutable* module-global `Map` (`shared/tools/registry.ts`, whose
+ * doc explains why tests must reset it), `loadTypeCatalog` returns a FRESH
+ * catalog on every call, held on the per-project `GraphState`
+ * (`state.typeCatalog`) — there is no shared mutable singleton here. So a test
+ * gets isolation just by loading against its own temp `rootPath`; there's no
+ * process-global catalog state to clear between tests.
  */
 import fs from 'node:fs/promises';
 import path from 'node:path';


### PR DESCRIPTION
Closes #1630.

Architecture review **P3** asked for a documented note on the module-global registry pattern in `shared/`, on both `shared/tools/registry.ts` **and** the type-catalog loader.

`shared/tools/registry.ts` already carries that note (per-process singleton design + the "a test mutates a shared singleton, so register into a clean state" caveat). This PR completes the pair on the **type-catalog loader** (`src/main/types/loader.ts`) and draws the key contrast:

- the tool registry is a *mutable* module-global `Map` (persists across tests → must be reset);
- `loadTypeCatalog` returns a **fresh** catalog on every call, held on per-project `GraphState` (`state.typeCatalog`) — **no** shared mutable singleton, so tests isolate simply by loading against a temp `rootPath`.

Comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)