### PR TITLE
test(git): verify src/main/git coverage + add a floor to lock it in (#1614)

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -99,6 +99,18 @@ export default defineConfig({
           statements: 74,
           branches: 60,
         },
+        // git publish — the isomorphic-git push engine + gh/HTTPS-token auth
+        // (#254). Was 0% at the stale baseline; live is well-covered by the
+        // publish-git / auth / push suites. Measured ~74% L / 74% F / 73% S /
+        // 78% B; floors ~10pts below so a refactor won't flap but new untested
+        // code fails. Remaining gaps in publish-git.ts are the real-remote push
+        // paths, best left to integration rather than unit tests (#1614).
+        'src/main/git/**': {
+          lines: 64,
+          functions: 62,
+          statements: 62,
+          branches: 66,
+        },
         // IPC registrars — mostly thin channel→module glue that was entirely
         // unfenced (QA C1 / #1612). The layer is deliberately low-covered (the
         // underlying modules carry the real tests), so this is a BACKSTOP, not a


### PR DESCRIPTION
Closes #1614.

The quality review (L1) flagged `src/main/git/**` as **0%** — but that was the stale baseline. **Live coverage is ~74% L / 74% F / 73% S / 78% B** (`index.ts` 88–96%, `publish-git.ts` ~64%), covered by `tests/main/git/**`, `publish-git-auth`, and `publish-to-git`.

So no new tests were warranted. Instead I fenced it with a per-glob **coverage floor** (`src/main/git/**`: 64 L / 62 F / 62 S / 66 B — ~10pts below measured, matching the other feature trees) so a future refactor can't silently regress it.

## Verification
- Scoped measurement (git suites only): 73.21 S / 77.55 B / 73.91 F / 74.15 L.
- Full `pnpm coverage` (544 files) green with the new floor in place — `src/main/git` reports the same numbers, comfortably above the floor.

Remaining `publish-git.ts` gaps are the real-remote push paths, best left to integration rather than unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)