### PR TITLE
refactor(settings): extract Editor / Appearance / Web panels (#1600, part 4)

### DIFF
--- a/src/renderer/lib/components/AppearanceSettings.svelte
+++ b/src/renderer/lib/components/AppearanceSettings.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+  /**
+   * Appearance settings panel (#1600) — extracted from SettingsDialog. Theme,
+   * content font, editor font size, and window zoom. All apply LIVE (not on
+   * Done): theme/font via the $effects below, font-size/zoom via the host
+   * callbacks. Self-contained bar the two App-level apply hooks it takes as props.
+   */
+  import { onMount } from 'svelte';
+  import { api } from '../ipc/client';
+  import { getThemeMode, setThemeMode, THEME_MODES, type ThemeMode } from '../theme';
+  import { getFontFamily, setFontFamily, FONT_FAMILY_PRESETS, type FontFamilyPreset } from '../appearance/settings';
+  import { isFontInstalled } from '../appearance/font-detect';
+  import { clampFontSize, parseStoredFontSize, MIN_FONT, MAX_FONT, DEFAULT_FONT } from '../editor/font-size';
+  import { setZoom, getStoredZoom, MIN_ZOOM, MAX_ZOOM } from '../appearance/zoom';
+
+  let { onApplyFontSize, onThemeChanged }: {
+    onApplyFontSize: (px: number) => void;
+    onThemeChanged: () => void;
+  } = $props();
+
+  let theme = $state<ThemeMode>(getThemeMode());
+  let fontFamily = $state<FontFamilyPreset>(getFontFamily());
+  // Font size seeds from the stored value; zoom reads the *live* frame factor in
+  // onMount so the field reflects whatever the View-menu zoom shortcuts left.
+  let editorFontSize = $state(clampFontSize(parseStoredFontSize(localStorage.getItem('editorFontSize'))));
+  let zoomPercent = $state(Math.round(getStoredZoom() * 100));
+
+  onMount(() => {
+    zoomPercent = Math.round(api.view.getZoomFactor() * 100);
+  });
+
+  function applyEditorFontSize(px: number): void {
+    if (!Number.isFinite(px)) return; // ignore an empty / mid-edit field
+    editorFontSize = clampFontSize(px);
+    onApplyFontSize(editorFontSize);
+  }
+
+  function applyZoomPercent(percent: number): void {
+    if (!Number.isFinite(percent)) return;
+    const applied = setZoom(percent / 100);
+    zoomPercent = Math.round(applied * 100);
+  }
+
+  const fontPresets = Object.entries(FONT_FAMILY_PRESETS).map(([id, def]) => ({
+    id: id as FontFamilyPreset,
+    label: def.label,
+  }));
+  // Soft "font not installed" hint: only named-face presets carry a `probe`;
+  // heuristic, so it never blocks the choice — just surfaces the silent fallback.
+  const fontProbe = $derived(FONT_FAMILY_PRESETS[fontFamily].probe);
+  const fontMissing = $derived(fontProbe !== undefined && !isFontInstalled(fontProbe));
+
+  // Live-apply theme + font as the user picks them (no Done gate).
+  $effect(() => {
+    setThemeMode(theme);
+    onThemeChanged();
+  });
+  $effect(() => {
+    setFontFamily(fontFamily);
+  });
+</script>
+
+<div class="appearance">
+      <div class="field">
+        <label for="theme">Theme</label>
+        <select id="theme" bind:value={theme}>
+          {#each THEME_MODES as opt}
+            <option value={opt.value}>{opt.label}</option>
+          {/each}
+        </select>
+        <p class="hint">
+          You can also cycle themes from the status bar or with <kbd>⌘⇧T</kbd>.
+        </p>
+      </div>
+      <div class="field">
+        <label for="font-family">Content font</label>
+        <select id="font-family" bind:value={fontFamily}>
+          {#each fontPresets as p}
+            <option value={p.id}>{p.label}</option>
+          {/each}
+        </select>
+        <p class="hint">
+          Applies to the markdown editor and preview. App chrome always uses the system font.
+        </p>
+        {#if fontMissing && fontProbe}
+          <p class="hint font-missing">
+            “{fontProbe}” doesn’t appear to be installed — the editor will use a fallback font.
+            Install {fontProbe}, or pick another option.
+          </p>
+        {/if}
+      </div>
+      <div class="field">
+        <label for="editor-font-size">Editor font size</label>
+        <div class="inline-num">
+          <input
+            id="editor-font-size"
+            type="number"
+            min={MIN_FONT}
+            max={MAX_FONT}
+            step="1"
+            value={editorFontSize}
+            onchange={(e) => applyEditorFontSize(parseInt(e.currentTarget.value, 10))}
+          />
+          <span class="unit">px</span>
+          <button class="btn-inline" onclick={() => applyEditorFontSize(DEFAULT_FONT)}>Reset</button>
+        </div>
+        <p class="hint">
+          Size of the text in the source editor only ({MIN_FONT}–{MAX_FONT}px). Also
+          adjustable with <kbd>⌘⇧=</kbd> / <kbd>⌘⇧-</kbd>.
+        </p>
+      </div>
+      <div class="field">
+        <label for="window-zoom">Window zoom</label>
+        <div class="inline-num">
+          <input
+            id="window-zoom"
+            type="number"
+            min={Math.round(MIN_ZOOM * 100)}
+            max={Math.round(MAX_ZOOM * 100)}
+            step="10"
+            value={zoomPercent}
+            onchange={(e) => applyZoomPercent(parseInt(e.currentTarget.value, 10))}
+          />
+          <span class="unit">%</span>
+          <button class="btn-inline" onclick={() => applyZoomPercent(100)}>Reset</button>
+        </div>
+        <p class="hint">
+          Scales the whole window — sidebar, toolbar, dialogs, and the editor together.
+          Also adjustable with <kbd>⌘+</kbd> / <kbd>⌘-</kbd> / <kbd>⌘0</kbd>.
+        </p>
+      </div>
+
+</div>
+
+<style>
+  .appearance { display: flex; flex-direction: column; gap: 14px; }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field label {
+    color: var(--text);
+  }
+  .field select {
+    padding: 5px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: inherit;
+  }
+  .field select:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .inline-num {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .inline-num .unit {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .inline-num input[type="number"] {
+    width: 80px;
+    padding: 4px 6px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+  }
+  .btn-inline {
+    padding: 4px 10px;
+    background: var(--bg-button, var(--bg));
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .btn-inline:hover {
+    border-color: var(--accent);
+  }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .hint.font-missing {
+    color: var(--rust);
+    margin-top: 4px;
+  }
+  kbd {
+    background: var(--bg-button);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 0 4px;
+    font-size: 10px;
+    font-family: ui-monospace, monospace;
+  }
+</style>

--- a/src/renderer/lib/components/EditorSettings.svelte
+++ b/src/renderer/lib/components/EditorSettings.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  /**
+   * Editor settings panel (#1600) — extracted from SettingsDialog. Tab size +
+   * editor toggles. Done-batched: the parent owns the `editor` state (bound here)
+   * and persists it in handleDone via onApplyEditor.
+   */
+  import type { EditorSettings } from '../editor/settings';
+
+  let { editor = $bindable() }: { editor: EditorSettings } = $props();
+</script>
+
+<div class="editor-settings">
+      <div class="field">
+        <label for="tab-size">Tab size</label>
+        <input
+          id="tab-size"
+          type="number"
+          min="1"
+          max="8"
+          bind:value={editor.tabSize}
+        />
+      </div>
+      <div class="field checkbox">
+        <label>
+          <input type="checkbox" bind:checked={editor.wordWrap} />
+          Word wrap
+        </label>
+      </div>
+      <div class="field checkbox">
+        <label>
+          <input type="checkbox" bind:checked={editor.lineNumbers} />
+          Show line numbers
+        </label>
+      </div>
+      <div class="field checkbox">
+        <label>
+          <input type="checkbox" bind:checked={editor.showWhitespace} />
+          Show whitespace
+        </label>
+      </div>
+      <div class="field checkbox">
+        <label>
+          <input type="checkbox" bind:checked={editor.alwaysCollapseFrontmatter} />
+          Always collapse frontmatter
+        </label>
+        <p class="hint">
+          Automatically folds the YAML frontmatter block at the top of a note when it's opened.
+        </p>
+      </div>
+      <div class="field checkbox">
+        <label>
+          <input type="checkbox" bind:checked={editor.numberedHeadings} />
+          Numbered section headings
+        </label>
+        <p class="hint">
+          Prefixes each H2 in the preview with a "§ 01" section numeral. Best for long-form
+          essays; leave off for journals and lists.
+        </p>
+      </div>
+
+</div>
+
+<style>
+  .editor-settings { display: flex; flex-direction: column; gap: 14px; }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field label {
+    color: var(--text);
+  }
+  .field.checkbox label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+  .field input[type="checkbox"] {
+    cursor: pointer;
+  }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .field input[type="number"] {
+    width: 80px;
+    padding: 4px 6px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+  }
+</style>

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -1,21 +1,14 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { getEditorSettings, type EditorSettings } from '../editor/settings';
-  import {
-    getFontFamily,
-    setFontFamily,
-    FONT_FAMILY_PRESETS,
-    type FontFamilyPreset,
-  } from '../appearance/settings';
-  import { isFontInstalled } from '../appearance/font-detect';
-  import { getThemeMode, setThemeMode, THEME_MODES, type ThemeMode } from '../theme';
-  import { clampFontSize, parseStoredFontSize, MIN_FONT, MAX_FONT, DEFAULT_FONT } from '../editor/font-size';
-  import { setZoom, getStoredZoom, MIN_ZOOM, MAX_ZOOM } from '../appearance/zoom';
   import { api } from '../ipc/client';
   import type { LLMSettingsUpdate } from '../../../shared/tools/types';
   import { getSettingsStore } from '../stores/settings.svelte';
   import { makePatch } from '../make-patch';
   import BehaviorsSettings from './BehaviorsSettings.svelte';
+  import EditorSettingsPanel from './EditorSettings.svelte';
+  import AppearanceSettings from './AppearanceSettings.svelte';
+  import WebSettings from './WebSettings.svelte';
   import FormatterSettings from './FormatterSettings.svelte';
   import ClipperSettings from './ClipperSettings.svelte';
   import SourcesSettings from './SourcesSettings.svelte';
@@ -139,38 +132,6 @@
   // Editor settings
   let editor = $state<EditorSettings>(getEditorSettings());
 
-  // Appearance settings
-  let theme = $state<ThemeMode>(getThemeMode());
-  let fontFamily = $state<FontFamilyPreset>(getFontFamily());
-  // Editor font size (px) + whole-window zoom (%). Font size seeds from the
-  // stored value; zoom reads the *live* frame factor in onMount so the field
-  // reflects whatever the View-menu zoom shortcuts left on screen.
-  let editorFontSize = $state(clampFontSize(parseStoredFontSize(localStorage.getItem('editorFontSize'))));
-  let zoomPercent = $state(Math.round(getStoredZoom() * 100));
-
-  function applyEditorFontSize(px: number): void {
-    if (!Number.isFinite(px)) return; // ignore an empty / mid-edit field
-    editorFontSize = clampFontSize(px);
-    onApplyFontSize(editorFontSize);
-  }
-
-  function applyZoomPercent(percent: number): void {
-    if (!Number.isFinite(percent)) return;
-    const applied = setZoom(percent / 100);
-    zoomPercent = Math.round(applied * 100);
-  }
-
-  // Font presets as an array for the select
-  const fontPresets = Object.entries(FONT_FAMILY_PRESETS).map(([id, def]) => ({
-    id: id as FontFamilyPreset,
-    label: def.label,
-  }));
-
-  // Soft "font not installed" hint (#...): only the named-face presets carry a
-  // `probe`; the check is a heuristic, so this never blocks the choice — it just
-  // makes the silent fallback visible. Re-evaluated when the selection changes.
-  const fontProbe = $derived(FONT_FAMILY_PRESETS[fontFamily].probe);
-  const fontMissing = $derived(fontProbe !== undefined && !isFontInstalled(fontProbe));
 
   // Privileged sites now live in SitesSettings.svelte (self-contained panel).
 
@@ -217,9 +178,6 @@
   // ComputeSettings.svelte (self-contained).
 
   onMount(async () => {
-    // Reflect the live window zoom (the View-menu shortcuts may have changed it
-    // since it was last persisted).
-    zoomPercent = Math.round(api.view.getZoomFactor() * 100);
     try {
       const s = await api.tools.getSettings();
       model = s.model;
@@ -269,11 +227,6 @@
     // Editor — localStorage via Editor component
     onApplyEditor(editor);
 
-    // Appearance — already applied live (theme + font) but persist just in case.
-    setThemeMode(theme);
-    setFontFamily(fontFamily);
-    onThemeChanged();
-
     // Web + AI — build the settings update and save. Per-provider keys are
     // tri-state (BYOM #1498): clear → '', a typed value → that key, otherwise
     // OMIT so main preserves the stored key without decrypting; base URLs send
@@ -317,16 +270,6 @@
     onClose();
   }
 
-  // Live-apply theme and font changes as the user picks them, so they can
-  // preview without committing — mirrors how the status-bar cycle already
-  // applies immediately.
-  $effect(() => {
-    setThemeMode(theme);
-    onThemeChanged();
-  });
-  $effect(() => {
-    setFontFamily(fontFamily);
-  });
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -367,123 +310,10 @@
           </div>
         {/if}
         {#if activeTab === 'editor'}
-          <div class="field">
-            <label for="tab-size">Tab size</label>
-            <input
-              id="tab-size"
-              type="number"
-              min="1"
-              max="8"
-              bind:value={editor.tabSize}
-            />
-          </div>
-          <div class="field checkbox">
-            <label>
-              <input type="checkbox" bind:checked={editor.wordWrap} />
-              Word wrap
-            </label>
-          </div>
-          <div class="field checkbox">
-            <label>
-              <input type="checkbox" bind:checked={editor.lineNumbers} />
-              Show line numbers
-            </label>
-          </div>
-          <div class="field checkbox">
-            <label>
-              <input type="checkbox" bind:checked={editor.showWhitespace} />
-              Show whitespace
-            </label>
-          </div>
-          <div class="field checkbox">
-            <label>
-              <input type="checkbox" bind:checked={editor.alwaysCollapseFrontmatter} />
-              Always collapse frontmatter
-            </label>
-            <p class="hint">
-              Automatically folds the YAML frontmatter block at the top of a note when it's opened.
-            </p>
-          </div>
-          <div class="field checkbox">
-            <label>
-              <input type="checkbox" bind:checked={editor.numberedHeadings} />
-              Numbered section headings
-            </label>
-            <p class="hint">
-              Prefixes each H2 in the preview with a "§ 01" section numeral. Best for long-form
-              essays; leave off for journals and lists.
-            </p>
-          </div>
+          <EditorSettingsPanel bind:editor />
 
         {:else if activeTab === 'appearance'}
-          <div class="field">
-            <label for="theme">Theme</label>
-            <select id="theme" bind:value={theme}>
-              {#each THEME_MODES as opt}
-                <option value={opt.value}>{opt.label}</option>
-              {/each}
-            </select>
-            <p class="hint">
-              You can also cycle themes from the status bar or with <kbd>⌘⇧T</kbd>.
-            </p>
-          </div>
-          <div class="field">
-            <label for="font-family">Content font</label>
-            <select id="font-family" bind:value={fontFamily}>
-              {#each fontPresets as p}
-                <option value={p.id}>{p.label}</option>
-              {/each}
-            </select>
-            <p class="hint">
-              Applies to the markdown editor and preview. App chrome always uses the system font.
-            </p>
-            {#if fontMissing && fontProbe}
-              <p class="hint font-missing">
-                “{fontProbe}” doesn’t appear to be installed — the editor will use a fallback font.
-                Install {fontProbe}, or pick another option.
-              </p>
-            {/if}
-          </div>
-          <div class="field">
-            <label for="editor-font-size">Editor font size</label>
-            <div class="inline-num">
-              <input
-                id="editor-font-size"
-                type="number"
-                min={MIN_FONT}
-                max={MAX_FONT}
-                step="1"
-                value={editorFontSize}
-                onchange={(e) => applyEditorFontSize(parseInt(e.currentTarget.value, 10))}
-              />
-              <span class="unit">px</span>
-              <button class="btn-inline" onclick={() => applyEditorFontSize(DEFAULT_FONT)}>Reset</button>
-            </div>
-            <p class="hint">
-              Size of the text in the source editor only ({MIN_FONT}–{MAX_FONT}px). Also
-              adjustable with <kbd>⌘⇧=</kbd> / <kbd>⌘⇧-</kbd>.
-            </p>
-          </div>
-          <div class="field">
-            <label for="window-zoom">Window zoom</label>
-            <div class="inline-num">
-              <input
-                id="window-zoom"
-                type="number"
-                min={Math.round(MIN_ZOOM * 100)}
-                max={Math.round(MAX_ZOOM * 100)}
-                step="10"
-                value={zoomPercent}
-                onchange={(e) => applyZoomPercent(parseInt(e.currentTarget.value, 10))}
-              />
-              <span class="unit">%</span>
-              <button class="btn-inline" onclick={() => applyZoomPercent(100)}>Reset</button>
-            </div>
-            <p class="hint">
-              Scales the whole window — sidebar, toolbar, dialogs, and the editor together.
-              Also adjustable with <kbd>⌘+</kbd> / <kbd>⌘-</kbd> / <kbd>⌘0</kbd>.
-            </p>
-          </div>
+          <AppearanceSettings {onApplyFontSize} {onThemeChanged} />
 
         {:else if activeTab === 'behaviors'}
           <BehaviorsSettings />
@@ -621,42 +451,7 @@
           <FormatterSettings />
 
         {:else if activeTab === 'web'}
-          <div class="field checkbox">
-            <label>
-              <input type="checkbox" bind:checked={webEnabled} />
-              Enable web access for conversations
-            </label>
-            <p class="hint">
-              When off, the assistant cannot call <code>web_search</code> or <code>web_fetch</code>.
-            </p>
-          </div>
-          <div class="field" class:disabled={!webEnabled}>
-            <label for="allowed-domains">Allowed domains</label>
-            <textarea
-              id="allowed-domains"
-              rows="3"
-              bind:value={allowedDomainsText}
-              disabled={!webEnabled}
-              placeholder="One domain per line (e.g. arxiv.org)"
-            ></textarea>
-            <p class="hint">
-              If any domains are listed, web searches are restricted to them.
-              Leave blank to search the whole web.
-            </p>
-          </div>
-          <div class="field" class:disabled={!webEnabled}>
-            <label for="blocked-domains">Blocked domains</label>
-            <textarea
-              id="blocked-domains"
-              rows="3"
-              bind:value={blockedDomainsText}
-              disabled={!webEnabled}
-              placeholder="One domain per line"
-            ></textarea>
-            <p class="hint">
-              Ignored when an allowlist is set. The API accepts one or the other.
-            </p>
-          </div>
+          <WebSettings bind:webEnabled bind:allowedDomainsText bind:blockedDomainsText />
 
         {:else if activeTab === 'sources'}
           <SourcesSettings bind:importUpstreamTags />

--- a/src/renderer/lib/components/WebSettings.svelte
+++ b/src/renderer/lib/components/WebSettings.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  /**
+   * Web-access settings panel (#1600) — extracted from SettingsDialog. Enable
+   * flag + allow/block domain lists. Done-batched: the parent owns the state
+   * (bound here) and folds it into the LLMSettingsUpdate saved in handleDone.
+   */
+  let {
+    webEnabled = $bindable(),
+    allowedDomainsText = $bindable(),
+    blockedDomainsText = $bindable(),
+  }: { webEnabled: boolean; allowedDomainsText: string; blockedDomainsText: string } = $props();
+</script>
+
+<div class="web-settings">
+      <div class="field checkbox">
+        <label>
+          <input type="checkbox" bind:checked={webEnabled} />
+          Enable web access for conversations
+        </label>
+        <p class="hint">
+          When off, the assistant cannot call <code>web_search</code> or <code>web_fetch</code>.
+        </p>
+      </div>
+      <div class="field" class:disabled={!webEnabled}>
+        <label for="allowed-domains">Allowed domains</label>
+        <textarea
+          id="allowed-domains"
+          rows="3"
+          bind:value={allowedDomainsText}
+          disabled={!webEnabled}
+          placeholder="One domain per line (e.g. arxiv.org)"
+        ></textarea>
+        <p class="hint">
+          If any domains are listed, web searches are restricted to them.
+          Leave blank to search the whole web.
+        </p>
+      </div>
+      <div class="field" class:disabled={!webEnabled}>
+        <label for="blocked-domains">Blocked domains</label>
+        <textarea
+          id="blocked-domains"
+          rows="3"
+          bind:value={blockedDomainsText}
+          disabled={!webEnabled}
+          placeholder="One domain per line"
+        ></textarea>
+        <p class="hint">
+          Ignored when an allowlist is set. The API accepts one or the other.
+        </p>
+      </div>
+
+</div>
+
+<style>
+  .web-settings { display: flex; flex-direction: column; gap: 14px; }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .field label {
+    color: var(--text);
+  }
+  .field.checkbox label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+  .field input[type="checkbox"] {
+    cursor: pointer;
+  }
+  .hint {
+    margin: 2px 0 0 0;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .field.disabled label,
+  .field.disabled .hint {
+    opacity: 0.5;
+  }
+  .field textarea {
+    padding: 5px 8px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: inherit;
+    resize: vertical;
+    min-height: 60px;
+  }
+  .field textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .hint code {
+    background: var(--bg-button);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 10px;
+  }
+</style>


### PR DESCRIPTION
Completes #1600 — the SettingsDialog panel split. This final part lifts the
last four Workspace/Ingest panels out of the monolith, leaving `SettingsDialog.svelte`
as a thin tab-router that owns state and hands each panel its slice.

## Panels extracted
- **`EditorSettings.svelte`** — Done-batched (`bind:editor`; the parent persists in `handleDone` via `onApplyEditor`).
- **`WebSettings.svelte`** — Done-batched (`bind:webEnabled` / `allowedDomainsText` / `blockedDomainsText`; the parent builds the `LLMSettingsUpdate` in `handleDone`).
- **`AppearanceSettings.svelte`** — full extraction, **live-apply**. The panel owns `theme` / `fontFamily` / `editorFontSize` / `zoomPercent` state and applies each change immediately via its own `$effect`s + the `onApplyFontSize` / `onThemeChanged` callbacks, so the now-redundant appearance lines are gone from `handleDone`.

`ai` was already extracted (`AiSettings.svelte`) in an earlier part.

## Notes
- Each sibling carries its own copy of the shared `.field`/`.hint` styles and a flex-column root wrapper to match the parent `.panel` gap.
- No behavior change intended.

## Please visually verify
Settings → **Editor**, **Appearance**, **Web** render and apply exactly as before — especially Appearance's *live* theme / font-family / editor-font-size / zoom apply (no Done click needed), and that Editor + Web still persist on Done.

Green: `pnpm lint` clean, full suite 547 files / 5424 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)