### PR TITLE
feat(inspections): re-enable the Inspections right-sidebar panel (#1446)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -170,8 +170,9 @@
   /** Thoughtbase Properties dialog visibility (#1443), opened from File → Thoughtbase Properties…. */
   let showThoughtbaseProperties = $state(false);
 
-  // Inspections hidden for v1.0 — kept at 0 (no polling), so the status-bar
-  // badge never shows. See the disabled polling in the project-open handler.
+  // The Inspections panel is re-enabled (#1446), but the status-bar count
+  // badge is still un-polled — inspectionCount stays 0 so the badge stays
+  // hidden. See the deferred polling note in the project-open handler.
   let inspectionCount = $state(0);
   let backlinkCount = $state(0);
   /** Semantic-index backfill progress, or null when idle (#836). */

--- a/src/renderer/lib/app/ipc-wiring.ts
+++ b/src/renderer/lib/app/ipc-wiring.ts
@@ -402,9 +402,11 @@ export function registerAppIpc(ctx: IpcWiringCtx): void {
     ctx.getSidebar()?.refreshTables();
     await ctx.refreshSourcesCache();
     await ctx.refreshAliasMap();
-    // Inspections hidden for v1.0: count polling disabled so the status-bar
-    // badge stays hidden (inspectionCount stays 0). Restore the
-    // setTimeout/setInterval(refreshInspectionCount) to re-enable.
+    // The Inspections panel is re-enabled (#1446), but the status-bar count
+    // badge stays un-polled for now (inspectionCount stays 0): the panel loads
+    // its own results on demand, and periodic count polling is deferred with
+    // the deterministic-fix work. Restore setInterval(refreshInspectionCount)
+    // to re-light the badge.
     // Restore cursor/scroll for every pane's active note tab after the
     // split layout has rendered and each pane's Editor has mounted (#816 —
     // restore is now multi-group, not just the focused pane).

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -69,11 +69,16 @@
         { id: 'bookmarks', label: 'Bookmarks', icon: 'bookmark' },
       ],
     },
-    // Activity group retired (#1527): proposals moved to the always-available
-    // left sidebar (#1523), and Inspections is hidden for v1.0. The
-    // InspectionsPanel component, its 'inspections' PanelType, and its render
-    // branch below are kept dormant — to re-enable, restore an Activity group
-    // here with a `{ id: 'inspections', … }` tab entry.
+    // Activity group (#1527 retired it; #1446 restores it): proposals live in
+    // the always-available left sidebar (#1523), so Inspections is the sole
+    // member for now.
+    {
+      id: 'activity',
+      label: 'Activity',
+      items: [
+        { id: 'inspections', label: 'Inspections', icon: 'inspections' },
+      ],
+    },
   ];
 
   /** Reverse lookup: panel → its parent group. Built once at module


### PR DESCRIPTION
## What

Re-enables the **Inspections** panel in the right sidebar. It was retired for v1.0 (#786, later #1527) by removing its one tab entry from the Activity group; the `InspectionsPanel` component, the `'inspections'` `PanelType`, and its render branch were all kept dormant. This restores the tab entry — nothing else was needed to make the panel work again.

The panel is self-sufficient: it loads results via `api.graph.inspections()` on mount and re-fetches on `revision` change, with a manual **Run** button that calls `inspections:run`. The main-side health checks and IPC were never disabled.

## Scope note

The status-bar count **badge** stays intentionally un-polled in this PR (`inspectionCount` remains 0, so the badge stays hidden). Restoring periodic count polling re-introduces an interval-lifecycle concern and is deferred to the follow-up that makes inspections offer **deterministic quick-fixes** instead of always launching an LLM conversation (the real point of #1446). The now-stale "hidden for v1.0" comments in `App.svelte` and `ipc-wiring.ts` are updated to reflect this.

## Changes
- `RightSidebar.svelte` — restore the Activity group with the `{ id: 'inspections', label: 'Inspections', icon: 'inspections' }` tab (byte-for-byte the entry #786 removed; Proposals stay in the left sidebar per #1523).
- `App.svelte` / `ipc-wiring.ts` — correct the stale hidden-for-v1.0 comments.

## Testing
- `pnpm lint` clean (tsc · svelte-check · eslint).
- Manual: open the right sidebar → **Activity → Inspections** → panel lists inspections, **Run** re-runs the checks, By severity / By type sort both work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)