### PR TITLE
refactor(ipc): reconcile channel-domain ↔ client-namespace + verb naming (#1634)

### DIFF
--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -347,7 +347,7 @@ contextBridge.exposeInMainWorld('api', {
     load: () => invoke(Channels.TABS_LOAD),
   },
   refactor: {
-    autoTag: (relativePath: string) => invoke(Channels.REFACTOR_AUTO_TAG_SUGGEST, relativePath),
+    autoTagSuggest: (relativePath: string) => invoke(Channels.REFACTOR_AUTO_TAG_SUGGEST, relativePath),
     autoTagApply: (relativePath: string, acceptedTags: string[]) =>
       invoke(Channels.REFACTOR_AUTO_TAG_APPLY, relativePath, acceptedTags),
     autoLinkSuggest: (relativePath: string) =>

--- a/src/renderer/lib/app/refactor-ops.svelte.ts
+++ b/src/renderer/lib/app/refactor-ops.svelte.ts
@@ -725,7 +725,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
       // SUGGEST phase (#940): the LLM proposes tags and writes NOTHING. The user
       // reviews them in the dialog; Apply routes through the approval engine.
       const result = await busy.withBusy('Auto-tagging…', () =>
-        api.refactor.autoTag(relativePath),
+        api.refactor.autoTagSuggest(relativePath),
       );
       if (result.added.length === 0) {
         await showConfirm(

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -696,7 +696,7 @@ export interface TabsApi {
 
 export interface RefactorApi {
   /** SUGGEST phase (#940): ask the LLM for tags; writes nothing. */
-  autoTag(relativePath: string): Promise<{ added: string[] }>;
+  autoTagSuggest(relativePath: string): Promise<{ added: string[] }>;
   /** APPLY phase (#940): file the accepted tags through the note_rewrite approval payload. */
   autoTagApply(relativePath: string, acceptedTags: string[]): Promise<{ applied: string[] }>;
   autoLinkSuggest(relativePath: string): Promise<{

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -1,3 +1,19 @@
+/**
+ * IPC channel constants. Naming convention (#1634):
+ *
+ * - **Shape:** `domain:verbNoun` in camelCase (`notebase:readFile`,
+ *   `sources:setReadStatus`). Reads use `get*`/`list*`; the destructive verb is
+ *   `delete` (collection-membership removal may use `remove*`, e.g.
+ *   `collections:removeSource`). A *suggest → apply* pair keeps a consistent
+ *   suffix on both halves: `refactor:autoTagSuggest` / `refactor:autoTagApply`,
+ *   `refactor:autoLinkSuggest` / `refactor:autoLinkApply`.
+ * - **Namespace invariant:** a channel's `domain` prefix must match the
+ *   `window.api.<namespace>` it's exposed under — either exactly, or as its
+ *   plural (`conversation:` → `api.conversations`). A few cross-domain groupings
+ *   are intentional (`excerpt:` / `ingest:` → `api.sources`, `inspections:` →
+ *   `api.graph`, …); those are enumerated + rationalised in
+ *   `tests/shared/ipc-naming.test.ts`, which fails CI if a new channel drifts.
+ */
 export const Channels = {
   // Notebase
   NOTEBASE_OPEN: 'notebase:open',

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -299,8 +299,8 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "autoLinkInboundApply",
     "autoLinkInboundSuggest",
     "autoLinkSuggest",
-    "autoTag",
     "autoTagApply",
+    "autoTagSuggest",
   ],
   "search": [
     "query",

--- a/tests/renderer/app/refactor-ops.test.ts
+++ b/tests/renderer/app/refactor-ops.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const h = vi.hoisted(() => {
   const api = {
     refactor: {
-      autoTag: vi.fn(),
+      autoTagSuggest: vi.fn(),
       autoTagApply: vi.fn(),
       autoLinkSuggest: vi.fn(),
       autoLinkInboundSuggest: vi.fn(),
@@ -87,9 +87,9 @@ beforeEach(() => {
 
 describe('handleAutoTag (SUGGEST phase, #940)', () => {
   it('opens the review dialog with the suggested tags and writes nothing', async () => {
-    h.api.refactor.autoTag.mockResolvedValue({ added: ['x', 'y'] });
+    h.api.refactor.autoTagSuggest.mockResolvedValue({ added: ['x', 'y'] });
     await ops.handleAutoTag('note.md');
-    expect(h.api.refactor.autoTag).toHaveBeenCalledWith('note.md');
+    expect(h.api.refactor.autoTagSuggest).toHaveBeenCalledWith('note.md');
     // Review state is set — apply hasn't run, so nothing was written.
     expect(flow.autoTagReview?.relativePath).toBe('note.md');
     expect(flow.autoTagReview?.tags).toEqual(['x', 'y']);
@@ -99,14 +99,14 @@ describe('handleAutoTag (SUGGEST phase, #940)', () => {
   });
 
   it('shows a notice and leaves review null when nothing was suggested', async () => {
-    h.api.refactor.autoTag.mockResolvedValue({ added: [] });
+    h.api.refactor.autoTagSuggest.mockResolvedValue({ added: [] });
     await ops.handleAutoTag('note.md');
     expect(h.dialog.showConfirm).toHaveBeenCalled();
     expect(flow.autoTagReview).toBeNull();
   });
 
   it('skips the failure dialog when the error is a missing API key', async () => {
-    h.api.refactor.autoTag.mockRejectedValue(new Error('no key'));
+    h.api.refactor.autoTagSuggest.mockRejectedValue(new Error('no key'));
     maybeMissing.mockResolvedValue(true);
     await ops.handleAutoTag('note.md');
     expect(maybeMissing).toHaveBeenCalled();
@@ -431,7 +431,7 @@ describe('handleAutoLink (error branch)', () => {
 
 describe('handleAutoTag (failure branch)', () => {
   it('shows the failure dialog on a non-key error', async () => {
-    h.api.refactor.autoTag.mockRejectedValue(new Error('rate limit'));
+    h.api.refactor.autoTagSuggest.mockRejectedValue(new Error('rate limit'));
     await ops.handleAutoTag('note.md');
     const msg = h.dialog.showConfirm.mock.calls.at(-1)?.[0] as string;
     expect(msg).toContain('Auto-tag failed');

--- a/tests/shared/ipc-naming.test.ts
+++ b/tests/shared/ipc-naming.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment node
+ *
+ * IPC channel-domain ↔ client-namespace consistency (#1634). A channel string is
+ * `domain:verbNoun`; the renderer reaches it as `window.api.<namespace>.<method>`.
+ * When the domain prefix and the namespace disagree, the `api.*` surface is hard
+ * to discover (someone hunting `excerpt:` won't look under `api.sources`). The API
+ * review flagged this drift and recommended a test to hold the line rather than a
+ * risky hard-rename.
+ *
+ * This asserts, for every renderer-facing channel, that its domain prefix maps to
+ * the `api.*` namespace it's exposed under — via the naming rules:
+ *   1. namespace === domain (the common case), OR
+ *   2. namespace === domain + 's' (channels are singular, namespaces plural —
+ *      `conversation:` → `api.conversations`, `proposal:` → `api.proposals`), OR
+ *   3. a DOCUMENTED cross-domain exception below (with its rationale).
+ *
+ * A new channel that drifts without being a documented exception fails HERE —
+ * forcing the author to either land it under the matching namespace or justify
+ * the exception. (Parsed straight from channels.ts + preload.ts so it can't go
+ * stale.)
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Channels whose domain intentionally differs from their client namespace,
+ * because the operation semantically belongs to the host domain.
+ */
+const NAMESPACE_EXCEPTIONS: Record<string, string> = {
+  excerpt: 'sources',      // an excerpt belongs to a source
+  excerpts: 'sources',     // excerpts:changed — a source-library event
+  ingest: 'sources',       // ingest creates sources
+  inspections: 'graph',    // graph-integrity inspections
+  project: 'menu',         // project-lifecycle events ride the app/menu event surface
+  recent: 'notebase',      // recent-projects is a notebase-open concern
+};
+
+/** channel constant name → string value, from channels.ts. */
+function channelValues(): Record<string, string> {
+  const src = readFileSync('src/shared/channels.ts', 'utf8');
+  const out: Record<string, string> = {};
+  for (const m of src.matchAll(/^\s*([A-Z0-9_]+):\s*'([^']+)',/gm)) out[m[1]!] = m[2]!;
+  return out;
+}
+
+/** channel value → the api.* namespace(s) it's exposed under, from preload.ts. */
+function channelNamespaces(values: Record<string, string>): Record<string, Set<string>> {
+  const src = readFileSync('src/preload/preload.ts', 'utf8');
+  const body = src.slice(src.indexOf("exposeInMainWorld('api', {"));
+  const out: Record<string, Set<string>> = {};
+  let depth = 0;
+  let ns: string | null = null;
+  for (const line of body.split('\n')) {
+    const nsm = line.match(/^ {2}(\w+):\s*\{/); // a top-level namespace key (depth 1)
+    if (depth === 1 && nsm) ns = nsm[1]!;
+    if (ns) {
+      for (const cm of line.matchAll(/Channels\.([A-Z0-9_]+)/g)) {
+        const v = values[cm[1]!];
+        if (v) (out[v] ??= new Set()).add(ns);
+      }
+      for (const cm of line.matchAll(/(?:invoke|subscribe)\('([a-z][a-zA-Z:]+)'/g)) {
+        (out[cm[1]!] ??= new Set()).add(ns);
+      }
+    }
+    for (const c of line) { if (c === '{') depth++; else if (c === '}') depth--; }
+    if (depth <= 0) break;
+  }
+  return out;
+}
+
+const okForDomain = (domain: string, namespace: string): boolean =>
+  namespace === domain || namespace === `${domain}s` || NAMESPACE_EXCEPTIONS[domain] === namespace;
+
+describe('IPC channel-domain ↔ client-namespace consistency (#1634)', () => {
+  const values = channelValues();
+  const nsMap = channelNamespaces(values);
+
+  it('maps the renderer-facing channel surface (parser sanity)', () => {
+    expect(Object.keys(nsMap).length).toBeGreaterThan(200);
+  });
+
+  it('exposes every channel under a namespace matching its domain (rule or documented exception)', () => {
+    const violations: string[] = [];
+    for (const [channel, namespaces] of Object.entries(nsMap)) {
+      const domain = channel.split(':')[0]!;
+      for (const ns of namespaces) {
+        if (!okForDomain(domain, ns)) violations.push(`${channel}  →  api.${ns}`);
+      }
+    }
+    expect(
+      violations.sort(),
+      'Channel(s) exposed under a namespace that doesn\'t match their domain prefix. ' +
+        'Land the channel under the matching namespace, or — if the grouping is intentional — ' +
+        'add the domain to NAMESPACE_EXCEPTIONS in this test with a one-line rationale.\n' +
+        violations.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('keeps every documented exception live (no stale entries)', () => {
+    const seenDomains = new Set(Object.keys(nsMap).map((c) => c.split(':')[0]!));
+    const stale = Object.keys(NAMESPACE_EXCEPTIONS).filter((d) => !seenDomains.has(d));
+    expect(stale, `NAMESPACE_EXCEPTIONS entries no longer used — remove: ${stale.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1634.

The channel domains and `window.api.*` namespaces had drifted, hurting discoverability (someone hunting `excerpt:` won't look under `api.sources`). The API review recommended **document + test, not a risky hard-rename** — so this codifies the convention and holds the line.

## What's in it
- **Naming-consistency test** (`tests/shared/ipc-naming.test.ts`): parses `channels.ts` + `preload.ts` and asserts every channel's `domain:` prefix maps to the `api.<namespace>` it's exposed under. The rules: namespace === domain, or its **plural** (`conversation:` → `api.conversations`, `proposal:` → `api.proposals`), or one of **6 documented cross-domain exceptions** — `excerpt`/`excerpts`/`ingest` → `sources` (excerpts + ingest are source ops), `inspections` → `graph`, `project` → `menu`, `recent` → `notebase` — each with a one-line rationale in `NAMESPACE_EXCEPTIONS`. A new channel that drifts without a documented exception **fails CI**. (This is the regression guard the review asked for.)
- **Convention doc** atop `channels.ts`: `domain:verbNoun` shape, the delete-verb rule (`delete` destructive; `remove*` for collection-membership), the **suggest/apply suffix-pair** rule, and the namespace invariant (pointing at the test).
- **Verb fix:** `api.refactor.autoTag` → **`autoTagSuggest`**, aligning it with its channel (`refactor:autoTagSuggest`) and its sibling `autoLinkSuggest` — the one outlier that dropped the suffix. **Client method only**; the channel string is unchanged. Preload-bridge snapshot regenerated.

## Deliberately *not* done
No channel **string values** were renamed — they're the wire contract, and the reviewer explicitly advised against churny hard-renames. The 6 cross-domain groupings are all semantically justified and now documented + test-locked rather than moved. `remove` vs `delete` is settled by the documented convention rather than a mass rename.

## Verification
`pnpm lint` clean; full suite green (**547 files / 5424 tests**, incl. the 3 new naming tests); `refactor-ops` mock + preload snapshot updated for the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)