### PR TITLE
feat(ipc): typed EventMap + broadcast/subscribe for one-way channels (#1633)

### DIFF
--- a/src/main/ipc/broadcast.ts
+++ b/src/main/ipc/broadcast.ts
@@ -1,0 +1,20 @@
+/**
+ * Typed one-way (main → renderer) broadcast (#1633). The main-side mirror of the
+ * invoke `handle`: the channel + payload are checked against `EventMap`, so a
+ * sender that disagrees with the renderer's subscriber fails `tsc` instead of the
+ * payload arriving as `unknown`.
+ *
+ * A leaf module (electron + a type-only contract import) so every layer — the
+ * watcher, window-manager, menu, and the register-* handlers — can call it
+ * without an import cycle through `ipc/helpers`.
+ */
+import type { BrowserWindow } from 'electron';
+import type { EventMap } from '../../shared/ipc-contract';
+
+export function broadcast<K extends keyof EventMap>(
+  win: BrowserWindow,
+  channel: K,
+  ...args: Parameters<EventMap[K]>
+): void {
+  win.webContents.send(channel, ...args);
+}

--- a/src/main/ipc/helpers.ts
+++ b/src/main/ipc/helpers.ts
@@ -10,6 +10,7 @@ import * as vectors from '../embeddings/vector-store';
 import { projectContext } from '../project-context-types';
 import { getRootPath, markPathHandled, windowsForProject } from '../window-manager';
 import type { WritePipelineHooks } from '../notebase/write-pipeline';
+import { broadcast } from './broadcast';
 
 export function winFromEvent(e: Electron.IpcMainInvokeEvent): BrowserWindow {
   return BrowserWindow.fromWebContents(e.sender)!;
@@ -119,13 +120,13 @@ export async function persistIndexes(rootPath: string): Promise<void> {
 export function broadcastRewritten(rootPath: string, paths: string[]): void {
   if (paths.length === 0) return;
   for (const targetWin of windowsForProject(rootPath)) {
-    targetWin.webContents.send(Channels.NOTEBASE_REWRITTEN, paths);
+    broadcast(targetWin, Channels.NOTEBASE_REWRITTEN, paths);
   }
 }
 
 export function broadcastHeadingRename(rootPath: string, candidate: graph.HeadingRenameCandidate): void {
   for (const targetWin of windowsForProject(rootPath)) {
-    targetWin.webContents.send(Channels.NOTEBASE_HEADING_RENAME_SUGGESTED, candidate);
+    broadcast(targetWin, Channels.NOTEBASE_HEADING_RENAME_SUGGESTED, candidate);
   }
 }
 
@@ -137,7 +138,7 @@ export function broadcastHeadingRename(rootPath: string, candidate: graph.Headin
  */
 export function broadcastProposalsChanged(rootPath: string): void {
   for (const targetWin of windowsForProject(rootPath)) {
-    targetWin.webContents.send(Channels.PROPOSALS_CHANGED);
+    broadcast(targetWin, Channels.PROPOSALS_CHANGED);
   }
 }
 

--- a/src/main/ipc/register-conversation-drafts.ts
+++ b/src/main/ipc/register-conversation-drafts.ts
@@ -12,6 +12,7 @@
  * moved here with it.
  */
 import { Channels } from '../../shared/channels';
+import { broadcast } from './broadcast';
 import * as notebaseFs from '../notebase/fs';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
@@ -394,7 +395,7 @@ export function registerConversationDrafts(): void {
       if (anyIngested) {
         await persistIndexes(rootPath);
         if (!win.isDestroyed()) {
-          win.webContents.send(Channels.SOURCES_CHANGED);
+          broadcast(win, Channels.SOURCES_CHANGED);
         }
       }
       return { outcomes };

--- a/src/main/ipc/register-graph.ts
+++ b/src/main/ipc/register-graph.ts
@@ -1,6 +1,7 @@
 import { dialog } from 'electron';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
+import { broadcast } from './broadcast';
 import { handle } from './typed-ipc';
 import * as graph from '../graph/index';
 import * as search from '../search/index';
@@ -40,7 +41,7 @@ export function registerGraph(): void {
     ]);
     await tables.registerAllCsvs(ctx);
     await tables.registerAllNoteTables(ctx);
-    if (win && !win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+    if (win && !win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
     return { ok: true as const };
   }));
 

--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -2,6 +2,7 @@ import { app, dialog } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
+import { broadcast } from './broadcast';
 import * as notebaseFs from '../notebase/fs';
 import { renameWithLinkRewrites } from '../notebase/rename';
 import { mergeNotes, previewMergeNotes } from '../notebase/merge';
@@ -106,7 +107,7 @@ export function registerNotebase(): void {
     const freshWin = createWindow();
     freshWin.webContents.once('did-finish-load', async () => {
       await openProjectInWindow(freshWin, rootPath);
-      freshWin.webContents.send(Channels.PROJECT_OPENED, { rootPath, name: resolveDisplayName(rootPath) });
+      broadcast(freshWin, Channels.PROJECT_OPENED, { rootPath, name: resolveDisplayName(rootPath) });
     });
     return { rootPath, name: resolveDisplayName(rootPath) };
   });
@@ -134,7 +135,7 @@ export function registerNotebase(): void {
     const freshWin = createWindow();
     freshWin.webContents.once('did-finish-load', async () => {
       await openProjectInWindow(freshWin, rootPath);
-      freshWin.webContents.send(Channels.PROJECT_OPENED, { rootPath, name: resolveDisplayName(rootPath) });
+      broadcast(freshWin, Channels.PROJECT_OPENED, { rootPath, name: resolveDisplayName(rootPath) });
     });
     return { rootPath, name: resolveDisplayName(rootPath) };
   });
@@ -151,7 +152,7 @@ export function registerNotebase(): void {
     const freshWin = createWindow();
     freshWin.webContents.once('did-finish-load', async () => {
       await openProjectInWindow(freshWin, rootPath);
-      freshWin.webContents.send(Channels.PROJECT_OPENED, { rootPath, name: resolveDisplayName(rootPath) });
+      broadcast(freshWin, Channels.PROJECT_OPENED, { rootPath, name: resolveDisplayName(rootPath) });
     });
     return { rootPath, name: resolveDisplayName(rootPath) };
   });
@@ -160,7 +161,7 @@ export function registerNotebase(): void {
     const freshWin = createWindow();
     freshWin.webContents.once('did-finish-load', async () => {
       await openProjectInWindow(freshWin, rootPath);
-      freshWin.webContents.send(Channels.PROJECT_OPENED, { rootPath, name: resolveDisplayName(rootPath) });
+      broadcast(freshWin, Channels.PROJECT_OPENED, { rootPath, name: resolveDisplayName(rootPath) });
     });
     return { rootPath, name: resolveDisplayName(rootPath) };
   });
@@ -266,10 +267,10 @@ export function registerNotebase(): void {
     // refresh paths and content instead of silently overwriting on next save.
     for (const targetWin of windowsForProject(rootPath)) {
       if (transitions.length > 0) {
-        targetWin.webContents.send(Channels.NOTEBASE_RENAMED, transitions);
+        broadcast(targetWin, Channels.NOTEBASE_RENAMED, transitions);
       }
       if (rewrittenPaths.length > 0) {
-        targetWin.webContents.send(Channels.NOTEBASE_REWRITTEN, rewrittenPaths);
+        broadcast(targetWin, Channels.NOTEBASE_REWRITTEN, rewrittenPaths);
       }
     }
 
@@ -300,16 +301,16 @@ export function registerNotebase(): void {
     // editor tabs to drop / reroute) plus the rewritten set so other
     // windows reload affected files.
     for (const targetWin of windowsForProject(rootPath)) {
-      targetWin.webContents.send(Channels.NOTEBASE_RENAMED, [
+      broadcast(targetWin, Channels.NOTEBASE_RENAMED, [
         { old: sourceRelPath, new: '' /* sentinel: deletion */ },
       ]);
       if (result.rewrittenPaths.length > 0) {
-        targetWin.webContents.send(Channels.NOTEBASE_REWRITTEN, [
+        broadcast(targetWin, Channels.NOTEBASE_REWRITTEN, [
           ...result.rewrittenPaths,
           targetRelPath,
         ]);
       } else {
-        targetWin.webContents.send(Channels.NOTEBASE_REWRITTEN, [targetRelPath]);
+        broadcast(targetWin, Channels.NOTEBASE_REWRITTEN, [targetRelPath]);
       }
     }
     await persistIndexes(rootPath);
@@ -357,7 +358,7 @@ export function registerNotebase(): void {
       // refresh in place so the next auto-save doesn't undo the anchor rewrite.
       if (rewrittenPaths.length > 0) {
         for (const targetWin of windowsForProject(rootPath)) {
-          targetWin.webContents.send(Channels.NOTEBASE_REWRITTEN, rewrittenPaths);
+          broadcast(targetWin, Channels.NOTEBASE_REWRITTEN, rewrittenPaths);
         }
       }
 

--- a/src/main/ipc/register-proposals.ts
+++ b/src/main/ipc/register-proposals.ts
@@ -7,6 +7,7 @@
  */
 import { Notification } from 'electron';
 import { Channels } from '../../shared/channels';
+import { broadcast } from './broadcast';
 import * as approval from '../llm/approval';
 import type { Proposal } from '../llm/approval';
 import { projectContext } from '../project-context-types';
@@ -43,7 +44,7 @@ export function registerProposals(): void {
       if (win.isMinimized()) win.restore();
       win.show();
       win.focus();
-      win.webContents.send(Channels.PROPOSALS_SHOW);
+      broadcast(win, Channels.PROPOSALS_SHOW);
     });
     notice.show();
   });

--- a/src/main/ipc/register-sources.ts
+++ b/src/main/ipc/register-sources.ts
@@ -2,6 +2,7 @@ import { dialog, BrowserWindow } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
+import { broadcast } from './broadcast';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import { privilegedFetch } from '../privileged-sites';
@@ -74,7 +75,7 @@ export function registerSources(): void {
   handle(Channels.SOURCES_CREATE_REFERENCE_STUBS, withRootPathWin(async (rootPath, win, params: { sourceId: string; refs: ParsedReference[] }) => {
     const result = await createReferenceStubs(rootPath, params.sourceId, params.refs);
     await persistIndexes(rootPath);
-    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
     return result;
   }));
 
@@ -85,7 +86,7 @@ export function registerSources(): void {
   handle(Channels.SOURCES_APPLY_STUB_RESOLUTION, withRootPathWin(async (rootPath, win, params: { sourceId: string; doi: string }) => {
     const ok = await applyStubResolution(rootPath, params.sourceId, params.doi, { fetchImpl: privilegedFetch });
     await persistIndexes(rootPath);
-    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
     return { ok };
   }));
 
@@ -105,7 +106,7 @@ export function registerSources(): void {
     return await importBibtex(rootPath, result.filePaths[0]!, {
       onProgress: (progress) => {
         if (!win.isDestroyed()) {
-          win.webContents.send(Channels.SOURCES_IMPORT_BIBTEX_PROGRESS, progress);
+          broadcast(win, Channels.SOURCES_IMPORT_BIBTEX_PROGRESS, progress);
         }
       },
     });
@@ -122,7 +123,7 @@ export function registerSources(): void {
     return await importZoteroRdf(rootPath, result.filePaths[0]!, {
       onProgress: (progress) => {
         if (!win.isDestroyed()) {
-          win.webContents.send(Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS, progress);
+          broadcast(win, Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS, progress);
         }
       },
     });
@@ -175,7 +176,7 @@ export function registerSources(): void {
     await finishPdfOcrIngest(rootPath, sourceId, pages);
     await reindexFile(rootPath, `.minerva/sources/${sourceId}/meta.ttl`);
     await persistIndexes(rootPath);
-    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
   }));
 
   handle(Channels.SOURCES_LIST_ALL, withRootPathOr([], (rootPath) =>
@@ -185,8 +186,8 @@ export function registerSources(): void {
     const result = await deleteSource(rootPath, sourceId);
     await persistIndexes(rootPath);
     if (!win.isDestroyed()) {
-      win.webContents.send(Channels.SOURCES_CHANGED);
-      win.webContents.send(Channels.EXCERPTS_CHANGED);
+      broadcast(win, Channels.SOURCES_CHANGED);
+      broadcast(win, Channels.EXCERPTS_CHANGED);
     }
     return result;
   }));
@@ -196,8 +197,8 @@ export function registerSources(): void {
       const result = await mergeSources(rootPath, params.srcId, params.destId);
       await persistIndexes(rootPath);
       if (!win.isDestroyed()) {
-        win.webContents.send(Channels.SOURCES_CHANGED);
-        win.webContents.send(Channels.EXCERPTS_CHANGED);
+        broadcast(win, Channels.SOURCES_CHANGED);
+        broadcast(win, Channels.EXCERPTS_CHANGED);
       }
       return result;
     } catch (err) {
@@ -216,37 +217,37 @@ export function registerSources(): void {
   handle(Channels.SOURCES_SET_READ_STATUS, withRootPathWin(async (rootPath, win, params: { sourceId: string; status: ReadStatus | null }) => {
     await setSourceReadStatus(rootPath, params.sourceId, params.status);
     await persistIndexes(rootPath);
-    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
   }));
 
   handle(Channels.SOURCES_SET_TITLE, withRootPathWin(async (rootPath, win, params: { sourceId: string; title: string }) => {
     await setSourceTitle(rootPath, params.sourceId, params.title);
     await persistIndexes(rootPath);
-    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
   }));
 
   handle(Channels.SOURCES_ADD_TAG, withRootPathWin(async (rootPath, win, params: { sourceId: string; tag: string }) => {
     await addSourceTag(rootPath, params.sourceId, params.tag);
     await persistIndexes(rootPath);
-    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
   }));
 
   handle(Channels.SOURCES_REMOVE_TAG, withRootPathWin(async (rootPath, win, params: { sourceId: string; tag: string }) => {
     await removeSourceTag(rootPath, params.sourceId, params.tag);
     await persistIndexes(rootPath);
-    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
   }));
 
   handle(Channels.SOURCES_SET_READ_DUE_BY, withRootPathWin(async (rootPath, win, params: { sourceId: string; dueBy: string | null }) => {
     await setSourceReadDueBy(rootPath, params.sourceId, params.dueBy);
     await persistIndexes(rootPath);
-    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
   }));
 
   handle(Channels.SOURCES_STRIP_UPSTREAM_TAGS, withRootPathWin(async (rootPath, win, sourceId: string) => {
     const result = await stripUpstreamTags(rootPath, sourceId);
     await persistIndexes(rootPath);
-    if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
     return result;
   }));
 
@@ -259,7 +260,7 @@ export function registerSources(): void {
 
   // ── Collections (#470) ────────────────────────────────────────────────────
   const broadcastCollectionsChanged = (win: BrowserWindow) => {
-    if (!win.isDestroyed()) win.webContents.send(Channels.COLLECTIONS_CHANGED);
+    if (!win.isDestroyed()) broadcast(win, Channels.COLLECTIONS_CHANGED);
   };
 
   handle(Channels.COLLECTIONS_LIST, withRootPathOr<[], { collections: never[] } | Promise<CollectionsFile>>({ collections: [] }, async (rootPath) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
+import { broadcast } from './ipc/broadcast';
 import { registerIpcHandlers } from './ipc';
 import { resolveDisplayName } from './project-config';
 import { buildMenu, rebuildMenu, clearMenuEditorState } from './menu';
@@ -87,7 +88,7 @@ void app.whenReady().then(async () => {
         boot(`renderer loaded — opening project ${path.basename(state.rootPath)}`);
         await openProjectInWindow(win, state.rootPath);
         boot(`project indexed ${path.basename(state.rootPath)}`);
-        win.webContents.send(Channels.PROJECT_OPENED, {
+        broadcast(win, Channels.PROJECT_OPENED, {
           rootPath: state.rootPath,
           name: resolveDisplayName(state.rootPath),
         });

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,6 +1,7 @@
 import { Menu, shell, dialog, BrowserWindow } from 'electron';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
+import { broadcast } from './ipc/broadcast';
 import { THEME_MODES, type ThemeMode } from '../shared/theme';
 import { getRecentProjects } from './recent-projects';
 import { resolveDisplayName } from './project-config';
@@ -184,7 +185,7 @@ function buildRecentSubmenu(): Electron.MenuItemConstructorOptions[] {
               const win = createWindow();
               win.webContents.once('did-finish-load', async () => {
                 await openProjectInWindow(win, projectPath);
-                win.webContents.send(Channels.PROJECT_OPENED, { rootPath: projectPath, name: resolveDisplayName(projectPath) });
+                broadcast(win, Channels.PROJECT_OPENED, { rootPath: projectPath, name: resolveDisplayName(projectPath) });
               });
             }
           },
@@ -361,7 +362,7 @@ function buildFileMenu(gate: Gate, isMac: boolean): Electron.MenuItemConstructor
           await tables.registerAllCsvs(ctx);
           // Note tables after CSVs — CSV wins on a shared name (#1358).
           await tables.registerAllNoteTables(ctx);
-          if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+          if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
         },
       }),
       gate({

--- a/src/main/notebase/watcher.ts
+++ b/src/main/notebase/watcher.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { BrowserWindow } from 'electron';
 import { Channels } from '../../shared/channels';
+import { broadcast } from '../ipc/broadcast';
 
 import { INDEXABLE_EXTS } from './indexable-files';
 import { wasHandled } from './path-dedup';
@@ -165,12 +166,12 @@ export function startWatching(
     clearTimeout(pending.timer);
     pendingUnlinks.delete(absPath);
     if (win.isDestroyed()) return;
-    win.webContents.send(Channels.NOTEBASE_FILE_DELETED, pending.relative);
+    broadcast(win, Channels.NOTEBASE_FILE_DELETED, pending.relative);
     indexDeleted(pending.relative);
   };
 
   const emitCreate = (relative: string) => {
-    win.webContents.send(Channels.NOTEBASE_FILE_CREATED, relative);
+    broadcast(win, Channels.NOTEBASE_FILE_CREATED, relative);
     indexCreated(relative);
   };
 
@@ -179,7 +180,7 @@ export function startWatching(
     const ino = inodeOf(stats);
     if (ino !== undefined) inodeByPath.set(filePath, ino);
     const relative = filePath.slice(rootPath.length + 1);
-    win.webContents.send(Channels.NOTEBASE_FILE_CHANGED, relative);
+    broadcast(win, Channels.NOTEBASE_FILE_CHANGED, relative);
     indexChanged(relative);
   });
 
@@ -201,7 +202,7 @@ export function startWatching(
       // Tab follows the file (renderer); the index drops the old path and
       // picks up the new one. Crucially we do NOT emit FILE_DELETED for the
       // old path — that broadcast is what would close the tab.
-      win.webContents.send(Channels.NOTEBASE_RENAMED, [{ old: pending.relative, new: relative }]);
+      broadcast(win, Channels.NOTEBASE_RENAMED, [{ old: pending.relative, new: relative }]);
       indexDeleted(pending.relative);
       emitCreate(relative);
       return;
@@ -230,7 +231,7 @@ export function startWatching(
     // In-app renames already moved the tab via NOTEBASE_RENAMED; emit the
     // delete immediately (unchanged behavior) rather than debouncing it.
     if (wasHandled(relative)) {
-      win.webContents.send(Channels.NOTEBASE_FILE_DELETED, relative);
+      broadcast(win, Channels.NOTEBASE_FILE_DELETED, relative);
       indexDeleted(relative);
       return;
     }
@@ -244,7 +245,7 @@ export function startWatching(
       const added = recentAdds.get(movedTo)!;
       clearTimeout(added.timer);
       recentAdds.delete(movedTo);
-      win.webContents.send(Channels.NOTEBASE_RENAMED, [{ old: relative, new: added.relative }]);
+      broadcast(win, Channels.NOTEBASE_RENAMED, [{ old: relative, new: added.relative }]);
       indexDeleted(relative);
       return;
     }

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow } from 'electron';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
+import { broadcast } from './ipc/broadcast';
 import { appIconPath } from './app-icon';
 import { resolveDisplayName } from './project-config';
 import { startWatching, stopWatching } from './notebase/watcher';
@@ -118,7 +119,7 @@ export function createWindow(opts?: { x?: number; y?: number; width?: number; he
   win.webContents.on('did-finish-load', () => {
     const ctx = contexts.get(win.id);
     if (ctx?.rootPath && !win.isDestroyed()) {
-      win.webContents.send(Channels.PROJECT_OPENED, {
+      broadcast(win, Channels.PROJECT_OPENED, {
         rootPath: ctx.rootPath,
         name: resolveDisplayName(ctx.rootPath),
       });
@@ -190,7 +191,7 @@ export function broadcastBackfillProgress(
   progress: { done: number; total: number; running: boolean },
 ): void {
   for (const win of windowsForProject(rootPath)) {
-    if (!win.isDestroyed()) win.webContents.send(Channels.EMBEDDINGS_BACKFILL_PROGRESS, progress);
+    if (!win.isDestroyed()) broadcast(win, Channels.EMBEDDINGS_BACKFILL_PROGRESS, progress);
   }
 }
 
@@ -256,7 +257,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   // toast pointing at `table_name:` as the fix. Unsub on window
   // close to avoid leaking listeners across project reopens.
   const unsubCollision = tables.onCsvTableCollision(rootPath, (collision) => {
-    if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_NAME_COLLISION, collision);
+    if (!win.isDestroyed()) broadcast(win, Channels.TABLES_NAME_COLLISION, collision);
   });
   win.once('closed', () => { unsubCollision(); });
 
@@ -348,7 +349,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
     if (!csvPath) return;
     try {
       await tables.registerCsv(projectCtx, csvPath);
-      if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+      if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
       // Collisions broadcast via the per-project listener attached
       // before acquireProject — no extra wiring here.
     } catch (err) {
@@ -366,7 +367,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       if (relativePath.toLowerCase().endsWith('.csv')) {
         try {
           await tables.registerCsv(projectCtx, relativePath);
-          if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+          if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
         } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
       } else {
         await reregisterSibling(relativePath);
@@ -389,7 +390,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         // Captioned markdown tables in the note re-register in DuckDB (#1358).
         if (relativePath.toLowerCase().endsWith('.md')) {
           const r = await tables.reregisterNoteTables(projectCtx, relativePath, content);
-          if (r.changed && !win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+          if (r.changed && !win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
         }
         debouncedPersist();
       } catch (err) {
@@ -403,7 +404,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       if (relativePath.toLowerCase().endsWith('.csv')) {
         try {
           await tables.registerCsv(projectCtx, relativePath);
-          if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+          if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
         } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
       } else {
         await reregisterSibling(relativePath);
@@ -421,7 +422,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         search.indexNote(projectCtx, relativePath, content);
         if (relativePath.toLowerCase().endsWith('.md')) {
           const r = await tables.reregisterNoteTables(projectCtx, relativePath, content);
-          if (r.changed && !win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+          if (r.changed && !win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
         }
         debouncedPersist();
       } catch (err) {
@@ -433,7 +434,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       if (relativePath.toLowerCase().endsWith('.csv')) {
         try {
           await tables.unregisterCsv(projectCtx, relativePath);
-          if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+          if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
         } catch (err) { console.warn(`[tables] unregisterCsv failed for ${relativePath}:`, err); }
       } else {
         // Schema sidecar deleted → CSV reverts to read_csv_auto. Same
@@ -449,7 +450,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         // surfaces as delete+create, so the create half re-registers them.
         if (relativePath.toLowerCase().endsWith('.md')) {
           await tables.unregisterNoteTables(projectCtx, relativePath);
-          if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+          if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
         }
       } catch (err) {
         console.warn(`[watcher] removeNote failed for ${relativePath}:`, err);
@@ -466,14 +467,14 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         graph.indexSource(projectCtx, sourceId, metaContent, bodyContent);
         void vectors.indexSource(projectCtx, sourceId, bodyContent ?? ''); // #839
         debouncedPersist();
-        if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+        if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
       } catch { /* meta.ttl may have been deleted between events */ }
     },
     onSourceMetaDeleted: (sourceId) => {
       graph.removeSource(projectCtx, sourceId);
       void vectors.removeSource(projectCtx, sourceId); // #839
       debouncedPersist();
-      if (!win.isDestroyed()) win.webContents.send(Channels.SOURCES_CHANGED);
+      if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
     },
     onExcerptChanged: async (excerptId) => {
       try {
@@ -482,14 +483,14 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
         graph.indexExcerpt(projectCtx, excerptId, content);
         void vectors.indexExcerpt(projectCtx, excerptId, citedTextFromTtl(content) ?? ''); // #839
         debouncedPersist();
-        if (!win.isDestroyed()) win.webContents.send(Channels.EXCERPTS_CHANGED);
+        if (!win.isDestroyed()) broadcast(win, Channels.EXCERPTS_CHANGED);
       } catch { /* file may have been deleted between events */ }
     },
     onExcerptDeleted: (excerptId) => {
       graph.removeExcerpt(projectCtx, excerptId);
       void vectors.removeExcerpt(projectCtx, excerptId); // #839
       debouncedPersist();
-      if (!win.isDestroyed()) win.webContents.send(Channels.EXCERPTS_CHANGED);
+      if (!win.isDestroyed()) broadcast(win, Channels.EXCERPTS_CHANGED);
     },
   });
   watchers.set(win.id, rootPath);
@@ -498,7 +499,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   // scan so this window's sidebar populates without the renderer having to
   // poll. (For the second+ window on a project, the data is already
   // registered, but the renderer still needs a kick to load it.)
-  if (!win.isDestroyed()) win.webContents.send(Channels.TABLES_CHANGED);
+  if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
   persistSession();
   void syncClipperLifecycle();
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -3,16 +3,32 @@ import { Channels } from '../shared/channels';
 import { invoke } from './typed-invoke';
 import type { SearchInNotesOptions, ReplaceInNotesOptions, MenuEditorState, BookmarkNode, LayoutSession, NeighborhoodOptions } from '../shared/types';
 import type { ThemeMode } from '../shared/theme';
-import type { ChannelMap } from '../shared/ipc-contract';
+import type { ChannelMap, EventMap } from '../shared/ipc-contract';
 
 /**
  * Subscribe to an IPC channel and forward the typed payload to `cb`.
  * Centralises the unavoidable cast at the IPC boundary — the main
  * process owns the wire shape, so each subscriber names what it expects.
+ *
+ * Legacy path: prefer {@link subscribe} for any channel in EventMap (#1633),
+ * which derives the payload types from the shared contract instead of casting
+ * `unknown`. This remains for channels not yet migrated (conversation drafts,
+ * streaming, `menu:*` commands).
  */
 function subscribeIpc<T>(channel: string, cb: (payload: T) => void): () => void {
   // Wrapper captured by reference so `off` removes the exact handler.
   const handler = (_e: unknown, payload: unknown) => cb(payload as T);
+  ipcRenderer.on(channel, handler);
+  return () => { ipcRenderer.off(channel, handler); };
+}
+
+/**
+ * Typed main→renderer event subscription (#1633). The channel + the `cb` payload
+ * types are checked against {@link EventMap}, so a subscriber that disagrees with
+ * the sender fails `tsc` — no more `unknown` cast at this boundary.
+ */
+function subscribe<K extends keyof EventMap>(channel: K, cb: EventMap[K]): () => void {
+  const handler = (_e: unknown, ...args: unknown[]) => (cb as (...a: unknown[]) => void)(...args);
   ipcRenderer.on(channel, handler);
   return () => { ipcRenderer.off(channel, handler); };
 }
@@ -58,12 +74,12 @@ contextBridge.exposeInMainWorld('api', {
       invoke(Channels.NOTEBASE_COPY, srcRelPath, destRelPath),
     searchInNotes: (opts: SearchInNotesOptions) => invoke(Channels.NOTEBASE_SEARCH_IN_NOTES, opts),
     replaceInNotes: (opts: ReplaceInNotesOptions) => invoke(Channels.NOTEBASE_REPLACE_IN_NOTES, opts),
-    onFileChanged: (cb: (path: string) => void) => subscribeIpc(Channels.NOTEBASE_FILE_CHANGED, cb),
-    onFileCreated: (cb: (path: string) => void) => subscribeIpc(Channels.NOTEBASE_FILE_CREATED, cb),
-    onFileDeleted: (cb: (path: string) => void) => subscribeIpc(Channels.NOTEBASE_FILE_DELETED, cb),
+    onFileChanged: (cb: (path: string) => void) => subscribe(Channels.NOTEBASE_FILE_CHANGED, cb),
+    onFileCreated: (cb: (path: string) => void) => subscribe(Channels.NOTEBASE_FILE_CREATED, cb),
+    onFileDeleted: (cb: (path: string) => void) => subscribe(Channels.NOTEBASE_FILE_DELETED, cb),
     onRenamed: (cb: (transitions: Array<{ old: string; new: string }>) => void) =>
-      subscribeIpc(Channels.NOTEBASE_RENAMED, cb),
-    onRewritten: (cb: (paths: string[]) => void) => subscribeIpc(Channels.NOTEBASE_REWRITTEN, cb),
+      subscribe(Channels.NOTEBASE_RENAMED, cb),
+    onRewritten: (cb: (paths: string[]) => void) => subscribe(Channels.NOTEBASE_REWRITTEN, cb),
     onHeadingRenameSuggested: (cb: (candidate: {
       relativePath: string;
       oldSlug: string;
@@ -71,7 +87,7 @@ contextBridge.exposeInMainWorld('api', {
       newSlug: string;
       newText: string;
       incomingLinkCount: number;
-    }) => void) => subscribeIpc(Channels.NOTEBASE_HEADING_RENAME_SUGGESTED, cb),
+    }) => void) => subscribe(Channels.NOTEBASE_HEADING_RENAME_SUGGESTED, cb),
     renameAnchor: (targetRelativePath: string, oldSlug: string, newSlug: string) =>
       invoke(Channels.NOTEBASE_RENAME_ANCHOR, targetRelativePath, oldSlug, newSlug),
     renameSource: (oldId: string, newId: string) =>
@@ -145,7 +161,7 @@ contextBridge.exposeInMainWorld('api', {
   },
   embeddings: {
     onBackfillProgress: (cb: (p: { done: number; total: number; running: boolean }) => void) =>
-      subscribeIpc(Channels.EMBEDDINGS_BACKFILL_PROGRESS, cb),
+      subscribe(Channels.EMBEDDINGS_BACKFILL_PROGRESS, cb),
     related: (relativePath: string, limit?: number) =>
       invoke(Channels.EMBEDDINGS_RELATED, relativePath, limit),
     unlinkedMentions: (relativePath: string, limit?: number) =>
@@ -156,12 +172,9 @@ contextBridge.exposeInMainWorld('api', {
   tables: {
     query: (sql: string) => invoke(Channels.TABLES_QUERY, sql),
     list: () => invoke(Channels.TABLES_LIST),
-    onChanged: (cb: () => void) => {
-      ipcRenderer.on(Channels.TABLES_CHANGED, () => cb());
-    },
-    onNameCollision: (cb: (collision: import('../shared/types').CsvTableCollision) => void) => {
-      ipcRenderer.on(Channels.TABLES_NAME_COLLISION, (_e, collision) => cb(collision as import('../shared/types').CsvTableCollision));
-    },
+    onChanged: (cb: () => void) => subscribe(Channels.TABLES_CHANGED, cb),
+    onNameCollision: (cb: (collision: import('../shared/types').CsvTableCollision) => void) =>
+      subscribe(Channels.TABLES_NAME_COLLISION, cb),
   },
   tags: {
     list: () => invoke(Channels.TAGS_LIST),
@@ -327,18 +340,14 @@ contextBridge.exposeInMainWorld('api', {
     /** The pending-proposal set changed — filed in-app, filed out-of-process
      *  and routed through the substrate server, approved, rejected, or expired
      *  (#1524). The proposals store re-fetches on this. */
-    onChanged: (cb: () => void) => {
-      ipcRenderer.on(Channels.PROPOSALS_CHANGED, () => cb());
-    },
+    onChanged: (cb: () => void) => subscribe(Channels.PROPOSALS_CHANGED, cb),
     /** Ask main to raise a native OS notification for a proposal that arrived
      *  while Minerva was unfocused (#1541). */
     notifyArrival: (arg: { count: number; proposer: string }) =>
       invoke(Channels.PROPOSALS_NOTIFY_ARRIVAL, arg),
     /** Main asks the renderer to surface the Proposals panel (native arrival
      *  notification clicked, #1541). */
-    onShowRequested: (cb: () => void) => {
-      ipcRenderer.on(Channels.PROPOSALS_SHOW, () => cb());
-    },
+    onShowRequested: (cb: () => void) => subscribe(Channels.PROPOSALS_SHOW, cb),
   },
   bookmarks: {
     load: () => invoke(Channels.BOOKMARKS_LOAD),
@@ -382,10 +391,10 @@ contextBridge.exposeInMainWorld('api', {
       invoke(Channels.SOURCES_FINISH_PDF_OCR, sourceId, pages),
     importBibtex: () => invoke(Channels.SOURCES_IMPORT_BIBTEX),
     onImportBibtexProgress: (cb: (progress: { done: number; total: number; currentTitle: string }) => void) =>
-      subscribeIpc(Channels.SOURCES_IMPORT_BIBTEX_PROGRESS, cb),
+      subscribe(Channels.SOURCES_IMPORT_BIBTEX_PROGRESS, cb),
     importZoteroRdf: () => invoke(Channels.SOURCES_IMPORT_ZOTERO_RDF),
     onImportZoteroRdfProgress: (cb: (progress: { done: number; total: number; currentTitle: string }) => void) =>
-      subscribeIpc(Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS, cb),
+      subscribe(Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS, cb),
     listAll: () => invoke(Channels.SOURCES_LIST_ALL),
     delete: (sourceId: string) => invoke(Channels.SOURCES_DELETE, sourceId),
     merge: (srcId: string, destId: string) =>
@@ -417,9 +426,7 @@ contextBridge.exposeInMainWorld('api', {
       invoke(Channels.SOURCES_RESOLVE_STUB, sourceId),
     applyStubResolution: (sourceId: string, doi: string) =>
       invoke(Channels.SOURCES_APPLY_STUB_RESOLUTION, { sourceId, doi }),
-    onChanged: (cb: () => void) => {
-      ipcRenderer.on(Channels.SOURCES_CHANGED, () => cb());
-    },
+    onChanged: (cb: () => void) => subscribe(Channels.SOURCES_CHANGED, cb),
     createExcerpt: (params: {
       sourceId: string;
       citedText: string;
@@ -427,7 +434,7 @@ contextBridge.exposeInMainWorld('api', {
       pageRange?: string | null;
       locationText?: string | null;
     }) => invoke(Channels.SOURCES_CREATE_EXCERPT, params),
-    onExcerptsChanged: (cb: () => void) => subscribeIpc(Channels.EXCERPTS_CHANGED, () => cb()),
+    onExcerptsChanged: (cb: () => void) => subscribe(Channels.EXCERPTS_CHANGED, () => cb()),
   },
   collections: {
     list: () => invoke(Channels.COLLECTIONS_LIST),
@@ -449,9 +456,7 @@ contextBridge.exposeInMainWorld('api', {
       invoke(Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, { id, predicate }),
     smartMembers: (id: string) =>
       invoke(Channels.COLLECTIONS_SMART_MEMBERS, id),
-    onChanged: (cb: () => void) => {
-      ipcRenderer.on(Channels.COLLECTIONS_CHANGED, () => cb());
-    },
+    onChanged: (cb: () => void) => subscribe(Channels.COLLECTIONS_CHANGED, cb),
   },
   formatter: {
     formatContent: (content: string, settings: Parameters<ChannelMap['formatter:formatContent']>[1], relativePath?: string) =>
@@ -713,7 +718,7 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.on(Channels.MENU_IMPORT_ZOTERO_RDF, () => cb());
     },
     onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) =>
-      subscribeIpc(Channels.PROJECT_OPENED, cb),
+      subscribe(Channels.PROJECT_OPENED, cb),
   },
 });
 

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -54,6 +54,7 @@ import type {
   NeighborhoodHop,
   RelatedNotesResult,
   SourceDetail,
+  CsvTableCollision,
 } from './types';
 import type { ClipperState } from './clipper-pairing';
 import type { Proposal } from './proposals';
@@ -535,6 +536,40 @@ export interface ChannelMap {
   'conversation:fileReorgDraft': (draft: ConversationReorgDraft, selected: Array<{ fromPath: string; toPath: string }>) => { proposalUri: string | null; applied: boolean };
   'conversation:fileDeleteDraft': (draft: ConversationDeleteDraft, selected: string[]) => { proposalUri: string | null; applied: boolean };
   'conversation:fileNoteBodyDraft': (draft: ConversationNoteBodyDraft) => FileNoteBodyDraftResult;
+}
+
+/**
+ * One-way (main → renderer) event channels (#1633). The invoke contract above
+ * is request/response; these are `webContents.send` broadcasts (file/graph change
+ * notifications, ingest progress). Each key is the channel string literal; each
+ * value is the *payload* signature `(...args) => void`. The typed `broadcast`
+ * (main) and `subscribe` (preload) wrappers derive their arg types from here, so
+ * a sender and a subscriber that disagree fail `tsc` instead of the payload
+ * arriving as `unknown` — the drift this closes for the payloaded event channels
+ * the API review flagged (`*:changed` / `*:progress` / file + rename events).
+ *
+ * Rollout is staged: this first batch covers the data-broadcast events. The
+ * conversation-draft, streaming, and `menu:*` command channels still use the
+ * legacy `subscribeIpc` forwarder and will move here next.
+ */
+export interface EventMap {
+  'project:opened': (meta: { rootPath: string; name: string }) => void;
+  'notebase:fileChanged': (path: string) => void;
+  'notebase:fileCreated': (path: string) => void;
+  'notebase:fileDeleted': (path: string) => void;
+  'notebase:renamed': (transitions: Array<{ old: string; new: string }>) => void;
+  'notebase:rewritten': (paths: string[]) => void;
+  'notebase:headingRenameSuggested': (candidate: HeadingRenameCandidate) => void;
+  'embeddings:backfillProgress': (p: { done: number; total: number; running: boolean }) => void;
+  'sources:changed': () => void;
+  'sources:importBibtexProgress': (progress: { done: number; total: number; currentTitle: string }) => void;
+  'sources:importZoteroRdfProgress': (progress: { done: number; total: number; currentTitle: string }) => void;
+  'excerpts:changed': () => void;
+  'collections:changed': () => void;
+  'tables:changed': () => void;
+  'tables:nameCollision': (collision: CsvTableCollision) => void;
+  'proposals:changed': () => void;
+  'proposals:show': () => void;
 }
 
 /** A configured publish destination (#254; multi-transport #1444). Mirror of the


### PR DESCRIPTION
Part 1 of #1633.

`ChannelMap` is invoke-only. The main→renderer **event** channels were typed in three places that could silently drift — main `webContents.send` (untyped args), the preload forwarders (`unknown` cast), and the client. This introduces **`EventMap`** as the single source of truth for event payloads, plus typed wrappers both sides derive from — mirroring what `handle`/`invoke` did for request/response.

- **`EventMap`** in `shared/ipc-contract.ts`.
- **`broadcast<K>(win, channel, …payload)`** — a leaf module (`ipc/broadcast.ts`, so no import cycle through `ipc/helpers`), the main-side mirror of `handle`.
- **`subscribe<K>(channel, cb)`** in preload — replaces the `unknown`-casting `subscribeIpc` for migrated channels.

**Migrated this PR — the data-broadcast events** (drift-prone `*:changed` / `*:progress` / file / rename / heading-rename / project-opened, 17 total):
- all **17 preload forwarders** now type-check against `EventMap` — **no more `unknown`** at the receiver;
- all **53 main send sites** (watcher, window-manager, menu, main, register-* handlers) go through typed `broadcast`;
- a sender whose payload disagrees with the subscriber now **fails `tsc`**.

**Types-only — runtime is identical** (`broadcast` → `webContents.send`, `subscribe` → `ipcRenderer.on`). `pnpm lint` clean; **full suite green (546 files / 5421 tests)**.

## Staged rollout
Kept reviewable by scope. The conversation-draft, streaming, and ~70 `menu:*` command channels still use the legacy `subscribeIpc` (not payload-drift-prone) and move to `EventMap` in follow-up parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)