### PR TITLE
refactor(settings): extract Formatter / Clipper / Sources panels (#1600, part 3)

### DIFF
--- a/src/renderer/lib/components/ClipperSettings.svelte
+++ b/src/renderer/lib/components/ClipperSettings.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+  /**
+   * Browser-clipper settings panel (#1600, #791) — extracted from SettingsDialog.
+   * Enable toggle + pairing code + status. Self-contained: the toggle applies
+   * immediately (it starts/stops a loopback server), not on Done.
+   */
+  import { onMount } from 'svelte';
+  import { api } from '../ipc/client';
+  import { getSettingsStore } from '../stores/settings.svelte';
+  import type { ClipperState } from '../../../shared/clipper-pairing';
+
+  const settings = getSettingsStore();
+
+  let clipper = $state<ClipperState | null>(null);
+  let clipperRevealed = $state(false);
+  let clipperCopied = $state(false);
+
+  onMount(async () => {
+    try {
+      clipper = await api.clipper.getState();
+    } catch (e) {
+      console.error('[settings] failed to load clipper state:', e);
+    }
+  });
+
+  async function toggleClipper(enabled: boolean) {
+    try {
+      clipper = await settings.setClipperEnabled(enabled);
+      clipperRevealed = false;
+      clipperCopied = false;
+    } catch (e) {
+      console.error('[settings] failed to toggle clipper:', e);
+    }
+  }
+
+  async function regenerateClipperSecret() {
+    try {
+      clipper = await settings.regenerateClipperSecret();
+      clipperCopied = false;
+    } catch (e) {
+      console.error('[settings] failed to regenerate clipper secret:', e);
+    }
+  }
+
+  async function copyPairingCode() {
+    if (!clipper?.pairingCode) return;
+    try {
+      await navigator.clipboard.writeText(clipper.pairingCode);
+      clipperCopied = true;
+      setTimeout(() => { clipperCopied = false; }, 1500);
+    } catch (e) {
+      console.error('[settings] failed to copy pairing code:', e);
+    }
+  }
+</script>
+
+<div class="clipper">
+      <div class="field checkbox">
+        <label>
+          <input
+            type="checkbox"
+            checked={clipper?.enabled ?? false}
+            onchange={(e) => toggleClipper(e.currentTarget.checked)}
+          />
+          Enable browser clipper
+        </label>
+        <p class="hint">
+          Runs a small server on <code>127.0.0.1</code> that the Minerva
+          browser extension sends clipped pages to — the page you're reading
+          becomes a Source (and your selection a linked excerpt) without a
+          copy-paste. Off by default; the endpoint only listens while this is
+          on and a thoughtbase is open.
+        </p>
+      </div>
+
+      {#if clipper?.enabled}
+        {#if clipper.running && clipper.pairingCode}
+          <div class="field">
+            <label for="clipper-pairing">Pairing code</label>
+            <div class="clipper-pair-row">
+              <input
+                id="clipper-pairing"
+                class="clipper-pair-code"
+                type={clipperRevealed ? 'text' : 'password'}
+                readonly
+                value={clipper.pairingCode}
+              />
+              <button class="btn secondary" onclick={() => (clipperRevealed = !clipperRevealed)}>
+                {clipperRevealed ? 'Hide' : 'Reveal'}
+              </button>
+              <button class="btn secondary" onclick={copyPairingCode}>
+                {clipperCopied ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+            <p class="hint">
+              Paste this into the browser extension once to pair it. Listening
+              on port <code>{clipper.port}</code>. Keep it private — anyone
+              with the code can send pages to this thoughtbase.
+            </p>
+          </div>
+
+          <div class="field">
+            <button class="btn secondary" onclick={regenerateClipperSecret}>Regenerate code</button>
+            <p class="hint">Invalidates the old code; you'll need to re-pair the extension.</p>
+          </div>
+        {:else}
+          <p class="hint">
+            Open a thoughtbase to start the clipper and reveal its pairing code.
+          </p>
+        {/if}
+      {/if}
+
+</div>
+
+<style>
+  .clipper { display: flex; flex-direction: column; gap: 14px; }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field.checkbox label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+  .field input[type="checkbox"] {
+    cursor: pointer;
+  }
+  .clipper-pair-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+  .clipper-pair-code {
+    flex: 1;
+    min-width: 0;
+    padding: 5px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: var(--font-mono);
+  }
+  .clipper-pair-code:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .hint code {
+    background: var(--bg-button);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 10px;
+  }
+  .btn {
+    padding: 5px 14px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .secondary {
+    background: var(--bg-button);
+    color: var(--text);
+  }
+  .secondary:hover {
+    background: var(--bg-button-hover);
+  }
+</style>

--- a/src/renderer/lib/components/FormatterSettings.svelte
+++ b/src/renderer/lib/components/FormatterSettings.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  /**
+   * Formatter settings panel (#1600) — extracted from SettingsDialog. Lists the
+   * registered Refactor ▸ Format rules by category with per-rule toggles + a
+   * "Restore house style" reset. Self-contained: each toggle persists
+   * immediately via setFormatSettings (no Done-batch).
+   */
+  import {
+    getFormatSettings,
+    setFormatSettings,
+    resetFormatToHouseStyle,
+  } from '../formatter/settings';
+  import {
+    listRulesByCategory,
+    CATEGORY_ORDER,
+  } from '../../../shared/formatter/registry';
+  import '../../../shared/formatter/rules/index';
+  import { isRuleEnabled, type FormatSettings } from '../../../shared/formatter/engine';
+
+  // Formatter settings (#154). Mirror the persisted map into local state so
+  // the Done-close reset path can rehydrate without an IPC round-trip.
+  let formatter = $state<FormatSettings>({
+    enabled: { ...getFormatSettings().enabled },
+    configs: { ...getFormatSettings().configs },
+  });
+  function toggleFormatterRule(id: string, on: boolean): void {
+    formatter = {
+      enabled: { ...formatter.enabled, [id]: on },
+      configs: formatter.configs,
+    };
+    setFormatSettings({ enabled: { [id]: on } });
+  }
+  // True when nothing overrides the shipped defaults — no enable/disable
+  // toggles and no per-rule config tuning. Both must be clear, or "Restore
+  // house style" would stay disabled while a tuned config still lingered.
+  let atHouseStyle = $derived(
+    Object.keys(formatter.enabled).length === 0 &&
+    Object.keys(formatter.configs).length === 0,
+  );
+  function restoreHouseStyle(): void {
+    const next = resetFormatToHouseStyle();
+    formatter = {
+      enabled: { ...next.enabled },
+      configs: { ...next.configs },
+    };
+  }
+  const FORMATTER_CATEGORY_LABELS: Record<string, string> = {
+    yaml: 'YAML frontmatter',
+    heading: 'Headings',
+    content: 'Content',
+    footnote: 'Footnotes',
+    spacing: 'Spacing',
+    minerva: 'Minerva-specific',
+  };
+  const formatterSections = CATEGORY_ORDER.map((cat) => ({
+    category: cat,
+    label: FORMATTER_CATEGORY_LABELS[cat] ?? cat,
+    rules: listRulesByCategory(cat),
+  }));
+  const hasAnyFormatterRules = formatterSections.some((s) => s.rules.length > 0);
+</script>
+
+<div class="formatter">
+      <p class="section-intro">
+        Deterministic normalizations applied by the <strong>Refactor ▸ Format</strong> commands.
+        A curated <em>house style</em> — safe whitespace, frontmatter, and link
+        tidying — is on by default; everything else is opt-in. Toggle any rule to
+        override. Choices are stored in
+        <code>.minerva/formatter.json</code> so they travel with the thoughtbase.
+      </p>
+
+      {#if !hasAnyFormatterRules}
+        <div class="empty-state">
+          No formatter rules are registered yet. Rule sets land per category
+          in follow-up tickets (#155–#161); once any of those merge, rules
+          appear here as rows you can enable.
+        </div>
+      {:else}
+        <div class="fm-actions">
+          <button
+            class="btn secondary"
+            disabled={atHouseStyle}
+            onclick={restoreHouseStyle}
+          >Restore house style</button>
+          <span class="hint">Clears every override — rule toggles and per-rule tuning alike — back to the default curated set.</span>
+        </div>
+      {/if}
+
+      {#each formatterSections as section}
+        {#if section.rules.length > 0}
+          <h3 class="fm-category">{section.label}</h3>
+          <div class="fm-rules">
+            {#each section.rules as rule (rule.id)}
+              <div class="field checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={isRuleEnabled(formatter, rule.id)}
+                    onchange={(e) => toggleFormatterRule(rule.id, e.currentTarget.checked)}
+                  />
+                  {rule.title}
+                </label>
+                <p class="hint">{rule.description}</p>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      {/each}
+</div>
+
+<style>
+  .formatter { display: flex; flex-direction: column; gap: 14px; }
+  .section-intro {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    margin: 0 0 16px 0;
+  }
+  .section-intro code {
+    font-size: 11px;
+    color: var(--text);
+  }
+  .empty-state {
+    padding: 12px;
+    border: 1px dashed var(--border);
+    border-radius: 6px;
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+  .fm-category {
+    margin: 18px 0 8px 0;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .fm-rules {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .fm-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 4px;
+  }
+  .fm-actions .hint {
+    margin: 0;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field.checkbox label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+  .field input[type="checkbox"] {
+    cursor: pointer;
+  }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .hint code {
+    background: var(--bg-button);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 10px;
+  }
+  .btn {
+    padding: 5px 14px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .secondary {
+    background: var(--bg-button);
+    color: var(--text);
+  }
+  .secondary:hover {
+    background: var(--bg-button-hover);
+  }
+</style>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -16,24 +16,15 @@
   import { getSettingsStore } from '../stores/settings.svelte';
   import { makePatch } from '../make-patch';
   import BehaviorsSettings from './BehaviorsSettings.svelte';
+  import FormatterSettings from './FormatterSettings.svelte';
+  import ClipperSettings from './ClipperSettings.svelte';
+  import SourcesSettings from './SourcesSettings.svelte';
   import {
     getRefactorSettings,
     setRefactorSettings,
     type DestinationMode,
     type RefactorSettings,
   } from '../refactor/settings';
-  import {
-    getFormatSettings,
-    setFormatSettings,
-    resetFormatToHouseStyle,
-  } from '../formatter/settings';
-  import {
-    listRulesByCategory,
-    CATEGORY_ORDER,
-  } from '../../../shared/formatter/registry';
-  import '../../../shared/formatter/rules/index';
-  import { isRuleEnabled, type FormatSettings } from '../../../shared/formatter/engine';
-  import SitesSettings from './SitesSettings.svelte';
   import ComputeSettings from './ComputeSettings.svelte';
   import SkillsSettings from './SkillsSettings.svelte';
   import ObjectTypesSettings from './ObjectTypesSettings.svelte';
@@ -134,47 +125,6 @@
   // sidebar / breadcrumbs / conversations toggles + the confirm-suppression list
   // now live in BehaviorsSettings.svelte (self-contained, per-change).
 
-  // Formatter settings (#154). Mirror the persisted map into local state so
-  // the Done-close reset path can rehydrate without an IPC round-trip.
-  let formatter = $state<FormatSettings>({
-    enabled: { ...getFormatSettings().enabled },
-    configs: { ...getFormatSettings().configs },
-  });
-  function toggleFormatterRule(id: string, on: boolean): void {
-    formatter = {
-      enabled: { ...formatter.enabled, [id]: on },
-      configs: formatter.configs,
-    };
-    setFormatSettings({ enabled: { [id]: on } });
-  }
-  // True when nothing overrides the shipped defaults — no enable/disable
-  // toggles and no per-rule config tuning. Both must be clear, or "Restore
-  // house style" would stay disabled while a tuned config still lingered.
-  let atHouseStyle = $derived(
-    Object.keys(formatter.enabled).length === 0 &&
-    Object.keys(formatter.configs).length === 0,
-  );
-  function restoreHouseStyle(): void {
-    const next = resetFormatToHouseStyle();
-    formatter = {
-      enabled: { ...next.enabled },
-      configs: { ...next.configs },
-    };
-  }
-  const FORMATTER_CATEGORY_LABELS: Record<string, string> = {
-    yaml: 'YAML frontmatter',
-    heading: 'Headings',
-    content: 'Content',
-    footnote: 'Footnotes',
-    spacing: 'Spacing',
-    minerva: 'Minerva-specific',
-  };
-  const formatterSections = CATEGORY_ORDER.map((cat) => ({
-    category: cat,
-    label: FORMATTER_CATEGORY_LABELS[cat] ?? cat,
-    rules: listRulesByCategory(cat),
-  }));
-  const hasAnyFormatterRules = formatterSections.some((s) => s.rules.length > 0);
   const DESTINATION_OPTIONS: { value: DestinationMode; label: string }[] = [
     { value: 'same-folder', label: 'Same folder as source note' },
     { value: 'root', label: 'Thoughtbase root' },
@@ -253,12 +203,6 @@
   let blockedDomainsText = $state('');
   // Ingest settings — per-machine, used by identifier ingest paths (#473).
   let importUpstreamTags = $state(true);
-  // Browser-clipper state — per-machine enable + pairing (#791). Applied
-  // immediately on toggle (not deferred to Done) since it starts/stops a
-  // loopback server.
-  let clipper = $state<import('../../../shared/clipper-pairing').ClipperState | null>(null);
-  let clipperRevealed = $state(false);
-  let clipperCopied = $state(false);
   let model = $state(DEFAULT_MODEL);
   let effort = $state<import('../../../shared/tools/effort').Effort | undefined>(undefined);
   // Per-provider credential inputs + loaded status (BYOM #1498).
@@ -306,42 +250,8 @@
     } catch (e) {
       console.error('[settings] failed to load ingest settings:', e);
     }
-    try {
-      clipper = await api.clipper.getState();
-    } catch (e) {
-      console.error('[settings] failed to load clipper state:', e);
-    }
   });
 
-  async function toggleClipper(enabled: boolean) {
-    try {
-      clipper = await settings.setClipperEnabled(enabled);
-      clipperRevealed = false;
-      clipperCopied = false;
-    } catch (e) {
-      console.error('[settings] failed to toggle clipper:', e);
-    }
-  }
-
-  async function regenerateClipperSecret() {
-    try {
-      clipper = await settings.regenerateClipperSecret();
-      clipperCopied = false;
-    } catch (e) {
-      console.error('[settings] failed to regenerate clipper secret:', e);
-    }
-  }
-
-  async function copyPairingCode() {
-    if (!clipper?.pairingCode) return;
-    try {
-      await navigator.clipboard.writeText(clipper.pairingCode);
-      clipperCopied = true;
-      setTimeout(() => { clipperCopied = false; }, 1500);
-    } catch (e) {
-      console.error('[settings] failed to copy pairing code:', e);
-    }
-  }
 
 
   function parseDomains(text: string): string[] {
@@ -708,51 +618,7 @@
           </div>
 
         {:else if activeTab === 'formatter'}
-          <p class="section-intro">
-            Deterministic normalizations applied by the <strong>Refactor ▸ Format</strong> commands.
-            A curated <em>house style</em> — safe whitespace, frontmatter, and link
-            tidying — is on by default; everything else is opt-in. Toggle any rule to
-            override. Choices are stored in
-            <code>.minerva/formatter.json</code> so they travel with the thoughtbase.
-          </p>
-
-          {#if !hasAnyFormatterRules}
-            <div class="empty-state">
-              No formatter rules are registered yet. Rule sets land per category
-              in follow-up tickets (#155–#161); once any of those merge, rules
-              appear here as rows you can enable.
-            </div>
-          {:else}
-            <div class="fm-actions">
-              <button
-                class="btn secondary"
-                disabled={atHouseStyle}
-                onclick={restoreHouseStyle}
-              >Restore house style</button>
-              <span class="hint">Clears every override — rule toggles and per-rule tuning alike — back to the default curated set.</span>
-            </div>
-          {/if}
-
-          {#each formatterSections as section}
-            {#if section.rules.length > 0}
-              <h3 class="fm-category">{section.label}</h3>
-              <div class="fm-rules">
-                {#each section.rules as rule (rule.id)}
-                  <div class="field checkbox">
-                    <label>
-                      <input
-                        type="checkbox"
-                        checked={isRuleEnabled(formatter, rule.id)}
-                        onchange={(e) => toggleFormatterRule(rule.id, e.currentTarget.checked)}
-                      />
-                      {rule.title}
-                    </label>
-                    <p class="hint">{rule.description}</p>
-                  </div>
-                {/each}
-              </div>
-            {/if}
-          {/each}
+          <FormatterSettings />
 
         {:else if activeTab === 'web'}
           <div class="field checkbox">
@@ -793,80 +659,10 @@
           </div>
 
         {:else if activeTab === 'sources'}
-          <h3 class="settings-subsection">Ingest</h3>
-          <div class="field checkbox">
-            <label>
-              <input type="checkbox" bind:checked={importUpstreamTags} />
-              Import upstream subject tags on source ingest
-            </label>
-            <p class="hint">
-              When on, identifier ingest (DOI / arXiv id / PMID) applies the
-              subject taxonomy each API surfaces as namespaced tags on the
-              source: <code>crossref/sociology</code>,
-              <code>arxiv/cs-lg</code>, <code>mesh/genetics</code>. Use the
-              source's right-click "Strip upstream tags" to remove them
-              after the fact.
-            </p>
-          </div>
-
-          <h3 class="settings-subsection">Privileged sites</h3>
-          <SitesSettings />
+          <SourcesSettings bind:importUpstreamTags />
 
         {:else if activeTab === 'clipper'}
-          <div class="field checkbox">
-            <label>
-              <input
-                type="checkbox"
-                checked={clipper?.enabled ?? false}
-                onchange={(e) => toggleClipper(e.currentTarget.checked)}
-              />
-              Enable browser clipper
-            </label>
-            <p class="hint">
-              Runs a small server on <code>127.0.0.1</code> that the Minerva
-              browser extension sends clipped pages to — the page you're reading
-              becomes a Source (and your selection a linked excerpt) without a
-              copy-paste. Off by default; the endpoint only listens while this is
-              on and a thoughtbase is open.
-            </p>
-          </div>
-
-          {#if clipper?.enabled}
-            {#if clipper.running && clipper.pairingCode}
-              <div class="field">
-                <label for="clipper-pairing">Pairing code</label>
-                <div class="clipper-pair-row">
-                  <input
-                    id="clipper-pairing"
-                    class="clipper-pair-code"
-                    type={clipperRevealed ? 'text' : 'password'}
-                    readonly
-                    value={clipper.pairingCode}
-                  />
-                  <button class="btn secondary" onclick={() => (clipperRevealed = !clipperRevealed)}>
-                    {clipperRevealed ? 'Hide' : 'Reveal'}
-                  </button>
-                  <button class="btn secondary" onclick={copyPairingCode}>
-                    {clipperCopied ? 'Copied' : 'Copy'}
-                  </button>
-                </div>
-                <p class="hint">
-                  Paste this into the browser extension once to pair it. Listening
-                  on port <code>{clipper.port}</code>. Keep it private — anyone
-                  with the code can send pages to this thoughtbase.
-                </p>
-              </div>
-
-              <div class="field">
-                <button class="btn secondary" onclick={regenerateClipperSecret}>Regenerate code</button>
-                <p class="hint">Invalidates the old code; you'll need to re-pair the extension.</p>
-              </div>
-            {:else}
-              <p class="hint">
-                Open a thoughtbase to start the clipper and reveal its pairing code.
-              </p>
-            {/if}
-          {/if}
+          <ClipperSettings />
 
         {:else if activeTab === 'objectTypes'}
           <ObjectTypesSettings />

--- a/src/renderer/lib/components/SourcesSettings.svelte
+++ b/src/renderer/lib/components/SourcesSettings.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  /**
+   * Sources settings panel (#1600) — extracted from SettingsDialog. Ingest
+   * options + the privileged-sites list. `importUpstreamTags` is a Done-batched
+   * setting, so it's bound back to the host (which loads + saves it), matching
+   * the AiSettings pattern; SitesSettings is self-contained.
+   */
+  import SitesSettings from './SitesSettings.svelte';
+
+  let { importUpstreamTags = $bindable() }: { importUpstreamTags: boolean } = $props();
+</script>
+
+<div class="sources">
+      <h3 class="settings-subsection">Ingest</h3>
+      <div class="field checkbox">
+        <label>
+          <input type="checkbox" bind:checked={importUpstreamTags} />
+          Import upstream subject tags on source ingest
+        </label>
+        <p class="hint">
+          When on, identifier ingest (DOI / arXiv id / PMID) applies the
+          subject taxonomy each API surfaces as namespaced tags on the
+          source: <code>crossref/sociology</code>,
+          <code>arxiv/cs-lg</code>, <code>mesh/genetics</code>. Use the
+          source's right-click "Strip upstream tags" to remove them
+          after the fact.
+        </p>
+      </div>
+
+      <h3 class="settings-subsection">Privileged sites</h3>
+      <SitesSettings />
+
+</div>
+
+<style>
+  .sources { display: flex; flex-direction: column; gap: 14px; }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field.checkbox label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+  .field input[type="checkbox"] {
+    cursor: pointer;
+  }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .hint code {
+    background: var(--bg-button);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 10px;
+  }
+  .settings-subsection {
+    margin: 18px 0 8px 0;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .settings-subsection:first-child {
+    margin-top: 0;
+  }
+</style>


### PR DESCRIPTION
Part 3 of #1600 (part 1 = `makePatch`, part 2 = Behaviors).

Three more panels lifted out of SettingsDialog:

- **`FormatterSettings.svelte`** — the Refactor ▸ Format rule list + per-rule toggles + Restore-house-style. Self-contained (each toggle persists immediately via `setFormatSettings`). Moved verbatim.
- **`ClipperSettings.svelte`** — browser-clipper enable + pairing code + status. Self-contained; owns its own `onMount(getState)` load and per-change toggle/regenerate.
- **`SourcesSettings.svelte`** — ingest options + the privileged-sites list. Its one **Done-batched** setting (`importUpstreamTags`) is `bind:`-bound back to the host, which still loads it in `onMount` + saves it in `handleDone` (the `AiSettings` pattern) — so behaviour is identical; `SitesSettings` moves inside it.

SettingsDialog sheds their state/logic/imports (**1297 → 1093 lines**). **Pure extraction — behaviour identical.** `pnpm lint` clean; full suite green (**547 files / 5424 tests**).

## Please visually verify 🙏
- **Settings → Formatter**: the rule categories/toggles render, toggling a rule sticks, "Restore house style" enables/disables correctly.
- **Settings → Browser Clipper**: enable toggles the loopback server, pairing code reveal/copy/regenerate work.
- **Settings → Sources**: the "Import upstream subject tags" toggle (still commits on **Done**, discards on **Cancel**) + the privileged-sites list.

## Remaining
The Done-batched group — **editor / appearance / web / ai** — is last; those persist in `handleDone`, so I'll extract them with the `bind:` pattern (as sources here) so behaviour stays identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)