### PR TITLE
build(tooling): add shared editor config (.vscode/ + .editorconfig) (#1643)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig — shared formatting baseline so every editor agrees before code
+# reaches `pnpm lint` (#1643). https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+# Markdown uses two trailing spaces as a hard line break — don't strip them.
+trim_trailing_whitespace = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  // Recommended extensions for working on Minerva (a Svelte 5 runes + strict-TS
+  // Electron app). VS Code offers to install these on first open (#1643).
+  "recommendations": [
+    "svelte.svelte-vscode",
+    "dbaeumer.vscode-eslint",
+    "editorconfig.editorconfig"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Debug configs for Minerva (#1643).
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Debug the Electron MAIN process. Uses electron-forge's documented VS Code
+      // integration: `--vscode` makes forge emit a marker VS Code auto-attaches
+      // to, so main-process breakpoints (IPC handlers, graph indexing, menus) hit.
+      // The renderer keeps running with Vite HMR as under `pnpm dev`.
+      "name": "Electron: Main",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron-forge",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron-forge.cmd"
+      },
+      "runtimeArgs": ["start", "--vscode"],
+      "console": "integratedTerminal"
+    }
+  ]
+  // Renderer (Svelte UI) debugging: open the in-window DevTools with
+  // Cmd+Opt+I (macOS) / Ctrl+Shift+I — the renderer is a Chromium context with
+  // source maps, so breakpoints and the console work there directly.
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+  // Workspace defaults (#1643).
+
+  // Format-on-save is intentionally OFF: the repo's gate is `pnpm lint`
+  // (tsc + svelte-check + eslint), and there is no Prettier config — a
+  // reformat-on-save would fight the existing style.
+  "editor.formatOnSave": false,
+
+  // Use the workspace TypeScript + Svelte so the editor and `pnpm lint` agree
+  // on versions (this repo is on TS 6 / Svelte 5).
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "svelte.enable-ts-plugin": true,
+
+  // Let ESLint lint .svelte alongside .ts/.js (matches `eslint .`).
+  "eslint.validate": ["javascript", "typescript", "svelte"],
+
+  "files.eol": "\n",
+
+  // Build output and heavy dirs aren't useful in search / file watching.
+  "search.exclude": {
+    "**/.vite": true,
+    "**/out": true,
+    "**/coverage": true,
+    "**/node_modules": true
+  }
+}


### PR DESCRIPTION
Closes #1643.

A fresh clone had no shared editor config — only `.idea/`, which is gitignored — so a new contributor got no Svelte language-server recommendation and no debug config. Adds:

- **`.editorconfig`** — utf-8 / LF / 2-space / final-newline / trim-trailing-whitespace (except Markdown, whose two-space hard breaks are preserved), matching the codebase.
- **`.vscode/extensions.json`** — recommends `svelte.svelte-vscode`, `dbaeumer.vscode-eslint`, `editorconfig.editorconfig` (VS Code prompts on first open).
- **`.vscode/settings.json`** — format-on-save **off** (the gate is `pnpm lint`; there's no Prettier config), workspace TS + Svelte SDK, ESLint validates `.svelte`, LF, search excludes for `.vite`/`out`/`coverage`.
- **`.vscode/launch.json`** — Electron **main**-process debug via electron-forge's documented `start --vscode` VS Code integration; **renderer** debugging via the in-window DevTools (Cmd+Opt+I — a Chromium context with source maps).

`pnpm lint` clean (these files are outside eslint's globs).

Note: I couldn't launch the Electron GUI on this machine to click-verify the debug config end-to-end — it follows electron-forge's official VS Code recipe, worth a quick local confirm on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)