### PR TITLE
feat(config): configVersion field + explicit migration path (#1641)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,17 @@ thrown error already propagates cleanly. Build on that:
 - Migrated so far: `ingest-settings`, `python-settings`, `project-config`. Still
   hand-rolled (migrate when you touch them): `clipper-config` (decrypt + lazy
   secret upgrade), `llm/settings` (nested providers/models), `menu-config-store`.
+- **Versioning + migration (#1641):** persist a `configVersion` via
+  `stampConfigVersion(config, VERSION)` in the save path, and pass
+  `{ version, migrate }` to `loadConfigFile`. `migrate(raw, fromVersion)` brings
+  an older on-disk shape up to the current version — the explicit, testable
+  replacement for shape-sniffing (`detectConfigVersion` reads the field; absent
+  ⇒ 0 = legacy). Bump `VERSION` + add a `migrate` step when a config's shape
+  changes, instead of sniffing shapes at each read. `ingest-settings` /
+  `python-settings` are versioned (v1); the existing shape-sniffs to convert as
+  they adopt this: `menu-config-store`'s `normalizeMenuConfig`, `clipper-config`'s
+  legacy-plaintext-secret upgrade, the renderer's legacy `tabs.json` session
+  migration, and `project-config` (its `config.json` travels with the thoughtbase).
 
 ### File System
 - All paths are relative to the project root

--- a/src/main/compute/python-settings.ts
+++ b/src/main/compute/python-settings.ts
@@ -18,7 +18,11 @@ import { app } from 'electron';
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { loadConfigFile, asString, asRecord } from '../config/config-store';
+import { loadConfigFile, asString, asRecord, stampConfigVersion } from '../config/config-store';
+
+/** Schema version persisted in `configVersion` (#1641). Bump + add a `migrate`
+ *  step in `getPythonSettings` when the on-disk shape changes. */
+const PYTHON_SETTINGS_VERSION = 1;
 
 export interface PythonSettings {
   /**
@@ -62,13 +66,17 @@ export async function getPythonSettings(): Promise<PythonSettings> {
       // truthy-non-bool value fails closed (matches the consent gate's posture).
       allowNetwork: o.allowNetwork === true,
     };
-  }, DEFAULT_SETTINGS);
+  }, DEFAULT_SETTINGS, { version: PYTHON_SETTINGS_VERSION });
 }
 
 export async function setPythonSettings(settings: PythonSettings): Promise<void> {
   await fs.writeFile(
     settingsPath(),
-    JSON.stringify({ pythonPath: settings.pythonPath, allowNetwork: settings.allowNetwork === true }, null, 2),
+    JSON.stringify(
+      stampConfigVersion({ pythonPath: settings.pythonPath, allowNetwork: settings.allowNetwork === true }, PYTHON_SETTINGS_VERSION),
+      null,
+      2,
+    ),
     'utf-8',
   );
 }

--- a/src/main/config/config-store.ts
+++ b/src/main/config/config-store.ts
@@ -33,6 +33,35 @@ export type ConfigDecoder<T> = (raw: unknown) => T;
 
 type Phase = 'read' | 'parse' | 'validate';
 
+/** The reserved key that stamps a persisted config's schema version (#1641).
+ *  Absent ⇒ version 0 (a pre-versioning / legacy file). */
+export const CONFIG_VERSION_KEY = 'configVersion';
+
+export interface MigrationOptions {
+  /** The schema version this build writes and expects after decode. */
+  version: number;
+  /**
+   * Bring a raw parsed object from its stored version up to `version`, keyed off
+   * the version field — the explicit replacement for ad-hoc shape-sniffing
+   * (#1641). Receives the raw object + its detected stored version (0 when the
+   * file predates versioning) and returns the migrated raw (still pre-decode).
+   * Only invoked when the stored version is behind `version`. Omit when no
+   * migration is needed yet (a fresh config is born at `version`).
+   */
+  migrate?: (raw: Record<string, unknown>, fromVersion: number) => Record<string, unknown>;
+}
+
+/** Read the stamped schema version off a raw parsed config (0 = legacy). */
+export function detectConfigVersion(raw: unknown): number {
+  return asFiniteNumber(asRecord(raw)[CONFIG_VERSION_KEY], 0);
+}
+
+/** Stamp the current schema version onto a config for persistence (#1641). Call
+ *  in the save path so every write records the version the migration keys off. */
+export function stampConfigVersion<T extends object>(config: T, version: number): T & { configVersion: number } {
+  return { ...config, [CONFIG_VERSION_KEY]: version };
+}
+
 /** Consistent, surfaced config failure. Loud (not the old silent swallow) but
  *  non-fatal — a bad config must not crash startup. Exported so a future PR can
  *  route it to a user-facing toast; today it logs with a recognizable prefix. */
@@ -51,7 +80,7 @@ function clone<T>(v: T): T {
   return v !== null && typeof v === 'object' ? structuredClone(v) : v;
 }
 
-function decodeText<T>(absPath: string, text: string, decode: ConfigDecoder<T>, defaults: T): T {
+function decodeText<T>(absPath: string, text: string, decode: ConfigDecoder<T>, defaults: T, opts?: MigrationOptions): T {
   let raw: unknown;
   try {
     raw = JSON.parse(text);
@@ -60,6 +89,10 @@ function decodeText<T>(absPath: string, text: string, decode: ConfigDecoder<T>, 
     return clone(defaults);
   }
   try {
+    if (opts?.migrate) {
+      const from = detectConfigVersion(raw);
+      if (from < opts.version) raw = opts.migrate(asRecord(raw), from);
+    }
     return decode(raw);
   } catch (err) {
     reportConfigError(absPath, 'validate', err);
@@ -69,7 +102,7 @@ function decodeText<T>(absPath: string, text: string, decode: ConfigDecoder<T>, 
 
 /** Load + validate a JSON config file (async). `getPath` returns the absolute
  *  path; see module header for why it's a thunk. */
-export async function loadConfigFile<T>(getPath: () => string, decode: ConfigDecoder<T>, defaults: T): Promise<T> {
+export async function loadConfigFile<T>(getPath: () => string, decode: ConfigDecoder<T>, defaults: T, opts?: MigrationOptions): Promise<T> {
   const absPath = resolvePath(getPath);
   if (absPath === null) return clone(defaults);
   let text: string;
@@ -80,12 +113,12 @@ export async function loadConfigFile<T>(getPath: () => string, decode: ConfigDec
     reportConfigError(absPath, 'read', err);
     return clone(defaults);
   }
-  return decodeText(absPath, text, decode, defaults);
+  return decodeText(absPath, text, decode, defaults, opts);
 }
 
 /** Synchronous variant, for the hot read paths that can't await (e.g.
  *  `readProjectConfig`, consulted during indexing). Same semantics. */
-export function loadConfigFileSync<T>(getPath: () => string, decode: ConfigDecoder<T>, defaults: T): T {
+export function loadConfigFileSync<T>(getPath: () => string, decode: ConfigDecoder<T>, defaults: T, opts?: MigrationOptions): T {
   const absPath = resolvePath(getPath);
   if (absPath === null) return clone(defaults);
   let text: string;
@@ -96,7 +129,7 @@ export function loadConfigFileSync<T>(getPath: () => string, decode: ConfigDecod
     reportConfigError(absPath, 'read', err);
     return clone(defaults);
   }
-  return decodeText(absPath, text, decode, defaults);
+  return decodeText(absPath, text, decode, defaults, opts);
 }
 
 /** Resolve the path thunk; `null` = couldn't even locate the config (e.g.

--- a/src/main/sources/ingest-settings.ts
+++ b/src/main/sources/ingest-settings.ts
@@ -8,7 +8,10 @@
 import { app } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { loadConfigFile, asBool, asRecord } from '../config/config-store';
+import { loadConfigFile, asBool, asRecord, stampConfigVersion } from '../config/config-store';
+
+/** Schema version persisted in `configVersion` (#1641). */
+const INGEST_SETTINGS_VERSION = 1;
 
 export interface IngestSettings {
   /** When true, the identifier-ingest adapters extract upstream
@@ -32,9 +35,13 @@ export async function getIngestSettings(): Promise<IngestSettings> {
     return {
       importUpstreamTags: asBool(o.importUpstreamTags, DEFAULT_INGEST_SETTINGS.importUpstreamTags),
     };
-  }, DEFAULT_INGEST_SETTINGS);
+  }, DEFAULT_INGEST_SETTINGS, { version: INGEST_SETTINGS_VERSION });
 }
 
 export async function saveIngestSettings(settings: IngestSettings): Promise<void> {
-  await fs.writeFile(settingsPath(), JSON.stringify(settings, null, 2), 'utf-8');
+  await fs.writeFile(
+    settingsPath(),
+    JSON.stringify(stampConfigVersion(settings, INGEST_SETTINGS_VERSION), null, 2),
+    'utf-8',
+  );
 }

--- a/tests/main/config/config-store.test.ts
+++ b/tests/main/config/config-store.test.ts
@@ -18,6 +18,9 @@ import {
   asEnum,
   asRecord,
   asStringArray,
+  stampConfigVersion,
+  detectConfigVersion,
+  CONFIG_VERSION_KEY,
 } from '../../../src/main/config/config-store';
 
 interface Cfg { name: string; count: number; on: boolean }
@@ -134,5 +137,39 @@ describe('loadConfigFile (#1640)', () => {
   it('reportConfigError formats a recognizable, prefixed message', () => {
     reportConfigError('/tmp/x.json', 'read', new Error('EACCES'));
     expect(String(errSpy.mock.calls.at(-1)![0])).toMatch(/^\[config\] failed to read "\/tmp\/x\.json": EACCES/);
+  });
+
+  // ── Versioning + migration (#1641) ──────────────────────────────────────────
+
+  it('stampConfigVersion / detectConfigVersion round-trip; absent ⇒ 0', () => {
+    const stamped = stampConfigVersion({ a: 1 }, 3);
+    expect(stamped).toEqual({ a: 1, [CONFIG_VERSION_KEY]: 3 });
+    expect(detectConfigVersion(stamped)).toBe(3);
+    expect(detectConfigVersion({ a: 1 })).toBe(0); // legacy, unversioned
+    expect(detectConfigVersion('nonsense')).toBe(0);
+  });
+
+  it('migrates a legacy (v0) config via a version-keyed migration — the shape-sniffing replacement', async () => {
+    // A pre-versioning file with the OLD field name. v1 renames `label` → `name`.
+    await fs.writeFile(p('legacy.json'), JSON.stringify({ label: 'hello', count: 9 }), 'utf-8');
+    const migrate = (raw: Record<string, unknown>, from: number): Record<string, unknown> =>
+      from < 1 ? { name: raw.label, count: raw.count, [CONFIG_VERSION_KEY]: 1 } : raw;
+
+    const out = await loadConfigFile(() => p('legacy.json'), decode, DEFAULTS, { version: 1, migrate });
+    expect(out).toEqual({ name: 'hello', count: 9, on: false });
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT run the migration when the stored version is already current', async () => {
+    await fs.writeFile(p('current.json'), JSON.stringify({ name: 'x', count: 1, on: true, [CONFIG_VERSION_KEY]: 1 }), 'utf-8');
+    const migrate = vi.fn((raw: Record<string, unknown>) => raw);
+    const out = await loadConfigFile(() => p('current.json'), decode, DEFAULTS, { version: 1, migrate });
+    expect(out).toEqual({ name: 'x', count: 1, on: true });
+    expect(migrate).not.toHaveBeenCalled();
+  });
+
+  it('a stamped config round-trips through save → load', async () => {
+    await fs.writeFile(p('rt.json'), JSON.stringify(stampConfigVersion({ name: 'z', count: 4, on: true }, 1)), 'utf-8');
+    await expect(loadConfigFile(() => p('rt.json'), decode, DEFAULTS, { version: 1 })).resolves.toEqual({ name: 'z', count: 4, on: true });
   });
 });


### PR DESCRIPTION
Closes #1641.

> **Stacked on #1640** (base branch `feat/1640-shared-config-schema`). It builds directly on that PR's `config-store` helper — review/merge #1640 first, then this. The diff shown is against #1640; I'll retarget to `main` once #1640 lands.

## Problem

Config files carried no version field, so migrating a config's shape across app versions meant ad-hoc shape-sniffing at each read.

## Change

Adds explicit, testable versioning on top of #1640's shared helper:

- **`stampConfigVersion(config, VERSION)`** — call in the save path; persists a reserved `configVersion` key so every write records the version.
- **`{ version, migrate }` option on `loadConfigFile` / `loadConfigFileSync`** — `migrate(raw, fromVersion)` brings an older on-disk shape up to the current version, **keyed off the version field** and run only when the stored version is behind. This is the explicit replacement for shape-sniffing.
- **`detectConfigVersion(raw)`** — reads the field (absent ⇒ 0 = legacy).
- **Versioned `ingest-settings` + `python-settings`** (v1): stamp on save, declare the version on load. Legacy unversioned files still read (decoder is lenient); the mechanism is ready for the next shape change to add a `migrate` step instead of sniffing.
- CLAUDE.md documents the pattern and names the existing shape-sniffs to convert as they adopt it: menu-config's `normalizeMenuConfig`, clipper's legacy-plaintext-secret upgrade, the renderer's legacy `tabs.json` session migration, and `project-config`.

## Honest scope note

None of the config-store-managed configs (ingest/python/project) had an *active* shape-migration to convert — they're simple and their decoders already handle field presence leniently. So this PR establishes + versions them and **proves the migration path with a real tested migration** (a v0→v1 field rename), then documents the genuine legacy-shape sites for incremental conversion. That's the "explicit migration path with tests replaces shape-sniffing" criterion met by mechanism + example, with the real sniff sites tracked.

## Verification

- `pnpm lint` clean.
- New tests: stamp/detect round-trip; legacy v0 config migrated via a version-keyed field rename; migration skipped when already current; stamped round-trip. Existing `python-settings` / `clipper-ingest` suites green (the added `configVersion` key doesn't perturb their field-level assertions).
- **Full coverage gate exit 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)