### PR TITLE
test(renderer): per-file coverage floors on the 1000+-line components (#1613)

### DIFF
--- a/tests/renderer/components/Editor.test.ts
+++ b/tests/renderer/components/Editor.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Editor render/smoke test (#1600 baseline). Editor.svelte is the CodeMirror
+ * host — the largest renderer component and previously at 0% coverage of its
+ * own file. This mounts the REAL component (real CodeMirror + real editor/*
+ * extensions) against a mocked IPC surface + the couple of rune stores it
+ * reads, and asserts the visible wiring: it mounts a CodeMirror view for the
+ * given group, renders the doc, opens the right-click context menu, routes a
+ * menu action back through the host callback, and reflects an external
+ * content-prop change into the buffer.
+ *
+ * The goal is a green, non-flaky smoke that actually executes the component
+ * script (onMount, the extensions array, the context-menu template, the
+ * content-sync $effect) rather than exhaustive assertions.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+
+const h = vi.hoisted(() => ({
+  api: {
+    shell: {
+      openExternal: vi.fn(),
+      revealFile: vi.fn(),
+      openInDefault: vi.fn(),
+      openInTerminal: vi.fn(),
+    },
+    notebase: { readFile: vi.fn() },
+    compute: { runCell: vi.fn() },
+    tags: { allNames: vi.fn() },
+    types: { list: vi.fn() },
+  },
+  voiceSettings: { enabled: false },
+  getToolInfosByCategory: vi.fn(() => []),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/voice/voice-settings.svelte', () => ({
+  voiceSettings: h.voiceSettings,
+}));
+// Keep the Tools-for-Thought submenu empty and deterministic — the registry
+// contents aren't what this test exercises.
+vi.mock('../../../src/renderer/lib/tools/tool-registry', () => ({
+  getToolInfosByCategory: h.getToolInfosByCategory,
+}));
+
+import Editor from '../../../src/renderer/lib/components/Editor.svelte';
+
+function props(over: Record<string, unknown> = {}) {
+  return {
+    groupId: 'group-1',
+    filePath: 'notes/hello.md',
+    content: '# Hello World\n\nsome body text\n',
+    onContentChange: vi.fn(),
+    onSave: vi.fn(),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  // happy-dom's localStorage isn't wired for a functional getItem here; the
+  // editor reads/writes the font-size key at mount. In-memory stand-in.
+  const ls: Record<string, string> = {};
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => ls[k] ?? null,
+    setItem: (k: string, v: string) => { ls[k] = v; },
+    removeItem: (k: string) => { delete ls[k]; },
+    clear: () => { for (const k of Object.keys(ls)) delete ls[k]; },
+  });
+  h.api.notebase.readFile.mockResolvedValue('');
+  h.api.tags.allNames.mockResolvedValue([]);
+  h.api.types.list.mockResolvedValue({ types: [] });
+  h.getToolInfosByCategory.mockReturnValue([]);
+  h.voiceSettings.enabled = false;
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); vi.clearAllMocks(); });
+
+describe('Editor (#1600)', () => {
+  it('mounts a CodeMirror view for the group and renders the document', async () => {
+    const { container } = render(Editor, props());
+    const wrapper = container.querySelector('.editor-wrapper');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper?.getAttribute('data-group-id')).toBe('group-1');
+    // CodeMirror actually mounted inside the wrapper.
+    await waitFor(() => expect(container.querySelector('.cm-editor')).toBeTruthy());
+    await waitFor(() =>
+      expect(container.querySelector('.cm-content')?.textContent).toContain('Hello World'),
+    );
+  });
+
+  it('opens the right-click context menu and routes a menu action to the host', async () => {
+    const onOpenConversation = vi.fn();
+    const { container } = render(Editor, props({ onOpenConversation }));
+    await waitFor(() => expect(container.querySelector('.cm-content')).toBeTruthy());
+
+    const content = container.querySelector('.cm-content')!;
+    await fireEvent.contextMenu(content);
+
+    // The context menu (with the standard clipboard entries) is now open.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Copy' })).toBeTruthy());
+    expect(screen.getByRole('button', { name: 'Paste' })).toBeTruthy();
+
+    // Clicking a host-callback action fires it and dismisses the menu.
+    await fireEvent.click(screen.getByRole('button', { name: 'Ask About This...' }));
+    expect(onOpenConversation).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Copy' })).toBeNull());
+  });
+
+  it('shows the Dictate entry only when voice is enabled', async () => {
+    h.voiceSettings.enabled = true;
+    const { container } = render(Editor, props());
+    await waitFor(() => expect(container.querySelector('.cm-content')).toBeTruthy());
+    await fireEvent.contextMenu(container.querySelector('.cm-content')!);
+    await waitFor(() => expect(screen.getByRole('button', { name: /Dictate/ })).toBeTruthy());
+  });
+
+  it('syncs an external content-prop change into the editor buffer', async () => {
+    const { container, rerender } = render(Editor, props());
+    await waitFor(() =>
+      expect(container.querySelector('.cm-content')?.textContent).toContain('Hello World'),
+    );
+    await rerender(props({ content: 'replaced from disk\n' }));
+    await waitFor(() =>
+      expect(container.querySelector('.cm-content')?.textContent).toContain('replaced from disk'),
+    );
+  });
+
+  it('mounts a plain-text editor without the markdown layers', async () => {
+    const { container } = render(Editor, props({ plainText: true, filePath: 'notes/plain.txt' }));
+    await waitFor(() => expect(container.querySelector('.cm-editor')).toBeTruthy());
+    // The plain-text buffer advertises itself for the drag-link opt-out.
+    await waitFor(() =>
+      expect(container.querySelector('.cm-editor[data-plaintext="true"]')).toBeTruthy(),
+    );
+  });
+});

--- a/tests/renderer/components/Preview.test.ts
+++ b/tests/renderer/components/Preview.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Preview render/smoke test. Preview.svelte is the note-preview pane — a large
+ * markdown → HTML renderer with a click-routing table, a read-only right-click
+ * menu, and a battery of post-render hydration passes. It had 0% coverage of
+ * its own file. This mounts the REAL component with the REAL markdown pipeline
+ * (createPreviewMarkdown + sanitizeNoteHtml, both proven under happy-dom by
+ * markdown-config.test.ts) so `{@html rendered}` shows genuine output, and
+ * asserts a handful of user-visible behaviors: markdown renders, wiki-link /
+ * tag clicks route to the right callback, and the note context menu wires its
+ * tool entries through `onToolInvoke`.
+ *
+ * The post-render hydration modules (mermaid / vega / card-callout / hydrate /
+ * citation-render / typed-link / query-blocks) are mocked to inert no-ops so
+ * the requestAnimationFrame pass is deterministic — Preview's own `$effect`
+ * bodies still execute (they call the mocks), so its line coverage is unaffected.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, screen, waitFor } from '@testing-library/svelte';
+import type { ThinkingToolInfo } from '../../../src/shared/tools/types';
+
+const h = vi.hoisted(() => ({
+  api: {
+    notebase: { readFile: vi.fn() },
+    types: { noteProperties: vi.fn() },
+    shell: {
+      openExternal: vi.fn(),
+      revealFile: vi.fn(),
+      openInDefault: vi.fn(),
+      openInTerminal: vi.fn(),
+    },
+  },
+  getToolInfosByCategory: vi.fn((_category: string) => [] as ThinkingToolInfo[]),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/tools/tool-registry', () => ({
+  getToolInfosByCategory: h.getToolInfosByCategory,
+}));
+
+// Inert post-render hydration passes — keep the rAF work deterministic. Preview's
+// own effect bodies still run and invoke these; only the heavy DOM/library work
+// is stubbed. Types are re-exported as `unknown`-shaped no-ops.
+vi.mock('../../../src/renderer/lib/markdown/mermaid-renderer', () => ({
+  hydrateMermaidBlocks: vi.fn(),
+  invalidateMermaidTheme: vi.fn(),
+}));
+vi.mock('../../../src/renderer/lib/markdown/vega-renderer', () => ({
+  hydrateVegaBlocks: vi.fn(),
+  invalidateVegaTheme: vi.fn(),
+}));
+vi.mock('../../../src/renderer/lib/markdown/card-callout', () => ({
+  hydrateCardCallouts: vi.fn(),
+}));
+vi.mock('../../../src/renderer/lib/preview/hydrate', () => ({
+  highlightCodeBlocks: vi.fn(),
+  hydrateLocalImages: vi.fn(),
+  hydrateRemoteImages: vi.fn(),
+  hydrateYouTubeThumbnails: vi.fn(),
+  hydrateTransclusions: vi.fn(),
+  hydrateLocalMedia: vi.fn(),
+}));
+vi.mock('../../../src/renderer/lib/preview/citation-render', () => ({
+  applyCslMarkers: vi.fn(),
+  resolveCiteQuoteLabels: vi.fn(),
+}));
+vi.mock('../../../src/renderer/lib/preview/typed-link-render', () => ({
+  hydrateTypedCards: vi.fn(),
+}));
+vi.mock('../../../src/renderer/lib/preview/query-blocks', () => ({
+  executeQueryBlock: vi.fn(),
+}));
+
+import Preview from '../../../src/renderer/lib/components/Preview.svelte';
+
+function props(over: Record<string, unknown> = {}) {
+  return {
+    content: '# Hello World\n\nThis is **bold** body text.\n',
+    notePath: 'notes/hello.md',
+    onNavigate: vi.fn(),
+    onTagSelect: vi.fn(),
+    ...over,
+  };
+}
+
+function tool(id: string, name: string, category: string): ThinkingToolInfo {
+  return {
+    id, name, category, description: '', longDescription: '',
+    context: [], outputMode: 'note',
+  } as unknown as ThinkingToolInfo;
+}
+
+beforeEach(() => {
+  h.api.notebase.readFile.mockResolvedValue('');
+  h.api.types.noteProperties.mockResolvedValue({ type: null, properties: {} });
+  h.getToolInfosByCategory.mockReturnValue([]);
+});
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe('Preview (render/smoke)', () => {
+  it('renders markdown content to HTML', () => {
+    const { container } = render(Preview, props());
+    const preview = container.querySelector('.preview')!;
+    expect(preview.textContent).toContain('Hello World');
+    // Inline emphasis survives the DOMPurify pass and reaches `{@html rendered}`.
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+    expect(container.querySelector('p')?.textContent).toContain('bold body text');
+  });
+
+  it('routes a wiki-link click through onNavigate with the link target', async () => {
+    const p = props({ content: 'See [[Some Note]] for details.\n' });
+    const { container } = render(Preview, p);
+    const link = container.querySelector<HTMLElement>('a.wiki-link');
+    expect(link?.dataset.target).toBe('Some Note');
+    await fireEvent.click(link!);
+    expect(p.onNavigate).toHaveBeenCalledWith('Some Note');
+  });
+
+  it('routes a tag click through onTagSelect with the tag name', async () => {
+    const p = props({ content: 'Filed under #research today.\n' });
+    const { container } = render(Preview, p);
+    const tagEl = container.querySelector<HTMLElement>('.note-tag');
+    expect(tagEl?.dataset.tag).toBe('research');
+    await fireEvent.click(tagEl!);
+    expect(p.onTagSelect).toHaveBeenCalledWith('research');
+  });
+
+  it('re-renders when the content prop changes (debounced effect)', async () => {
+    const { container, rerender } = render(Preview, props());
+    expect(container.textContent).toContain('Hello World');
+    await rerender(props({ content: '## Second Heading\n\nWholly new text.\n' }));
+    // The $effect debounces the re-render (~120ms) — poll for the new body.
+    await waitFor(() => expect(container.textContent).toContain('Wholly new text.'));
+    expect(container.textContent).not.toContain('Hello World');
+  });
+
+  it('opens the read-only note context menu and wires tool entries through onToolInvoke', async () => {
+    h.getToolInfosByCategory.mockImplementation((category: string) =>
+      category === 'learning' ? [tool('learn.summarize', 'Summarize', 'learning')] : [],
+    );
+    const onToolInvoke = vi.fn();
+    const { container } = render(Preview, props({ onToolInvoke }));
+
+    await fireEvent.contextMenu(container.querySelector('.preview')!);
+    const menu = container.querySelector('.note-context-menu');
+    expect(menu).toBeTruthy();
+
+    // The Learning submenu holds a button per learning tool.
+    const toolBtn = screen.getByRole('button', { name: 'Summarize' });
+    await fireEvent.click(toolBtn);
+    expect(onToolInvoke).toHaveBeenCalledWith('learn.summarize');
+    // Menu closes after acting.
+    expect(container.querySelector('.note-context-menu')).toBeFalsy();
+  });
+
+  it('suppresses the context menu when no callbacks and no notePath are wired', async () => {
+    const { container } = render(Preview, props({ notePath: null, onTagSelect: undefined }));
+    await fireEvent.contextMenu(container.querySelector('.preview')!);
+    expect(container.querySelector('.note-context-menu')).toBeFalsy();
+  });
+
+  it('renders a .ttl note as highlighted turtle source rather than markdown', () => {
+    const { container } = render(Preview, props({
+      notePath: 'graph/data.ttl',
+      content: '@prefix ex: <http://example.org/> .\n# a comment\n',
+    }));
+    // renderTurtle emits token-classed spans instead of markdown-parsed HTML.
+    expect(container.querySelector('.ttl-directive')?.textContent).toBe('@prefix');
+    expect(container.querySelector('.ttl-comment')?.textContent).toContain('# a comment');
+    expect(container.querySelector('.ttl-iri')?.textContent).toContain('http://example.org/');
+  });
+});

--- a/tests/renderer/components/PropertiesPanel.test.ts
+++ b/tests/renderer/components/PropertiesPanel.test.ts
@@ -1,0 +1,249 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * PropertiesPanel render test (#471 / #1596). The frontmatter property editor is
+ * a data-loss-prone surface (it rewrites the note's YAML on every edit) that had
+ * 0% coverage of its own `.svelte` file — the round-trip engine lives in the
+ * unit-tested `frontmatter-rows.ts`, but the panel's own parse→render→mutate glue
+ * was untested. This mounts the real component against a mocked IPC client + a
+ * mocked notebase store and asserts the visible rows plus the edit/add/remove
+ * interactions that route back through `onContentChange`.
+ *
+ * The four child components (Icon, PropertyValueEditor, AutocompleteDropdown) and
+ * the shared frontmatter/property-shape helpers are pure and render unmocked.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+
+const h = vi.hoisted(() => ({
+  api: {
+    graph: {
+      frontmatterKeys: vi.fn(),
+      aliasMap: vi.fn(),
+    },
+    notebase: {
+      listFiles: vi.fn(),
+    },
+  },
+  notebase: {
+    onRewritten: vi.fn(() => () => {}),
+    onFileCreated: vi.fn(() => () => {}),
+    onFileDeleted: vi.fn(() => () => {}),
+  },
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({
+  getNotebaseStore: () => h.notebase,
+}));
+
+import PropertiesPanel from '../../../src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte';
+
+const CONTENT = [
+  '---',
+  'title: Hello World',
+  'count: 5',
+  'done: true',
+  'tags:',
+  '  - alpha',
+  '  - beta',
+  'link: "[[Target Note]]"',
+  '---',
+  '# Body',
+  '',
+].join('\n');
+
+function props(over: Record<string, unknown> = {}) {
+  return {
+    content: CONTENT,
+    onContentChange: vi.fn(),
+    onNavigate: vi.fn(),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  h.api.graph.frontmatterKeys.mockResolvedValue([]);
+  h.api.graph.aliasMap.mockResolvedValue({});
+  h.api.notebase.listFiles.mockResolvedValue([]);
+  h.notebase.onRewritten.mockReturnValue(() => {});
+  h.notebase.onFileCreated.mockReturnValue(() => {});
+  h.notebase.onFileDeleted.mockReturnValue(() => {});
+});
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+/** The final call's rewritten-content argument (edits are parent-controlled, so
+ *  the mock captures each rewrite without the prop actually changing). */
+function lastRewrite(onContentChange: ReturnType<typeof vi.fn>): string {
+  const calls = onContentChange.mock.calls;
+  return calls[calls.length - 1]![0] as string;
+}
+
+describe('PropertiesPanel (#471 / #1596)', () => {
+  it('renders every frontmatter row with its typed value control', async () => {
+    render(PropertiesPanel, props());
+    // Keys render as editable inputs seeded from the parsed frontmatter.
+    expect(screen.getByDisplayValue('title')).toBeTruthy();
+    expect(screen.getByDisplayValue('count')).toBeTruthy();
+    // Scalar values: string + number editors seeded from content.
+    expect(screen.getByDisplayValue('Hello World')).toBeTruthy();
+    const num = screen.getByDisplayValue('5');
+    expect(num.type).toBe('number');
+    // Boolean row renders a checkbox reflecting `done: true`.
+    expect((screen.getByRole('checkbox')).checked).toBe(true);
+    // string-list row renders one chip per item.
+    expect(screen.getByText('alpha')).toBeTruthy();
+    expect(screen.getByText('beta')).toBeTruthy();
+    // wiki-link row renders a clickable chip labelled by its target.
+    expect(screen.getByText('Target Note')).toBeTruthy();
+  });
+
+  it('fetches project keys + note basenames and subscribes to notebase events on mount', async () => {
+    render(PropertiesPanel, props());
+    await waitFor(() => expect(h.api.graph.frontmatterKeys).toHaveBeenCalled());
+    expect(h.api.notebase.listFiles).toHaveBeenCalled();
+    expect(h.api.graph.aliasMap).toHaveBeenCalled();
+    expect(h.notebase.onRewritten).toHaveBeenCalledTimes(1);
+    expect(h.notebase.onFileCreated).toHaveBeenCalledTimes(1);
+    expect(h.notebase.onFileDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggling a boolean commits the new value immediately through onContentChange', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    await fireEvent.click(screen.getByRole('checkbox'));
+    expect(onContentChange).toHaveBeenCalledTimes(1);
+    expect(lastRewrite(onContentChange)).toContain('done: false');
+  });
+
+  it('editing a string value commits on blur, preserving the note body', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    const input = screen.getByDisplayValue('Hello World');
+    input.value = 'Hello Universe';
+    await fireEvent.blur(input);
+    expect(onContentChange).toHaveBeenCalled();
+    const next = lastRewrite(onContentChange);
+    expect(next).toContain('title: Hello Universe');
+    expect(next).toContain('# Body'); // body survives the round-trip
+  });
+
+  it('typing into a scalar value schedules a draft flush (debounced input path)', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    const input = screen.getByDisplayValue('5');
+    // oninput drives onScalarInput → scheduleFlush; committing on blur applies it.
+    await fireEvent.input(input, { target: { value: '42' } });
+    await fireEvent.blur(input);
+    expect(onContentChange).toHaveBeenCalled();
+    expect(lastRewrite(onContentChange)).toContain('count: 42');
+  });
+
+  it('renaming a key rewrites the frontmatter under the new key', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    const keyInput = screen.getByDisplayValue('title');
+    await fireEvent.change(keyInput, { target: { value: 'name' } });
+    expect(onContentChange).toHaveBeenCalled();
+    const next = lastRewrite(onContentChange);
+    expect(next).toContain('name: Hello World');
+    expect(next).not.toMatch(/^title:/m);
+  });
+
+  it('removing a property drops its key from the rewritten frontmatter', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Remove title' }));
+    expect(onContentChange).toHaveBeenCalledTimes(1);
+    const next = lastRewrite(onContentChange);
+    expect(next).not.toMatch(/^title:/m);
+    expect(next).toContain('count: 5'); // siblings untouched
+  });
+
+  it('adding a chip to a string-list appends it and rewrites the list', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    const chipInput = screen.getByPlaceholderText('Add…');
+    await fireEvent.input(chipInput, { target: { value: 'gamma' } });
+    await fireEvent.keyDown(chipInput, { key: 'Enter' });
+    expect(onContentChange).toHaveBeenCalled();
+    expect(lastRewrite(onContentChange)).toContain('gamma');
+  });
+
+  it('removing a chip drops it from the string-list', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Remove alpha' }));
+    expect(onContentChange).toHaveBeenCalledTimes(1);
+    const next = lastRewrite(onContentChange);
+    expect(next).not.toContain('alpha');
+    expect(next).toContain('beta');
+  });
+
+  it('opens the type-switch menu and re-types a value on selection', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    // The number row's type icon is a button that opens the type menu.
+    await fireEvent.click(screen.getByTitle('Change type (number)'));
+    const menu = await screen.findByRole('menu');
+    expect(menu).toBeTruthy();
+    // Re-type the number as a string → value is stringified + re-coerced.
+    const stringItem = screen.getByRole('menuitemradio', { name: 'string' });
+    await fireEvent.click(stringItem);
+    expect(onContentChange).toHaveBeenCalled();
+    expect(lastRewrite(onContentChange)).toMatch(/count:\s*['"]?5['"]?/);
+  });
+
+  it('quick-adds a canonical key from a suggestion chip', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    // `creator` is the first canonical suggestion not already present.
+    await fireEvent.click(screen.getByRole('button', { name: /\+ creator/ }));
+    expect(onContentChange).toHaveBeenCalled();
+    expect(lastRewrite(onContentChange)).toMatch(/^creator:/m);
+  });
+
+  it('adds a new property from the add-row autocomplete on Enter', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    const addInput = screen.getByPlaceholderText('Add property…');
+    await fireEvent.input(addInput, { target: { value: 'status' } });
+    await fireEvent.keyDown(addInput, { key: 'Enter' });
+    await waitFor(() => expect(onContentChange).toHaveBeenCalled());
+    expect(lastRewrite(onContentChange)).toMatch(/^status:/m);
+  });
+
+  it('swaps the wiki-link chip for an autocomplete editor and commits a new target', async () => {
+    const onContentChange = vi.fn();
+    render(PropertiesPanel, props({ onContentChange }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit link target' }));
+    const linkInput = await screen.findByPlaceholderText('Note name…');
+    await fireEvent.input(linkInput, { target: { value: 'Other Note' } });
+    await fireEvent.keyDown(linkInput, { key: 'Enter' });
+    expect(onContentChange).toHaveBeenCalled();
+    expect(lastRewrite(onContentChange)).toContain('[[Other Note]]');
+  });
+
+  it('invokes onNavigate when the wiki-link chip is clicked', async () => {
+    const onNavigate = vi.fn();
+    render(PropertiesPanel, props({ onNavigate }));
+    await fireEvent.click(screen.getByRole('button', { name: /Target Note/ }));
+    expect(onNavigate).toHaveBeenCalledWith('Target Note');
+  });
+
+  it('shows the empty state with an Add-property affordance for a note with no frontmatter', async () => {
+    render(PropertiesPanel, props({ content: '# Just a body\n' }));
+    await waitFor(() => expect(screen.getByText('No frontmatter')).toBeTruthy());
+    expect(screen.getByPlaceholderText('Add property…')).toBeTruthy();
+  });
+
+  it('surfaces a YAML error banner and disables editing for malformed frontmatter', async () => {
+    render(PropertiesPanel, props({ content: '---\ntitle: [unterminated\n---\n# Body\n' }));
+    await waitFor(() =>
+      expect(screen.getByText('Frontmatter has a YAML error')).toBeTruthy(),
+    );
+    expect(screen.getByRole('alert')).toBeTruthy();
+    // Editing is disabled — no key/value inputs render in the error state.
+    expect(screen.queryByDisplayValue('title')).toBeNull();
+  });
+});

--- a/tests/renderer/components/SettingsDialog.test.ts
+++ b/tests/renderer/components/SettingsDialog.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * SettingsDialog shell render test (#1600). SettingsDialog was refactored to
+ * delegate each tab's body to an extracted panel child (Editor / Appearance /
+ * Behaviors / … / AI / Skills), each with its own test. This exercises the
+ * *shell*: the on-mount settings load, the grouped tab navigation + section
+ * switching, the inline "Notes" (refactoring) panel that still lives in the
+ * shell, and the Cancel / Done wiring to the settings store.
+ *
+ * Only light panels are mounted (Editor = prop-only, Web = bind-only, and the
+ * inline Notes body), so no heavy child (AI / Skills / Compute) is pulled in —
+ * keeps the shell test green and non-flaky.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+
+const h = vi.hoisted(() => ({
+  api: {
+    tools: {
+      getSettings: vi.fn(),
+      getKeyStorage: vi.fn(),
+      checkConnection: vi.fn(),
+    },
+    sources: {
+      getExcerptNoteFolder: vi.fn(),
+      getIngestSettings: vi.fn(),
+    },
+  },
+  settings: {
+    setToolSettings: vi.fn(),
+    setIngestSettings: vi.fn(),
+    setExcerptNoteFolder: vi.fn(),
+  },
+  refactor: {
+    destination: 'same-folder' as const,
+    destinationTemplate: '',
+    filenamePrefix: '',
+    normalizeHeadings: false,
+    transcludeByDefault: false,
+    linkTemplate: '',
+    refactoredNoteTemplate: '',
+  },
+  setRefactorSettings: vi.fn(),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/stores/settings.svelte', () => ({
+  getSettingsStore: () => h.settings,
+}));
+vi.mock('../../../src/renderer/lib/refactor/settings', () => ({
+  getRefactorSettings: () => ({ ...h.refactor }),
+  setRefactorSettings: h.setRefactorSettings,
+}));
+
+import SettingsDialog from '../../../src/renderer/lib/components/SettingsDialog.svelte';
+
+function props(over: Record<string, unknown> = {}) {
+  return {
+    onApplyEditor: vi.fn(),
+    onApplyFontSize: vi.fn(),
+    onThemeChanged: vi.fn(),
+    onClose: vi.fn(),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  h.api.tools.getSettings.mockResolvedValue({
+    model: 'claude-opus-5',
+    effort: undefined,
+    providers: {},
+    customModels: [],
+    web: { enabled: true, allowedDomains: [], blockedDomains: [] },
+    toolModelOverrides: {},
+  });
+  h.api.tools.getKeyStorage.mockResolvedValue({ available: false });
+  h.api.sources.getExcerptNoteFolder.mockResolvedValue('');
+  h.api.sources.getIngestSettings.mockResolvedValue({ importUpstreamTags: true });
+  h.settings.setToolSettings.mockResolvedValue(undefined);
+  h.settings.setIngestSettings.mockResolvedValue(undefined);
+  h.settings.setExcerptNoteFolder.mockResolvedValue(undefined);
+});
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe('SettingsDialog shell (#1600)', () => {
+  it('renders the dialog and lands on the Editor tab, loading settings on mount', async () => {
+    render(SettingsDialog, props());
+    // Dialog chrome + default panel header (eyebrow group "Workspace" + title).
+    expect(screen.getByRole('dialog', { name: 'Settings' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Editor', level: 3 })).toBeTruthy();
+    // "Workspace" shows both as the nav group label and the active panel eyebrow.
+    expect(screen.getAllByText('Workspace').length).toBeGreaterThanOrEqual(1);
+    // The Editor child panel is mounted (its "Word wrap" toggle is present).
+    expect(screen.getByText('Word wrap')).toBeTruthy();
+    // On-mount load reached the settings/ingest reads (getIngestSettings is the
+    // last awaited call in onMount, so waiting on it flushes the whole chain).
+    await waitFor(() => expect(h.api.sources.getIngestSettings).toHaveBeenCalled());
+    expect(h.api.tools.getSettings).toHaveBeenCalled();
+    expect(h.api.sources.getExcerptNoteFolder).toHaveBeenCalled();
+  });
+
+  it('renders all four settings groups with their tab labels', () => {
+    render(SettingsDialog, props());
+    for (const group of ['Workspace', 'Authoring', 'Ingest & compute', 'AI']) {
+      // Group labels appear in the nav (and, for the active tab's group, as the
+      // panel eyebrow too), so assert at least one match rather than exactly one.
+      expect(screen.getAllByText(group).length).toBeGreaterThanOrEqual(1);
+    }
+    // A tab from a non-default group is present in the nav.
+    expect(screen.getByRole('button', { name: /Bibliography/ })).toBeTruthy();
+  });
+
+  it('switches sections when a tab is clicked — Editor → Web mounts the Web panel', async () => {
+    render(SettingsDialog, props());
+    expect(screen.getByText('Word wrap')).toBeTruthy(); // editor panel first
+
+    await fireEvent.click(screen.getByRole('button', { name: /Web/ }));
+
+    // Web panel header + the Web child panel's own controls are now shown,
+    // and the Editor panel is gone.
+    expect(screen.getByRole('heading', { name: 'Web', level: 3 })).toBeTruthy();
+    expect(screen.getByText('Allowed domains')).toBeTruthy();
+    expect(screen.queryByText('Word wrap')).toBeNull();
+  });
+
+  it('shows the inline Notes (refactoring) panel and reveals the custom template field', async () => {
+    render(SettingsDialog, props());
+    await fireEvent.click(screen.getByRole('button', { name: /Notes/ }));
+
+    // The refactoring form is rendered directly by the shell.
+    const destination = screen.getByLabelText('Destination for new notes');
+    expect(destination).toBeTruthy();
+    expect(screen.getByLabelText('Filename prefix')).toBeTruthy();
+    // Custom template field is hidden until "custom" is chosen.
+    expect(screen.queryByLabelText('Custom folder template')).toBeNull();
+
+    await fireEvent.change(destination, { target: { value: 'custom' } });
+    // Persisted through the refactor-settings write-through helper…
+    expect(h.setRefactorSettings).toHaveBeenCalledWith({ destination: 'custom' });
+    // …and the conditional custom-template field now appears.
+    expect(screen.getByLabelText('Custom folder template')).toBeTruthy();
+  });
+
+  it('honors initialTab by opening directly on that section', async () => {
+    render(SettingsDialog, props({ initialTab: 'notes' }));
+    // Lands on Notes without any click.
+    expect(screen.getByRole('heading', { name: 'Notes', level: 3 })).toBeTruthy();
+    expect(screen.getByLabelText('Destination for new notes')).toBeTruthy();
+    expect(screen.queryByText('Word wrap')).toBeNull();
+  });
+
+  it('Cancel routes to onClose without persisting settings', async () => {
+    const p = props();
+    render(SettingsDialog, p);
+    await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(p.onClose).toHaveBeenCalledTimes(1);
+    expect(h.settings.setToolSettings).not.toHaveBeenCalled();
+  });
+
+  it('Done persists editor + LLM + ingest settings through the store, then closes', async () => {
+    const p = props();
+    render(SettingsDialog, p);
+    // Let onMount finish so handleDone builds the update from loaded state.
+    await waitFor(() => expect(h.api.tools.getSettings).toHaveBeenCalled());
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+
+    // Editor settings applied via the host callback.
+    await waitFor(() => expect(p.onApplyEditor).toHaveBeenCalledTimes(1));
+    // LLM/tools settings saved through the settings store with the loaded model + web block.
+    await waitFor(() => expect(h.settings.setToolSettings).toHaveBeenCalledTimes(1));
+    const update = h.settings.setToolSettings.mock.calls[0]![0];
+    expect(update.model).toBe('claude-opus-5');
+    expect(update.web).toEqual({ enabled: true, allowedDomains: [], blockedDomains: [] });
+    // Ingest settings persisted, then the dialog closes.
+    expect(h.settings.setIngestSettings).toHaveBeenCalledWith({ importUpstreamTags: true });
+    expect(p.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/renderer/components/SourcesPanel.test.ts
+++ b/tests/renderer/components/SourcesPanel.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * SourcesPanel render/smoke test (baseline coverage). SourcesPanel is the
+ * left-sidebar Sources view: it owns the collection tree, the reading-queue
+ * rows, the free-text filter, the flat source list, and every source /
+ * collection context menu. It had 0% coverage of its own file. This mounts the
+ * real component against mocked IPC + the source-data store and asserts the
+ * user-visible wiring: the source list renders from `api.sources.listAll`,
+ * the filter narrows it, selecting a collection scopes it to that collection's
+ * members, selecting a queue view re-queries members, row clicks route to
+ * `onSourceSelect`, and the right-click menu routes rename / delete through the
+ * `source-actions` helpers.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+import type { SourceMetadata, Collection, CollectionsFile } from '../../../src/shared/types';
+
+function source(over: Partial<SourceMetadata> = {}): SourceMetadata {
+  return {
+    sourceId: 'paxos', subtype: 'article', title: 'The Part-Time Parliament',
+    creators: ['Lamport, Leslie'], year: '1998', publisher: null, doi: null, uri: null,
+    abstract: null, readStatus: null, readDueBy: null, stubStatus: null, tags: [],
+    ...over,
+  };
+}
+
+const paxos = source();
+const raft = source({
+  sourceId: 'raft', title: 'In Search of an Understandable Consensus Algorithm',
+  creators: ['Ongaro, Diego'], year: '2014',
+});
+const consensus: Collection = { id: 'c1', name: 'Consensus', parent: null, members: ['paxos'] };
+
+const h = vi.hoisted(() => ({
+  api: {
+    sources: {
+      listAll: vi.fn(),
+      queueMembers: vi.fn(),
+    },
+    collections: {
+      list: vi.fn(),
+      smartMembers: vi.fn(),
+    },
+  },
+  sourceData: {
+    onCollectionsChanged: vi.fn(() => () => {}),
+    setReadStatus: vi.fn(),
+    setReadDueBy: vi.fn(),
+    merge: vi.fn(),
+    ingestSmart: vi.fn(),
+    stripUpstreamTags: vi.fn(),
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    removeCollection: vi.fn(),
+    addSourceToCollection: vi.fn(),
+    removeSourceFromCollection: vi.fn(),
+    createSmartCollection: vi.fn(),
+    renameSmartCollection: vi.fn(),
+    removeSmartCollection: vi.fn(),
+    updateSmartPredicate: vi.fn(),
+  },
+  linkDrag: { start: vi.fn() },
+  renameSource: vi.fn(),
+  deleteSource: vi.fn(),
+  addSourceTag: vi.fn(),
+  sourceTagSuggestions: vi.fn(),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
+vi.mock('../../../src/renderer/lib/stores/source-data.svelte', () => ({ getSourceDataStore: () => h.sourceData }));
+vi.mock('../../../src/renderer/lib/stores/link-drag.svelte', () => ({ getLinkDrag: () => h.linkDrag }));
+vi.mock('../../../src/renderer/lib/sources/source-actions', () => ({
+  renameSource: h.renameSource,
+  deleteSource: h.deleteSource,
+  addSourceTag: h.addSourceTag,
+  sourceTagSuggestions: h.sourceTagSuggestions,
+}));
+
+import SourcesPanel from '../../../src/renderer/lib/components/SourcesPanel.svelte';
+
+function props(over: Record<string, unknown> = {}) {
+  return {
+    onSourceSelect: vi.fn(),
+    onSourceDeleted: vi.fn(),
+    onShowConfirm: vi.fn().mockResolvedValue(true),
+    onShowPrompt: vi.fn().mockResolvedValue(null),
+    onSourceOpened: vi.fn(),
+    ...over,
+  };
+}
+
+const collectionsFile: CollectionsFile = { collections: [consensus], smartCollections: [] };
+
+beforeEach(() => {
+  h.api.sources.listAll.mockResolvedValue([paxos, raft]);
+  h.api.sources.queueMembers.mockResolvedValue([]);
+  h.api.collections.list.mockResolvedValue(collectionsFile);
+  h.api.collections.smartMembers.mockResolvedValue([]);
+  h.sourceTagSuggestions.mockResolvedValue([]);
+});
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe('SourcesPanel (baseline)', () => {
+  it('renders the source list and the "All sources" count from listAll', async () => {
+    render(SourcesPanel, props());
+    await waitFor(() => expect(screen.getByText('The Part-Time Parliament')).toBeTruthy());
+    expect(screen.getByText('In Search of an Understandable Consensus Algorithm')).toBeTruthy();
+    expect(h.api.sources.listAll).toHaveBeenCalled();
+    expect(h.api.collections.list).toHaveBeenCalled();
+    // The "All sources" row shows the total (2).
+    const allRow = screen.getByText('All sources').closest('button')!;
+    expect(allRow.textContent).toContain('2');
+  });
+
+  it('renders the collection tree from collections.list', async () => {
+    render(SourcesPanel, props());
+    await waitFor(() => expect(screen.getByText('Consensus')).toBeTruthy());
+  });
+
+  it('routes a source row click to onSourceSelect', async () => {
+    const p = props();
+    render(SourcesPanel, p);
+    await waitFor(() => expect(screen.getByText('The Part-Time Parliament')).toBeTruthy());
+    await fireEvent.click(screen.getByText('The Part-Time Parliament'));
+    expect(p.onSourceSelect).toHaveBeenCalledWith('paxos');
+  });
+
+  it('narrows the visible list with the free-text filter', async () => {
+    render(SourcesPanel, props());
+    await waitFor(() => expect(screen.getByText('The Part-Time Parliament')).toBeTruthy());
+    await fireEvent.input(screen.getByPlaceholderText('Filter sources…'), { target: { value: 'raft' } });
+    await waitFor(() => expect(screen.queryByText('The Part-Time Parliament')).toBeNull());
+    expect(screen.getByText('In Search of an Understandable Consensus Algorithm')).toBeTruthy();
+  });
+
+  it('scopes the list to a collection when its row is selected', async () => {
+    render(SourcesPanel, props());
+    await waitFor(() => expect(screen.getByText('Consensus')).toBeTruthy());
+    await fireEvent.click(screen.getByText('Consensus'));
+    // Consensus contains only paxos; raft drops out of the list.
+    await waitFor(() => expect(screen.queryByText('In Search of an Understandable Consensus Algorithm')).toBeNull());
+    expect(screen.getByText('The Part-Time Parliament')).toBeTruthy();
+  });
+
+  it('re-queries members and shows the empty state when a queue view is selected', async () => {
+    render(SourcesPanel, props());
+    await waitFor(() => expect(screen.getByText('The Part-Time Parliament')).toBeTruthy());
+    await fireEvent.click(screen.getByText('Unread'));
+    expect(h.api.sources.queueMembers).toHaveBeenCalledWith('unread');
+    // queueMembers resolves [] → the queue view is empty.
+    await waitFor(() => expect(screen.getByText('Nothing in this queue view.')).toBeTruthy());
+  });
+
+  it('opens the source context menu and routes "Delete Source" through the source-actions helper', async () => {
+    const p = props();
+    render(SourcesPanel, p);
+    await waitFor(() => expect(screen.getByText('The Part-Time Parliament')).toBeTruthy());
+    await fireEvent.contextMenu(screen.getByText('The Part-Time Parliament'));
+    await fireEvent.click(await screen.findByText('Delete Source'));
+    expect(h.deleteSource).toHaveBeenCalledTimes(1);
+    expect(h.deleteSource.mock.calls[0]![0]).toMatchObject({ sourceId: 'paxos' });
+    expect(h.deleteSource.mock.calls[0]![1]).toBe(p.onShowConfirm);
+  });
+
+  it('routes "Rename…" through the source-actions helper with the host prompt', async () => {
+    const p = props();
+    render(SourcesPanel, p);
+    await waitFor(() => expect(screen.getByText('The Part-Time Parliament')).toBeTruthy());
+    await fireEvent.contextMenu(screen.getByText('The Part-Time Parliament'));
+    await fireEvent.click(await screen.findByText('Rename…'));
+    expect(h.renameSource).toHaveBeenCalledTimes(1);
+    expect(h.renameSource.mock.calls[0]![0]).toMatchObject({ sourceId: 'paxos' });
+    expect(h.renameSource.mock.calls[0]![1]).toBe(p.onShowPrompt);
+  });
+
+  it('prompts on the add-source button and ingests the entered input', async () => {
+    const p = props({ onShowPrompt: vi.fn().mockResolvedValue('https://example.com/paper') });
+    h.sourceData.ingestSmart.mockResolvedValue({ sourceId: 'new', title: 'New', duplicate: false });
+    render(SourcesPanel, p);
+    await waitFor(() => expect(screen.getByText('The Part-Time Parliament')).toBeTruthy());
+    await fireEvent.click(screen.getByLabelText('Add source'));
+    await waitFor(() => expect(h.sourceData.ingestSmart).toHaveBeenCalledWith('https://example.com/paper'));
+    expect(p.onSourceOpened).toHaveBeenCalledWith('new');
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -192,6 +192,63 @@ export default defineConfig({
           statements: 42,
           branches: 34,
         },
+        // Per-file floors on the 1000+-line renderer components (#1613). The
+        // `src/renderer/**` aggregate above is met by the many small, well-
+        // tested files, so a large component sitting near 0% — or silently
+        // rotting from a real number back toward it — never trips the aggregate
+        // net. These per-file gates catch that: each is a genuine defect surface
+        // (the editor, the markdown preview, the source browser, the settings
+        // shell, the frontmatter editor) whose own coverage can't regress
+        // unnoticed. Files matching a specific path here are still counted in the
+        // `src/renderer/**` aggregate — this only adds a stricter per-file check.
+        // Baselines established by the render/smoke tests added in #1613 (the
+        // #1597 SourceDetail test is the template); floors sit ~8-10pts below the
+        // measured-at-floor-time v8 numbers (in parens) so a small refactor won't
+        // flap but a real regression fails. Ratchet upward as these gain tests.
+        //
+        // Editor.svelte ~38.6 L / 37.1 S / 23.2 F / 21.4 B.
+        'src/renderer/lib/components/Editor.svelte': {
+          lines: 30,
+          statements: 28,
+          functions: 14,
+          branches: 12,
+        },
+        // Preview.svelte ~40.3 L / 38.9 S / 35.0 F / 23.4 B.
+        'src/renderer/lib/components/Preview.svelte': {
+          lines: 30,
+          statements: 30,
+          functions: 25,
+          branches: 14,
+        },
+        // SourceDetail.svelte ~40.2 L / 33.7 S / 27.0 F / 25.8 B (#1597).
+        'src/renderer/lib/components/SourceDetail.svelte': {
+          lines: 30,
+          statements: 24,
+          functions: 18,
+          branches: 16,
+        },
+        // SourcesPanel.svelte ~43.4 L / 41.9 S / 35.3 F / 30.0 B.
+        'src/renderer/lib/components/SourcesPanel.svelte': {
+          lines: 34,
+          statements: 32,
+          functions: 26,
+          branches: 20,
+        },
+        // SettingsDialog.svelte ~77.1 L / 80.8 S / 58.1 F / 47.8 B (the shell;
+        // extracted panels carry their own tests + the #999/#1094 aggregate).
+        'src/renderer/lib/components/SettingsDialog.svelte': {
+          lines: 68,
+          statements: 70,
+          functions: 48,
+          branches: 38,
+        },
+        // PropertiesPanel.svelte ~89.9 L / 86.2 S / 88.8 F / 59.5 B.
+        'src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte': {
+          lines: 80,
+          statements: 76,
+          functions: 78,
+          branches: 50,
+        },
       },
     },
   },


### PR DESCRIPTION
Closes #1613.

## Problem

The `src/renderer/**` aggregate coverage floor (42% lines) is met by the many small, well-tested renderer files. That masks the largest defect surfaces: the handful of 1000+-line components sat near **0%** own-file coverage and never tripped the aggregate net — and nothing stopped a tested one from silently rotting back toward zero.

## Change

Following the #1597 SourceDetail template, add render/smoke tests that mount each oversized component against mocked IPC + stores, then fence each with a **per-file threshold** in `vitest.config.mts` set ~8–10 points below the measured v8 numbers (headroom-below-measured, so a real regression fails but a refactor won't flap):

| Component | Before → after (lines) | Floor (L/S/F/B) | New tests |
|---|---|---|---|
| `Editor.svelte` | 0 → ~38.6% | 30 / 28 / 14 / 12 | 5 |
| `Preview.svelte` | 0 → ~40.3% | 30 / 30 / 25 / 14 | 7 |
| `SourceDetail.svelte` | ~40.2% (existing, #1597) | 30 / 24 / 18 / 16 | — |
| `SourcesPanel.svelte` | 0 → ~43.4% | 34 / 32 / 26 / 20 | 9 |
| `SettingsDialog.svelte` | 0 → ~77.1% | 68 / 70 / 48 / 38 | 7 |
| `right-sidebar/PropertiesPanel.svelte` | 0 → ~89.9% | 80 / 76 / 78 / 50 | 16 |

The per-file keys are **additive** — these files stay counted in the `src/renderer/**` aggregate; the entries only layer a stricter per-file gate on top. Continues the documented renderer ratchet (bucket B, #1452).

The tests mount the **real** components (real CodeMirror stack for Editor, real markdown pipeline for Preview, real child components/pure helpers elsewhere) and assert user-visible wiring, so the coverage reflects genuine behavior rather than smoke.

## Verification

- `pnpm coverage` (full suite + all thresholds) exits 0 — new per-file floors and the renderer aggregate all pass.
- `pnpm lint` clean (tsc · svelte-check · eslint).
- All 44 new tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)