### PR TITLE
feat(ipc): finish the EventMap migration — drafts, streams, menu commands (#1633)

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -8,7 +8,9 @@ import { readThoughtbaseDoc, thoughtbaseDocPromptBlock } from '../llm/thoughtbas
 import type { ContextBundle, ConversationMessage } from '../../shared/types';
 import type { ConversationDraftBase } from '../../shared/conversation-draft-base';
 import { rootPathFromEvent, winFromEvent } from './helpers';
+import { broadcast } from './broadcast';
 import { handle } from './typed-ipc';
+import type { EventMap } from '../../shared/ipc-contract';
 
 const DEFAULT_CONVERSATION_SYSTEM_PROMPT = [
   'You are an assistant embedded in Minerva, a markdown-based thinking tool.',
@@ -120,14 +122,18 @@ function buildStreamCallbacks(
   signal: AbortSignal,
   pendingAskUser: PendingAskUser,
 ): StreamCallbacks {
+  // All draft channels carry ConversationDraftBase; the channel is typed against
+  // EventMap but the send stays raw — TS can't verify a single-arg spread against
+  // a generic `Parameters<EventMap[K]>` tuple, and every subscriber is typed via
+  // `subscribe`, so the payload is checked on the receiving side (#1633).
   const draftEmit =
-    (channel: string) =>
+    (channel: keyof EventMap) =>
     (draft: ConversationDraftBase) => {
       if (!win.isDestroyed()) win.webContents.send(channel, draft);
     };
   return {
     onChunk: (chunk: string) => {
-      if (!win.isDestroyed()) win.webContents.send(Channels.CONVERSATION_STREAM, chunk);
+      if (!win.isDestroyed()) broadcast(win, Channels.CONVERSATION_STREAM, chunk);
     },
     onDraft: draftEmit(Channels.CONVERSATION_DRAFT),
     onSourceDraft: draftEmit(Channels.CONVERSATION_SOURCE_DRAFT),
@@ -144,11 +150,12 @@ function buildStreamCallbacks(
       return new Promise<string>((resolve, reject) => {
         pendingAskUser.set(questionId, { winId: win.id, resolve, reject });
         if (!win.isDestroyed()) {
-          win.webContents.send(Channels.CONVERSATION_ASK_USER, {
+          broadcast(win, Channels.CONVERSATION_ASK_USER, {
             questionId,
             conversationId: convId,
             question,
-            choices,
+            // `choices` is optional (exactOptionalPropertyTypes) — omit when absent.
+            ...(choices ? { choices } : {}),
           });
         } else {
           pendingAskUser.delete(questionId);

--- a/src/main/ipc/register-tools.ts
+++ b/src/main/ipc/register-tools.ts
@@ -13,6 +13,7 @@ import { checkConnection } from '../llm/validate';
 import type { ToolExecutionRequest, LLMSettingsUpdate } from '../../shared/tools/types';
 import type { ProviderId } from '../../shared/tools/providers';
 import { winFromEvent } from './helpers';
+import { broadcast } from './broadcast';
 
 export function registerTools(): void {
   // Tools for Thought
@@ -28,7 +29,7 @@ export function registerTools(): void {
         request,
         (chunk: string) => {
           if (!win.isDestroyed()) {
-            win.webContents.send(Channels.TOOL_STREAM, chunk);
+            broadcast(win, Channels.TOOL_STREAM, chunk);
           }
         },
         controller.signal,

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -2,6 +2,7 @@ import { Menu, shell, dialog, BrowserWindow } from 'electron';
 import path from 'node:path';
 import { Channels } from '../shared/channels';
 import { broadcast } from './ipc/broadcast';
+import type { EventMap } from '../shared/ipc-contract';
 import { THEME_MODES, type ThemeMode } from '../shared/theme';
 import { getRecentProjects } from './recent-projects';
 import { resolveDisplayName } from './project-config';
@@ -27,9 +28,9 @@ import {
   getUpdateState,
 } from './auto-update';
 
-function send(channel: string, ...args: unknown[]) {
+function send<K extends keyof EventMap>(channel: K, ...args: Parameters<EventMap[K]>) {
   const win = BrowserWindow.getFocusedWindow();
-  if (win) win.webContents.send(channel, ...args);
+  if (win) broadcast(win, channel, ...args);
 }
 
 // Current theme, mirrored from the renderer (which owns it in localStorage) so

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -6,26 +6,10 @@ import type { ThemeMode } from '../shared/theme';
 import type { ChannelMap, EventMap } from '../shared/ipc-contract';
 
 /**
- * Subscribe to an IPC channel and forward the typed payload to `cb`.
- * Centralises the unavoidable cast at the IPC boundary — the main
- * process owns the wire shape, so each subscriber names what it expects.
- *
- * Legacy path: prefer {@link subscribe} for any channel in EventMap (#1633),
- * which derives the payload types from the shared contract instead of casting
- * `unknown`. This remains for channels not yet migrated (conversation drafts,
- * streaming, `menu:*` commands).
- */
-function subscribeIpc<T>(channel: string, cb: (payload: T) => void): () => void {
-  // Wrapper captured by reference so `off` removes the exact handler.
-  const handler = (_e: unknown, payload: unknown) => cb(payload as T);
-  ipcRenderer.on(channel, handler);
-  return () => { ipcRenderer.off(channel, handler); };
-}
-
-/**
  * Typed main→renderer event subscription (#1633). The channel + the `cb` payload
  * types are checked against {@link EventMap}, so a subscriber that disagrees with
- * the sender fails `tsc` — no more `unknown` cast at this boundary.
+ * the sender fails `tsc` — no more `unknown` cast at this boundary. Every
+ * main→renderer channel now flows through here.
  */
 function subscribe<K extends keyof EventMap>(channel: K, cb: EventMap[K]): () => void {
   const handler = (_e: unknown, ...args: unknown[]) => (cb as (...a: unknown[]) => void)(...args);
@@ -279,47 +263,47 @@ contextBridge.exposeInMainWorld('api', {
       invoke(Channels.CONVERSATION_SEND, convId, userMessage, systemPrompt, currentNotePath, extraTools),
     loadUIState: () => invoke(Channels.CONVERSATION_UI_STATE_LOAD),
     saveUIState: (state: Parameters<ChannelMap['conversation:uiStateSave']>[0]) => invoke(Channels.CONVERSATION_UI_STATE_SAVE, state),
-    onAskUser: (cb: (req: unknown) => void) => subscribeIpc(Channels.CONVERSATION_ASK_USER, cb),
+    onAskUser: (cb: (req: unknown) => void) => subscribe(Channels.CONVERSATION_ASK_USER, cb),
     askUserReply: (questionId: string, answer: string) =>
       invoke(Channels.CONVERSATION_ASK_USER_REPLY, questionId, answer),
-    onStream: (cb: (chunk: string) => void) => subscribeIpc(Channels.CONVERSATION_STREAM, cb),
+    onStream: (cb: (chunk: string) => void) => subscribe(Channels.CONVERSATION_STREAM, cb),
     cancel: () => invoke(Channels.CONVERSATION_CANCEL),
-    onDraft: (cb: (draft: unknown) => void) => subscribeIpc(Channels.CONVERSATION_DRAFT, cb),
+    onDraft: (cb: (draft: unknown) => void) => subscribe(Channels.CONVERSATION_DRAFT, cb),
     fileDraft: (draft: Parameters<ChannelMap['conversation:fileDraft']>[0]) => invoke(Channels.CONVERSATION_FILE_DRAFT, draft),
     onSourceDraft: (cb: (draft: unknown) => void) =>
-      subscribeIpc(Channels.CONVERSATION_SOURCE_DRAFT, cb),
+      subscribe(Channels.CONVERSATION_SOURCE_DRAFT, cb),
     fileSourceDraft: (draft: Parameters<ChannelMap['conversation:fileSourceDraft']>[0]) =>
       invoke(Channels.CONVERSATION_FILE_SOURCE_DRAFT, draft),
     onPropertyDraft: (cb: (draft: unknown) => void) =>
-      subscribeIpc(Channels.CONVERSATION_PROPERTY_DRAFT, cb),
+      subscribe(Channels.CONVERSATION_PROPERTY_DRAFT, cb),
     filePropertyDraft: (draft: Parameters<ChannelMap['conversation:filePropertyDraft']>[0]) =>
       invoke(Channels.CONVERSATION_FILE_PROPERTY_DRAFT, draft),
     onSourcePropertyDraft: (cb: (draft: unknown) => void) =>
-      subscribeIpc(Channels.CONVERSATION_SOURCE_PROPERTY_DRAFT, cb),
+      subscribe(Channels.CONVERSATION_SOURCE_PROPERTY_DRAFT, cb),
     fileSourcePropertyDraft: (draft: Parameters<ChannelMap['conversation:fileSourcePropertyDraft']>[0]) =>
       invoke(Channels.CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT, draft),
     onClaimsDraft: (cb: (draft: unknown) => void) =>
-      subscribeIpc(Channels.CONVERSATION_CLAIMS_DRAFT, cb),
+      subscribe(Channels.CONVERSATION_CLAIMS_DRAFT, cb),
     fileClaimsDraft: (draft: Parameters<ChannelMap['conversation:fileClaimsDraft']>[0]) =>
       invoke(Channels.CONVERSATION_FILE_CLAIMS_DRAFT, draft),
     onComputeDraft: (cb: (draft: unknown) => void) =>
-      subscribeIpc(Channels.CONVERSATION_COMPUTE_DRAFT, cb),
+      subscribe(Channels.CONVERSATION_COMPUTE_DRAFT, cb),
     runComputeDraft: (input: Parameters<ChannelMap['conversation:runComputeDraft']>[0]) =>
       invoke(Channels.CONVERSATION_RUN_COMPUTE_DRAFT, input),
     onRefactorDraft: (cb: (draft: unknown) => void) =>
-      subscribeIpc(Channels.CONVERSATION_REFACTOR_DRAFT, cb),
+      subscribe(Channels.CONVERSATION_REFACTOR_DRAFT, cb),
     fileRefactorDraft: (draft: Parameters<ChannelMap['conversation:fileRefactorDraft']>[0]) =>
       invoke(Channels.CONVERSATION_FILE_REFACTOR_DRAFT, draft),
     onReorgDraft: (cb: (draft: unknown) => void) =>
-      subscribeIpc(Channels.CONVERSATION_REORG_DRAFT, cb),
+      subscribe(Channels.CONVERSATION_REORG_DRAFT, cb),
     fileReorgDraft: (draft: Parameters<ChannelMap['conversation:fileReorgDraft']>[0], selected: Parameters<ChannelMap['conversation:fileReorgDraft']>[1]) =>
       invoke(Channels.CONVERSATION_FILE_REORG_DRAFT, draft, selected),
     onDeleteDraft: (cb: (draft: unknown) => void) =>
-      subscribeIpc(Channels.CONVERSATION_DELETE_DRAFT, cb),
+      subscribe(Channels.CONVERSATION_DELETE_DRAFT, cb),
     fileDeleteDraft: (draft: Parameters<ChannelMap['conversation:fileDeleteDraft']>[0], selected: Parameters<ChannelMap['conversation:fileDeleteDraft']>[1]) =>
       invoke(Channels.CONVERSATION_FILE_DELETE_DRAFT, draft, selected),
     onNoteBodyDraft: (cb: (draft: unknown) => void) =>
-      subscribeIpc(Channels.CONVERSATION_NOTE_BODY_DRAFT, cb),
+      subscribe(Channels.CONVERSATION_NOTE_BODY_DRAFT, cb),
     fileNoteBodyDraft: (draft: Parameters<ChannelMap['conversation:fileNoteBodyDraft']>[0]) =>
       invoke(Channels.CONVERSATION_FILE_NOTE_BODY_DRAFT, draft),
     insertComputeDraft: (input: Parameters<ChannelMap['conversation:insertComputeDraft']>[0]) =>
@@ -473,13 +457,13 @@ contextBridge.exposeInMainWorld('api', {
     execute: (request: Parameters<ChannelMap['tool:execute']>[0]) => invoke(Channels.TOOL_EXECUTE, request),
     prepareConversation: (request: Parameters<ChannelMap['tool:prepareConversation']>[0]) => invoke(Channels.TOOL_PREPARE_CONVERSATION, request),
     cancel: () => invoke(Channels.TOOL_CANCEL),
-    onStream: (cb: (chunk: string) => void) => subscribeIpc(Channels.TOOL_STREAM, cb),
+    onStream: (cb: (chunk: string) => void) => subscribe(Channels.TOOL_STREAM, cb),
     getSettings: () => invoke(Channels.TOOL_GET_SETTINGS),
     setSettings: (settings: Parameters<ChannelMap['tool:setSettings']>[0]) => invoke(Channels.TOOL_SET_SETTINGS, settings),
     getKeyStorage: () => invoke(Channels.TOOL_GET_KEY_STORAGE),
     checkConnection: (providerId: Parameters<ChannelMap['tool:checkConnection']>[0], candidateKey?: string, baseURL?: string) =>
       invoke(Channels.TOOL_CHECK_CONNECTION, providerId, candidateKey, baseURL),
-    onInvoke: (cb: (toolId: string) => void) => subscribeIpc(Channels.TOOL_INVOKE, cb),
+    onInvoke: (cb: (toolId: string) => void) => subscribe(Channels.TOOL_INVOKE, cb),
   },
   types: {
     list: () => invoke(Channels.TYPES_LIST),
@@ -527,196 +511,74 @@ contextBridge.exposeInMainWorld('api', {
       invoke(Channels.CITATION_RENDER_INLINE, refs),
   },
   menu: {
-    onNewNote: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_NEW_NOTE, () => cb());
-    },
-    onEditThoughtbaseDoc: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_EDIT_THOUGHTBASE_DOC, () => cb());
-    },
-    onThoughtbaseProperties: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_THOUGHTBASE_PROPERTIES, () => cb());
-    },
-    onSave: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_SAVE, () => cb());
-    },
-    onSaveAsObjectType: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_SAVE_AS_OBJECT_TYPE, () => cb());
-    },
-    onSaveAsTemplate: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_SAVE_AS_TEMPLATE, () => cb());
-    },
-    onInsertTemplate: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_INSERT_TEMPLATE, () => cb());
-    },
-    onToggleSidebar: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_TOGGLE_SIDEBAR, () => cb());
-    },
-    onTogglePreview: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_TOGGLE_PREVIEW, () => cb());
-    },
-    onQuickOpen: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_QUICK_OPEN, () => cb());
-    },
-    onCycleTheme: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_CYCLE_THEME, () => cb());
-    },
-    onSetTheme: (cb: (mode: ThemeMode) => void) => {
-      ipcRenderer.on(Channels.MENU_SET_THEME, (_e, mode: ThemeMode) => cb(mode));
-    },
+    onNewNote: (cb: () => void) => subscribe(Channels.MENU_NEW_NOTE, cb),
+    onEditThoughtbaseDoc: (cb: () => void) => subscribe(Channels.MENU_EDIT_THOUGHTBASE_DOC, cb),
+    onThoughtbaseProperties: (cb: () => void) => subscribe(Channels.MENU_THOUGHTBASE_PROPERTIES, cb),
+    onSave: (cb: () => void) => subscribe(Channels.MENU_SAVE, cb),
+    onSaveAsObjectType: (cb: () => void) => subscribe(Channels.MENU_SAVE_AS_OBJECT_TYPE, cb),
+    onSaveAsTemplate: (cb: () => void) => subscribe(Channels.MENU_SAVE_AS_TEMPLATE, cb),
+    onInsertTemplate: (cb: () => void) => subscribe(Channels.MENU_INSERT_TEMPLATE, cb),
+    onToggleSidebar: (cb: () => void) => subscribe(Channels.MENU_TOGGLE_SIDEBAR, cb),
+    onTogglePreview: (cb: () => void) => subscribe(Channels.MENU_TOGGLE_PREVIEW, cb),
+    onQuickOpen: (cb: () => void) => subscribe(Channels.MENU_QUICK_OPEN, cb),
+    onCycleTheme: (cb: () => void) => subscribe(Channels.MENU_CYCLE_THEME, cb),
+    onSetTheme: (cb: (mode: ThemeMode) => void) => subscribe(Channels.MENU_SET_THEME, cb),
     reportTheme: (mode: ThemeMode) => ipcRenderer.send(Channels.MENU_REPORT_THEME, mode),
     reportEditorState: (state: MenuEditorState) => ipcRenderer.send(Channels.MENU_REPORT_EDITOR_STATE, state),
-    onSplitRight: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_SPLIT_RIGHT, () => cb());
-    },
-    onSplitDown: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_SPLIT_DOWN, () => cb());
-    },
-    onFocusNextGroup: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_FOCUS_NEXT_GROUP, () => cb());
-    },
-    onFocusPrevGroup: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_FOCUS_PREV_GROUP, () => cb());
-    },
-    onCloseGroup: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_CLOSE_GROUP, () => cb());
-    },
-    onFontIncrease: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_FONT_INCREASE, () => cb());
-    },
-    onFontDecrease: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_FONT_DECREASE, () => cb());
-    },
-    onFontReset: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_FONT_RESET, () => cb());
-    },
-    onToggleRightSidebar: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_TOGGLE_RIGHT_SIDEBAR, () => cb());
-    },
-    onToggleConversations: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_TOGGLE_CONVERSATIONS, () => cb());
-    },
-    onNewConversation: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_NEW_CONVERSATION, () => cb());
-    },
-    onNavBack: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_NAV_BACK, () => cb());
-    },
-    onNavForward: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_NAV_FORWARD, () => cb());
-    },
-    onGotoLine: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_GOTO_LINE, () => cb());
-    },
-    onFind: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_FIND, () => cb());
-    },
-    onFindReplace: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_FIND_REPLACE, () => cb());
-    },
-    onFindInNotes: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_FIND_IN_NOTES, () => cb());
-    },
-    onReplaceInNotes: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REPLACE_IN_NOTES, () => cb());
-    },
-    onNewQuery: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_NEW_QUERY, () => cb());
-    },
+    onSplitRight: (cb: () => void) => subscribe(Channels.MENU_SPLIT_RIGHT, cb),
+    onSplitDown: (cb: () => void) => subscribe(Channels.MENU_SPLIT_DOWN, cb),
+    onFocusNextGroup: (cb: () => void) => subscribe(Channels.MENU_FOCUS_NEXT_GROUP, cb),
+    onFocusPrevGroup: (cb: () => void) => subscribe(Channels.MENU_FOCUS_PREV_GROUP, cb),
+    onCloseGroup: (cb: () => void) => subscribe(Channels.MENU_CLOSE_GROUP, cb),
+    onFontIncrease: (cb: () => void) => subscribe(Channels.MENU_FONT_INCREASE, cb),
+    onFontDecrease: (cb: () => void) => subscribe(Channels.MENU_FONT_DECREASE, cb),
+    onFontReset: (cb: () => void) => subscribe(Channels.MENU_FONT_RESET, cb),
+    onToggleRightSidebar: (cb: () => void) => subscribe(Channels.MENU_TOGGLE_RIGHT_SIDEBAR, cb),
+    onToggleConversations: (cb: () => void) => subscribe(Channels.MENU_TOGGLE_CONVERSATIONS, cb),
+    onNewConversation: (cb: () => void) => subscribe(Channels.MENU_NEW_CONVERSATION, cb),
+    onNavBack: (cb: () => void) => subscribe(Channels.MENU_NAV_BACK, cb),
+    onNavForward: (cb: () => void) => subscribe(Channels.MENU_NAV_FORWARD, cb),
+    onGotoLine: (cb: () => void) => subscribe(Channels.MENU_GOTO_LINE, cb),
+    onFind: (cb: () => void) => subscribe(Channels.MENU_FIND, cb),
+    onFindReplace: (cb: () => void) => subscribe(Channels.MENU_FIND_REPLACE, cb),
+    onFindInNotes: (cb: () => void) => subscribe(Channels.MENU_FIND_IN_NOTES, cb),
+    onReplaceInNotes: (cb: () => void) => subscribe(Channels.MENU_REPLACE_IN_NOTES, cb),
+    onNewQuery: (cb: () => void) => subscribe(Channels.MENU_NEW_QUERY, cb),
     onOpenStockQuery: (cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void) =>
-      subscribeIpc(Channels.MENU_OPEN_STOCK_QUERY, cb),
-    onEditSavedQueries: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_EDIT_SAVED_QUERIES, () => cb());
-    },
-    onSortLines: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_SORT_LINES, () => cb());
-    },
-    onOpenSettings: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_OPEN_SETTINGS, () => cb());
-    },
-    onOpenProject: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_OPEN_PROJECT, () => cb());
-    },
-    onNewProject: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_NEW_PROJECT, () => cb());
-    },
-    onInstallTutorial: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_INSTALL_TUTORIAL, () => cb());
-    },
-    onOpenRecentProject: (cb: (path: string) => void) => subscribeIpc('menu:openRecentProject', cb),
-    onCloseProject: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_CLOSE_PROJECT, () => cb());
-    },
-    onClearRecent: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_CLEAR_RECENT, () => cb());
-    },
-    onPrint: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_PRINT, () => cb());
-    },
-    onAbout: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_ABOUT, () => cb());
-    },
-    onShortcuts: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_SHORTCUTS, () => cb());
-    },
-    onOpenInDefault: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_OPEN_IN_DEFAULT, () => cb());
-    },
-    onOpenInTerminal: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_OPEN_IN_TERMINAL, () => cb());
-    },
-    onRefactorRename: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REFACTOR_RENAME, () => cb());
-    },
-    onRefactorMove: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REFACTOR_MOVE, () => cb());
-    },
-    onRefactorCopy: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REFACTOR_COPY, () => cb());
-    },
-    onRefactorExtract: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REFACTOR_EXTRACT, () => cb());
-    },
-    onRefactorSplitHere: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REFACTOR_SPLIT_HERE, () => cb());
-    },
-    onRefactorSplitByHeading: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REFACTOR_SPLIT_BY_HEADING, () => cb());
-    },
-    onRefactorAutoTag: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REFACTOR_AUTOTAG, () => cb());
-    },
-    onRefactorAutoLink: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REFACTOR_AUTOLINK, () => cb());
-    },
-    onRefactorAutoLinkInbound: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REFACTOR_AUTOLINK_INBOUND, () => cb());
-    },
-    onRefactorDecompose: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_REFACTOR_DECOMPOSE, () => cb());
-    },
-    onFormat: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_FORMAT, () => cb());
-    },
-    onBibliography: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_BIBLIOGRAPHY, () => cb());
-    },
-    onIngestUrl: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_INGEST_URL, () => cb());
-    },
-    onIngestIdentifier: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_INGEST_IDENTIFIER, () => cb());
-    },
-    onIngestFile: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_INGEST_FILE, () => cb());
-    },
-    onExport: (cb: (exporterId: string) => void) => subscribeIpc(Channels.MENU_EXPORT, cb),
-    onPublish: (cb: () => void) => subscribeIpc(Channels.MENU_PUBLISH, cb),
-    onImportBibtex: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_IMPORT_BIBTEX, () => cb());
-    },
-    onImportZoteroRdf: (cb: () => void) => {
-      ipcRenderer.on(Channels.MENU_IMPORT_ZOTERO_RDF, () => cb());
-    },
+      subscribe(Channels.MENU_OPEN_STOCK_QUERY, cb),
+    onEditSavedQueries: (cb: () => void) => subscribe(Channels.MENU_EDIT_SAVED_QUERIES, cb),
+    onSortLines: (cb: () => void) => subscribe(Channels.MENU_SORT_LINES, cb),
+    onOpenSettings: (cb: () => void) => subscribe(Channels.MENU_OPEN_SETTINGS, cb),
+    onOpenProject: (cb: () => void) => subscribe(Channels.MENU_OPEN_PROJECT, cb),
+    onNewProject: (cb: () => void) => subscribe(Channels.MENU_NEW_PROJECT, cb),
+    onInstallTutorial: (cb: () => void) => subscribe(Channels.MENU_INSTALL_TUTORIAL, cb),
+    onOpenRecentProject: (cb: (path: string) => void) => subscribe('menu:openRecentProject', cb),
+    onCloseProject: (cb: () => void) => subscribe(Channels.MENU_CLOSE_PROJECT, cb),
+    onClearRecent: (cb: () => void) => subscribe(Channels.MENU_CLEAR_RECENT, cb),
+    onPrint: (cb: () => void) => subscribe(Channels.MENU_PRINT, cb),
+    onAbout: (cb: () => void) => subscribe(Channels.MENU_ABOUT, cb),
+    onShortcuts: (cb: () => void) => subscribe(Channels.MENU_SHORTCUTS, cb),
+    onOpenInDefault: (cb: () => void) => subscribe(Channels.MENU_OPEN_IN_DEFAULT, cb),
+    onOpenInTerminal: (cb: () => void) => subscribe(Channels.MENU_OPEN_IN_TERMINAL, cb),
+    onRefactorRename: (cb: () => void) => subscribe(Channels.MENU_REFACTOR_RENAME, cb),
+    onRefactorMove: (cb: () => void) => subscribe(Channels.MENU_REFACTOR_MOVE, cb),
+    onRefactorCopy: (cb: () => void) => subscribe(Channels.MENU_REFACTOR_COPY, cb),
+    onRefactorExtract: (cb: () => void) => subscribe(Channels.MENU_REFACTOR_EXTRACT, cb),
+    onRefactorSplitHere: (cb: () => void) => subscribe(Channels.MENU_REFACTOR_SPLIT_HERE, cb),
+    onRefactorSplitByHeading: (cb: () => void) => subscribe(Channels.MENU_REFACTOR_SPLIT_BY_HEADING, cb),
+    onRefactorAutoTag: (cb: () => void) => subscribe(Channels.MENU_REFACTOR_AUTOTAG, cb),
+    onRefactorAutoLink: (cb: () => void) => subscribe(Channels.MENU_REFACTOR_AUTOLINK, cb),
+    onRefactorAutoLinkInbound: (cb: () => void) => subscribe(Channels.MENU_REFACTOR_AUTOLINK_INBOUND, cb),
+    onRefactorDecompose: (cb: () => void) => subscribe(Channels.MENU_REFACTOR_DECOMPOSE, cb),
+    onFormat: (cb: () => void) => subscribe(Channels.MENU_FORMAT, cb),
+    onBibliography: (cb: () => void) => subscribe(Channels.MENU_BIBLIOGRAPHY, cb),
+    onIngestUrl: (cb: () => void) => subscribe(Channels.MENU_INGEST_URL, cb),
+    onIngestIdentifier: (cb: () => void) => subscribe(Channels.MENU_INGEST_IDENTIFIER, cb),
+    onIngestFile: (cb: () => void) => subscribe(Channels.MENU_INGEST_FILE, cb),
+    onExport: (cb: (exporterId: string) => void) => subscribe(Channels.MENU_EXPORT, cb),
+    onPublish: (cb: () => void) => subscribe(Channels.MENU_PUBLISH, cb),
+    onImportBibtex: (cb: () => void) => subscribe(Channels.MENU_IMPORT_BIBTEX, cb),
+    onImportZoteroRdf: (cb: () => void) => subscribe(Channels.MENU_IMPORT_ZOTERO_RDF, cb),
     onProjectOpened: (cb: (meta: { rootPath: string; name: string }) => void) =>
       subscribe(Channels.PROJECT_OPENED, cb),
   },

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -87,7 +87,9 @@ import type {
 import type { ParsedReference } from './mine-references';
 import type { ResolveCandidate } from './resolve-stub';
 import type { Conversation, ConversationMessage, ContextBundle, ConversationsUIState, CompactResult } from './types';
-import type { ConversationToolKey } from './conversation-tools';
+import type { ConversationToolKey, AskUserRequest } from './conversation-tools';
+import type { ConversationDraftBase } from './conversation-draft-base';
+import type { ThemeMode } from './theme';
 import type { Effort } from './tools/effort';
 import type { ConversationDraft, FileDraftResult } from './conversation-drafts';
 import type { ConversationSourceDraft, FileSourceDraftResult } from './conversation-source-drafts';
@@ -570,6 +572,92 @@ export interface EventMap {
   'tables:nameCollision': (collision: CsvTableCollision) => void;
   'proposals:changed': () => void;
   'proposals:show': () => void;
+  // Conversation-draft cards — all carry ConversationDraftBase on the wire
+  // (draftEmit); the renderer refines to the specific draft type.
+  'conversation:draft': (draft: ConversationDraftBase) => void;
+  'conversation:sourceDraft': (draft: ConversationDraftBase) => void;
+  'conversation:propertyDraft': (draft: ConversationDraftBase) => void;
+  'conversation:sourcePropertyDraft': (draft: ConversationDraftBase) => void;
+  'conversation:claimsDraft': (draft: ConversationDraftBase) => void;
+  'conversation:computeDraft': (draft: ConversationDraftBase) => void;
+  'conversation:refactorDraft': (draft: ConversationDraftBase) => void;
+  'conversation:reorgDraft': (draft: ConversationDraftBase) => void;
+  'conversation:deleteDraft': (draft: ConversationDraftBase) => void;
+  'conversation:noteBodyDraft': (draft: ConversationDraftBase) => void;
+  // Conversation + tool streaming / prompts
+  'conversation:stream': (chunk: string) => void;
+  'conversation:askUser': (req: AskUserRequest) => void;
+  'tool:stream': (chunk: string) => void;
+  'tool:invoke': (toolId: string) => void;
+  'shell:revealFile': () => void; // fired by the native menu as a command event
+  // Native-menu command channels (#1633) — payloaded first, then void.
+  'menu:setTheme': (mode: ThemeMode) => void;
+  'menu:openStockQuery': (payload: { query: string; language: 'sparql' | 'sql' }) => void;
+  'menu:export': (exporterId: string) => void;
+  'menu:openRecentProject': (path: string) => void;
+  'menu:about': () => void;
+  'menu:bibliography': () => void;
+  'menu:clearRecent': () => void;
+  'menu:closeGroup': () => void;
+  'menu:closeProject': () => void;
+  'menu:cycleTheme': () => void;
+  'menu:editSavedQueries': () => void;
+  'menu:editThoughtbaseDoc': () => void;
+  'menu:find': () => void;
+  'menu:findInNotes': () => void;
+  'menu:findReplace': () => void;
+  'menu:focusNextGroup': () => void;
+  'menu:focusPrevGroup': () => void;
+  'menu:fontDecrease': () => void;
+  'menu:fontIncrease': () => void;
+  'menu:fontReset': () => void;
+  'menu:format': () => void;
+  'menu:gotoLine': () => void;
+  'menu:importBibtex': () => void;
+  'menu:importZoteroRdf': () => void;
+  'menu:ingestFile': () => void;
+  'menu:ingestIdentifier': () => void;
+  'menu:ingestUrl': () => void;
+  'menu:insertTemplate': () => void;
+  'menu:installTutorial': () => void;
+  'menu:navBack': () => void;
+  'menu:navForward': () => void;
+  'menu:newConversation': () => void;
+  'menu:newNote': () => void;
+  'menu:newProject': () => void;
+  'menu:newQuery': () => void;
+  'menu:openInDefault': () => void;
+  'menu:openInTerminal': () => void;
+  'menu:openProject': () => void;
+  'menu:openSettings': () => void;
+  'menu:print': () => void;
+  'menu:publish': () => void;
+  'menu:quickOpen': () => void;
+  'menu:refactor:autolink': () => void;
+  'menu:refactor:autolinkInbound': () => void;
+  'menu:refactor:autotag': () => void;
+  'menu:refactor:copy': () => void;
+  'menu:refactor:decompose': () => void;
+  'menu:refactor:extract': () => void;
+  'menu:refactor:move': () => void;
+  'menu:refactor:rename': () => void;
+  'menu:refactor:splitByHeading': () => void;
+  'menu:refactor:splitHere': () => void;
+  'menu:replaceInNotes': () => void;
+  'menu:reportEditorState': () => void;
+  'menu:reportTheme': () => void;
+  'menu:save': () => void;
+  'menu:saveAsObjectType': () => void;
+  'menu:saveAsTemplate': () => void;
+  'menu:shortcuts': () => void;
+  'menu:sortLines': () => void;
+  'menu:splitDown': () => void;
+  'menu:splitRight': () => void;
+  'menu:thoughtbaseProperties': () => void;
+  'menu:toggleConversations': () => void;
+  'menu:togglePreview': () => void;
+  'menu:toggleRightSidebar': () => void;
+  'menu:toggleSidebar': () => void;
 }
 
 /** A configured publish destination (#254; multi-transport #1444). Mirror of the


### PR DESCRIPTION
Part 2 of #1633 — completes it. (Part 1 covered the data-broadcast events.)

`EventMap` now covers **every** main→renderer event channel (98 total), the legacy `unknown`-casting `subscribeIpc` forwarder is **gone**, and every subscription flows through the typed `subscribe`.

- **EventMap +=** conversation-draft cards (typed `ConversationDraftBase` — the wire type `draftEmit` actually sends; the renderer refines to the specific draft), conversation/tool **streaming** + **ask_user**, **tool invoke**, and all ~65 **`menu:*`** command channels — including the raw-string `menu:openRecentProject` (not a `Channels.*` constant) and the payloaded `set-theme` / `open-stock-query` / `export`.
- **Preload:** every remaining forwarder migrated to `subscribe`; `subscribeIpc` **deleted** (no call sites left → no more `unknown` casts anywhere).
- **Senders:** `menu.ts`'s `send` is now `send<K extends keyof EventMap>` — typing all ~68 native-menu broadcasts at once; conversation stream/ask_user and tool stream go through `broadcast`.

The typed contract immediately **caught a real drift**: the `ask_user` payload passed `choices: undefined` where `AskUserRequest.choices` is optional (`exactOptionalPropertyTypes`) — now omitted when absent.

**Types-only — runtime identical.** `pnpm lint` clean; **full suite green (546 files / 5421 tests)**.

## #1633 complete
Both directions of every IPC channel — invoke (`ChannelMap`) and event (`EventMap`) — now have a single typed source of truth, with `handle`/`invoke` and `broadcast`/`subscribe` deriving from them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)