### PR TITLE
test(sources): add a SourceDetail.svelte render test (#1597)

### DIFF
--- a/tests/renderer/components/SourceDetail.test.ts
+++ b/tests/renderer/components/SourceDetail.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * SourceDetail render test (#1597). SourceDetail is the second-largest renderer
+ * file and a gated LLM write surface (propose_source_properties → meta.ttl), but
+ * had only its extracted `source-actions` logic covered. This mounts the real
+ * component against mocked IPC + stores and asserts the metadata display and the
+ * read-status / rename / delete / source-tools wiring. The source body is absent
+ * (meta-only source), so the heavy Preview child never mounts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+import type { SourceDetail as SourceDetailData, SourceMetadata } from '../../../src/shared/types';
+import type { ThinkingToolInfo } from '../../../src/shared/tools/types';
+
+const metadata: SourceMetadata = {
+  sourceId: 'paxos', subtype: 'article', title: 'The Part-Time Parliament',
+  creators: ['Lamport, Leslie'], year: '1998', publisher: null, doi: null, uri: null,
+  abstract: null, readStatus: null, readDueBy: null, stubStatus: null, tags: [],
+};
+const detail: SourceDetailData = { metadata, excerpts: [], backlinks: [], aboutNotes: [], references: [] };
+
+const h = vi.hoisted(() => ({
+  api: {
+    graph: { sourceDetail: vi.fn() },
+    notebase: { readFile: vi.fn() },
+    sources: { hasPdf: vi.fn() },
+    shell: { openExternal: vi.fn() },
+  },
+  sourceData: {
+    setReadStatus: vi.fn(),
+    setReadDueBy: vi.fn(),
+    removeTag: vi.fn(),
+    createExcerpt: vi.fn(),
+    onExcerptsChanged: vi.fn(() => () => {}), // returns an unsubscribe
+  },
+  notebase: { readFile: vi.fn(), writeFile: vi.fn() },
+  renameSource: vi.fn(),
+  deleteSource: vi.fn(),
+  addSourceTag: vi.fn(),
+  sourceTagSuggestions: vi.fn(),
+  getAllToolInfos: vi.fn(() => [] as ThinkingToolInfo[]),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/stores/source-data.svelte', () => ({ getSourceDataStore: () => h.sourceData }));
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({ getNotebaseStore: () => h.notebase }));
+vi.mock('../../../src/renderer/lib/sources/source-actions', () => ({
+  renameSource: h.renameSource,
+  deleteSource: h.deleteSource,
+  addSourceTag: h.addSourceTag,
+  sourceTagSuggestions: h.sourceTagSuggestions,
+}));
+vi.mock('../../../src/renderer/lib/tools/tool-registry', () => ({ getAllToolInfos: h.getAllToolInfos }));
+
+import SourceDetail from '../../../src/renderer/lib/components/SourceDetail.svelte';
+
+function props(over: Record<string, unknown> = {}) {
+  return {
+    sourceId: 'paxos',
+    onNavigate: vi.fn(),
+    onShowConfirm: vi.fn().mockResolvedValue(true),
+    onShowPrompt: vi.fn().mockResolvedValue(null),
+    onDeleted: vi.fn(),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  h.api.graph.sourceDetail.mockResolvedValue(detail);
+  h.api.notebase.readFile.mockRejectedValue(new Error('meta-only source, no body.md'));
+  h.api.sources.hasPdf.mockResolvedValue(false);
+  h.sourceData.setReadStatus.mockResolvedValue(undefined);
+  h.sourceTagSuggestions.mockResolvedValue([]);
+  h.getAllToolInfos.mockReturnValue([]);
+});
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe('SourceDetail (#1597)', () => {
+  it('loads and displays the source metadata', async () => {
+    render(SourceDetail, props());
+    await waitFor(() => expect(screen.getByText('The Part-Time Parliament')).toBeTruthy());
+    expect(h.api.graph.sourceDetail).toHaveBeenCalledWith('paxos');
+  });
+
+  it('wires the read-status buttons to the source-data store', async () => {
+    render(SourceDetail, props());
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Unread' })).toBeTruthy());
+    await fireEvent.click(screen.getByRole('button', { name: 'Unread' }));
+    // readStatus started null, so clicking "Unread" sets it.
+    expect(h.sourceData.setReadStatus).toHaveBeenCalledWith('paxos', 'unread');
+  });
+
+  it('routes "Rename source" through the source-actions helper with the host prompt', async () => {
+    const p = props();
+    render(SourceDetail, p);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Rename source' })).toBeTruthy());
+    await fireEvent.click(screen.getByRole('button', { name: 'Rename source' }));
+    expect(h.renameSource).toHaveBeenCalledTimes(1);
+    expect(h.renameSource.mock.calls[0]![0]).toMatchObject({ sourceId: 'paxos' }); // the loaded metadata
+    expect(h.renameSource.mock.calls[0]![1]).toBe(p.onShowPrompt);
+  });
+
+  it('routes "Delete source" through the source-actions helper with the host confirm', async () => {
+    const p = props();
+    render(SourceDetail, p);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Delete source' })).toBeTruthy());
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete source' }));
+    expect(h.deleteSource).toHaveBeenCalledTimes(1);
+    expect(h.deleteSource.mock.calls[0]![0]).toMatchObject({ sourceId: 'paxos' });
+    expect(h.deleteSource.mock.calls[0]![1]).toBe(p.onShowConfirm);
+  });
+
+  it('surfaces the source Tools entry point when a source-scoped tool + onInvokeTool exist', async () => {
+    h.getAllToolInfos.mockReturnValue([{
+      id: 'summarize-source', name: 'Summarize Source', category: 'research', scope: 'source',
+      description: '', longDescription: '', context: [], outputMode: 'note',
+    } as ThinkingToolInfo]);
+    render(SourceDetail, props({ onInvokeTool: vi.fn() }));
+    await waitFor(() => expect(screen.getByText('The Part-Time Parliament')).toBeTruthy());
+    expect(screen.getByRole('button', { name: /Tools/ })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #1597.

`SourceDetail.svelte` — the second-largest renderer file and a **gated LLM write surface** (`propose_source_properties` → `meta.ttl`) — had no component render test; only its extracted `source-actions` logic was covered. This mounts the real component against mocked IPC + stores and asserts the key behaviour:

- **loads + displays metadata** (`api.graph.sourceDetail`);
- **read-status** buttons → `sourceData.setReadStatus(sourceId, status)`;
- **"Rename source"** → `source-actions.renameSource(metadata, onShowPrompt, …)`;
- **"Delete source"** → `source-actions.deleteSource(metadata, onShowConfirm, …)`;
- the source **Tools** entry point renders for a source-scoped tool + `onInvokeTool`.

Uses a meta-only fixture (no `body.md`), so the heavy `Preview` child never mounts — keeping the test fast and hermetic. **Pure test addition — no production change.**

`pnpm lint` clean; suite 5/5 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)