### PR TITLE
refactor(properties): extract + unit-test the frontmatter round-trip engine (#1596)

### DIFF
--- a/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
@@ -32,6 +32,12 @@
     scalarToText,
     type ScalarType,
   } from '../../../../shared/refactor/property-shape';
+  import {
+    parseFrontmatter,
+    keyToString,
+    applyFrontmatterMutation,
+    type Row,
+  } from '../../../../shared/refactor/frontmatter-rows';
 
   /** Type-icon mapping per §13.1. The icon signals the value shape at
    *  a glance so a row reads as "number" or "list" without parsing
@@ -69,44 +75,6 @@
 
   const notebase = getNotebaseStore();
 
-  type ValueShape =
-    | { kind: 'string'; value: string }
-    | { kind: 'number'; value: number }
-    | { kind: 'boolean'; value: boolean }
-    | { kind: 'date'; value: string }
-    | { kind: 'string-list'; value: string[] }
-    | { kind: 'wiki-link'; target: string; display: string | null; raw: string }
-    | { kind: 'yaml'; raw: string };
-
-  interface Row {
-    key: string;
-    shape: ValueShape;
-  }
-
-  interface ParseResult {
-    ok: true;
-    rows: Row[];
-    /** Raw frontmatter block (between `---` fences, exclusive). */
-    body: string;
-    /** Index in `content` where the frontmatter block begins (`---\n`). */
-    blockStart: number;
-    /** Index in `content` where the frontmatter block ends (after the closing `---\n`). */
-    blockEnd: number;
-  }
-
-  interface ParseError {
-    ok: false;
-    error: string;
-  }
-
-  interface NoFrontmatter {
-    ok: true;
-    rows: [];
-    body: '';
-    blockStart: 0;
-    blockEnd: 0;
-    none: true;
-  }
 
   const parsed = $derived(parseFrontmatter(content));
 
@@ -121,133 +89,15 @@
   let drafts = $state<Record<string, string>>({});
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
-  function parseFrontmatter(text: string): ParseResult | ParseError | NoFrontmatter {
-    const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
-    if (!m) {
-      return { ok: true, rows: [], body: '', blockStart: 0, blockEnd: 0, none: true };
-    }
-    const body = m[1]!;
-    const blockEnd = m[0].length;
-    let doc: YAML.Document.Parsed;
-    try {
-      doc = YAML.parseDocument(body);
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
-    if (doc.errors.length > 0) {
-      return { ok: false, error: doc.errors[0]!.message };
-    }
-    if (!YAML.isMap(doc.contents)) {
-      return { ok: false, error: 'Frontmatter is not a key/value map.' };
-    }
-    const out: Row[] = [];
-    for (const pair of doc.contents.items) {
-      const key = keyToString(pair.key);
-      if (key === null) continue;
-      const value = pair.value;
-      out.push({ key, shape: detectShape(value) });
-    }
-    return { ok: true, rows: out, body, blockStart: 0, blockEnd };
-  }
-
-  function keyToString(k: unknown): string | null {
-    if (YAML.isScalar(k)) return String(k.value);
-    if (typeof k === 'string') return k;
-    return null;
-  }
-
-  /** Matches a single `[[target]]` or `[[target|display]]` (un-typed)
-   *  with no surrounding whitespace. Typed wiki-links (`type::target`)
-   *  fall through to the plain-string editor — the picker only knows
-   *  how to pick note paths. */
-  const WIKI_LINK_RE = /^\[\[([^|\]\n[]+)(?:\|([^\]\n]+))?\]\]$/;
-
-  function detectShape(value: unknown): ValueShape {
-    if (YAML.isScalar(value)) {
-      const v = value.value;
-      if (typeof v === 'boolean') return { kind: 'boolean', value: v };
-      if (typeof v === 'number') return { kind: 'number', value: v };
-      if (v instanceof Date) {
-        return { kind: 'date', value: v.toISOString().slice(0, 10) };
-      }
-      if (typeof v === 'string') {
-        if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return { kind: 'date', value: v };
-        const wl = v.match(WIKI_LINK_RE);
-        if (wl) {
-          return {
-            kind: 'wiki-link',
-            target: wl[1]!.trim(),
-            display: wl[2]?.trim() ?? null,
-            raw: v,
-          };
-        }
-        return { kind: 'string', value: v };
-      }
-      // null, undefined, or an oddball scalar shape — treat as empty
-      // string so the row is still editable. Bare `String(obj)` would
-      // surface "[object Object]" so we go through JSON.
-      if (v == null) return { kind: 'string', value: '' };
-      return { kind: 'string', value: JSON.stringify(v) };
-    }
-    if (YAML.isSeq(value)) {
-      const items = value.items;
-      const stringValues: string[] = [];
-      let allStrings = true;
-      for (const it of items) {
-        if (YAML.isScalar(it) && typeof it.value === 'string') {
-          stringValues.push(it.value);
-        } else {
-          allStrings = false;
-          break;
-        }
-      }
-      if (allStrings) {
-        return { kind: 'string-list', value: stringValues };
-      }
-      return { kind: 'yaml', raw: YAML.stringify(value).trimEnd() };
-    }
-    if (YAML.isMap(value)) {
-      return { kind: 'yaml', raw: YAML.stringify(value).trimEnd() };
-    }
-    return { kind: 'yaml', raw: YAML.stringify(value).trimEnd() };
-  }
-
   /**
-   * Apply a mutation to the YAML document and flush back to the
-   * editor buffer. Mutator runs inside a successfully-parsed doc;
-   * if parsing fails we no-op rather than overwrite the user's WIP.
+   * Apply a mutation to the frontmatter and flush the result back to the editor
+   * buffer. The parse → mutate → reserialize → splice engine lives in
+   * frontmatter-rows.ts (#1596); a null result means "unparseable — don't
+   * clobber the user's WIP", so we no-op.
    */
   function mutate(fn: (doc: YAML.Document) => void): void {
-    if (!parsed.ok) return;
-    if ('none' in parsed) {
-      // No frontmatter yet — caller is creating one. Build a fresh doc.
-      const doc = new YAML.Document({});
-      fn(doc);
-      const yaml = doc.toString().trimEnd();
-      const next = `---\n${yaml}\n---\n${content}`;
-      onContentChange(next);
-      return;
-    }
-    let doc: YAML.Document.Parsed;
-    try {
-      doc = YAML.parseDocument(parsed.body);
-      if (doc.errors.length > 0) return;
-    } catch {
-      return;
-    }
-    fn(doc);
-    let serialised = doc.toString();
-    if (serialised.endsWith('\n')) serialised = serialised.slice(0, -1);
-    // If the deletion left the map empty, drop the entire block —
-    // an empty `---\n\n---` block reads as malformed YAML to readers.
-    if (YAML.isMap(doc.contents) && doc.contents.items.length === 0) {
-      onContentChange(content.slice(parsed.blockEnd));
-      return;
-    }
-    const next = content.slice(0, parsed.blockStart) +
-      `---\n${serialised}\n---\n` +
-      content.slice(parsed.blockEnd);
-    onContentChange(next);
+    const next = applyFrontmatterMutation(content, fn);
+    if (next !== null) onContentChange(next);
   }
 
   function setKeyValue(key: string, value: unknown): void {

--- a/src/shared/refactor/frontmatter-rows.ts
+++ b/src/shared/refactor/frontmatter-rows.ts
@@ -1,0 +1,181 @@
+/**
+ * YAML frontmatter round-trip engine for the note Properties panel (#1596).
+ *
+ * Parses a note's leading `---` frontmatter block into typed rows, and applies
+ * edits by mutating the YAML document and splicing the reserialized block back
+ * into the note content by byte offset — preserving comments, key order, and the
+ * body. Extracted from PropertiesPanel.svelte (a zero-test, data-loss-prone
+ * surface) into this pure, unit-tested module, beside the property-shape helpers
+ * it complements.
+ */
+import YAML from 'yaml';
+
+export type ValueShape =
+  | { kind: 'string'; value: string }
+  | { kind: 'number'; value: number }
+  | { kind: 'boolean'; value: boolean }
+  | { kind: 'date'; value: string }
+  | { kind: 'string-list'; value: string[] }
+  | { kind: 'wiki-link'; target: string; display: string | null; raw: string }
+  | { kind: 'yaml'; raw: string };
+
+export interface Row {
+  key: string;
+  shape: ValueShape;
+}
+
+export interface ParseResult {
+  ok: true;
+  rows: Row[];
+  /** Raw frontmatter block (between `---` fences, exclusive). */
+  body: string;
+  /** Index in `content` where the frontmatter block begins (`---\n`). */
+  blockStart: number;
+  /** Index in `content` where the frontmatter block ends (after the closing `---\n`). */
+  blockEnd: number;
+}
+
+export interface ParseError {
+  ok: false;
+  error: string;
+}
+
+export interface NoFrontmatter {
+  ok: true;
+  rows: [];
+  body: '';
+  blockStart: 0;
+  blockEnd: 0;
+  none: true;
+}
+
+export function keyToString(k: unknown): string | null {
+  if (YAML.isScalar(k)) return String(k.value);
+  if (typeof k === 'string') return k;
+  return null;
+}
+
+/** Matches a single `[[target]]` or `[[target|display]]` (un-typed)
+ *  with no surrounding whitespace. Typed wiki-links (`type::target`)
+ *  fall through to the plain-string editor — the picker only knows
+ *  how to pick note paths. */
+const WIKI_LINK_RE = /^\[\[([^|\]\n[]+)(?:\|([^\]\n]+))?\]\]$/;
+
+export function detectShape(value: unknown): ValueShape {
+  if (YAML.isScalar(value)) {
+    const v = value.value;
+    if (typeof v === 'boolean') return { kind: 'boolean', value: v };
+    if (typeof v === 'number') return { kind: 'number', value: v };
+    if (v instanceof Date) {
+      return { kind: 'date', value: v.toISOString().slice(0, 10) };
+    }
+    if (typeof v === 'string') {
+      if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return { kind: 'date', value: v };
+      const wl = v.match(WIKI_LINK_RE);
+      if (wl) {
+        return {
+          kind: 'wiki-link',
+          target: wl[1]!.trim(),
+          display: wl[2]?.trim() ?? null,
+          raw: v,
+        };
+      }
+      return { kind: 'string', value: v };
+    }
+    // null, undefined, or an oddball scalar shape — treat as empty
+    // string so the row is still editable. Bare `String(obj)` would
+    // surface "[object Object]" so we go through JSON.
+    if (v == null) return { kind: 'string', value: '' };
+    return { kind: 'string', value: JSON.stringify(v) };
+  }
+  if (YAML.isSeq(value)) {
+    const items = value.items;
+    const stringValues: string[] = [];
+    let allStrings = true;
+    for (const it of items) {
+      if (YAML.isScalar(it) && typeof it.value === 'string') {
+        stringValues.push(it.value);
+      } else {
+        allStrings = false;
+        break;
+      }
+    }
+    if (allStrings) {
+      return { kind: 'string-list', value: stringValues };
+    }
+    return { kind: 'yaml', raw: YAML.stringify(value).trimEnd() };
+  }
+  if (YAML.isMap(value)) {
+    return { kind: 'yaml', raw: YAML.stringify(value).trimEnd() };
+  }
+  return { kind: 'yaml', raw: YAML.stringify(value).trimEnd() };
+}
+
+export function parseFrontmatter(text: string): ParseResult | ParseError | NoFrontmatter {
+  const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
+  if (!m) {
+    return { ok: true, rows: [], body: '', blockStart: 0, blockEnd: 0, none: true };
+  }
+  const body = m[1]!;
+  const blockEnd = m[0].length;
+  let doc: YAML.Document.Parsed;
+  try {
+    doc = YAML.parseDocument(body);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+  if (doc.errors.length > 0) {
+    return { ok: false, error: doc.errors[0]!.message };
+  }
+  if (!YAML.isMap(doc.contents)) {
+    return { ok: false, error: 'Frontmatter is not a key/value map.' };
+  }
+  const out: Row[] = [];
+  for (const pair of doc.contents.items) {
+    const key = keyToString(pair.key);
+    if (key === null) continue;
+    const value = pair.value;
+    out.push({ key, shape: detectShape(value) });
+  }
+  return { ok: true, rows: out, body, blockStart: 0, blockEnd };
+}
+
+/**
+ * Apply a mutation to a note's frontmatter and return the new note content, or
+ * `null` to no-op. Mutator runs inside a successfully-parsed YAML doc; if parsing
+ * fails we return null rather than overwrite the user's work-in-progress. Three
+ * cases: no frontmatter yet (build a fresh block), a deletion that empties the
+ * map (drop the whole block, since `---\n\n---` reads as malformed), and the
+ * normal splice-by-offset rewrite that preserves the note body.
+ */
+export function applyFrontmatterMutation(
+  content: string,
+  fn: (doc: YAML.Document) => void,
+): string | null {
+  const parsed = parseFrontmatter(content);
+  if (!parsed.ok) return null;
+  if ('none' in parsed) {
+    const doc = new YAML.Document({});
+    fn(doc);
+    const yaml = doc.toString().trimEnd();
+    return `---\n${yaml}\n---\n${content}`;
+  }
+  let doc: YAML.Document.Parsed;
+  try {
+    doc = YAML.parseDocument(parsed.body);
+    if (doc.errors.length > 0) return null;
+  } catch {
+    return null;
+  }
+  fn(doc);
+  let serialised = doc.toString();
+  if (serialised.endsWith('\n')) serialised = serialised.slice(0, -1);
+  // If the deletion left the map empty, drop the entire block — an empty
+  // `---\n\n---` block reads as malformed YAML to readers.
+  if (YAML.isMap(doc.contents) && doc.contents.items.length === 0) {
+    return content.slice(parsed.blockEnd);
+  }
+  return content.slice(0, parsed.blockStart) +
+    `---\n${serialised}\n---\n` +
+    content.slice(parsed.blockEnd);
+}

--- a/tests/shared/refactor/frontmatter-rows.test.ts
+++ b/tests/shared/refactor/frontmatter-rows.test.ts
@@ -1,0 +1,122 @@
+/**
+ * YAML frontmatter round-trip engine (#1596). This is the data-loss surface the
+ * note Properties panel edits through, so the round-trip + edge cases are
+ * pinned here: parse → typed rows, and mutate → reserialized block spliced back
+ * by offset (comments/order/body preserved).
+ */
+import { describe, it, expect } from 'vitest';
+import YAML from 'yaml';
+import {
+  parseFrontmatter,
+  detectShape,
+  applyFrontmatterMutation,
+  type ParseResult,
+} from '../../../src/shared/refactor/frontmatter-rows';
+
+const fm = (body: string, rest = 'Body text.\n') => `---\n${body}\n---\n${rest}`;
+/** Mutator that sets a key on the frontmatter map. */
+const setKey = (key: string, value: unknown) => (doc: YAML.Document) => {
+  if (YAML.isMap(doc.contents)) doc.set(key, value);
+};
+
+describe('parseFrontmatter', () => {
+  it('reports no frontmatter for a plain note', () => {
+    const r = parseFrontmatter('# Just a heading\n');
+    expect(r.ok).toBe(true);
+    expect('none' in r && r.none).toBe(true);
+    if (r.ok) expect(r.rows).toEqual([]);
+  });
+
+  it('parses scalars into typed rows', () => {
+    const r = parseFrontmatter(fm('title: Hello\ncount: 3\ndraft: true')) as ParseResult;
+    expect(r.ok).toBe(true);
+    expect(r.rows).toEqual([
+      { key: 'title', shape: { kind: 'string', value: 'Hello' } },
+      { key: 'count', shape: { kind: 'number', value: 3 } },
+      { key: 'draft', shape: { kind: 'boolean', value: true } },
+    ]);
+  });
+
+  it('detects ISO dates (as string or YAML date) and string-lists', () => {
+    const r = parseFrontmatter(fm('due: 2026-08-02\ntags:\n  - a\n  - b')) as ParseResult;
+    expect(r.rows[0]).toEqual({ key: 'due', shape: { kind: 'date', value: '2026-08-02' } });
+    expect(r.rows[1]).toEqual({ key: 'tags', shape: { kind: 'string-list', value: ['a', 'b'] } });
+  });
+
+  it('detects wiki-links, with and without a display alias', () => {
+    const r = parseFrontmatter(fm('a: "[[Note]]"\nb: "[[Note|Shown]]"')) as ParseResult;
+    expect(r.rows[0]!.shape).toEqual({ kind: 'wiki-link', target: 'Note', display: null, raw: '[[Note]]' });
+    expect(r.rows[1]!.shape).toEqual({ kind: 'wiki-link', target: 'Note', display: 'Shown', raw: '[[Note|Shown]]' });
+  });
+
+  it('renders a nested map / mixed list as an opaque yaml shape', () => {
+    const r = parseFrontmatter(fm('meta:\n  x: 1\n  y: 2')) as ParseResult;
+    expect(r.rows[0]!.shape.kind).toBe('yaml');
+  });
+
+  it('fails on a non-map document', () => {
+    const r = parseFrontmatter(fm('just a bare string'));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/not a key\/value map/);
+  });
+
+  it('fails on malformed YAML rather than throwing', () => {
+    const r = parseFrontmatter(fm('key: : : bad'));
+    expect(r.ok).toBe(false);
+  });
+
+  it('handles CRLF line endings and reports block offsets', () => {
+    const content = '---\r\ntitle: Hi\r\n---\r\nBody\r\n';
+    const r = parseFrontmatter(content) as ParseResult;
+    expect(r.ok).toBe(true);
+    expect(r.rows[0]).toEqual({ key: 'title', shape: { kind: 'string', value: 'Hi' } });
+    expect(content.slice(r.blockStart, r.blockEnd)).toBe('---\r\ntitle: Hi\r\n---\r\n');
+  });
+});
+
+describe('detectShape edge cases', () => {
+  it('treats a null scalar as an empty string (still editable)', () => {
+    const r = parseFrontmatter(fm('empty:')) as ParseResult;
+    expect(r.rows[0]!.shape).toEqual({ kind: 'string', value: '' });
+  });
+  it('does not mistake a plain 2026 title for a date', () => {
+    expect(detectShape(new YAML.Scalar('The Year 2026'))).toEqual({ kind: 'string', value: 'The Year 2026' });
+  });
+});
+
+describe('applyFrontmatterMutation', () => {
+  it('sets a key and preserves the note body', () => {
+    const next = applyFrontmatterMutation(fm('title: A'), setKey('draft', true));
+    expect(next).toBe(fm('title: A\ndraft: true'));
+  });
+
+  it('preserves comments and key order through an edit', () => {
+    const src = '---\n# leading comment\ntitle: A  # inline\nb: 2\n---\nBody.\n';
+    const next = applyFrontmatterMutation(src, setKey('b', 3))!;
+    expect(next).toContain('# leading comment');
+    expect(next).toContain('# inline');
+    expect(next).toContain('b: 3');
+    expect(next.indexOf('title')).toBeLessThan(next.indexOf('b:')); // order kept
+  });
+
+  it('builds a fresh block when the note has no frontmatter yet', () => {
+    const next = applyFrontmatterMutation('# Heading\n\nText.\n', setKey('title', 'New'));
+    expect(next).toBe('---\ntitle: New\n---\n# Heading\n\nText.\n');
+  });
+
+  it('drops the whole block when the last key is deleted', () => {
+    const del = (doc: YAML.Document) => { if (YAML.isMap(doc.contents)) doc.delete('only'); };
+    const next = applyFrontmatterMutation(fm('only: 1', 'Body.\n'), del);
+    expect(next).toBe('Body.\n'); // no empty `---\n\n---` left behind
+  });
+
+  it('keeps the block when deleting one of several keys', () => {
+    const del = (doc: YAML.Document) => { if (YAML.isMap(doc.contents)) doc.delete('a'); };
+    const next = applyFrontmatterMutation(fm('a: 1\nb: 2'), del);
+    expect(next).toBe(fm('b: 2'));
+  });
+
+  it('no-ops (returns null) on malformed frontmatter rather than clobbering WIP', () => {
+    expect(applyFrontmatterMutation(fm('key: : : bad'), setKey('x', 1))).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1596.

`PropertiesPanel.svelte` carried a ~220-line YAML frontmatter round-trip engine (parse → typed rows → mutate → reserialize → splice-by-offset) with **zero tests** — a data-loss surface. Moved the pure core to **`src/shared/refactor/frontmatter-rows.ts`** and added a unit suite.

- **Extracted verbatim:** `parseFrontmatter`, `keyToString`, `detectShape`, the `Row`/`ValueShape`/`ParseResult` types, plus a new `applyFrontmatterMutation(content, fn)` that encapsulates the old `mutate` engine — the three cases (build a fresh block, drop the whole block when a deletion empties the map, and the offset-splice rewrite that preserves the body), returning `null` to no-op on unparseable input so it never clobbers WIP.
- The component keeps its glue (drafts/debounce, `commit*`, type switcher); its `mutate` is now a thin wrapper. The moved logic is **byte-for-byte**, so behaviour is unchanged.
- **16 unit tests**: scalar/number/boolean/date coercion, ISO-date + wiki-link (`[[x]]`, `[[x|y]]`) detection, string-lists, nested-map → opaque yaml, non-map + malformed guards, CRLF + block offsets, and round-trip mutation (comment/order/body preservation, fresh-block build, empty-map deletion, malformed no-op).

Path note: placed in `shared/refactor` — where `property-shape.ts` (the sibling the issue said to sit "beside") actually lives and is tested — not the `renderer/lib/refactor` path the issue guessed. The engine is pure (`yaml` + `property-shape`), and `shared/refactor` already uses `yaml`.

## Verify
`pnpm lint` clean; new suite 16/16 green. Since it's a data path, worth a quick in-app check of the note Properties panel: add / edit / delete / rename a key, switch a value's type, and confirm comments + body survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)