### PR TITLE
refactor(editor): extract EditorContextMenu + collapse the menu prop surface (#1625)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -1166,8 +1166,6 @@
                           onSearchQueryConsumed={() => { pendingSearchQuery = null; }}
                           onEditorStateSave={editor.saveEditorState}
                           onCursorChange={(info) => { cursorInfo = info; }}
-                          onToolInvoke={handleToolInvoke}
-                          onOpenConversation={openConversation}
                           onNavigate={handleNavigate}
                           onOpenSource={handleOpenSource}
                           onOpenExcerpt={handleOpenExcerpt}
@@ -1175,36 +1173,40 @@
                           getSources={() => sourcesCache}
                           getAliases={() => aliasEntries}
                           resolveInlineTypeCreate={handleInlineTypeCreate}
-                          onBookmark={() => bookmarkStore.add(note.fileName.replace(/\.(md|ttl|csv)$/, ''), note.relativePath)}
-                          onBookmarkSection={() => { void handleBookmarkSection(); }}
-                          onBookmarkLine={handleBookmarkLine}
                           bookmarks={collectBookmarksForPath(bookmarkStore.tree, note.relativePath)}
-                          onExtractSelection={handleExtractSelection}
-                          onSplitHere={handleSplitHere}
-                          onSplitByHeading={handleSplitByHeading}
-                          onRename={() => void handleRename(note.relativePath)}
-                          onMove={() => void handleMoveWithPrompt(note.relativePath)}
-                          onCopyFile={() => void handleCopyWithPrompt(note.relativePath)}
-                          onMerge={() => handleMerge(note.relativePath)}
-                          onAutoTag={() => void handleAutoTag(note.relativePath)}
-                          onAutoLink={() => void handleAutoLink(note.relativePath)}
-                          onAutoLinkInbound={() => void handleAutoLinkInbound(note.relativePath)}
-                          onFormatCurrentNote={() => handleFormat()}
-                          onAddTagCurrentNote={() => void handleAddTag(note.relativePath, false, { targetOnly: true })}
-                          onRemoveTagCurrentNote={() => void handleRemoveTag(note.relativePath, false, { targetOnly: true })}
-                          onAddPropertyCurrentNote={() => void handleAddProperty(note.relativePath, false, { targetOnly: true })}
-                          onRemovePropertyCurrentNote={() => void handleRemoveProperty(note.relativePath, false, { targetOnly: true })}
                           onUploadError={(message) => {
                             void showConfirm(message, CONFIRM_KEYS.imageUploadFailed, 'OK');
                           }}
                           onRunCell={(language, code, notePath) =>
                             runCellWithTrust(language, code, notePath, { showConsent: showComputeConsent })
                           }
-                          onInsertQueryList={async () => {
-                            const tag = await showPrompt('Tag name:');
-                            if (!tag) return;
-                            const block = `\n:::query-list\nSELECT ?title ?path WHERE {\n  ?note minerva:hasTag ?t .\n  ?t minerva:tagName "${tag}" .\n  ?note dc:title ?title .\n  ?note minerva:relativePath ?path .\n} ORDER BY ?title\n:::\n`;
-                            editorComponents[groupId]?.insertText(block);
+                          menuOps={{
+                            invokeTool: handleToolInvoke,
+                            openConversation: openConversation,
+                            bookmark: () => bookmarkStore.add(note.fileName.replace(/\.(md|ttl|csv)$/, ''), note.relativePath),
+                            bookmarkSection: () => { void handleBookmarkSection(); },
+                            bookmarkLine: handleBookmarkLine,
+                            extractSelection: handleExtractSelection,
+                            splitHere: handleSplitHere,
+                            splitByHeading: handleSplitByHeading,
+                            rename: () => void handleRename(note.relativePath),
+                            move: () => void handleMoveWithPrompt(note.relativePath),
+                            copyFile: () => void handleCopyWithPrompt(note.relativePath),
+                            merge: () => handleMerge(note.relativePath),
+                            autoTag: () => void handleAutoTag(note.relativePath),
+                            autoLink: () => void handleAutoLink(note.relativePath),
+                            autoLinkInbound: () => void handleAutoLinkInbound(note.relativePath),
+                            formatCurrentNote: () => handleFormat(),
+                            addTagCurrentNote: () => void handleAddTag(note.relativePath, false, { targetOnly: true }),
+                            removeTagCurrentNote: () => void handleRemoveTag(note.relativePath, false, { targetOnly: true }),
+                            addPropertyCurrentNote: () => void handleAddProperty(note.relativePath, false, { targetOnly: true }),
+                            removePropertyCurrentNote: () => void handleRemoveProperty(note.relativePath, false, { targetOnly: true }),
+                            insertQueryList: async () => {
+                              const tag = await showPrompt('Tag name:');
+                              if (!tag) return;
+                              const block = `\n:::query-list\nSELECT ?title ?path WHERE {\n  ?note minerva:hasTag ?t .\n  ?t minerva:tagName "${tag}" .\n  ?note dc:title ?title .\n  ?note minerva:relativePath ?path .\n} ORDER BY ?title\n:::\n`;
+                              editorComponents[groupId]?.insertText(block);
+                            },
                           }}
                         />
                       {/key}

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import Icon from './Icon.svelte';
+  import EditorContextMenu from './EditorContextMenu.svelte';
   import { installDismissOnClickOutside } from '../dismiss-menu';
   import { EditorView, keymap } from '@codemirror/view';
   import { basicSetup } from 'codemirror';
@@ -23,17 +23,8 @@
     type UploadResult,
   } from '../editor/image-upload';
   import { sortLines, selectionTracker } from '../editor/commands';
-  import {
-    toggleBold, toggleItalic, toggleCode, toggleStrikethrough, toggleHighlight,
-    toggleH1, toggleH2, toggleH3, toggleQuote, toggleBulletList, toggleNumberedList,
-    insertTable, insertHorizontalRule, insertFootnote, insertLink, insertImage,
-    insertWikiLink, insertTypedLinks, insertCallouts, insertCardCallout,
-    insertSparqlQuery, insertSqlQuery, insertPythonScript, insertMermaidDiagram,
-    insertYouTubeEmbed, vegaLiteInserts,
-  } from '../editor/formatting';
   import { resolveKeyBindings } from '../editor/command-registry';
   import { toggleEditorDictation } from '../editor/dictation';
-  import { voiceSettings } from '../voice/voice-settings.svelte';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
   import { highlightDecorations } from '../editor/highlight-decorations';
   import { computeCellsExtension, type RunAllRef } from '../editor/compute-cells';
@@ -60,6 +51,7 @@
   import { findFrontmatterFoldRange } from '../editor/frontmatter';
   import { clampMenuToViewport, clampSubmenu } from '../utils/menuClamp';
   import { extractClaimUri } from '../../../shared/refactor/find-arguments';
+  import type { EditorContextMenuState, EditorMenuOps } from '../editor/context-menu-ops';
 
   export interface CursorInfo {
     line: number;
@@ -69,7 +61,7 @@
   }
 
   import { getToolInfosByCategory } from '../tools/tool-registry';
-  import { isSourceScoped, toolRequiresSelection, type ThinkingToolInfo } from '../../../shared/tools/types';
+  import { isSourceScoped } from '../../../shared/tools/types';
   import { groupToolsByGroup } from '../../../shared/tools/grouping';
 
   interface Props {
@@ -101,41 +93,21 @@
      */
     initialHistory?: unknown;
     onCursorChange?: (info: CursorInfo) => void;
-    onToolInvoke?: (toolId: string) => void;
-    onOpenConversation?: () => void;
-    onBookmark?: () => void;
-    /** Bookmark the section (nearest heading at/above the cursor). The
-     *  handler reads the cursor via `getOffset()` and resolves the slug. */
-    onBookmarkSection?: () => void;
-    /** Bookmark the current line — stores the cursor offset so opening
-     *  jumps back to it (#756). */
-    onBookmarkLine?: () => void;
     /** Position-bearing bookmarks for the current file. The editor renders
      *  a filled-ribbon flag in the gutter on each resolved line (#756). */
     bookmarks?: readonly BookmarkRef[];
-    onInsertQueryList?: () => void;
     onNavigate?: (target: string) => void;
     /** Click on a `[[cite::source-id]]` in the editor → open the source tab. */
     onOpenSource?: (sourceId: string) => void;
     /** Click on a `[[quote::excerpt-id]]` in the editor → open the source tab with excerpt highlighted. */
     onOpenExcerpt?: (excerptId: string) => void;
-    onExtractSelection?: () => void;
-    onSplitHere?: () => void;
-    onSplitByHeading?: () => void;
-    onRename?: () => void;
-    onMove?: () => void;
-    onCopyFile?: () => void;
-    onMerge?: () => void;
-    onAutoTag?: () => void;
-    onAutoLink?: () => void;
-    onAutoLinkInbound?: () => void;
-    onFormatCurrentNote?: () => void;
-    /** Frontmatter metadata actions on the note being edited (mirrors the
-     *  sidebar's tag menu). */
-    onAddTagCurrentNote?: () => void;
-    onRemoveTagCurrentNote?: () => void;
-    onAddPropertyCurrentNote?: () => void;
-    onRemovePropertyCurrentNote?: () => void;
+    /**
+     * The host actions the right-click context menu fans out to, grouped into
+     * one object (#1625). Replaces the ~20 one-shot `on*` forwarder props the
+     * menu used to take. Every entry is optional — the menu shows an item only
+     * when its op is supplied. Forwarded straight to `EditorContextMenu`.
+     */
+    menuOps?: EditorMenuOps;
     /** Live list of note paths for wiki-link autocomplete. */
     getNotePaths?: () => string[];
     /** Live list of Sources for `[[cite::…]]` autocomplete. */
@@ -187,31 +159,11 @@
     onSearchQueryConsumed,
     onEditorStateSave,
     onCursorChange,
-    onToolInvoke,
-    onOpenConversation,
-    onBookmark,
-    onBookmarkSection,
-    onBookmarkLine,
     bookmarks,
-    onInsertQueryList,
     onNavigate,
     onOpenSource,
     onOpenExcerpt,
-    onExtractSelection,
-    onSplitHere,
-    onSplitByHeading,
-    onRename,
-    onMove,
-    onCopyFile,
-    onMerge,
-    onAutoTag,
-    onAutoLink,
-    onAutoLinkInbound,
-    onFormatCurrentNote,
-    onAddTagCurrentNote,
-    onRemoveTagCurrentNote,
-    onAddPropertyCurrentNote,
-    onRemovePropertyCurrentNote,
+    menuOps = {},
     getNotePaths,
     getSources,
     getAliases,
@@ -242,7 +194,7 @@
   // Populated by computeCellsExtension; lets the host trigger Run-all.
   const runAllRef: RunAllRef = { run: null };
   let ignoreNextUpdate = false;
-  let contextMenu = $state<{ x: number; y: number; link: LinkRange | null; hasSelection: boolean; docPos: number | null; claimUri: string | null } | null>(null);
+  let contextMenu = $state<EditorContextMenuState | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
   // Separate from the main context menu: right-click anywhere in the
   // gutter opens a tiny toggle for line-number visibility. Keeps the
@@ -1057,244 +1009,23 @@
   </div>
 {/if}
 
-{#snippet toolButton(tool: ThinkingToolInfo)}
-  {@const needsSelection = toolRequiresSelection(tool) && !contextMenu?.hasSelection}
-  {@const needsClaim = (tool.context?.includes('claimUnderCursor') ?? false) && !contextMenu?.claimUri}
-  <button
-    onclick={() => handleMenuAction(() => onToolInvoke?.(tool.id))}
-    disabled={needsSelection || needsClaim}
-    title={needsClaim
-      ? 'Right-click on a line containing a claim URI'
-      : needsSelection
-        ? 'Select text first'
-        : tool.description}
-  >{tool.name}</button>
-{/snippet}
-
 {#if contextMenu}
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div
-    class="context-menu"
-    bind:this={contextMenuEl}
-    style:left="{contextMenu.x}px"
-    style:top="{contextMenu.y}px"
-    onmousedown={(e) => e.preventDefault()}
-  >
-    {#if contextMenu.link}
-      <button onclick={() => openLink(contextMenu!.link!)}>Open Link</button>
-      <button onclick={() => editLink(contextMenu!.link!)}>Edit Link</button>
-      <div class="separator"></div>
-    {/if}
-    <button onclick={() => execCommand('cut')}>Cut</button>
-    <button onclick={() => execCommand('copy')}>Copy</button>
-    <button onclick={() => execCommand('paste')}>Paste</button>
-    {#if filePath}
-      <button onclick={() => copyBlockLink()}>Copy Block Link</button>
-    {/if}
-    <div class="separator"></div>
-    <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Highlight<Icon name="chevronRight" size={10} /></span>
-      <div class="submenu">
-        <button onclick={() => runCmd(toggleHighlight)}>Colored Highlight</button>
-        <button onclick={() => runCmd(toggleBold)}>Bold</button>
-        <button onclick={() => runCmd(toggleItalic)}>Italic</button>
-        <button onclick={() => runCmd(toggleCode)}>Code</button>
-        <button onclick={() => runCmd(toggleStrikethrough)}>Strikethrough</button>
-      </div>
-    </div>
-    <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Link<Icon name="chevronRight" size={10} /></span>
-      <div class="submenu">
-        <button onclick={() => runCmd(insertWikiLink)}>Wiki Link</button>
-        <button onclick={() => runCmd(insertLink)}>URL Link</button>
-        <div class="submenu-item" onmouseenter={adjustSubmenu}>
-          <span class="submenu-trigger">Typed Link...<Icon name="chevronRight" size={10} /></span>
-          <div class="submenu">
-            {#each insertTypedLinks as { linkType, command }}
-              <button onclick={() => runCmd(command)}>
-                <span class="typed-link-dot" style:background={linkType.color}></span>
-                {linkType.label} Link
-              </button>
-            {/each}
-          </div>
-        </div>
-        <div class="submenu-separator"></div>
-        <button onclick={() => runCmd(insertFootnote)}>Footnote</button>
-      </div>
-    </div>
-    <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Paragraph<Icon name="chevronRight" size={10} /></span>
-      <div class="submenu">
-        <button onclick={() => runCmd(toggleH1)}>Heading 1</button>
-        <button onclick={() => runCmd(toggleH2)}>Heading 2</button>
-        <button onclick={() => runCmd(toggleH3)}>Heading 3</button>
-        <div class="submenu-separator"></div>
-        <button onclick={() => runCmd(toggleQuote)}>Quote</button>
-        <div class="submenu-item" onmouseenter={adjustSubmenu}>
-          <span class="submenu-trigger">Callout...<Icon name="chevronRight" size={10} /></span>
-          <div class="submenu">
-            {#each insertCallouts as { label, command }}
-              <button onclick={() => runCmd(command)}>{label}</button>
-            {/each}
-          </div>
-        </div>
-        <button onclick={() => runCmd(insertHorizontalRule)}>Horizontal Rule</button>
-      </div>
-    </div>
-    <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Elements<Icon name="chevronRight" size={10} /></span>
-      <div class="submenu">
-        <button onclick={() => runCmd(insertTable)}>Table</button>
-        <button onclick={() => runCmd(insertImage)}>Image</button>
-        <button onclick={() => runCmd(toggleBulletList)}>Bulleted List</button>
-        <button onclick={() => runCmd(toggleNumberedList)}>Numbered List</button>
-        <div class="submenu-separator"></div>
-        <div class="submenu-item" onmouseenter={adjustSubmenu}>
-          <span class="submenu-trigger">Query...<Icon name="chevronRight" size={10} /></span>
-          <div class="submenu">
-            <button onclick={() => runCmd(insertSqlQuery)}>SQL</button>
-            <button onclick={() => runCmd(insertSparqlQuery)}>SPARQL</button>
-          </div>
-        </div>
-        <button onclick={() => runCmd(insertPythonScript)}>Python Script</button>
-        <button onclick={() => runCmd(insertMermaidDiagram)}>Mermaid Diagram</button>
-        <button onclick={() => runCmd(insertYouTubeEmbed)}>YouTube Video</button>
-        <button onclick={() => runCmd(insertCardCallout)}>Flashcard</button>
-        <div class="submenu-item" onmouseenter={adjustSubmenu}>
-          <span class="submenu-trigger">Chart...<Icon name="chevronRight" size={10} /></span>
-          <div class="submenu">
-            {#each vegaLiteInserts as t (t.label)}
-              <button onclick={() => runCmd(t.command)}>{t.label}</button>
-            {/each}
-          </div>
-        </div>
-        <div class="submenu-separator"></div>
-        <button onclick={() => handleMenuAction(() => onInsertQueryList?.())}>Link List for Tag...</button>
-      </div>
-    </div>
-    {#if onToolInvoke && toolMenus.length > 0}
-      <div class="separator"></div>
-      {#each toolMenus as menu (menu.id)}
-        <div class="submenu-item" onmouseenter={adjustSubmenu}>
-          <span class="submenu-trigger">{menu.label}<Icon name="chevronRight" size={10} /></span>
-          <div class="submenu">
-            <!-- Named groups nest into submenus; ungrouped skills stay inline
-                 (like the Source tools menu) rather than being swept into a
-                 "General" bucket, so adding a group to one skill is a local
-                 change, not a menu-wide restructure. -->
-            {#each menu.groups as group (group.label ?? ' ungrouped')}
-              {#if group.label}
-                <div class="submenu-item" onmouseenter={adjustSubmenu}>
-                  <span class="submenu-trigger">{group.label}<Icon name="chevronRight" size={10} /></span>
-                  <div class="submenu">
-                    {#each group.tools as tool (tool.id)}{@render toolButton(tool)}{/each}
-                  </div>
-                </div>
-              {:else}
-                {#each group.tools as tool (tool.id)}{@render toolButton(tool)}{/each}
-              {/if}
-            {/each}
-          </div>
-        </div>
-      {/each}
-    {/if}
-    {#if onAddTagCurrentNote || onRemoveTagCurrentNote || onAddPropertyCurrentNote || onRemovePropertyCurrentNote}
-      <div class="separator"></div>
-      <div class="submenu-item" onmouseenter={adjustSubmenu}>
-        <span class="submenu-trigger">Metadata<Icon name="chevronRight" size={10} /></span>
-        <div class="submenu">
-          {#if onAddTagCurrentNote}
-            <button onclick={() => handleMenuAction(() => onAddTagCurrentNote?.())}>Add Tag&hellip;</button>
-          {/if}
-          {#if onRemoveTagCurrentNote}
-            <button onclick={() => handleMenuAction(() => onRemoveTagCurrentNote?.())}>Remove Tag&hellip;</button>
-          {/if}
-          {#if onAddPropertyCurrentNote}
-            <button onclick={() => handleMenuAction(() => onAddPropertyCurrentNote?.())}>Add Property&hellip;</button>
-          {/if}
-          {#if onRemovePropertyCurrentNote}
-            <button onclick={() => handleMenuAction(() => onRemovePropertyCurrentNote?.())}>Remove Property&hellip;</button>
-          {/if}
-        </div>
-      </div>
-    {/if}
-    <div class="separator"></div>
-    {#if onExtractSelection || onSplitHere || onSplitByHeading || onRename || onMove || onCopyFile || onMerge || onAutoTag || onAutoLink || onAutoLinkInbound}
-      <div class="submenu-item" onmouseenter={adjustSubmenu}>
-        <span class="submenu-trigger">Refactor<Icon name="chevronRight" size={10} /></span>
-        <div class="submenu">
-          {#if onRename}
-            <button onclick={() => handleMenuAction(() => onRename?.())}>Rename&hellip;</button>
-          {/if}
-          {#if onMove}
-            <button onclick={() => handleMenuAction(() => onMove?.())}>Move&hellip;</button>
-          {/if}
-          {#if onCopyFile}
-            <button onclick={() => handleMenuAction(() => onCopyFile?.())}>Copy&hellip;</button>
-          {/if}
-          {#if onMerge}
-            <button onclick={() => handleMenuAction(() => onMerge?.())}>Merge into&hellip;</button>
-          {/if}
-          {#if onRename || onMove || onCopyFile || onMerge}
-            <div class="separator"></div>
-          {/if}
-          {#if onExtractSelection}
-            <button
-              onclick={() => handleMenuAction(() => onExtractSelection?.())}
-              disabled={!contextMenu.hasSelection}
-            >Extract Selection to New Note</button>
-          {/if}
-          {#if onSplitHere}
-            <button onclick={() => handleMenuAction(() => onSplitHere?.())}>Split Note Here</button>
-          {/if}
-          {#if onSplitByHeading}
-            <button onclick={() => handleMenuAction(() => onSplitByHeading?.())}>Split by Heading&hellip;</button>
-          {/if}
-          {#if onAutoTag || onAutoLink || onAutoLinkInbound}
-            {#if onExtractSelection || onSplitHere || onSplitByHeading}
-              <div class="separator"></div>
-            {/if}
-            {#if onAutoTag}
-              <button onclick={() => handleMenuAction(() => onAutoTag?.())}>Auto-tag</button>
-            {/if}
-            {#if onAutoLink}
-              <button onclick={() => handleMenuAction(() => onAutoLink?.())}>Auto-link outbound&hellip;</button>
-            {/if}
-            {#if onAutoLinkInbound}
-              <button onclick={() => handleMenuAction(() => onAutoLinkInbound?.())}>Auto-link inbound&hellip;</button>
-            {/if}
-          {/if}
-          {#if onFormatCurrentNote}
-            <div class="separator"></div>
-            <button onclick={() => handleMenuAction(() => onFormatCurrentNote?.())}>Format Note</button>
-          {/if}
-        </div>
-      </div>
-      <div class="separator"></div>
-    {/if}
-    <button onclick={() => handleMenuAction(() => onOpenConversation?.())}>Ask About This...</button>
-    {#if voiceSettings.enabled}
-      <button onclick={() => handleMenuAction(() => void toggleEditorDictation(view))}>Dictate…</button>
-    {/if}
-    <button onclick={() => handleMenuAction(() => onBookmark?.())}>Bookmark This Note</button>
-    {#if onBookmarkSection}
-      <button onclick={() => handleMenuAction(() => onBookmarkSection?.())}>Bookmark Section</button>
-    {/if}
-    {#if onBookmarkLine}
-      <button onclick={() => handleMenuAction(() => onBookmarkLine?.())}>Bookmark Line</button>
-    {/if}
-    <div class="separator"></div>
-    <div class="submenu-item" onmouseenter={adjustSubmenu}>
-      <span class="submenu-trigger">Open In<Icon name="chevronRight" size={10} /></span>
-      <div class="submenu">
-        <button onclick={() => { void api.shell.revealFile(filePath); closeMenu(); }}>Reveal in Finder</button>
-        <button onclick={() => { void api.shell.openInDefault(filePath); closeMenu(); }}>Open in Default App</button>
-        <button onclick={() => { void api.shell.openInTerminal(filePath); closeMenu(); }}>Open in Terminal</button>
-      </div>
-    </div>
-    <div class="separator"></div>
-    <button onclick={() => execCommand('selectAll')}>Select All</button>
-  </div>
+  <EditorContextMenu
+    menu={contextMenu}
+    bind:menuEl={contextMenuEl}
+    {filePath}
+    {toolMenus}
+    ops={menuOps}
+    onExec={execCommand}
+    onRunCmd={runCmd}
+    onCopyBlockLink={copyBlockLink}
+    onOpenLink={openLink}
+    onEditLink={editLink}
+    onAdjustSubmenu={adjustSubmenu}
+    onMenuAction={handleMenuAction}
+    onClose={closeMenu}
+    onDictate={() => void toggleEditorDictation(view)}
+  />
 {/if}
 
 <style>
@@ -1395,64 +1126,11 @@
     background: var(--bg-button);
   }
 
+  /* The gutter menu (right-click in the line-number gutter) reuses the
+     `.context-menu` base above; its own tweaks stay here. The submenu /
+     separator / typed-link-dot styles moved to EditorContextMenu.svelte
+     along with the menu markup (#1625). */
   .gutter-menu { min-width: 180px; }
   .gutter-menu button { display: flex; align-items: center; gap: 8px; }
   .gutter-menu .check { width: 12px; text-align: center; color: var(--accent); }
-
-  .submenu-item {
-    position: relative;
-  }
-
-  .submenu-trigger {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    padding: 6px 12px;
-    font-size: 12px;
-    color: var(--text);
-    cursor: default;
-  }
-
-  .submenu-item:hover > .submenu-trigger {
-    background: var(--bg-button);
-  }
-
-  .submenu {
-    display: none;
-    position: absolute;
-    left: 100%;
-    top: -4px;
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    padding: 4px 0;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    min-width: 150px;
-  }
-
-  .submenu-item:hover > .submenu {
-    display: block;
-  }
-
-  .submenu-separator {
-    height: 1px;
-    background: var(--border);
-    margin: 4px 0;
-  }
-
-  .typed-link-dot {
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    margin-right: 4px;
-    vertical-align: middle;
-  }
-
-  .separator {
-    height: 1px;
-    background: var(--border);
-    margin: 4px 0;
-  }
 </style>

--- a/src/renderer/lib/components/EditorContextMenu.svelte
+++ b/src/renderer/lib/components/EditorContextMenu.svelte
@@ -1,0 +1,398 @@
+<script lang="ts">
+  // The editor's right-click context menu, extracted from Editor.svelte (#1625).
+  // Presentational: it renders the menu tree and dispatches through the handlers
+  // the parent passes — editor-internal commands (exec / runCmd / block-link /
+  // link open+edit / submenu-clamp / menu lifecycle) plus the grouped `ops`
+  // object of host forwarders. It owns no editor state; `menu` is the parent's
+  // reactive menu model and `menuEl` binds back so the parent's viewport-clamp
+  // effect can read this element.
+  import type { EditorView } from '@codemirror/view';
+  import Icon from './Icon.svelte';
+  import { api } from '../ipc/client';
+  import { voiceSettings } from '../voice/voice-settings.svelte';
+  import {
+    toggleBold, toggleItalic, toggleCode, toggleStrikethrough, toggleHighlight,
+    toggleH1, toggleH2, toggleH3, toggleQuote, toggleBulletList, toggleNumberedList,
+    insertTable, insertHorizontalRule, insertFootnote, insertLink, insertImage,
+    insertWikiLink, insertTypedLinks, insertCallouts, insertCardCallout,
+    insertSparqlQuery, insertSqlQuery, insertPythonScript, insertMermaidDiagram,
+    insertYouTubeEmbed, vegaLiteInserts,
+  } from '../editor/formatting';
+  import { toolRequiresSelection, type ThinkingToolInfo } from '../../../shared/tools/types';
+  import type { LinkRange } from '../editor/link-decorations';
+  import type {
+    EditorContextMenuState,
+    EditorMenuOps,
+    EditorToolMenu,
+  } from '../editor/context-menu-ops';
+
+  interface Props {
+    /** The open-menu model (position + what was clicked). */
+    menu: EditorContextMenuState;
+    /** Bound back to the parent so its viewport-clamp effect can measure. */
+    menuEl?: HTMLDivElement | undefined;
+    /** Path of the note being edited — gates block-link + open-in items. */
+    filePath: string;
+    /** Tools-for-Thought submenus (Learning / Research / Analysis). */
+    toolMenus: EditorToolMenu[];
+    /** Grouped host forwarders — see EditorMenuOps. */
+    ops: EditorMenuOps;
+    /** Run a `document.execCommand` (cut / copy / paste / selectAll). */
+    onExec: (cmd: string) => void;
+    /** Run a CodeMirror command against the editor view. */
+    onRunCmd: (cmd: (v: EditorView) => boolean) => void;
+    onCopyBlockLink: () => void;
+    onOpenLink: (link: LinkRange) => void;
+    onEditLink: (link: LinkRange) => void;
+    /** onmouseenter on a submenu trigger — reflow it inside the viewport. */
+    onAdjustSubmenu: (event: MouseEvent) => void;
+    /** Restore selection + close the menu, then run the action. */
+    onMenuAction: (action: () => void) => void;
+    onClose: () => void;
+    /** Toggle editor dictation (needs the view, so the parent supplies it). */
+    onDictate: () => void;
+  }
+
+  let {
+    menu,
+    menuEl = $bindable(),
+    filePath,
+    toolMenus,
+    ops,
+    onExec,
+    onRunCmd,
+    onCopyBlockLink,
+    onOpenLink,
+    onEditLink,
+    onAdjustSubmenu,
+    onMenuAction,
+    onClose,
+    onDictate,
+  }: Props = $props();
+</script>
+
+{#snippet toolButton(tool: ThinkingToolInfo)}
+  {@const needsSelection = toolRequiresSelection(tool) && !menu.hasSelection}
+  {@const needsClaim = (tool.context?.includes('claimUnderCursor') ?? false) && !menu.claimUri}
+  <button
+    onclick={() => onMenuAction(() => ops.invokeTool?.(tool.id))}
+    disabled={needsSelection || needsClaim}
+    title={needsClaim
+      ? 'Right-click on a line containing a claim URI'
+      : needsSelection
+        ? 'Select text first'
+        : tool.description}
+  >{tool.name}</button>
+{/snippet}
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="context-menu"
+  bind:this={menuEl}
+  style:left="{menu.x}px"
+  style:top="{menu.y}px"
+  onmousedown={(e) => e.preventDefault()}
+>
+  {#if menu.link}
+    <button onclick={() => onOpenLink(menu.link!)}>Open Link</button>
+    <button onclick={() => onEditLink(menu.link!)}>Edit Link</button>
+    <div class="separator"></div>
+  {/if}
+  <button onclick={() => onExec('cut')}>Cut</button>
+  <button onclick={() => onExec('copy')}>Copy</button>
+  <button onclick={() => onExec('paste')}>Paste</button>
+  {#if filePath}
+    <button onclick={() => onCopyBlockLink()}>Copy Block Link</button>
+  {/if}
+  <div class="separator"></div>
+  <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+    <span class="submenu-trigger">Highlight<Icon name="chevronRight" size={10} /></span>
+    <div class="submenu">
+      <button onclick={() => onRunCmd(toggleHighlight)}>Colored Highlight</button>
+      <button onclick={() => onRunCmd(toggleBold)}>Bold</button>
+      <button onclick={() => onRunCmd(toggleItalic)}>Italic</button>
+      <button onclick={() => onRunCmd(toggleCode)}>Code</button>
+      <button onclick={() => onRunCmd(toggleStrikethrough)}>Strikethrough</button>
+    </div>
+  </div>
+  <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+    <span class="submenu-trigger">Link<Icon name="chevronRight" size={10} /></span>
+    <div class="submenu">
+      <button onclick={() => onRunCmd(insertWikiLink)}>Wiki Link</button>
+      <button onclick={() => onRunCmd(insertLink)}>URL Link</button>
+      <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+        <span class="submenu-trigger">Typed Link...<Icon name="chevronRight" size={10} /></span>
+        <div class="submenu">
+          {#each insertTypedLinks as { linkType, command }}
+            <button onclick={() => onRunCmd(command)}>
+              <span class="typed-link-dot" style:background={linkType.color}></span>
+              {linkType.label} Link
+            </button>
+          {/each}
+        </div>
+      </div>
+      <div class="submenu-separator"></div>
+      <button onclick={() => onRunCmd(insertFootnote)}>Footnote</button>
+    </div>
+  </div>
+  <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+    <span class="submenu-trigger">Paragraph<Icon name="chevronRight" size={10} /></span>
+    <div class="submenu">
+      <button onclick={() => onRunCmd(toggleH1)}>Heading 1</button>
+      <button onclick={() => onRunCmd(toggleH2)}>Heading 2</button>
+      <button onclick={() => onRunCmd(toggleH3)}>Heading 3</button>
+      <div class="submenu-separator"></div>
+      <button onclick={() => onRunCmd(toggleQuote)}>Quote</button>
+      <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+        <span class="submenu-trigger">Callout...<Icon name="chevronRight" size={10} /></span>
+        <div class="submenu">
+          {#each insertCallouts as { label, command }}
+            <button onclick={() => onRunCmd(command)}>{label}</button>
+          {/each}
+        </div>
+      </div>
+      <button onclick={() => onRunCmd(insertHorizontalRule)}>Horizontal Rule</button>
+    </div>
+  </div>
+  <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+    <span class="submenu-trigger">Elements<Icon name="chevronRight" size={10} /></span>
+    <div class="submenu">
+      <button onclick={() => onRunCmd(insertTable)}>Table</button>
+      <button onclick={() => onRunCmd(insertImage)}>Image</button>
+      <button onclick={() => onRunCmd(toggleBulletList)}>Bulleted List</button>
+      <button onclick={() => onRunCmd(toggleNumberedList)}>Numbered List</button>
+      <div class="submenu-separator"></div>
+      <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+        <span class="submenu-trigger">Query...<Icon name="chevronRight" size={10} /></span>
+        <div class="submenu">
+          <button onclick={() => onRunCmd(insertSqlQuery)}>SQL</button>
+          <button onclick={() => onRunCmd(insertSparqlQuery)}>SPARQL</button>
+        </div>
+      </div>
+      <button onclick={() => onRunCmd(insertPythonScript)}>Python Script</button>
+      <button onclick={() => onRunCmd(insertMermaidDiagram)}>Mermaid Diagram</button>
+      <button onclick={() => onRunCmd(insertYouTubeEmbed)}>YouTube Video</button>
+      <button onclick={() => onRunCmd(insertCardCallout)}>Flashcard</button>
+      <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+        <span class="submenu-trigger">Chart...<Icon name="chevronRight" size={10} /></span>
+        <div class="submenu">
+          {#each vegaLiteInserts as t (t.label)}
+            <button onclick={() => onRunCmd(t.command)}>{t.label}</button>
+          {/each}
+        </div>
+      </div>
+      <div class="submenu-separator"></div>
+      <button onclick={() => onMenuAction(() => ops.insertQueryList?.())}>Link List for Tag...</button>
+    </div>
+  </div>
+  {#if ops.invokeTool && toolMenus.length > 0}
+    <div class="separator"></div>
+    {#each toolMenus as menu (menu.id)}
+      <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+        <span class="submenu-trigger">{menu.label}<Icon name="chevronRight" size={10} /></span>
+        <div class="submenu">
+          <!-- Named groups nest into submenus; ungrouped skills stay inline
+               (like the Source tools menu) rather than being swept into a
+               "General" bucket, so adding a group to one skill is a local
+               change, not a menu-wide restructure. -->
+          {#each menu.groups as group (group.label ?? '__ungrouped__')}
+            {#if group.label}
+              <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+                <span class="submenu-trigger">{group.label}<Icon name="chevronRight" size={10} /></span>
+                <div class="submenu">
+                  {#each group.tools as tool (tool.id)}{@render toolButton(tool)}{/each}
+                </div>
+              </div>
+            {:else}
+              {#each group.tools as tool (tool.id)}{@render toolButton(tool)}{/each}
+            {/if}
+          {/each}
+        </div>
+      </div>
+    {/each}
+  {/if}
+  {#if ops.addTagCurrentNote || ops.removeTagCurrentNote || ops.addPropertyCurrentNote || ops.removePropertyCurrentNote}
+    <div class="separator"></div>
+    <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+      <span class="submenu-trigger">Metadata<Icon name="chevronRight" size={10} /></span>
+      <div class="submenu">
+        {#if ops.addTagCurrentNote}
+          <button onclick={() => onMenuAction(() => ops.addTagCurrentNote?.())}>Add Tag&hellip;</button>
+        {/if}
+        {#if ops.removeTagCurrentNote}
+          <button onclick={() => onMenuAction(() => ops.removeTagCurrentNote?.())}>Remove Tag&hellip;</button>
+        {/if}
+        {#if ops.addPropertyCurrentNote}
+          <button onclick={() => onMenuAction(() => ops.addPropertyCurrentNote?.())}>Add Property&hellip;</button>
+        {/if}
+        {#if ops.removePropertyCurrentNote}
+          <button onclick={() => onMenuAction(() => ops.removePropertyCurrentNote?.())}>Remove Property&hellip;</button>
+        {/if}
+      </div>
+    </div>
+  {/if}
+  <div class="separator"></div>
+  {#if ops.extractSelection || ops.splitHere || ops.splitByHeading || ops.rename || ops.move || ops.copyFile || ops.merge || ops.autoTag || ops.autoLink || ops.autoLinkInbound}
+    <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+      <span class="submenu-trigger">Refactor<Icon name="chevronRight" size={10} /></span>
+      <div class="submenu">
+        {#if ops.rename}
+          <button onclick={() => onMenuAction(() => ops.rename?.())}>Rename&hellip;</button>
+        {/if}
+        {#if ops.move}
+          <button onclick={() => onMenuAction(() => ops.move?.())}>Move&hellip;</button>
+        {/if}
+        {#if ops.copyFile}
+          <button onclick={() => onMenuAction(() => ops.copyFile?.())}>Copy&hellip;</button>
+        {/if}
+        {#if ops.merge}
+          <button onclick={() => onMenuAction(() => ops.merge?.())}>Merge into&hellip;</button>
+        {/if}
+        {#if ops.rename || ops.move || ops.copyFile || ops.merge}
+          <div class="separator"></div>
+        {/if}
+        {#if ops.extractSelection}
+          <button
+            onclick={() => onMenuAction(() => ops.extractSelection?.())}
+            disabled={!menu.hasSelection}
+          >Extract Selection to New Note</button>
+        {/if}
+        {#if ops.splitHere}
+          <button onclick={() => onMenuAction(() => ops.splitHere?.())}>Split Note Here</button>
+        {/if}
+        {#if ops.splitByHeading}
+          <button onclick={() => onMenuAction(() => ops.splitByHeading?.())}>Split by Heading&hellip;</button>
+        {/if}
+        {#if ops.autoTag || ops.autoLink || ops.autoLinkInbound}
+          {#if ops.extractSelection || ops.splitHere || ops.splitByHeading}
+            <div class="separator"></div>
+          {/if}
+          {#if ops.autoTag}
+            <button onclick={() => onMenuAction(() => ops.autoTag?.())}>Auto-tag</button>
+          {/if}
+          {#if ops.autoLink}
+            <button onclick={() => onMenuAction(() => ops.autoLink?.())}>Auto-link outbound&hellip;</button>
+          {/if}
+          {#if ops.autoLinkInbound}
+            <button onclick={() => onMenuAction(() => ops.autoLinkInbound?.())}>Auto-link inbound&hellip;</button>
+          {/if}
+        {/if}
+        {#if ops.formatCurrentNote}
+          <div class="separator"></div>
+          <button onclick={() => onMenuAction(() => ops.formatCurrentNote?.())}>Format Note</button>
+        {/if}
+      </div>
+    </div>
+    <div class="separator"></div>
+  {/if}
+  <button onclick={() => onMenuAction(() => ops.openConversation?.())}>Ask About This...</button>
+  {#if voiceSettings.enabled}
+    <button onclick={() => onMenuAction(onDictate)}>Dictate…</button>
+  {/if}
+  <button onclick={() => onMenuAction(() => ops.bookmark?.())}>Bookmark This Note</button>
+  {#if ops.bookmarkSection}
+    <button onclick={() => onMenuAction(() => ops.bookmarkSection?.())}>Bookmark Section</button>
+  {/if}
+  {#if ops.bookmarkLine}
+    <button onclick={() => onMenuAction(() => ops.bookmarkLine?.())}>Bookmark Line</button>
+  {/if}
+  <div class="separator"></div>
+  <div class="submenu-item" onmouseenter={onAdjustSubmenu}>
+    <span class="submenu-trigger">Open In<Icon name="chevronRight" size={10} /></span>
+    <div class="submenu">
+      <button onclick={() => { void api.shell.revealFile(filePath); onClose(); }}>Reveal in Finder</button>
+      <button onclick={() => { void api.shell.openInDefault(filePath); onClose(); }}>Open in Default App</button>
+      <button onclick={() => { void api.shell.openInTerminal(filePath); onClose(); }}>Open in Terminal</button>
+    </div>
+  </div>
+  <div class="separator"></div>
+  <button onclick={() => onExec('selectAll')}>Select All</button>
+</div>
+
+<style>
+  /* Base menu chrome — duplicated with Editor.svelte's gutter menu (which also
+     wears `.context-menu`); scoped styles don't cross the component boundary. */
+  .context-menu {
+    position: fixed;
+    z-index: 1000;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    min-width: 160px;
+  }
+
+  .context-menu button {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .context-menu button:hover {
+    background: var(--bg-button);
+  }
+
+  .submenu-item {
+    position: relative;
+  }
+
+  .submenu-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--text);
+    cursor: default;
+  }
+
+  .submenu-item:hover > .submenu-trigger {
+    background: var(--bg-button);
+  }
+
+  .submenu {
+    display: none;
+    position: absolute;
+    left: 100%;
+    top: -4px;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    min-width: 150px;
+  }
+
+  .submenu-item:hover > .submenu {
+    display: block;
+  }
+
+  .submenu-separator {
+    height: 1px;
+    background: var(--border);
+    margin: 4px 0;
+  }
+
+  .typed-link-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-right: 4px;
+    vertical-align: middle;
+  }
+
+  .separator {
+    height: 1px;
+    background: var(--border);
+    margin: 4px 0;
+  }
+</style>

--- a/src/renderer/lib/editor/context-menu-ops.ts
+++ b/src/renderer/lib/editor/context-menu-ops.ts
@@ -1,0 +1,63 @@
+// Types for the editor context menu (#1625). The menu was extracted out of
+// Editor.svelte into EditorContextMenu.svelte; these types are the contract
+// between the two, plus the single grouped ops object that replaced ~20
+// one-shot forwarder props on Editor.
+
+import type { LinkRange } from './link-decorations';
+import type { ThinkingToolInfo } from '../../../shared/tools/types';
+import type { ToolGroup } from '../../../shared/tools/grouping';
+
+/** Live state of the open context menu: where it sits and what the
+ *  right-click landed on. `null` when the menu is closed. */
+export interface EditorContextMenuState {
+  x: number;
+  y: number;
+  /** The wiki/URL link under the cursor, if the click was on one. */
+  link: LinkRange | null;
+  hasSelection: boolean;
+  /** Document offset of the click — used to anchor a `^block-id`. */
+  docPos: number | null;
+  /** A `thought:Claim` URI resolved from the selection/line, gating the
+   *  argument-mining tools. */
+  claimUri: string | null;
+}
+
+/**
+ * The host-side actions the context menu fans out to, grouped into one object
+ * so Editor takes a single `menuOps` prop instead of ~20 `on*` callbacks. Every
+ * entry is optional: the menu renders an item only when its op is supplied
+ * (same `{#if onX}` guarding the individual props had). The wiring lives in the
+ * App ops clusters; Editor just forwards this straight to EditorContextMenu.
+ */
+export interface EditorMenuOps {
+  openConversation?: () => void;
+  bookmark?: () => void;
+  bookmarkSection?: () => void;
+  bookmarkLine?: () => void;
+  insertQueryList?: () => void;
+  extractSelection?: () => void;
+  splitHere?: () => void;
+  splitByHeading?: () => void;
+  rename?: () => void;
+  move?: () => void;
+  copyFile?: () => void;
+  merge?: () => void;
+  autoTag?: () => void;
+  autoLink?: () => void;
+  autoLinkInbound?: () => void;
+  formatCurrentNote?: () => void;
+  addTagCurrentNote?: () => void;
+  removeTagCurrentNote?: () => void;
+  addPropertyCurrentNote?: () => void;
+  removePropertyCurrentNote?: () => void;
+  invokeTool?: (toolId: string) => void;
+}
+
+/** One Tools-for-Thought submenu (Learning / Research / Analysis), built to
+ *  mirror the native menu. Matches the shape Editor derives from the registry. */
+export interface EditorToolMenu {
+  id: 'learning' | 'research' | 'analysis';
+  label: string;
+  tools: ThinkingToolInfo[];
+  groups: ToolGroup<ThinkingToolInfo>[];
+}

--- a/tests/renderer/components/Editor.test.ts
+++ b/tests/renderer/components/Editor.test.ts
@@ -90,7 +90,7 @@ describe('Editor (#1600)', () => {
 
   it('opens the right-click context menu and routes a menu action to the host', async () => {
     const onOpenConversation = vi.fn();
-    const { container } = render(Editor, props({ onOpenConversation }));
+    const { container } = render(Editor, props({ menuOps: { openConversation: onOpenConversation } }));
     await waitFor(() => expect(container.querySelector('.cm-content')).toBeTruthy());
 
     const content = container.querySelector('.cm-content')!;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -206,12 +206,25 @@ export default defineConfig({
         // measured-at-floor-time v8 numbers (in parens) so a small refactor won't
         // flap but a real regression fails. Ratchet upward as these gain tests.
         //
-        // Editor.svelte ~38.6 L / 37.1 S / 23.2 F / 21.4 B.
+        // Editor.svelte ~31.2 L / 28.6 S / 27.7 F / 20.8 B. Retuned down from
+        // the original #1613 floor (38.6 L): #1625 extracted the ~225-line
+        // right-click menu into EditorContextMenu.svelte, moving Editor's most
+        // testable interactive surface (now floored separately below) out, so
+        // its own ratio dropped — floors sit ~6pts under the new measured.
         'src/renderer/lib/components/Editor.svelte': {
-          lines: 30,
-          statements: 28,
-          functions: 14,
+          lines: 25,
+          statements: 22,
+          functions: 18,
           branches: 12,
+        },
+        // EditorContextMenu.svelte — the extracted right-click menu (#1625),
+        // exercised end-to-end by the Editor render test. ~56.3 L / 45.2 S /
+        // 20.0 F / 26.5 B; floors ~6-8pts below.
+        'src/renderer/lib/components/EditorContextMenu.svelte': {
+          lines: 48,
+          statements: 38,
+          functions: 12,
+          branches: 18,
         },
         // Preview.svelte ~40.3 L / 38.9 S / 35.0 F / 23.4 B.
         'src/renderer/lib/components/Preview.svelte': {


### PR DESCRIPTION
Closes #1625.

## Problem

`Editor.svelte`'s hand-built right-click context menu (~225 lines) existed only to fan out ~20 one-shot callback props — a `{#if onX}<button onclick={() => handleMenuAction(() => onX?.())}>` for each. That bloated both the template and Editor's prop surface.

## Change

- **New `EditorContextMenu.svelte`** renders the entire menu tree. It receives the menu model (`menu` + a bound `menuEl`), the editor-internal command handlers (`onExec`/`onRunCmd`/`onCopyBlockLink`/`onOpenLink`/`onEditLink`/`onAdjustSubmenu`/`onMenuAction`/`onClose`/`onDictate`), and a **single grouped `ops` object**. It imports the formatting commands, voice store, and `api.shell` side-effects it needs directly (the shell calls are stateless OS side-effects, allowed in components per the data-flow rule).
- **New `editor/context-menu-ops.ts`** holds the contract shared by both components and the App caller: `EditorMenuOps` (the 21 grouped host forwarders, all optional), `EditorContextMenuState`, and `EditorToolMenu`.
- **`Editor.svelte`** drops the 21 menu-only props for one `menuOps` prop — **surface ~42 → ~22** — keeps the editor-internal handlers (which touch `view`/selection/`contextMenu`), and just forwards `menuOps` to the child. The submenu/separator/typed-link CSS and now-unused formatting imports move out with the markup. **1458 → 1136 lines.**
- **`App.svelte`** passes the same handlers through one `menuOps={{ … }}` literal instead of 21 attributes.
- Incidentally removes a **stray NUL byte** that lived in the old menu's keyed-`each` sentinel (`group.label ?? '\0ungrouped'`) — it made `ripgrep`/`ugrep` treat the whole file as binary and silently skip it. The new key is a plain `'__ungrouped__'` string (keys are internal to reconciliation, never displayed).

## Verification

- **`pnpm lint`** clean (tsc · svelte-check · eslint).
- The **#1613 Editor render test** now drives the *real* Editor mounting the *real* `EditorContextMenu` end-to-end: right-click → menu opens (Copy/Paste present) → "Ask About This…" routes to `menuOps.openConversation` → menu dismisses; plus Dictate gating. Updated to the new `menuOps` API; **5/5 pass**. All 1849 renderer tests green.
- **Full coverage gate green (exit 0).** Floors retuned for the moved surface: `Editor.svelte` 30→25 L (its most testable interactive surface moved to the child), new `EditorContextMenu.svelte` floor at 48 L (measured ~56%). Net coverage locked is higher, not lower.

Note: in-app manual click-through wasn't run headlessly in the sandbox; the end-to-end render test against the real components is the automated proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)