### PR TITLE
ci(coverage): enable Codecov trend + per-PR coverage-delta comment (#1096)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,11 @@ jobs:
       - name: Test + coverage
         run: pnpm coverage
 
-      # Trend-tracking only — the floors above are the gate. Non-fatal so CI
-      # isn't blocked before the repo is enrolled on Codecov / CODECOV_TOKEN is
-      # set; activates automatically once it is.
+      # Trend + per-PR coverage-delta visibility (#1096 / QA H4); tuned by
+      # `codecov.yml`. The floors above (pnpm coverage) remain the hard gate —
+      # Codecov is informational and never blocks a PR (fail_ci_if_error: false).
+      # Non-fatal so CI isn't blocked before the repo is enrolled / CODECOV_TOKEN
+      # is set; the upload + PR comment activate automatically once it is.
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,57 @@
+# Codecov configuration (#1096 / QA H4).
+#
+# Purpose: TREND + per-PR coverage-delta VISIBILITY, not gating. The hard gate
+# stays the per-area floors in `vitest.config.mts` (enforced by `pnpm coverage`
+# in ci.yml, which fails the build on a floor breach). Codecov never blocks a
+# PR here — it surfaces erosion that happens *within the headroom above* the
+# floors, which the pass/fail floors can't see.
+#
+# Requires the `CODECOV_TOKEN` repo secret (set once by a maintainer after
+# enrolling the repo at app.codecov.io). The ci.yml upload step already passes
+# `token: ${{ secrets.CODECOV_TOKEN }}` with `fail_ci_if_error: false`, so until
+# the secret is set the upload is a silent no-op; it activates automatically once
+# the token exists. This file changes nothing until uploads start landing.
+
+codecov:
+  # Only ingest coverage from a green CI run, so a failed build doesn't publish
+  # a misleading number.
+  require_ci_to_pass: true
+  notify:
+    # Wait for the single coverage upload before notifying/commenting.
+    after_n_builds: 1
+
+coverage:
+  # Report to 2 decimals so sub-percent drift within the floor headroom shows.
+  precision: 2
+  round: down
+  status:
+    # INFORMATIONAL: Codecov posts a project/patch status with the delta, but it
+    # never fails the PR (the vitest floors are the gate). Keeps H4 visibility
+    # without a second, competing hard gate.
+    project:
+      default:
+        informational: true
+        target: auto        # compare against the base commit → shows the delta
+        threshold: 0%       # any drop is reported (informational only)
+    patch:
+      default:
+        informational: true
+
+# The per-PR coverage-delta comment — the visible H4 signal. Posts on every PR
+# (even at 0 delta) so trend/erosion is always in view, updating one comment in
+# place rather than spamming.
+comment:
+  layout: "condensed_header, diff, flags, components, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+
+# Exclusions mirror the spirit of vitest.config's coverage.exclude — generated
+# shells, test files, and non-source data shouldn't count toward the trend.
+ignore:
+  - "**/*.test.ts"
+  - "**/*.d.ts"
+  - "tests/**"
+  - "src/main/publish/csl/bundled/**"
+  - "**/*.ttl"


### PR DESCRIPTION
Closes #1096 (the code side — see the maintainer action below).

## Problem (H4)

The `codecov/codecov-action` step already exists in `ci.yml`, but the only coverage signal today is the vitest **floors** (pass/fail). There's no visible trend and no per-PR delta, so coverage can silently erode *within the headroom above* the floors without anyone noticing.

## Change

- **New `codecov.yml`:**
  - `coverage.status.project` / `patch` are **`informational: true`** — Codecov posts a status with the delta vs the base commit but **never fails the PR**. The `vitest.config.mts` floors (`pnpm coverage`) remain the single hard gate, exactly matching the step's existing `fail_ci_if_error: false`.
  - **`comment:`** enables the per-PR coverage-delta comment — posts on every PR (even at 0 delta so the trend is always in view) and updates one comment in place.
  - `precision: 2` so sub-percent drift shows; `ignore:` mirrors the spirit of `vitest.config`'s coverage excludes.
- **`ci.yml`:** refreshed the step comment to describe the H4 wiring (no behavior change — the step already passed the token with `fail_ci_if_error: false`).

## Remaining: one maintainer action (I can't do it from a PR)

Set the **`CODECOV_TOKEN`** repo secret after enrolling the repo at app.codecov.io (`gh secret set CODECOV_TOKEN`). Until then the upload + comment are a **silent no-op** — `fail_ci_if_error: false` means CI is never blocked — and they **activate automatically** once the token exists. So this PR is safe to merge now and "lights up" when the secret lands.

Success criteria status:
- [x] Config for PR coverage-delta comment + informational status (this PR)
- [ ] `CODECOV_TOKEN` configured; upload succeeds — **maintainer action**
- [ ] Trend visible over time — follows automatically once uploads land

🤖 Generated with [Claude Code](https://claude.com/claude-code)