### PR TITLE
chore(ipc): validator coverage + record IdeApi/validator decisions (#1635)

### DIFF
--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -867,6 +867,26 @@ export interface MenuApi {
   onImportZoteroRdf(cb: () => void): void;
 }
 
+/**
+ * The renderer-facing `window.api` surface.
+ *
+ * DUPLICATION DECISION (#1635): this interface hand-restates signatures the
+ * `ChannelMap` (`src/shared/ipc-contract.ts`) already pins, so it's effectively
+ * a 6th wiring site. Deriving it from `ChannelMap` was explored and deferred —
+ * it isn't a clean mechanical transform:
+ *   1. `IdeApi` is NAMESPACED (`api.notebase.readFile`) while `ChannelMap` is
+ *      flat (`'notebase:readFile'`), and method names don't map 1:1 to channel
+ *      suffixes, so a template-literal remap would misalign on the exceptions.
+ *   2. Each `*Api` interface also carries event-subscription methods
+ *      (`onFileChanged`, `onRewritten`, …) that live in the `EventMap`
+ *      (#1633), NOT `ChannelMap`, plus intermixed shared type/DTO definitions.
+ * A safe incremental path (not yet done, tracked here): add a compile-time
+ * assertion that every invoke method's resolved return type equals its
+ * `ChannelMap` entry, catching drift without a rewrite — the preload-bridge
+ * snapshot test (`tests/preload/preload-bridge.test.ts`) already pins the method
+ * SET, so only per-method SIGNATURE drift is currently unguarded. Until then,
+ * keep this interface in sync by hand when you touch a channel.
+ */
 export interface IdeApi {
   notebase: NotebaseApi;
   links: LinksApi;

--- a/src/shared/ipc-validators.ts
+++ b/src/shared/ipc-validators.ts
@@ -12,6 +12,17 @@
  * follow. Channels returning `void` have no guard (nothing to check). Array
  * checks are intentionally SHALLOW — a main-side shape bug is uniform across
  * elements, so checking the first catches it without an O(n) walk on every call.
+ *
+ * SCOPE DECISION (#1635): coverage is *targeted*, not exhaustive. The ChannelMap
+ * already pins every channel's shape at compile time on both the handler and
+ * preload sides, so a runtime guard is only worth its cost on payloads where a
+ * silent main-side shape bug would corrupt durable/renderer state hard to trace
+ * back. Add a guard when a channel (a) returns a structured object/array the
+ * renderer trusts into state, AND (b) rides a path where a wrong shape wouldn't
+ * fail loudly on its own. Skip `void`, primitives already covered by TS at the
+ * boundary, and low-blast-radius reads. Started notebase-only (#983); now also
+ * covers the trust path (proposals) and the SPARQL result surface (graph:query),
+ * the two highest-value structured returns beyond notebase.
  */
 import type { ChannelMap } from './ipc-contract';
 import type {
@@ -20,6 +31,7 @@ import type {
   SearchInNotesFileResult,
   ReplaceInNotesResult,
 } from './types';
+import type { Proposal } from './proposals';
 
 type ResultOf<K extends keyof ChannelMap> = Awaited<ReturnType<ChannelMap[K]>>;
 
@@ -53,6 +65,18 @@ function isSearchFileResult(v: unknown): v is SearchInNotesFileResult {
 function isReplaceResult(v: unknown): v is ReplaceInNotesResult {
   return isObj(v) && isStringArray(v.changedPaths) && isNumber(v.replacedCount);
 }
+// Trust path (#1635): a Proposal the renderer files into the review UI. Shallow
+// — uri + status discriminate a corrupt/empty payload from a real proposal.
+function isProposal(v: unknown): v is Proposal {
+  return isObj(v) && isString(v.uri) && isString(v.status);
+}
+const isProposalOrNull = (v: unknown): v is Proposal | null => v === null || isProposal(v);
+// SPARQL result surface (#1635): the query panel renders `results`/`columns`;
+// `error` is an optional in-band field, so only the two required arrays are
+// checked.
+function isQueryResult(v: unknown): v is { results: unknown[]; columns: string[]; error?: string } {
+  return isObj(v) && Array.isArray(v.results) && isStringArray(v.columns);
+}
 
 export const CHANNEL_VALIDATORS: {
   [K in keyof ChannelMap]?: (v: unknown) => v is ResultOf<K>;
@@ -84,6 +108,14 @@ export const CHANNEL_VALIDATORS: {
   'notebase:renameSource': isRewrittenPaths,
   'notebase:renameExcerpt': isRewrittenPaths,
   'notebase:getOnboardingDismissed': isBool,
+
+  // Trust path (#1635): proposals the renderer files into the review UI.
+  'proposal:list': shallowArrayOf(isProposal),
+  'proposal:detail': isProposalOrNull,
+
+  // Graph SPARQL result surface (#1635).
+  'graph:query': isQueryResult,
+
   // Channels returning `void` (recent:clear, write*, create*, delete*, rename,
   // copy, setOnboardingDismissed) have nothing to validate.
 };

--- a/tests/shared/ipc-validators.test.ts
+++ b/tests/shared/ipc-validators.test.ts
@@ -63,4 +63,30 @@ describe('CHANNEL_VALIDATORS (#983)', () => {
     expect(CHANNEL_VALIDATORS[Channels.NOTEBASE_WRITE_FILE]).toBeUndefined();
     expect(CHANNEL_VALIDATORS[Channels.RECENT_CLEAR]).toBeUndefined();
   });
+
+  // #1635 — validators extended to the trust path (proposals) + SPARQL results.
+  const proposal = { uri: 'urn:p1', status: 'pending', operationType: 'note_rewrite', note: 'n', proposedBy: 'llm' };
+
+  it('proposal:list shallow-checks Proposal[]', () => {
+    const v = CHANNEL_VALIDATORS[Channels.PROPOSAL_LIST]!;
+    expect(v([])).toBe(true);
+    expect(v([proposal])).toBe(true);
+    expect(v([{ uri: 'x' }])).toBe(false); // missing status
+    expect(v('nope')).toBe(false);
+  });
+
+  it('proposal:detail accepts a Proposal or null, rejects junk', () => {
+    const v = CHANNEL_VALIDATORS[Channels.PROPOSAL_DETAIL]!;
+    expect(v(proposal)).toBe(true);
+    expect(v(null)).toBe(true);
+    expect(v({ uri: 1 })).toBe(false);
+  });
+
+  it('graph:query requires results[] + columns[] (error is optional)', () => {
+    const v = CHANNEL_VALIDATORS[Channels.GRAPH_QUERY]!;
+    expect(v({ results: [], columns: [] })).toBe(true);
+    expect(v({ results: [{}], columns: ['a'], error: 'boom' })).toBe(true);
+    expect(v({ results: [], columns: [1] })).toBe(false); // columns not strings
+    expect(v({ results: 'x', columns: [] })).toBe(false); // results not an array
+  });
 });


### PR DESCRIPTION
Closes #1635.

Low-priority housekeeping on the IPC contract — the three sub-tasks:

## 1. Stale scope comment — already fixed
The `ipc-contract.ts` header no longer says "for the notebase domain"; **#1606** already corrected it to "Began as the notebase domain; now spans EVERY domain." Verified via history — no change needed here.

## 2. Runtime validators — decision recorded + acted on
Recorded the **scope decision** in `ipc-validators.ts`: coverage is *targeted*, not exhaustive. The `ChannelMap` already pins every channel's shape at compile time on both the handler and preload sides, so a runtime guard earns its cost only where a channel returns a structured object/array the renderer trusts into state **and** rides a path where a wrong shape wouldn't fail loudly. Added the criteria for when to add a guard.

Acted on it — extended the notebase-only set (#983) to the two highest-value structured returns the issue names:
- **Trust path:** `proposal:list` (shallow `Proposal[]`), `proposal:detail` (`Proposal | null`).
- **SPARQL result surface:** `graph:query` (`{ results[], columns[], error? }`).

Each guard is compile-linked to its `ChannelMap` return type (a contract change forces the guard to follow) and unit-tested (accepts the real shape, rejects junk).

## 3. `IdeApi` duplication — plan noted
Explored deriving the hand-maintained `IdeApi` (~1118 lines) from `ChannelMap` and **deferred it** with a recorded decision comment, because it isn't a clean transform:
1. `IdeApi` is namespaced (`api.notebase.readFile`) vs the flat `ChannelMap` (`'notebase:readFile'`), and method names don't map 1:1 to channel suffixes.
2. Each `*Api` interface also carries event-subscription methods (`onFileChanged`, …) that live in the `EventMap` (#1633), not `ChannelMap`, plus intermixed DTO definitions.

The comment records the safe incremental path (a compile-time assertion that each invoke method's resolved return equals its `ChannelMap` entry — catching per-method signature drift the preload-bridge snapshot test doesn't) so a future PR can pick it up.

## Verification
`pnpm lint` clean (the extended validators must compile-match their `ChannelMap` returns); `ipc-validators` 11/11 and the preload/contract suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)