### PR TITLE
docs(ipc): standardize + document the IPC error-handling convention (#1631)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,65 @@ To add a new main-process operation:
 4. Expose it in `src/preload/preload.ts`
 5. Add the type to the API interface in `src/renderer/lib/ipc/client.ts`
 
+### IPC error handling (#1631)
+
+One convention so every caller reasons about failure the same way. Electron's
+`ipcRenderer.invoke` **rejects the renderer promise when a handler throws**, and
+the typed `invoke` wrapper (`src/preload/typed-invoke.ts`) surfaces it — so a
+thrown error already propagates cleanly. Build on that:
+
+1. **Default: throw.** A handler that cannot complete throws; the caller uses
+   `try/catch` / `.catch`. Do **not** invent an `{ ok: false }` object or a
+   `null` for a *generic* failure — throwing is the failure channel.
+2. **"No project open" throws.** Use `withRootPath` / `withRootPathWin`
+   (`ipc/helpers.ts`). `withRootPathOr(fallback, …)` is only for handlers whose
+   project-less answer is a *legitimate value* (an empty list `[]` a UI renders
+   as "nothing yet"), **not** a way to signal failure — and that fallback must
+   mean the same thing as a genuinely-empty result, never "error".
+3. **Discriminated `{ ok, … }` union — only when the caller must branch on an
+   EXPECTED, non-exceptional outcome.** A user's malformed SQL/SPARQL, a failed
+   network/auth check, or user code that errors are normal inputs the UI renders
+   inline, not bugs. These legitimately return a union: tables/graph query
+   results, `ConnectionCheckResult` (S3 / GitHub / model key), `PUBLISH_TO_GIT`,
+   compute `CellResult` / `PythonProbeResult` / `InterruptResult`. Give the
+   *failure* arm a real discriminant (`{ ok: false; error }`), and document on
+   the type that the call itself does not reject.
+4. **Per-item outcome catalogs are fine.** A call that succeeds while reporting
+   per-item problems (`SKILLS_LIST` / `TYPES_LIST` `errors[]`, the draft-filing
+   `outcomes[].error`) is not a failure channel — the call worked; the array
+   describes each item. Keep these.
+5. **`null` marks exactly ONE expected absence, documented on the client type.**
+   Either "user cancelled a native picker" **or** "not found" — never both, and
+   never "error". A corrupt store, an IO failure, or "no project" must not fold
+   into the same `null`.
+
+**Anti-patterns (do not add; migrate when you touch one):**
+
+- **Overloaded `null`/sentinel** — one `null` meaning several of {cancelled,
+  not-found, no-project, corrupt, error}. Split them: real errors throw, and the
+  sentinel keeps one meaning. Use `readJsonFileOr(absPath, fallback)`
+  (`ipc/helpers.ts`) for JSON stores — it returns `fallback` on ENOENT but
+  **rethrows a parse/IO error** instead of masquerading corruption as "empty".
+- **Swallowing** — `catch { return null | [] | fallback }` that discards a real
+  error. Only catch a *specific expected* condition (e.g. ENOENT → sentinel) and
+  let the rest throw.
+- **In-band `error?` on an otherwise-normal payload** — prefer the discriminated
+  union of rule 3 over baking an optional `error` onto the success shape.
+
+**Migration backlog** (audited outliers, fix incrementally per the rules above):
+
+- `null` no-project↔not-found: `GRAPH_SOURCE_DETAIL`, `GRAPH_EXCERPT_SOURCE`,
+  `PROPOSAL_DETAIL` (→ `withRootPath` so `null` means only "not found");
+  `TEMPLATES_GET`, `CONVERSATION_LOAD` (corrupt → throw).
+- boolean overloads: `NOTEBASE_FILE_EXISTS`, proposals `APPROVE` / `REJECT`
+  (`false` = no-project ↔ failed).
+- in-band `error?` → union: `GRAPH_QUERY` (`{ results, columns, error? }` should
+  match the `TABLES_QUERY` `{ ok:false; error }` shape).
+- swallows: `LINKS_CITATIONS_FOR_NOTE` (`.catch(()=>'')`), `CSL_REMOVE_STYLE` /
+  `CSL_REMOVE_LOCALE` (unlink swallows non-ENOENT), `FORMATTER_LOAD_SETTINGS`
+  (→ `readJsonFileOr`), `RUN_COMPUTE_DRAFT` (log-only append / audit-record).
+- vestigial: `GIT_COMMIT.success` (hardcoded `true` — any failure throws).
+
 ### File System
 - All paths are relative to the project root
 - `assertSafePath()` in `fs.ts` prevents path traversal — always use it//

--- a/src/main/ipc/helpers.ts
+++ b/src/main/ipc/helpers.ts
@@ -53,6 +53,11 @@ export function withRootPathOr<A extends unknown[], R>(
   };
 }
 
+// Re-exported so callers (and CLAUDE.md's IPC section) can reach it via the
+// helpers barrel; the implementation is a leaf module with no electron coupling
+// so it stays unit-testable in isolation.
+export { readJsonFileOr } from './read-json';
+
 /**
  * Like {@link withRootPath}, but also hands the handler its {@link BrowserWindow}.
  * The many handlers that resolve a project and then broadcast a change back to

--- a/src/main/ipc/read-json.ts
+++ b/src/main/ipc/read-json.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs/promises';
+
+/**
+ * Read + `JSON.parse` a file, returning `fallback` ONLY when the file is absent
+ * (ENOENT). A malformed-JSON parse error or any other read error is a genuine
+ * failure and is rethrown, so it surfaces as an invoke rejection the caller can
+ * see (#1631). This replaces the `try { readFile; JSON.parse } catch { return
+ * fallback }` idiom, which silently conflated "not written yet" (expected) with
+ * "corrupt on disk" (data loss the user should be told about). The IPC error
+ * convention (see CLAUDE.md → IPC error handling) is: a sentinel/fallback marks
+ * exactly ONE expected condition; real failures throw.
+ *
+ * Leaf module (only `node:fs/promises`) so it's unit-testable without pulling in
+ * electron via the `helpers` barrel that re-exports it.
+ */
+export async function readJsonFileOr<T>(absPath: string, fallback: T): Promise<T> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(absPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return fallback;
+    throw err;
+  }
+  return JSON.parse(raw) as T;
+}

--- a/src/main/ipc/register-bookmarks.ts
+++ b/src/main/ipc/register-bookmarks.ts
@@ -2,18 +2,15 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
 import type { TabSession, LayoutSession, BookmarkNode } from '../../shared/types';
-import { rootPathFromEvent, withRootPathOr } from './helpers';
+import { rootPathFromEvent, withRootPathOr, readJsonFileOr } from './helpers';
 import { handle } from './typed-ipc';
 
 export function registerBookmarks(): void {
-  // Bookmarks
-  handle(Channels.BOOKMARKS_LOAD, withRootPathOr<[], BookmarkNode[] | Promise<BookmarkNode[]>>([], async (rootPath) => {
-    try {
-      const bmPath = path.join(rootPath, '.minerva', 'bookmarks.json');
-      const data = await fs.readFile(bmPath, 'utf-8');
-      return JSON.parse(data) as BookmarkNode[];
-    } catch { return []; }
-  }));
+  // Bookmarks. A missing bookmarks.json means "none yet" → []; a corrupt one
+  // throws through readJsonFileOr rather than silently reading back as empty
+  // (#1631), so the user isn't quietly shown zero bookmarks over lost data.
+  handle(Channels.BOOKMARKS_LOAD, withRootPathOr<[], BookmarkNode[] | Promise<BookmarkNode[]>>([], (rootPath) =>
+    readJsonFileOr<BookmarkNode[]>(path.join(rootPath, '.minerva', 'bookmarks.json'), [])));
 
   handle(Channels.BOOKMARKS_SAVE, withRootPathOr(undefined, async (rootPath, tree: BookmarkNode[]) => {
     const bmPath = path.join(rootPath, '.minerva', 'bookmarks.json');
@@ -31,15 +28,17 @@ export function registerBookmarks(): void {
     await fs.writeFile(tabsPath, JSON.stringify(session, null, 2), 'utf-8');
   }));
 
+  // `null` = nothing to restore (no project open, or no tabs.json yet); the
+  // renderer starts a fresh session either way. A corrupt tabs.json throws
+  // instead of collapsing into that same null (#1631) — a parse error was
+  // previously indistinguishable from a first run, silently dropping the
+  // saved session.
   handle(Channels.TABS_LOAD, async (e): Promise<LayoutSession | TabSession | null> => {
     const rootPath = rootPathFromEvent(e);
     if (!rootPath) return null;
-    try {
-      const tabsPath = path.join(rootPath, '.minerva', 'tabs.json');
-      const data = await fs.readFile(tabsPath, 'utf-8');
-      return JSON.parse(data) as LayoutSession | TabSession;
-    } catch {
-      return null;
-    }
+    return readJsonFileOr<LayoutSession | TabSession | null>(
+      path.join(rootPath, '.minerva', 'tabs.json'),
+      null,
+    );
   });
 }

--- a/src/main/ipc/register-graph.ts
+++ b/src/main/ipc/register-graph.ts
@@ -95,6 +95,11 @@ export function registerGraph(): void {
         FILTER(CONTAINS(LCASE(?label), LCASE("${escaped}")))
       } LIMIT 5
     `);
+    // queryGraph reports an engine failure via an in-band `error` field rather
+    // than throwing (its query-panel callers render it inline). This handler has
+    // no such surface, so a dropped `error` would read as "no matches" — throw it
+    // instead so the failure reaches the caller as a rejection (#1631).
+    if (results.error) throw new Error(`grounding query failed: ${results.error}`);
     // The SELECT projects exactly ?node ?label ?type — narrow the generic
     // row shape to the typed contract the renderer consumes.
     return results.results as { node: string; label: string; type: string }[];

--- a/tests/main/ipc/read-json.test.ts
+++ b/tests/main/ipc/read-json.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `readJsonFileOr` — the IPC store-load helper that disambiguates "not written
+ * yet" from "corrupt on disk" (#1631). The old `try { readFile; JSON.parse }
+ * catch { return fallback }` idiom collapsed both into the fallback, silently
+ * losing a user's bookmarks/session when the file was corrupt. This pins:
+ *   - missing file (ENOENT) → fallback   (expected: "none yet")
+ *   - valid JSON            → parsed value
+ *   - corrupt JSON          → THROWS      (data loss must not read as "empty")
+ *   - other read error      → THROWS
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { readJsonFileOr } from '../../../src/main/ipc/read-json';
+
+describe('readJsonFileOr (#1631)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-readjson-'));
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns the fallback when the file is absent (ENOENT)', async () => {
+    const fallback = [{ marker: true }];
+    await expect(readJsonFileOr(path.join(dir, 'missing.json'), fallback)).resolves.toBe(fallback);
+  });
+
+  it('parses and returns valid JSON', async () => {
+    const p = path.join(dir, 'ok.json');
+    await fs.writeFile(p, JSON.stringify([1, 2, 3]), 'utf-8');
+    await expect(readJsonFileOr<number[]>(p, [])).resolves.toEqual([1, 2, 3]);
+  });
+
+  it('THROWS on corrupt JSON instead of masquerading as the fallback', async () => {
+    const p = path.join(dir, 'corrupt.json');
+    await fs.writeFile(p, '{ not: valid json, ', 'utf-8');
+    await expect(readJsonFileOr(p, [])).rejects.toThrow();
+  });
+
+  it('THROWS on a non-ENOENT read error (e.g. path is a directory)', async () => {
+    // Reading a directory as a file yields EISDIR, not ENOENT — a real failure.
+    await expect(readJsonFileOr(dir, [])).rejects.toThrow();
+  });
+});

--- a/tests/main/ipc/register-bookmarks.test.ts
+++ b/tests/main/ipc/register-bookmarks.test.ts
@@ -1,0 +1,83 @@
+/**
+ * BOOKMARKS_LOAD / TABS_LOAD store-load behaviour (#1631). Drives the real
+ * `registerBookmarks()` handlers against a temp project root, with the REAL
+ * `readJsonFileOr` leaf wired in (only electron + the project-scoping helpers
+ * are mocked). Pins that a corrupt store now rejects instead of silently
+ * reading back as "no bookmarks" / "fresh session" — the swallow the old
+ * `catch { return [] | null }` hid.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+const { handlers, state } = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  state: { root: null as string | null },
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { handlers.set(channel, fn); } },
+}));
+
+// Keep the REAL readJsonFileOr (the code under test); only stub the
+// project-scoping wrappers so we can steer/clear the root.
+vi.mock('../../../src/main/ipc/helpers', async () => {
+  const { readJsonFileOr } = await import('../../../src/main/ipc/read-json');
+  return {
+    readJsonFileOr,
+    rootPathFromEvent: () => state.root,
+    withRootPathOr:
+      <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A) => (state.root ? fn(state.root, ...args) : fallback),
+  };
+});
+
+import { registerBookmarks } from '../../../src/main/ipc/register-bookmarks';
+import { Channels } from '../../../src/shared/channels';
+
+registerBookmarks();
+
+const call = (channel: string, ...args: unknown[]) => handlers.get(channel)!({}, ...args);
+
+describe('register-bookmarks store loads (#1631)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-bm-'));
+    await fs.mkdir(path.join(dir, '.minerva'), { recursive: true });
+    state.root = dir;
+  });
+  afterEach(async () => {
+    state.root = null;
+    await fs.rm(dir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('BOOKMARKS_LOAD returns [] when the file is absent', async () => {
+    await expect(call(Channels.BOOKMARKS_LOAD)).resolves.toEqual([]);
+  });
+
+  it('BOOKMARKS_LOAD parses a valid bookmarks.json', async () => {
+    const tree = [{ id: 'a', label: 'A', kind: 'note', path: 'a.md' }];
+    await fs.writeFile(path.join(dir, '.minerva', 'bookmarks.json'), JSON.stringify(tree), 'utf-8');
+    await expect(call(Channels.BOOKMARKS_LOAD)).resolves.toEqual(tree);
+  });
+
+  it('BOOKMARKS_LOAD REJECTS on a corrupt bookmarks.json (no silent data loss)', async () => {
+    await fs.writeFile(path.join(dir, '.minerva', 'bookmarks.json'), '{ corrupt', 'utf-8');
+    await expect(call(Channels.BOOKMARKS_LOAD)).rejects.toThrow();
+  });
+
+  it('TABS_LOAD returns null with no project open, and when tabs.json is absent', async () => {
+    await expect(call(Channels.TABS_LOAD)).resolves.toBeNull();
+    state.root = null;
+    await expect(call(Channels.TABS_LOAD)).resolves.toBeNull();
+  });
+
+  it('TABS_LOAD REJECTS on a corrupt tabs.json instead of collapsing to null', async () => {
+    await fs.writeFile(path.join(dir, '.minerva', 'tabs.json'), 'not json at all', 'utf-8');
+    await expect(call(Channels.TABS_LOAD)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #1631.

## Problem

The IPC surface used 3–4 competing failure conventions with no documented rule — handlers variously `throw`, return an `{ok:false,error}` union, return a `null` sentinel (overloaded for cancelled / not-found / no-project / corrupt), or bake an `error` field onto a normal payload. Callers couldn't reason about failure uniformly, and some errors were silently swallowed.

## Audit

I audited **every** `handle(Channels.X, …)` across all ~25 `register-*.ts` modules plus `client.ts`/`helpers.ts` (fanned out in parallel). The verified inventory drove both the convention and the backlog. Headline: `throw` is already the de-facto majority; the outliers cluster into (a) `withRootPathOr` fallbacks signalling "no project" four incompatible ways, (b) `catch → null/[]` store-loads that hide corruption, and (c) a handful of legitimate "caller-must-branch" unions.

## Canonical convention (now in CLAUDE.md → "IPC error handling")

1. **Default: throw** — Electron rejects the invoke; the typed `invoke` wrapper surfaces it.
2. **No-project throws** (`withRootPath`); `withRootPathOr` only for a genuinely-empty legitimate value, never as a failure channel.
3. **Discriminated `{ok,error}` union only where the caller must branch on an EXPECTED outcome** — query results, `ConnectionCheckResult`, `PUBLISH_TO_GIT`, compute cells. Documented as non-rejecting on the type.
4. **Per-item `errors[]` catalogs are fine** (`SKILLS_LIST`, `TYPES_LIST`, draft `outcomes[]`).
5. **`null` marks exactly ONE documented absence** — cancelled *or* not-found, never both, never "error".

Plus an anti-pattern list and a **migration backlog** naming every remaining audited outlier (file-by-file), so the rest migrate incrementally as the issue asks.

## Concrete fixes on audited paths (criteria 2 & 3)

- **`readJsonFileOr(absPath, fallback)`** — new leaf helper: returns `fallback` on ENOENT but **rethrows** a parse/IO error, so a corrupt store surfaces instead of masquerading as empty. This is the reusable fix for the swallow-that-is-also-a-sentinel-overload.
- **`BOOKMARKS_LOAD` + `TABS_LOAD`** now use it — a corrupt `bookmarks.json`/`tabs.json` rejects instead of silently reading back as "no bookmarks" / "fresh session" (was silent data loss; also disambiguates their `[]`/`null` sentinel).
- **`GRAPH_GROUND_CHECK`** surfaces `queryGraph`'s in-band `error` (throws) instead of dropping it and returning `[]` as if there were no matches.

## Scope

Per the issue's "migrate the outliers **incrementally**", this PR sets the rule + fixes the cleanest, safest cluster (the store-load swallow/overload family + the ground-check drop) with tests, and documents the rest (graph/proposal no-project nulls, `GRAPH_QUERY` in-band→union, boolean overloads, `LINKS_CITATIONS`/CSL swallows, `GIT_COMMIT.success`) as a tracked backlog for follow-ups.

## Verification

- **`pnpm lint`** clean (tsc · svelte-check · eslint).
- **9 new tests**: `readJsonFileOr` (missing→fallback, valid→parsed, corrupt/EISDIR→throws) and the wired `BOOKMARKS_LOAD`/`TABS_LOAD` handlers (absent→sentinel, valid→parsed, corrupt→rejects). Full `tests/main/ipc` suite 25/25.
- **Full coverage gate exit 0** — the `src/main/ipc/**` threshold and all others hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)