### PR TITLE
test: add a global coverage-floor backstop in vitest.config.mts (#1598)

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -47,6 +47,16 @@ export default defineConfig({
       // shared ~? , llm ~74% lines / 51% branch, notebase ~89% lines. CI runs
       // `pnpm coverage`, so these gate on every PR.
       thresholds: {
+        // Global backstop (#1598): a coarse aggregate net over the whole
+        // `include` set, so a wholesale coverage regression fails CI even in
+        // trees without their own tuned floor below. Deliberately modest — the
+        // per-glob floors are the real per-area gates; this only trips on a
+        // broad drop. Measured aggregate at floor-time: ~65% S / 58% B / 58% F /
+        // 67% L, so these sit well below and won't flap on a small change.
+        statements: 45,
+        branches: 40,
+        functions: 40,
+        lines: 45,
         'src/shared/**': {
           lines: 70,
           functions: 70,


### PR DESCRIPTION
Closes #1598.

Coverage thresholds were **per-glob only**, so a regression in a tree without its own floor had no gate. Added a modest **global aggregate floor** over the whole `include` set as a coarse backstop:

```
statements: 45, branches: 40, functions: 40, lines: 45
```

Current aggregate is ~**65 S / 58 B / 58 F / 67 L**, so the floor sits well below (no flapping) and the tuned per-glob floors stay the real per-area gates — unchanged.

## Honest scope note
An **aggregate** global floor catches a *broad/wholesale* coverage drop, not a single new 0% module — one 300-line module barely moves a 31k-line aggregate, and a `perFile` global floor would fail the many existing thin/barrel files below it. So the effective mechanism for fencing a *specific* new tree remains a **per-glob floor** (as done for `src/main/git` in #1614 and `src/main/ipc` in #1612). This backstop complements those; it doesn't replace them.

## Verification
- Full `pnpm coverage` (544 files) green with the global floor in place, exit 0 — every per-glob floor still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)