### PR TITLE
docs(ipc): confirm typed contract spans every domain; fix stale "notebase" header (#1606)

### DIFF
--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -1,11 +1,25 @@
 /**
- * Typed IPC contract for the notebase domain (#981).
+ * Typed IPC contract — request/response (invoke) channels (#981, #1606).
+ *
+ * Began as the notebase domain; now spans EVERY domain — ~40 of them, incl.
+ * notebase, sources, compute, graph, conversation, publish, skills, types,
+ * collections, refactor, views, tags, … (one `ChannelMap` entry per invoke
+ * channel).
  *
  * ONE source of truth linking channel ↔ handler ↔ preload ↔ client
  * signatures. Keys are the channel string literals (matching the
  * `Channels.*` values in `./channels`); values are the renderer-facing
  * signature `(...args) => ReturnValue`, where `ReturnValue` is the
  * RESOLVED value (Promises are unwrapped — the wrappers re-wrap).
+ *
+ * Coverage is enforced structurally, not by convention: the typed `handle()`
+ * (main) and `invoke()` (preload) wrappers are both `<K extends keyof
+ * ChannelMap>`, and no handler uses raw `ipcMain.handle`. So a new invoke
+ * channel can't ship without a `ChannelMap` entry — it won't compile — and no
+ * handler falls back to `unknown` args.
+ *
+ * Scope: invoke channels only. One-way `send`/event channels (`*:changed`,
+ * `*:progress`, draft pushes) are typed separately (#1633).
  *
  * Pure type module: no runtime, no electron import. The typed
  * `handle`/`invoke` wrappers derive their arg + return types from here,


### PR DESCRIPTION
Closes #1606.

Audited `src/shared/ipc-contract.ts` against the handlers to confirm every domain's invoke channels are in the typed `ChannelMap` (so no handler falls back to `unknown` args). **It's complete by construction, not convention:**

- the typed `handle()` (main) and `invoke()` (preload) wrappers are both `<K extends keyof ChannelMap>`;
- there are **zero** raw `ipcMain.handle` calls anywhere in `src/main` — all 23 `register-*.ts` files use the typed wrapper;
- `ChannelMap` has **237 entries across ~40 domains** — including all the ones the review named (`skills` 6, `types` 7, `sources` 24, `publish` 9, `compute` 14).

So a new invoke channel **can't ship without a `ChannelMap` entry — it won't compile**, and no handler falls back to `unknown` args. Both success criteria hold.

The only actual defect was the **stale header**: it still read "Typed IPC contract for the notebase domain (#981)" though the contract long since grew to cover everything. Rewrote it to state the full-domain coverage, the structural completeness guarantee, and that one-way `send`/event channels are typed separately (#1633).

Comment-only change to a pure-type module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)