### PR TITLE
feat(config): shared config load + validation helper (#1640)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,18 @@ thrown error already propagates cleanly. Build on that:
   (→ `readJsonFileOr`), `RUN_COMPUTE_DRAFT` (log-only append / audit-record).
 - vestigial: `GIT_COMMIT.success` (hardcoded `true` — any failure throws).
 
+### Config files (#1640)
+- Load JSON config through the shared helper in `src/main/config/config-store.ts`
+  (`loadConfigFile` / `loadConfigFileSync`), NOT a hand-rolled `try { readFile;
+  JSON.parse } catch { return defaults }`. It gives one consistent behavior: a
+  missing file → defaults (silent, expected); a corrupt/unreadable file → surfaced
+  via `reportConfigError` (loud, not swallowed) then defaults; per-field coercion
+  through the shared `as*` decoders (`asString`/`asBool`/`asFiniteNumber`/`asEnum`/
+  `asRecord`/`asStringArray`), so each config's `decode(raw)` reads as its schema.
+- Migrated so far: `ingest-settings`, `python-settings`, `project-config`. Still
+  hand-rolled (migrate when you touch them): `clipper-config` (decrypt + lazy
+  secret upgrade), `llm/settings` (nested providers/models), `menu-config-store`.
+
 ### File System
 - All paths are relative to the project root
 - `assertSafePath()` in `fs.ts` prevents path traversal — always use it//

--- a/src/main/compute/python-settings.ts
+++ b/src/main/compute/python-settings.ts
@@ -18,6 +18,7 @@ import { app } from 'electron';
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import { loadConfigFile, asString, asRecord } from '../config/config-store';
 
 export interface PythonSettings {
   /**
@@ -53,18 +54,15 @@ function settingsPath(): string {
 }
 
 export async function getPythonSettings(): Promise<PythonSettings> {
-  try {
-    const raw = await fs.readFile(settingsPath(), 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<PythonSettings>;
+  return loadConfigFile(settingsPath, (raw) => {
+    const o = asRecord(raw);
     return {
-      pythonPath: typeof parsed.pythonPath === 'string' ? parsed.pythonPath : '',
+      pythonPath: asString(o.pythonPath, DEFAULT_SETTINGS.pythonPath),
       // Default off — only a literal `true` enables network, so a corrupt or
       // truthy-non-bool value fails closed (matches the consent gate's posture).
-      allowNetwork: parsed.allowNetwork === true,
+      allowNetwork: o.allowNetwork === true,
     };
-  } catch {
-    return { ...DEFAULT_SETTINGS };
-  }
+  }, DEFAULT_SETTINGS);
 }
 
 export async function setPythonSettings(settings: PythonSettings): Promise<void> {

--- a/src/main/config/config-store.ts
+++ b/src/main/config/config-store.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared load + validation for the app's JSON config files (#1640).
+ *
+ * Every config loader used to hand-roll the same shape: `try { readFile;
+ * JSON.parse; coerce each field } catch { return defaults }`. The bare `catch`
+ * silently turned a CORRUPT config into defaults — the user's settings vanish
+ * with no signal — and each file validated its fields a slightly different way.
+ *
+ * This centralizes the mechanism:
+ *   - A missing file (ENOENT) → defaults, silently (expected: "not saved yet").
+ *   - A read / parse / validate FAILURE → reported loudly + consistently via
+ *     `reportConfigError`, then defaults (the app still boots; the corruption is
+ *     no longer swallowed).
+ *   - Per-field coercion goes through the small shared `as*` decoders below, so
+ *     "schema" is one declarative `decode(raw)` per config instead of ad-hoc
+ *     `typeof` ladders scattered across ~10 files.
+ *
+ * The `decode` callback owns the config's shape (fill defaults per field, or
+ * throw to reject a structurally-invalid payload — a throw is caught and
+ * reported like a parse error). This module imports only `node:fs`, so it's
+ * unit-testable without electron.
+ *
+ * The path is supplied as a THUNK (`() => absPath`), evaluated inside the
+ * protected region: many config paths are built from `app.getPath('userData')`,
+ * which throws when electron isn't present (unit tests). A path we can't even
+ * resolve is treated like a missing file — quiet fallback to defaults — matching
+ * the pre-#1640 `try { … app.getPath … } catch { defaults }` behavior.
+ */
+import { readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+
+export type ConfigDecoder<T> = (raw: unknown) => T;
+
+type Phase = 'read' | 'parse' | 'validate';
+
+/** Consistent, surfaced config failure. Loud (not the old silent swallow) but
+ *  non-fatal — a bad config must not crash startup. Exported so a future PR can
+ *  route it to a user-facing toast; today it logs with a recognizable prefix. */
+export function reportConfigError(file: string, phase: Phase, err: unknown): void {
+  const detail = err instanceof Error ? err.message : String(err);
+  console.error(`[config] failed to ${phase} "${file}": ${detail} — using defaults`);
+}
+
+function isENOENT(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException | null)?.code === 'ENOENT';
+}
+
+/** Defensive copy so a caller mutating the result can't corrupt the shared
+ *  DEFAULT_* singletons (the old `return { ...DEFAULT }` idiom, generalized). */
+function clone<T>(v: T): T {
+  return v !== null && typeof v === 'object' ? structuredClone(v) : v;
+}
+
+function decodeText<T>(absPath: string, text: string, decode: ConfigDecoder<T>, defaults: T): T {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    reportConfigError(absPath, 'parse', err);
+    return clone(defaults);
+  }
+  try {
+    return decode(raw);
+  } catch (err) {
+    reportConfigError(absPath, 'validate', err);
+    return clone(defaults);
+  }
+}
+
+/** Load + validate a JSON config file (async). `getPath` returns the absolute
+ *  path; see module header for why it's a thunk. */
+export async function loadConfigFile<T>(getPath: () => string, decode: ConfigDecoder<T>, defaults: T): Promise<T> {
+  const absPath = resolvePath(getPath);
+  if (absPath === null) return clone(defaults);
+  let text: string;
+  try {
+    text = await readFile(absPath, 'utf-8');
+  } catch (err) {
+    if (isENOENT(err)) return clone(defaults);
+    reportConfigError(absPath, 'read', err);
+    return clone(defaults);
+  }
+  return decodeText(absPath, text, decode, defaults);
+}
+
+/** Synchronous variant, for the hot read paths that can't await (e.g.
+ *  `readProjectConfig`, consulted during indexing). Same semantics. */
+export function loadConfigFileSync<T>(getPath: () => string, decode: ConfigDecoder<T>, defaults: T): T {
+  const absPath = resolvePath(getPath);
+  if (absPath === null) return clone(defaults);
+  let text: string;
+  try {
+    text = readFileSync(absPath, 'utf-8');
+  } catch (err) {
+    if (isENOENT(err)) return clone(defaults);
+    reportConfigError(absPath, 'read', err);
+    return clone(defaults);
+  }
+  return decodeText(absPath, text, decode, defaults);
+}
+
+/** Resolve the path thunk; `null` = couldn't even locate the config (e.g.
+ *  `app.getPath` threw with no electron) → caller falls back to defaults. */
+function resolvePath(getPath: () => string): string | null {
+  try {
+    return getPath();
+  } catch {
+    return null;
+  }
+}
+
+// ── Field decoders (the shared "schema" vocabulary) ──────────────────────────
+// Each takes the raw value + a fallback and returns a well-typed value, so a
+// config's `decode` reads as a declaration of its shape.
+
+export function asString(v: unknown, fallback: string): string {
+  return typeof v === 'string' ? v : fallback;
+}
+
+export function asBool(v: unknown, fallback: boolean): boolean {
+  return typeof v === 'boolean' ? v : fallback;
+}
+
+export function asFiniteNumber(v: unknown, fallback: number): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+export function asEnum<T extends string>(v: unknown, allowed: readonly T[], fallback: T): T {
+  return allowed.includes(v as T) ? (v as T) : fallback;
+}
+
+/** A plain object (not null, not an array), or `{}` — the safe base for
+ *  reaching into nested config sections. */
+export function asRecord(v: unknown): Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+export function asStringArray(v: unknown, fallback: string[] = []): string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string') ? (v) : fallback;
+}

--- a/src/main/project-config.ts
+++ b/src/main/project-config.ts
@@ -10,6 +10,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { encryptSecret, decryptSecret } from './secret-storage';
+import { loadConfigFileSync, asRecord } from './config/config-store';
 
 export interface ProjectConfigShape {
   baseUri?: string;
@@ -122,14 +123,14 @@ function configPath(rootPath: string): string {
 }
 
 export function readProjectConfig(rootPath: string): ProjectConfigShape {
-  try {
-    const raw = fs.readFileSync(configPath(rootPath), 'utf-8');
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === 'object') return parsed;
-    return {};
-  } catch {
-    return {};
-  }
+  // A corrupt config.json now surfaces (reportConfigError) instead of silently
+  // reading back as an empty config (#1640); a missing one is still just {}.
+  // Field-level shape stays lenient — consumers read individual keys defensively.
+  return loadConfigFileSync<ProjectConfigShape>(
+    () => configPath(rootPath),
+    (raw) => asRecord(raw),
+    {},
+  );
 }
 
 /**

--- a/src/main/sources/ingest-settings.ts
+++ b/src/main/sources/ingest-settings.ts
@@ -8,6 +8,7 @@
 import { app } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import { loadConfigFile, asBool, asRecord } from '../config/config-store';
 
 export interface IngestSettings {
   /** When true, the identifier-ingest adapters extract upstream
@@ -26,18 +27,12 @@ function settingsPath(): string {
 }
 
 export async function getIngestSettings(): Promise<IngestSettings> {
-  try {
-    const raw = await fs.readFile(settingsPath(), 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<IngestSettings>;
+  return loadConfigFile(settingsPath, (raw) => {
+    const o = asRecord(raw);
     return {
-      importUpstreamTags:
-        typeof parsed.importUpstreamTags === 'boolean'
-          ? parsed.importUpstreamTags
-          : DEFAULT_INGEST_SETTINGS.importUpstreamTags,
+      importUpstreamTags: asBool(o.importUpstreamTags, DEFAULT_INGEST_SETTINGS.importUpstreamTags),
     };
-  } catch {
-    return { ...DEFAULT_INGEST_SETTINGS };
-  }
+  }, DEFAULT_INGEST_SETTINGS);
 }
 
 export async function saveIngestSettings(settings: IngestSettings): Promise<void> {

--- a/tests/main/config/config-store.test.ts
+++ b/tests/main/config/config-store.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Shared config load + validation (#1640). The point of the helper is that a
+ * CORRUPT config is reported loudly + consistently instead of silently reading
+ * back as defaults (the old per-file `catch { return defaults }`), while a
+ * MISSING config still falls back silently. Also pins the shared field decoders.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  loadConfigFile,
+  loadConfigFileSync,
+  reportConfigError,
+  asString,
+  asBool,
+  asFiniteNumber,
+  asEnum,
+  asRecord,
+  asStringArray,
+} from '../../../src/main/config/config-store';
+
+interface Cfg { name: string; count: number; on: boolean }
+const DEFAULTS: Cfg = { name: 'default', count: 0, on: false };
+const decode = (raw: unknown): Cfg => {
+  const o = asRecord(raw);
+  return {
+    name: asString(o.name, DEFAULTS.name),
+    count: asFiniteNumber(o.count, DEFAULTS.count),
+    on: asBool(o.on, DEFAULTS.on),
+  };
+};
+
+describe('config-store field decoders (#1640)', () => {
+  it('asString / asBool / asFiniteNumber fall back on the wrong type', () => {
+    expect(asString('x', 'd')).toBe('x');
+    expect(asString(42, 'd')).toBe('d');
+    expect(asBool(true, false)).toBe(true);
+    expect(asBool('true', false)).toBe(false);
+    expect(asFiniteNumber(3.5, 0)).toBe(3.5);
+    expect(asFiniteNumber(NaN, 7)).toBe(7);
+    expect(asFiniteNumber('3', 7)).toBe(7);
+  });
+
+  it('asEnum only accepts a member of the allowed set', () => {
+    const modes = ['a', 'b'] as const;
+    expect(asEnum('b', modes, 'a')).toBe('b');
+    expect(asEnum('z', modes, 'a')).toBe('a');
+  });
+
+  it('asRecord rejects null / arrays / primitives', () => {
+    expect(asRecord({ a: 1 })).toEqual({ a: 1 });
+    expect(asRecord(null)).toEqual({});
+    expect(asRecord([1, 2])).toEqual({});
+    expect(asRecord('x')).toEqual({});
+  });
+
+  it('asStringArray requires every element to be a string', () => {
+    expect(asStringArray(['a', 'b'])).toEqual(['a', 'b']);
+    expect(asStringArray(['a', 1])).toEqual([]);
+    expect(asStringArray('a')).toEqual([]);
+  });
+});
+
+describe('loadConfigFile (#1640)', () => {
+  let dir: string;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-cfg-'));
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(async () => {
+    errSpy.mockRestore();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  const p = (name: string) => path.join(dir, name);
+
+  it('returns defaults (silently) when the file is missing', async () => {
+    await expect(loadConfigFile(() => p('missing.json'), decode, DEFAULTS)).resolves.toEqual(DEFAULTS);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('decodes a valid config', async () => {
+    await fs.writeFile(p('ok.json'), JSON.stringify({ name: 'x', count: 5, on: true }), 'utf-8');
+    await expect(loadConfigFile(() => p('ok.json'), decode, DEFAULTS)).resolves.toEqual({ name: 'x', count: 5, on: true });
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('fills per-field defaults for a partial / wrong-typed config', async () => {
+    await fs.writeFile(p('partial.json'), JSON.stringify({ name: 'x', count: 'nope' }), 'utf-8');
+    await expect(loadConfigFile(() => p('partial.json'), decode, DEFAULTS)).resolves.toEqual({ name: 'x', count: 0, on: false });
+  });
+
+  it('REPORTS a corrupt config and falls back (not a silent swallow)', async () => {
+    await fs.writeFile(p('corrupt.json'), '{ not valid json ', 'utf-8');
+    await expect(loadConfigFile(() => p('corrupt.json'), decode, DEFAULTS)).resolves.toEqual(DEFAULTS);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(String(errSpy.mock.calls[0]![0])).toContain('[config] failed to parse');
+  });
+
+  it('REPORTS a decode/validate throw and falls back', async () => {
+    await fs.writeFile(p('bad.json'), JSON.stringify({ name: 'x' }), 'utf-8');
+    const strict = () => { throw new Error('missing required field'); };
+    await expect(loadConfigFile(() => p('bad.json'), strict, DEFAULTS)).resolves.toEqual(DEFAULTS);
+    expect(String(errSpy.mock.calls[0]![0])).toContain('[config] failed to validate');
+  });
+
+  it('clones defaults so a mutated result cannot corrupt the singleton', async () => {
+    const nested = { section: { flag: false } };
+    const out = await loadConfigFile<typeof nested>(() => p('none.json'), (r) => r as typeof nested, nested);
+    out.section.flag = true;
+    expect(nested.section.flag).toBe(false);
+  });
+
+  it('loadConfigFileSync mirrors the async semantics', async () => {
+    await fs.writeFile(p('sync.json'), JSON.stringify({ name: 'y', count: 2, on: true }), 'utf-8');
+    expect(loadConfigFileSync(() => p('sync.json'), decode, DEFAULTS)).toEqual({ name: 'y', count: 2, on: true });
+    await fs.writeFile(p('sync-bad.json'), 'nope', 'utf-8');
+    expect(loadConfigFileSync(() => p('sync-bad.json'), decode, DEFAULTS)).toEqual(DEFAULTS);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('falls back to defaults (silently) when the path thunk throws', async () => {
+    // Mirrors app.getPath('userData') throwing with no electron present: the
+    // config is unlocatable, treated like a missing file — quiet, not reported.
+    const boom = () => { throw new Error('no electron app'); };
+    await expect(loadConfigFile(boom, decode, DEFAULTS)).resolves.toEqual(DEFAULTS);
+    expect(loadConfigFileSync(boom, decode, DEFAULTS)).toEqual(DEFAULTS);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('reportConfigError formats a recognizable, prefixed message', () => {
+    reportConfigError('/tmp/x.json', 'read', new Error('EACCES'));
+    expect(String(errSpy.mock.calls.at(-1)![0])).toMatch(/^\[config\] failed to read "\/tmp\/x\.json": EACCES/);
+  });
+});


### PR DESCRIPTION
Closes #1640.

## Problem

Validation was hand-rolled per file across ~10 config loaders, each repeating `try { readFile; JSON.parse; coerce each field } catch { return defaults }`. The bare `catch` **silently turned a corrupt config into defaults** — the user's settings vanish with no signal (the same swallow class as #1631) — and every file validated its fields a slightly different way.

## Change

**New `src/main/config/config-store.ts`** — one shared mechanism:
- **Missing file (ENOENT) → defaults**, silently (expected: "not saved yet").
- **Corrupt / unreadable / decode-throwing → surfaced** via `reportConfigError` (loud + consistent, `[config] failed to parse "…"`), then defaults so the app still boots. No more silent swallow.
- **Per-field coercion through shared `as*` decoders** (`asString` / `asBool` / `asFiniteNumber` / `asEnum` / `asRecord` / `asStringArray`), so each config's `decode(raw)` reads as its schema instead of an ad-hoc `typeof` ladder.
- **`loadConfigFile` (async) + `loadConfigFileSync`** (for hot read paths like `readProjectConfig`).

**Migrated** `ingest-settings`, `python-settings`, and `project-config` to it; documented the helper and the not-yet-migrated loaders (`clipper-config`, `llm/settings`, `menu-config-store`) in CLAUDE.md so the rest follow incrementally.

## A subtle regression I caught

First pass moved the `settingsPath()` computation (which calls `app.getPath('userData')`) *outside* the loader's protected region. The old per-file `try/catch` had incidentally swallowed `app.getPath` throwing in unit tests that don't mock electron (e.g. the python-kernel integration tests) — so my refactor broke 30 of those tests. **The full coverage gate caught it where my targeted unit tests didn't.** Fix: the path is a **thunk**, resolved inside the protected region — an unlocatable config falls back like a missing file, exactly preserving pre-#1640 behavior. There's a regression test for it.

## Verification

- `pnpm lint` clean.
- 13 config-store tests (decoders + all load paths incl. the path-thunk-throws case); the previously-broken python-kernel/library suites green again.
- **Full coverage gate exit 0** — all thresholds hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)