### PR TITLE
refactor(settings): unify the patch* helpers into a makePatch factory (#1600, part 1)

### DIFF
--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -142,29 +142,27 @@
     SETTINGS_GROUPS.flatMap((g) => g.items.map((t) => [t.id, t] as const)),
   );
 
-  let refactor = $state<RefactorSettings>({ ...getRefactorSettings() });
-  function patchRefactor(patch: Partial<RefactorSettings>): void {
-    refactor = { ...refactor, ...patch };
-    setRefactorSettings(patch);
+  // A "patch" merges a delta into the local $state mirror AND persists it (these
+  // panels save per-change, unlike the Done-batched editor/appearance/web/ai).
+  // The four were byte-identical bar their state var + setter (#1600).
+  function makePatch<T>(read: () => T, write: (v: T) => void, persist: (patch: Partial<T>) => void) {
+    return (patch: Partial<T>): void => {
+      write({ ...read(), ...patch });
+      persist(patch);
+    };
   }
+
+  let refactor = $state<RefactorSettings>({ ...getRefactorSettings() });
+  const patchRefactor = makePatch(() => refactor, (v) => { refactor = v; }, setRefactorSettings);
 
   let sidebar = $state<SidebarSettings>({ ...getSidebarSettings() });
-  function patchSidebar(patch: Partial<SidebarSettings>): void {
-    sidebar = { ...sidebar, ...patch };
-    setSidebarSettings(patch);
-  }
+  const patchSidebar = makePatch(() => sidebar, (v) => { sidebar = v; }, setSidebarSettings);
 
   let breadcrumbs = $state<BreadcrumbsSettings>({ ...getBreadcrumbsSettings() });
-  function patchBreadcrumbs(patch: Partial<BreadcrumbsSettings>): void {
-    breadcrumbs = { ...breadcrumbs, ...patch };
-    setBreadcrumbsSettings(patch);
-  }
+  const patchBreadcrumbs = makePatch(() => breadcrumbs, (v) => { breadcrumbs = v; }, setBreadcrumbsSettings);
 
   let conversations = $state<ConversationsSettings>({ ...getConversationsSettings() });
-  function patchConversations(patch: Partial<ConversationsSettings>): void {
-    conversations = { ...conversations, ...patch };
-    setConversationsSettings(patch);
-  }
+  const patchConversations = makePatch(() => conversations, (v) => { conversations = v; }, setConversationsSettings);
 
   // Formatter settings (#154). Mirror the persisted map into local state so
   // the Done-close reset path can rehydrate without an IPC round-trip.


### PR DESCRIPTION
Part 1 of #1600.

The four per-change settings mutators — `patchRefactor` / `patchSidebar` / `patchBreadcrumbs` / `patchConversations` — were **byte-identical** bar their `$state` var and setter (merge the delta into the local mirror, then persist it). Collapsed into a **`makePatch(read, write, persist)`** factory + four one-line bindings.

**Pure-logic, no behaviour change** — the patch functions behave identically. `pnpm lint` clean (no SettingsDialog test exists to update).

## Why part 1 (the panel extractions are staged)
Investigating the 8 inline panels turned up a real wrinkle: **persistence is a mix**, not uniform.
- **Per-change panels** (behaviors, the refactor part of notes, sources, …) persist immediately via `patch*` / `setX` / direct `api` calls — cleanly extractable into self-contained child components.
- **Done-batched panels** (editor, appearance, web, ai) persist in `handleDone()` via parent callbacks (`onApplyEditor`, `setThemeMode`, a shared `LLMSettingsUpdate` build). Extracting these into children means reworking that batch-save lifecycle — an architectural change, not a plain component split.

So rather than force all 8 into one large, hard-to-verify change, this lands the safe factory now. The next PRs extract the per-change panels (starting with **behaviors** — it owns only `sidebar`/`breadcrumbs`/`conversations` + the confirm-suppression list, all self-contained), then tackle the Done-batched group with the lifecycle handled explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)