### PR TITLE
fix(tabs): scroll the active tab into view when it lands off-screen

### DIFF
--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -59,6 +59,19 @@
   let contextMenu = $state<{ x: number; y: number; index: number } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
 
+  /** Per-tab element refs, indexed by tab position. Used to scroll the active
+   *  tab into view when it lands off-screen (too many tabs open). */
+  let tabEls = $state<(HTMLElement | undefined)[]>([]);
+
+  /** Keep the active tab visible: opening or switching to a tab that has
+   *  scrolled off either edge of the strip scrolls it just into view. Uses
+   *  `inline: 'nearest'`, so a tab that's already visible doesn't move, and
+   *  `block: 'nearest'` so this never nudges the page vertically. */
+  $effect(() => {
+    const el = tabEls[activeIndex];
+    if (el) el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  });
+
   $effect(() => {
     if (!contextMenu || !contextMenuEl) return;
     const next = clampMenuToViewport(contextMenu.x, contextMenu.y, contextMenuEl);
@@ -94,6 +107,7 @@
       class="tab"
       class:active={i === activeIndex}
       class:dirty
+      bind:this={tabEls[i]}
       onpointerdown={(e) => { if (e.button === 0) onTabPointerDown?.(i, e); }}
       onauxclick={(e) => handleMiddleClick(e, i)}
       oncontextmenu={(e) => handleContextMenu(e, i)}


### PR DESCRIPTION
## Problem

When enough notes are open that the tab strip overflows, opening a new note — or switching to one whose tab had scrolled off either edge — left the active tab off-screen. The strip is horizontally scrollable (`overflow-x: auto`), but nothing scrolled the newly-active tab back into view.

## Fix

Self-contained change in `TabBar.svelte`:

- Each tab wrapper records its DOM element into a `tabEls` array via `bind:this`.
- An `$effect` keyed off `activeIndex` calls `scrollIntoView({ block: 'nearest', inline: 'nearest' })` on the active tab.

`inline: 'nearest'` is what makes this unobtrusive: a tab that's already fully visible doesn't move — only an off-screen tab scrolls *just* into view. `block: 'nearest'` prevents any vertical page nudging.

Because every open/activate path in the editor store (`openFile`, `switchTab`, `focusExistingTab`, and the split-pane openers) drives `activeIndex`, this covers opening a new note, clicking an already-open note in the sidebar, wiki-link navigation, and command-palette jumps.

## Testing

- `pnpm lint` clean (tsc · svelte-check · eslint).
- Manual: open ~15 notes so the strip overflows, then click an off-screen note in the sidebar → its tab scrolls into view; an already-visible tab stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)