### PR TITLE
refactor(source): extract NavList + SourceLinkRow for the navigable lists (#1628)

### DIFF
--- a/src/renderer/lib/components/NavList.svelte
+++ b/src/renderer/lib/components/NavList.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  // A bare <ul> reset wrapper for click-to-navigate lists (#1628). Pairs with
+  // SourceLinkRow, which owns the <li>. Extracted from the three near-identical
+  // lists in SourceDetail (notes / references / backlinks).
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    children: Snippet;
+  }
+
+  let { children }: Props = $props();
+</script>
+
+<ul class="nav-list">{@render children()}</ul>
+
+<style>
+  .nav-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+</style>

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -6,6 +6,8 @@
   import Icon from './Icon.svelte';
   import Eyebrow from './ui/Eyebrow.svelte';
   import Chip from './ui/Chip.svelte';
+  import NavList from './NavList.svelte';
+  import SourceLinkRow from './SourceLinkRow.svelte';
   import { renderInlineWithMath } from '../markdown/inline-math';
   import type { SourceDetail, SourceExcerpt, SourceBacklink, ReadStatus } from '../../../shared/types';
   import type { ThinkingToolInfo } from '../../../shared/tools/types';
@@ -691,34 +693,36 @@
       {#if detail.aboutNotes.length === 0}
         <p class="muted">No notes about this source yet.</p>
       {:else}
-        <ul class="about-list">
+        <NavList>
           {#each detail.aboutNotes as note (note.relativePath)}
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-            <li onclick={() => onNavigate(note.relativePath)}>
-              <span class="about-title">{note.title}</span>
-              <span class="about-path mono">{note.relativePath}</span>
-            </li>
+            <SourceLinkRow title={note.title} onClick={() => onNavigate(note.relativePath)}>
+              {#snippet meta()}
+                <span class="about-path mono">{note.relativePath}</span>
+              {/snippet}
+            </SourceLinkRow>
           {/each}
-        </ul>
+        </NavList>
       {/if}
     </section>
 
     {#if detail.references.length > 0}
       <section>
         <div class="sect-head"><Eyebrow>References <span class="ct">{detail.references.length}</span></Eyebrow></div>
-        <ul class="about-list">
+        <NavList>
           {#each detail.references as ref (ref.sourceId)}
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-            <li onclick={() => onOpenReference?.(ref.sourceId)} class:stub-row={ref.stubStatus === 'unresolved'}>
-              <span class="about-title">{ref.title}</span>
-              {#if ref.stubStatus === 'unresolved'}
-                <span class="stub-badge">stub</span>
-              {/if}
-            </li>
+            <SourceLinkRow
+              title={ref.title}
+              onClick={() => onOpenReference?.(ref.sourceId)}
+              stub={ref.stubStatus === 'unresolved'}
+            >
+              {#snippet meta()}
+                {#if ref.stubStatus === 'unresolved'}
+                  <span class="stub-badge">stub</span>
+                {/if}
+              {/snippet}
+            </SourceLinkRow>
           {/each}
-        </ul>
+        </NavList>
       </section>
     {/if}
 
@@ -727,22 +731,21 @@
       {#if detail.backlinks.length === 0}
         <p class="muted">No notes reference this source.</p>
       {:else}
-        <ul class="backlink-list">
+        <NavList>
           {#each detail.backlinks as b}
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-            <li onclick={() => onNavigate(b.relativePath)}>
-              <span class="backlink-title">{b.title}</span>
-              <span class="backlink-meta">
-                <span class="backlink-kind">{backlinkLabel(b)}</span>
-                {#if b.viaExcerptId}
-                  <span class="sep">·</span>
-                  <span class="mono">{b.viaExcerptId}</span>
-                {/if}
-              </span>
-            </li>
+            <SourceLinkRow title={b.title} onClick={() => onNavigate(b.relativePath)}>
+              {#snippet meta()}
+                <span class="backlink-meta">
+                  <span class="backlink-kind">{backlinkLabel(b)}</span>
+                  {#if b.viaExcerptId}
+                    <span class="sep">·</span>
+                    <span class="mono">{b.viaExcerptId}</span>
+                  {/if}
+                </span>
+              {/snippet}
+            </SourceLinkRow>
           {/each}
-        </ul>
+        </NavList>
       {/if}
     </section>
   {/if}
@@ -1176,7 +1179,7 @@
     font-style: italic;
   }
 
-  .excerpt-list, .backlink-list {
+  .excerpt-list {
     list-style: none;
     padding: 0;
     margin: 0;
@@ -1236,22 +1239,6 @@
     cursor: default;
   }
 
-  .backlink-list li {
-    padding: 8px 10px;
-    border-bottom: 1px solid var(--border);
-    cursor: pointer;
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 12px;
-  }
-  .backlink-list li:hover { background: var(--bg-button); }
-  .backlink-list li:last-child { border-bottom: none; }
-
-  .backlink-title {
-    color: var(--accent);
-  }
-
   .backlink-meta {
     font-size: 12px;
     color: var(--text-muted);
@@ -1289,35 +1276,11 @@
   }
   .section-action:disabled { cursor: default; opacity: 0.5; }
 
-  .about-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-  }
-  .about-list li {
-    padding: 8px 10px;
-    border-bottom: 1px solid var(--border);
-    cursor: pointer;
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 12px;
-  }
-  .about-list li:hover { background: var(--bg-button); }
-  .about-list li:last-child { border-bottom: none; }
-  .about-title { color: var(--accent); }
   .about-path {
     font-size: 11px;
     color: var(--text-faint);
   }
 
-  /* Stub source from reference mining (#106): italic title, dimmed
-     for visual distinction from fully-ingested sources. */
-  .about-list li.stub-row .about-title {
-    font-family: var(--font-display);
-    font-style: italic;
-    color: color-mix(in oklch, var(--accent) 60%, var(--text-muted));
-  }
   .stub-badge {
     font-family: var(--font-mono);
     font-size: 9.5px;

--- a/src/renderer/lib/components/SourceLinkRow.svelte
+++ b/src/renderer/lib/components/SourceLinkRow.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  // One click-to-navigate list row: an accent title plus an optional secondary
+  // line supplied by the caller (#1628). Extracted from the notes / references /
+  // backlinks lists in SourceDetail, which repeated this <li> + title + a11y
+  // boilerplate three times with only the meta content differing. Rendered
+  // inside a NavList (<ul>).
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    title: string;
+    onClick: () => void;
+    /** Reference-mining stub (#106): italicise + dim the title. */
+    stub?: boolean;
+    /** Secondary content (path / badge / kind+excerpt) — authored by the
+     *  caller, so its own styling stays scoped to the caller. */
+    meta?: Snippet;
+  }
+
+  let { title, onClick, stub = false, meta }: Props = $props();
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<li onclick={onClick} class:stub-row={stub}>
+  <span class="row-title">{title}</span>
+  {@render meta?.()}
+</li>
+
+<style>
+  li {
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+  }
+  li:hover { background: var(--bg-button); }
+  li:last-child { border-bottom: none; }
+
+  .row-title { color: var(--accent); }
+
+  /* Stub source from reference mining (#106): italic title, dimmed for visual
+     distinction from fully-ingested sources. */
+  li.stub-row .row-title {
+    font-family: var(--font-display);
+    font-style: italic;
+    color: color-mix(in oklch, var(--accent) 60%, var(--text-muted));
+  }
+</style>

--- a/tests/renderer/components/SourceDetail.test.ts
+++ b/tests/renderer/components/SourceDetail.test.ts
@@ -20,6 +20,22 @@ const metadata: SourceMetadata = {
 };
 const detail: SourceDetailData = { metadata, excerpts: [], backlinks: [], aboutNotes: [], references: [] };
 
+// A source with all three navigable lists populated, to exercise the extracted
+// NavList / SourceLinkRow rows and their click-to-navigate wiring (#1628).
+const withLists: SourceDetailData = {
+  metadata,
+  excerpts: [],
+  aboutNotes: [{ relativePath: 'notes/about-paxos.md', title: 'About Paxos' }],
+  references: [
+    { sourceId: 'lamport-clocks', title: 'Time, Clocks', stubStatus: null },
+    { sourceId: 'ghost-ref', title: 'Unresolved Ref', stubStatus: 'unresolved' },
+  ],
+  backlinks: [
+    { relativePath: 'notes/cites-paxos.md', title: 'Cites Paxos', kind: 'cite' },
+    { relativePath: 'notes/quotes-paxos.md', title: 'Quotes Paxos', kind: 'quote', viaExcerptId: 'exc-1' },
+  ],
+};
+
 const h = vi.hoisted(() => ({
   api: {
     graph: { sourceDetail: vi.fn() },
@@ -119,5 +135,43 @@ describe('SourceDetail (#1597)', () => {
     render(SourceDetail, props({ onInvokeTool: vi.fn() }));
     await waitFor(() => expect(screen.getByText('The Part-Time Parliament')).toBeTruthy());
     expect(screen.getByRole('button', { name: /Tools/ })).toBeTruthy();
+  });
+
+  describe('navigable lists (NavList / SourceLinkRow, #1628)', () => {
+    it('renders the notes / references / backlinks rows and routes each click to navigate', async () => {
+      h.api.graph.sourceDetail.mockResolvedValue(withLists);
+      const p = props({ onOpenReference: vi.fn() });
+      render(SourceDetail, p);
+
+      // An "about" note routes through onNavigate with its path.
+      await waitFor(() => expect(screen.getByText('About Paxos')).toBeTruthy());
+      await fireEvent.click(screen.getByText('About Paxos'));
+      expect(p.onNavigate).toHaveBeenCalledWith('notes/about-paxos.md');
+
+      // A reference routes through onOpenReference with its sourceId.
+      await fireEvent.click(screen.getByText('Time, Clocks'));
+      expect(p.onOpenReference).toHaveBeenCalledWith('lamport-clocks');
+
+      // A backlink routes through onNavigate with its path.
+      await fireEvent.click(screen.getByText('Quotes Paxos'));
+      expect(p.onNavigate).toHaveBeenCalledWith('notes/quotes-paxos.md');
+    });
+
+    it('marks an unresolved reference with a stub badge', async () => {
+      h.api.graph.sourceDetail.mockResolvedValue(withLists);
+      render(SourceDetail, props({ onOpenReference: vi.fn() }));
+      await waitFor(() => expect(screen.getByText('Unresolved Ref')).toBeTruthy());
+      expect(screen.getByText('stub')).toBeTruthy();
+    });
+
+    it('shows the backlink kind label and via-excerpt id', async () => {
+      h.api.graph.sourceDetail.mockResolvedValue(withLists);
+      render(SourceDetail, props({ onOpenReference: vi.fn() }));
+      await waitFor(() => expect(screen.getByText('Cites Paxos')).toBeTruthy());
+      // kind → 'cites' / 'quotes', plus the excerpt id on the quote backlink.
+      expect(screen.getByText('cites')).toBeTruthy();
+      expect(screen.getByText('quotes')).toBeTruthy();
+      expect(screen.getByText('exc-1')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
Closes #1628.

## Problem

`SourceDetail.svelte` rendered three near-identical click-to-navigate lists — **notes**, **references**, and **backlinks** — each repeating the same `<ul>` reset and a clickable `<li>` with an accent title, the two a11y-ignore comments, and a navigate handler. The three `.about-list li` / `.backlink-list li` CSS blocks were byte-for-byte identical and both titles were plain `var(--accent)`; only the secondary/meta line differed (path vs. stub badge vs. kind+excerpt).

## Change

- **New `NavList.svelte`** — owns the `<ul>` reset.
- **New `SourceLinkRow.svelte`** — owns the clickable `<li>` + accent title + a11y boilerplate, taking `title` / `onClick` / `stub` props and a `meta` snippet for the variable secondary content. The meta markup stays authored in the caller (SourceDetail), so its styling stays scoped there — only the truly-shared row/list/title CSS moved into the components.
- **SourceDetail** now renders all three lists as `<NavList><SourceLinkRow …>{#snippet meta()}…{/snippet}</SourceLinkRow></NavList>`, and its duplicated row/list CSS is gone. **Net −37 lines.**

## Verification

- **`pnpm lint`** clean (tsc · svelte-check · eslint) — including no unused-CSS-selector warnings, confirming exactly the dead selectors were removed and every kept one (`.about-path`, `.stub-badge`, `.backlink-meta`, `.backlink-kind`, `.mono`, `.sep`) is still used by a meta snippet.
- **3 new SourceDetail render tests** populate all three lists and assert each row's click routes through `onNavigate` / `onOpenReference` with the right argument, the unresolved-reference stub badge renders, and the backlink kind label + via-excerpt id show. This is the automated proxy for the issue's "manual verify navigation" — the prior #1597 test only rendered an empty (meta-only) source. **8/8 pass.**
- **Full coverage gate green (exit 0)** — SourceDetail's #1613 per-file floor and the `src/renderer/**` aggregate both hold (the populated-list tests lift SourceDetail's own coverage; the two new components are fully exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)