### PR TITLE
chore(ui): clear the svelte-check warnings (state/a11y/dead-CSS)

### DIFF
--- a/src/renderer/lib/components/ComputeSettings.svelte
+++ b/src/renderer/lib/components/ComputeSettings.svelte
@@ -223,7 +223,7 @@
 </div>
 
 <div class="field trust-field">
-  <label id="trust-heading">Trusted thoughtbases</label>
+  <div class="field-heading" id="trust-heading">Trusted thoughtbases</div>
   <p class="hint">
     Compute cells run with real access to your machine, so each cell is
     reviewed before its first run and the choice is remembered
@@ -259,7 +259,7 @@
 </div>
 
 <div class="field audit-field">
-  <label id="audit-heading">Execution audit log</label>
+  <div class="field-heading" id="audit-heading">Execution audit log</div>
   <p class="hint">
     Every compute cell that runs is recorded to a local log — when it ran,
     which thoughtbase and note, whether it came from the editor or a
@@ -281,7 +281,8 @@
     color: var(--text);
     font-size: 12px;
   }
-  .field label { color: var(--text); }
+  .field label,
+  .field .field-heading { color: var(--text); }
   .field input[type="text"] {
     padding: 5px 8px;
     background: var(--bg);

--- a/src/renderer/lib/components/EditSavedViewsDialog.svelte
+++ b/src/renderer/lib/components/EditSavedViewsDialog.svelte
@@ -82,7 +82,14 @@
                   onkeydown={(e) => { if (e.key === 'Enter') void commitRename(); else if (e.key === 'Escape') renamingPath = null; }}
                 />
               {:else}
-                <span class="name" ondblclick={() => startRename(v)}>{v.name}</span>
+                <span
+                  class="name"
+                  role="button"
+                  tabindex="0"
+                  title="Double-click or press Enter to rename"
+                  ondblclick={() => startRename(v)}
+                  onkeydown={(e) => { if (e.key === 'Enter' || e.key === 'F2') startRename(v); }}
+                >{v.name}</span>
               {/if}
               <span class="type-badge">{v.typeId}</span>
               <span class="mode-badge">{v.layout}</span>

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import EditorContextMenu from './EditorContextMenu.svelte';
   import { installDismissOnClickOutside } from '../dismiss-menu';
   import { EditorView, keymap } from '@codemirror/view';
@@ -423,17 +423,21 @@
 
   const initSettings = getEditorSettings();
 
+  // `plainText` is fixed for an Editor instance (a tab remounts on a md↔plain
+  // switch), so the extensions below read it once at build time. `untrack`
+  // expresses that intent and silences the `state_referenced_locally` warning.
+  const plainTextOnce = untrack(() => plainText);
   const extensions = [
     basicSetup,
     // Give the `role="textbox"` content DOM an accessible name (#1005 a11y) —
     // CodeMirror's editable div is otherwise unlabeled (axe aria-input-field-name).
-    EditorView.contentAttributes.of({ 'aria-label': plainText ? 'Text editor' : 'Note editor' }),
+    EditorView.contentAttributes.of({ 'aria-label': plainTextOnce ? 'Text editor' : 'Note editor' }),
     // Mark plain-text editors so the drag-to-add-link machinery skips them —
     // a [[wiki-link]] doesn't resolve in a non-markdown file (#1129 / #1130).
-    EditorView.editorAttributes.of(plainText ? { 'data-plaintext': 'true' } : {}),
+    EditorView.editorAttributes.of(plainTextOnce ? { 'data-plaintext': 'true' } : {}),
     // Markdown language + frontmatter fold are markdown-only (#1130). A
     // plain-text file gets a plain editable buffer with no md syntax layer.
-    ...(plainText ? [] : [
+    ...(plainTextOnce ? [] : [
       markdown({ codeLanguages: languages }),
       // Pin the frontmatter fold's gutter arrow to line 1 by claiming the
       // foldable range there ourselves. Without this, the markdown
@@ -463,7 +467,7 @@
     whitespaceCompartment.of(initSettings.showWhitespace ? highlightWhitespace() : []),
     // Markdown-only rendering layers (#1130): wiki-link/URL decorations,
     // bookmark gutter, runnable compute cells, footnote + highlight decorations.
-    ...(plainText ? [] : [
+    ...(plainTextOnce ? [] : [
       linkDecorations({
         onOpenNote: (target: string) => {
           if (onNavigate) onNavigate(target);

--- a/src/renderer/lib/components/FormatterSettings.svelte
+++ b/src/renderer/lib/components/FormatterSettings.svelte
@@ -172,12 +172,6 @@
     font-size: 11px;
     line-height: 1.45;
   }
-  .hint code {
-    background: var(--bg-button);
-    padding: 1px 4px;
-    border-radius: 3px;
-    font-size: 10px;
-  }
   .btn {
     padding: 5px 14px;
     border: 1px solid var(--border);

--- a/src/renderer/lib/components/PropertyValueEditor.svelte
+++ b/src/renderer/lib/components/PropertyValueEditor.svelte
@@ -52,6 +52,9 @@
     <span>{checked ? 'true' : 'false'}</span>
   </label>
 {:else if type === 'number'}
+  <!-- svelte-ignore a11y_autofocus -->
+  <!-- Edit-in-place: this input replaces the value on a user click, so focusing
+       it is the expected behavior, not a surprise focus-steal. -->
   <input
     class="pve-input"
     type="number"
@@ -62,6 +65,7 @@
     onkeydown={onKeydown}
   />
 {:else if type === 'date'}
+  <!-- svelte-ignore a11y_autofocus -->
   <input
     class="pve-input"
     type="date"
@@ -70,6 +74,7 @@
     onchange={(e) => onCommit?.(e.currentTarget.value)}
   />
 {:else}
+  <!-- svelte-ignore a11y_autofocus -->
   <input
     class="pve-input"
     type="text"

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -661,11 +661,6 @@
     font-size: 12px;
   }
 
-  .field.disabled label,
-  .field.disabled .hint {
-    opacity: 0.5;
-  }
-
   .field label {
     color: var(--text);
   }
@@ -675,39 +670,6 @@
     align-items: center;
     gap: 6px;
     cursor: pointer;
-  }
-
-  .field input[type="number"] {
-    width: 80px;
-    padding: 4px 6px;
-    background: var(--bg);
-    color: var(--text);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    font-size: 12px;
-  }
-
-  /* A number input paired with a unit label and a small Reset button. */
-  .inline-num {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .inline-num .unit {
-    font-size: 12px;
-    color: var(--text-muted);
-  }
-  .btn-inline {
-    padding: 4px 10px;
-    background: var(--bg-button, var(--bg));
-    color: var(--text);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    font-size: 11px;
-    cursor: pointer;
-  }
-  .btn-inline:hover {
-    border-color: var(--accent);
   }
 
   .field input[type="text"],
@@ -738,39 +700,11 @@
     cursor: pointer;
   }
 
-  .clipper-pair-row {
-    display: flex;
-    gap: 6px;
-    align-items: center;
-  }
-  .clipper-pair-code {
-    flex: 1;
-    min-width: 0;
-    padding: 5px 8px;
-    background: var(--bg);
-    color: var(--text);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    font-size: 12px;
-    font-family: var(--font-mono);
-  }
-  .clipper-pair-code:focus {
-    outline: none;
-    border-color: var(--accent);
-  }
-
   .hint {
     margin: 2px 0 0 0;
     color: var(--text-muted);
     font-size: 11px;
     line-height: 1.45;
-  }
-
-  /* Soft "font not installed" advisory — the sanctioned signal color (--rust),
-     not danger-red, and non-blocking. */
-  .hint.font-missing {
-    color: var(--rust);
-    margin-top: 4px;
   }
 
   .hint code {
@@ -780,47 +714,11 @@
     font-size: 10px;
   }
 
-  kbd {
-    background: var(--bg-button);
-    border: 1px solid var(--border);
-    border-radius: 3px;
-    padding: 0 4px;
-    font-size: 10px;
-    font-family: ui-monospace, monospace;
-  }
-
-  .hint.mono {
-    font-family: ui-monospace, monospace;
-  }
-
   .btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }
 
-  .section-intro {
-    font-size: 12px;
-    color: var(--text-muted);
-    line-height: 1.5;
-    margin: 0 0 16px 0;
-  }
-
-
-  .section-intro code {
-    font-size: 11px;
-    color: var(--text);
-  }
-
-  .empty-state {
-    padding: 12px;
-    border: 1px dashed var(--border);
-    border-radius: 6px;
-    font-size: 12px;
-    color: var(--text-muted);
-    line-height: 1.5;
-  }
-
-  .fm-category,
   .settings-subsection {
     margin: 18px 0 8px 0;
     font-size: 11px;
@@ -832,23 +730,6 @@
 
   .settings-subsection:first-child {
     margin-top: 0;
-  }
-
-  .fm-rules {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-  }
-
-  .fm-actions {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 4px;
-  }
-
-  .fm-actions .hint {
-    margin: 0;
   }
 
   footer {

--- a/src/renderer/lib/components/TypeEditorDialog.svelte
+++ b/src/renderer/lib/components/TypeEditorDialog.svelte
@@ -9,7 +9,7 @@
    * Opened blank (New), pre-filled from an existing type (Edit), or pre-filled
    * from a note ("Save Note as Object Type"). Editing keeps the original id.
    */
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { api } from '../ipc/client';
   import { objectTypesStore } from '../stores/object-types.svelte';
   import { PROPERTY_TYPES, titleCase, type PropertyDef, type PropertyType } from '../../../shared/objects/type-def';
@@ -22,8 +22,8 @@
   }
   let { initial, onClose, onSaved }: Props = $props();
   // The editor seeds its form from `initial` ONCE (it's a draft to edit, not a
-  // live binding); capture it so the one-time reads below aren't flagged.
-  const seed = initial;
+  // live binding); untrack the read so it isn't flagged as reactive.
+  const seed = untrack(() => initial);
 
   interface Row {
     name: string;

--- a/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte
@@ -706,29 +706,8 @@
   .row .value {
     min-width: 0;
   }
-  .row .value > input[type="text"],
-  .row .value > input[type="number"],
-  .row .value > input[type="date"] {
-    width: 100%;
-    background: none;
-    border: 1px solid transparent;
-    border-radius: 3px;
-    padding: 3px 6px;
-    color: var(--text);
-    font-size: 12px;
-    font-family: inherit;
-  }
-  .row .value > input[type="text"]:hover,
-  .row .value > input[type="number"]:hover,
-  .row .value > input[type="date"]:hover {
-    border-color: var(--border);
-  }
-  .row .value > input[type="text"]:focus,
-  .row .value > input[type="number"]:focus,
-  .row .value > input[type="date"]:focus {
-    border-color: var(--accent);
-    outline: none;
-  }
+  /* The value inputs render inside <PropertyValueEditor>, so their styling lives
+     there — scoped `.row .value > input` rules here never matched (#1600). */
 
   .chips {
     display: flex;


### PR DESCRIPTION
The app dev log carried ~40 benign `vite-plugin-svelte` warnings. Cleared them all — **svelte-check is now 0 errors / 0 warnings / 0 files-with-problems** (was 41 warnings / 8 files).

## Three buckets

**`state_referenced_locally`** (Editor ×4, TypeEditorDialog ×1) — `plainText` / `initial` are read once at build time for an instance that never sees them change (the tab remounts on the relevant switch). Wrapped the one-time reads in `untrack(...)` to say so explicitly. Same value, same behavior.

**a11y** (3):
- The EditSavedViewsDialog rename `<span>` (double-click) is now a real `role="button"` + `tabindex="0"` + Enter/F2 keyboard path — the complete fix, not a suppression.
- ComputeSettings had two section headings mis-tagged as `<label>` (they don't label a control); they're now `<div class="field-heading">`, and their `aria-labelledby` targets are preserved.
- PropertyValueEditor's edit-in-place `autofocus` is documented + `svelte-ignore`d — focusing a field the user *just clicked to edit* is expected, not a focus-steal, so the attribute stays.

**Dead scoped CSS** (~30) — selectors that matched no elements, left behind when #1600 extracted the settings panels (SettingsDialog ~20) and when the property inputs moved into a child component (PropertiesPanel ×9 — scoped `.row .value > input` can't reach a child's DOM) + a stray FormatterSettings `.hint code`. Removing them changes nothing rendered (they were inert).

## Verification

Warnings-only; no logic change (coverage-neutral, so no full gate). `pnpm lint` fully clean, and the affected component tests — Editor / SettingsDialog / PropertiesPanel / ComputeSettings / TypeProperties — stay green (39/39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)