### PR TITLE
feat(inspections): deterministic quick-fix affordance — broken_note_link → Create Note (#1446)

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -2,6 +2,7 @@ import { queryGraph, headingsFor } from './index';
 import type { ProjectContext } from '../project-context-types';
 import { LINK_TYPES } from '../../shared/link-types';
 import { DAY_MS } from './queries';
+import type { InspectionFix } from '../../shared/types';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -15,6 +16,9 @@ export interface Inspection {
   nodeLabel: string;
   message: string;
   suggestedAction?: string;
+  /** Optional deterministic quick-fix the panel can apply directly instead of
+   *  opening a conversation (#1446). Absent when the only remedy is prose. */
+  fix?: InspectionFix;
 }
 
 const lastResultsByProject = new Map<string, Inspection[]>();
@@ -506,6 +510,19 @@ function decodeSegmented(s: string): string {
   return s.split('/').map(decode).join('/');
 }
 
+/**
+ * Where "Create Note From Reference" (#1446) puts the new note: beside the
+ * referencing note. The basename is the link target's own basename (any
+ * directory part of the target is dropped — wiki-links are basename-scoped);
+ * the directory is the referencing note's folder.
+ */
+function createNoteTargetPath(referencingPath: string, targetStem: string): string {
+  const base = targetStem.split('/').pop() ?? targetStem;
+  const slashIdx = referencingPath.lastIndexOf('/');
+  const dir = slashIdx >= 0 ? referencingPath.slice(0, slashIdx) : '';
+  return dir ? `${dir}/${base}.md` : `${base}.md`;
+}
+
 function inspectionForBrokenLink(
   ctx: ProjectContext,
   row: { source: string; sourcePath: string; predicate: string; target: string },
@@ -541,9 +558,8 @@ function inspectionForBrokenLink(
   }
   if (classified.kind === 'note') {
     if (!validNotes.has(classified.id)) {
-      const linkText = classified.anchor
-        ? `${classified.id.replace(/\.md$/, '')}#${classified.anchor}`
-        : classified.id.replace(/\.md$/, '');
+      const stem = classified.id.replace(/\.md$/, '');
+      const linkText = classified.anchor ? `${stem}#${classified.anchor}` : stem;
       return {
         id: `broken-note-${index}`,
         type: 'broken_note_link',
@@ -552,6 +568,15 @@ function inspectionForBrokenLink(
         nodeLabel: row.sourcePath,
         message: `Note "${row.sourcePath}" links to a missing note: [[${linkText}]]`,
         suggestedAction: 'Create the target note, fix the spelling, or remove the link.',
+        // Deterministic quick-fix (#1446): create the missing note beside the
+        // note that references it. The basename comes from the link target;
+        // the directory from the referencing note's path (an anchor, if any,
+        // is dropped — we create the note, not the heading).
+        fix: {
+          kind: 'create-note',
+          label: 'Create Note',
+          targetPath: createNoteTargetPath(row.sourcePath, stem),
+        },
       };
     }
     // Note exists. Check anchor when one was specified.

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -42,7 +42,7 @@
   import MineReferencesDialog from './lib/components/MineReferencesDialog.svelte';
   import ResolveStubDialog from './lib/components/ResolveStubDialog.svelte';
   import SafeDeleteBlockerDialog from './lib/components/SafeDeleteBlockerDialog.svelte';
-  import type { SafeDeleteBlocker, MenuEditorState, SavedView } from '../shared/types';
+  import type { SafeDeleteBlocker, MenuEditorState, SavedView, InspectionFix } from '../shared/types';
   import CommandPaletteDialog from './lib/components/CommandPaletteDialog.svelte';
   import type { Command } from './lib/command-palette/types';
   import { buildCommandRegistry } from './lib/command-palette/registry';
@@ -714,10 +714,17 @@
     openTypeEditor: (initial, promoteNotePath) => { typeEditorState = { initial, promoteNotePath }; },
   };
   const {
-    handleNewNote, handleInlineTypeCreate, handlePromoteToType, handleSaveNoteAsObjectType, handleNewFolder, handleDelete, openFirstReferenceFromSafeDelete,
+    handleNewNote, createNoteFromReference, handleInlineTypeCreate, handlePromoteToType, handleSaveNoteAsObjectType, handleNewFolder, handleDelete, openFirstReferenceFromSafeDelete,
     handleCut, handleCopy, handleMove, handlePaste, handleMerge, performMerge,
     handleRename, handleCopyWithPrompt, handleMoveWithPrompt,
   } = createNoteOps(noteOpsCtx);
+
+  /** Apply an inspection's deterministic quick-fix (#1446). Maps the fix kind
+   *  to its note-ops handler; conversation is only the panel's fallback for
+   *  inspections that carry no fix. */
+  function applyInspectionFix(fix: InspectionFix) {
+    if (fix.kind === 'create-note') void createNoteFromReference(fix.targetPath);
+  }
 
   // Nav-ops + source-view-ops handler cluster (#670): position history
   // (back/forward), file / wiki-link navigation, and the source *view* handlers
@@ -1412,6 +1419,7 @@
           onOpenAtOffset={handleOpenAtOffset}
           onScrollToLine={(line) => editorComponent?.gotoLineColumn(line, 1)}
           onOpenConversation={(msg) => { void openConversationWithMessage(msg); }}
+          onApplyInspectionFix={applyInspectionFix}
           onOpenQuery={(sql) => editor.openQuery(sql, 'sql')}
           onOpenSource={handleOpenSource}
           onOpenExcerpt={handleOpenExcerpt}

--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -109,6 +109,24 @@ export function createNoteOps(ctx: NoteOpsCtx) {
   }
 
   /**
+   * Deterministic "Create Note From Reference" (#1446) — the quick-fix behind a
+   * `broken_note_link` inspection. No dialog: main already resolved the canonical
+   * `relativePath` (beside the referencing note), so we just create the empty
+   * note, refresh the tree, and open it. The originating link resolves once the
+   * file exists. Idempotent-ish: if the note now exists we still open it.
+   */
+  async function createNoteFromReference(relativePath: string) {
+    if (!notebase.meta) return;
+    if (!pathExistsInTree(relativePath, notebase.files)) {
+      await api.notebase.createFile(relativePath);
+      await notebase.refresh();
+    }
+    await editor.openFile(relativePath);
+    ctx.getSidebar()?.refreshTags();
+    ctx.getSidebar()?.refreshObjects?.();
+  }
+
+  /**
    * Inline `/book` typed creation (#1065). Prompts for a title, then EITHER
    * links an existing note that already resolves for it (link-don't-duplicate)
    * OR creates a fresh typed note (`type:` + scaffold + template, the #1064
@@ -594,5 +612,5 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     await handleMove(relativePath, destDir);
   }
 
-  return { handleNewNote, handleInlineTypeCreate, handlePromoteToType, handleSaveNoteAsObjectType, handleNewFolder, handleDelete, executeDeletes, openFirstReferenceFromSafeDelete, handleCut, handleCopy, handleMove, handlePaste, handleMerge, performMerge, handleRename, handleCopyWithPrompt, handleMoveWithPrompt };
+  return { handleNewNote, createNoteFromReference, handleInlineTypeCreate, handlePromoteToType, handleSaveNoteAsObjectType, handleNewFolder, handleDelete, executeDeletes, openFirstReferenceFromSafeDelete, handleCut, handleCopy, handleMove, handlePaste, handleMerge, performMerge, handleRename, handleCopyWithPrompt, handleMoveWithPrompt };
 }

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -15,6 +15,7 @@
   import CitationsPanel from './right-sidebar/CitationsPanel.svelte';
   import Icon from './Icon.svelte';
   import type { IconName } from './icons/registry';
+  import type { InspectionFix } from '../../../shared/types';
 
   type PanelType =
     | 'outline' | 'headingGraph' | 'footnotes' | 'properties' | 'fields' | 'history' | 'outgoing' | 'backlinks' | 'related' | 'tags' | 'tables' | 'citations'
@@ -104,6 +105,9 @@
     onOpenAtOffset?: (relativePath: string, offset: number) => void | Promise<void>;
     onScrollToLine: (line: number) => void;
     onOpenConversation?: (message: string) => void;
+    /** Apply an inspection's deterministic quick-fix (#1446). Routed to the
+     *  Inspections panel; App owns the note-ops mutation it triggers. */
+    onApplyInspectionFix?: (fix: InspectionFix) => void;
     onOpenQuery: (sql: string) => void;
     onOpenSource: (sourceId: string) => void;
     onOpenExcerpt: (excerptId: string) => void;
@@ -119,7 +123,7 @@
 
   let {
     activeFilePath, content, onFileSelect, onNavigate, onOpenAtOffset, onScrollToLine,
-    onOpenConversation, onOpenQuery, onOpenSource, onOpenExcerpt,
+    onOpenConversation, onApplyInspectionFix, onOpenQuery, onOpenSource, onOpenExcerpt,
     onContentChange, onOpenGraph, indexing = false, onRestore,
   }: Props = $props();
 
@@ -273,7 +277,7 @@
     {:else if activePanel === 'bookmarks'}
       <BookmarksPanel {activeFilePath} {onFileSelect} {...(onNavigate !== undefined ? { onNavigate } : {})} {...(onOpenAtOffset !== undefined ? { onOpenAtOffset } : {})} />
     {:else if activePanel === 'inspections'}
-      <InspectionsPanel {revision} {...(onOpenConversation !== undefined ? { onOpenConversation } : {})} />
+      <InspectionsPanel {revision} {...(onOpenConversation !== undefined ? { onOpenConversation } : {})} {...(onApplyInspectionFix !== undefined ? { onApplyFix: onApplyInspectionFix } : {})} />
     {/if}
   </div>
 </aside>

--- a/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
@@ -3,6 +3,7 @@
   import { getReviewStore } from '../../stores/review.svelte';
   import { onMount } from 'svelte';
   import Ribbon from './Ribbon.svelte';
+  import type { InspectionFix } from '../../../../shared/types';
 
   const review = getReviewStore();
 
@@ -14,14 +15,19 @@
     nodeLabel: string;
     message: string;
     suggestedAction?: string;
+    fix?: InspectionFix;
   }
 
   interface Props {
     revision: number;
     onOpenConversation?: (message: string) => void;
+    /** Apply an inspection's deterministic quick-fix (#1446). When present on a
+     *  row, it's the primary action — conversation is only the fallback for
+     *  inspections that carry no fix. */
+    onApplyFix?: (fix: InspectionFix) => void;
   }
 
-  let { revision, onOpenConversation }: Props = $props();
+  let { revision, onOpenConversation, onApplyFix }: Props = $props();
 
   let inspections = $state<Inspection[]>([]);
   let loading = $state(false);
@@ -75,6 +81,12 @@
   }
 
   function handleClick(inspection: Inspection) {
+    // Deterministic-first (#1446): a fixable inspection applies its fix; only
+    // inspections with no fix fall back to opening a conversation.
+    if (inspection.fix) {
+      onApplyFix?.(inspection.fix);
+      return;
+    }
     if (onOpenConversation) {
       onOpenConversation(`I'd like to discuss this inspection: "${inspection.message}". ${inspection.suggestedAction ?? ''}`);
     }
@@ -102,6 +114,21 @@
     </button>
   </div>
 
+  <!-- One row per inspection. A fixable inspection (#1446) shows its fix label
+       as a trailing pill and the whole row applies the fix; others keep the
+       conversation fallback. The row is a single button, so the pill is a
+       non-interactive span (no nested interactive element). -->
+  {#snippet row(insp: Inspection)}
+    <button class="inspection-item {insp.severity}" onclick={() => handleClick(insp)} title={insp.fix ? insp.fix.label : (insp.suggestedAction ?? '')}>
+      <span class="insp-icon">{severityIcon(insp.severity)}</span>
+      <div class="insp-body">
+        <span class="insp-label">{insp.nodeLabel}</span>
+        <span class="insp-message">{insp.message}</span>
+      </div>
+      {#if insp.fix}<span class="fix-hint">{insp.fix.label}</span>{/if}
+    </button>
+  {/snippet}
+
   {#if filtered().length === 0}
     <p class="empty">{loading ? 'Checking...' : (inspections.length === 0 ? 'No inspections' : 'No matches')}</p>
   {:else if sortId === 'type'}
@@ -110,13 +137,7 @@
         <div class="severity-group">
           <span class="group-label">{typeName.replace(/_/g, ' ')} ({items.length})</span>
           {#each items as insp}
-            <button class="inspection-item {insp.severity}" onclick={() => handleClick(insp)} title={insp.suggestedAction ?? ''}>
-              <span class="insp-icon">{severityIcon(insp.severity)}</span>
-              <div class="insp-body">
-                <span class="insp-label">{insp.nodeLabel}</span>
-                <span class="insp-message">{insp.message}</span>
-              </div>
-            </button>
+            {@render row(insp)}
           {/each}
         </div>
       {/each}
@@ -127,13 +148,7 @@
         <div class="severity-group">
           <span class="group-label concern">Concerns ({concerns.length})</span>
           {#each concerns as insp}
-            <button class="inspection-item concern" onclick={() => handleClick(insp)} title={insp.suggestedAction ?? ''}>
-              <span class="insp-icon">{severityIcon('concern')}</span>
-              <div class="insp-body">
-                <span class="insp-label">{insp.nodeLabel}</span>
-                <span class="insp-message">{insp.message}</span>
-              </div>
-            </button>
+            {@render row(insp)}
           {/each}
         </div>
       {/if}
@@ -141,13 +156,7 @@
         <div class="severity-group">
           <span class="group-label warning">Warnings ({warnings.length})</span>
           {#each warnings as insp}
-            <button class="inspection-item warning" onclick={() => handleClick(insp)} title={insp.suggestedAction ?? ''}>
-              <span class="insp-icon">{severityIcon('warning')}</span>
-              <div class="insp-body">
-                <span class="insp-label">{insp.nodeLabel}</span>
-                <span class="insp-message">{insp.message}</span>
-              </div>
-            </button>
+            {@render row(insp)}
           {/each}
         </div>
       {/if}
@@ -155,13 +164,7 @@
         <div class="severity-group">
           <span class="group-label info">Info ({infos.length})</span>
           {#each infos as insp}
-            <button class="inspection-item info" onclick={() => handleClick(insp)} title={insp.suggestedAction ?? ''}>
-              <span class="insp-icon">{severityIcon('info')}</span>
-              <div class="insp-body">
-                <span class="insp-label">{insp.nodeLabel}</span>
-                <span class="insp-message">{insp.message}</span>
-              </div>
-            </button>
+            {@render row(insp)}
           {/each}
         </div>
       {/if}
@@ -282,5 +285,25 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  /* Deterministic-fix affordance (#1446): a compact pill naming the action the
+     row applies (e.g. "Create Note"). Non-interactive — the row button owns the
+     click; it brightens with the row on hover to read as the action label. */
+  .fix-hint {
+    flex-shrink: 0;
+    align-self: center;
+    margin-left: auto;
+    padding: 1px 6px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    font-size: 10px;
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+
+  .inspection-item:hover .fix-hint {
+    color: var(--text);
+    border-color: var(--accent);
   }
 </style>

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,4 +1,4 @@
-import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SavedView, SavedViewInput, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate, MenuEditorState } from '../../../shared/types';
+import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SavedView, SavedViewInput, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate, MenuEditorState, InspectionFix } from '../../../shared/types';
 import type { ToolExecutionRequest, ToolExecutionResult, ConversationToolPayload } from '../../../shared/tools/types';
 import type { ClipperState } from '../../../shared/clipper-pairing';
 import type { Proposal } from '../../../shared/proposals';
@@ -140,8 +140,8 @@ export interface GraphApi {
   /** Rebase to a new base IRI + rebuild indexes (#1443 Part B). */
   setBaseUri(uri: string): Promise<{ ok: true } | { ok: false; error: string }>;
   groundCheck(claimText: string): Promise<{ node: string; label: string; type: string }[]>;
-  inspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;
-  runInspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[]>;
+  inspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix }[]>;
+  runInspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix }[]>;
   export(): Promise<void>;
   sourceDetail(sourceId: string): Promise<SourceDetail | null>;
   excerptSource(excerptId: string): Promise<{ sourceId: string } | null>;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -55,6 +55,7 @@ import type {
   RelatedNotesResult,
   SourceDetail,
   CsvTableCollision,
+  InspectionFix,
 } from './types';
 import type { ClipperState } from './clipper-pairing';
 import type { Proposal } from './proposals';
@@ -247,8 +248,8 @@ export interface ChannelMap {
   'graph:frontmatterKeys': () => string[];
 
   // Inspections (graph health checks)
-  'inspections:list': () => { id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[];
-  'inspections:run': () => { id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string }[];
+  'inspections:list': () => { id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix }[];
+  'inspections:run': () => { id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix }[];
 
   // Tables (DuckDB)
   'tables:query': (sql: string) =>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,16 @@
+/**
+ * A deterministic quick-fix an inspection can carry so the Inspections panel
+ * can apply it directly instead of routing to an LLM conversation (#1446).
+ * Discriminated on `kind`; `label` is the button text the panel shows.
+ *
+ * - `create-note` — the referenced target note doesn't exist; create it at
+ *   `targetPath` (a project-relative `.md` path the check already resolved,
+ *   e.g. beside the referencing note). Applied via `note-ops`
+ *   `createNoteFromReference`.
+ */
+export type InspectionFix =
+  | { kind: 'create-note'; label: string; targetPath: string };
+
 export interface NoteFile {
   name: string;
   relativePath: string;

--- a/tests/main/graph/broken-link-inspection.test.ts
+++ b/tests/main/graph/broken-link-inspection.test.ts
@@ -66,6 +66,28 @@ describe('broken-link inspection (#140)', () => {
     expect(inspections.some((i) => i.type === 'broken_note_link')).toBe(true);
   });
 
+  // ─── deterministic create-note fix (#1446) ──────────────────────────────
+
+  it('carries a create-note fix targeting a path beside the referencing note', async () => {
+    await indexNote(ctx, 'a.md', '# A\n\nLinks to [[missing-note]].\n');
+    const [broken] = (await runAllChecks(ctx)).filter((i) => i.type === 'broken_note_link');
+    expect(broken.fix).toEqual({ kind: 'create-note', label: 'Create Note', targetPath: 'missing-note.md' });
+  });
+
+  it('puts the create-note target in the referencing note\'s folder', async () => {
+    await indexNote(ctx, 'topic/deep/a.md', '# A\n\n[[Concept X]]\n');
+    const [broken] = (await runAllChecks(ctx)).filter((i) => i.type === 'broken_note_link');
+    expect(broken.fix?.kind).toBe('create-note');
+    expect(broken.fix && 'targetPath' in broken.fix ? broken.fix.targetPath : null).toBe('topic/deep/Concept X.md');
+  });
+
+  it('offers no create-note fix on a broken anchor link (the note exists)', async () => {
+    await indexNote(ctx, 'target.md', '# Real heading\n\nbody\n');
+    await indexNote(ctx, 'source.md', 'See [[target#missing-heading]]\n');
+    const [broken] = (await runAllChecks(ctx)).filter((i) => i.type === 'broken_anchor_link');
+    expect(broken.fix).toBeUndefined();
+  });
+
   // ─── broken anchor link ─────────────────────────────────────────────────
 
   it('flags a [[note#missing-heading]] when the note exists but the heading does not', async () => {


### PR DESCRIPTION
## What & why

Inspections used to **always** open an LLM conversation when clicked — regardless of type. Many inspections have a single, deterministic remedy where a conversation is pure friction. This introduces a structured **fix affordance** so a check can declare a deterministic action the panel applies directly, and wires up the first one.

## The mechanism

- **`InspectionFix`** (new, `shared/types.ts`) — a discriminated union carried optionally on `Inspection`. First member: `{ kind: 'create-note'; label; targetPath }`.
- The panel is now **deterministic-first**: a row with a `fix` applies it on click; only inspections **without** a fix fall back to the conversation. The fix's `label` renders as a trailing pill on the row.

## First fix: `broken_note_link` → Create Note From Reference

- The check resolves the canonical target path in main and attaches the fix. **Location rule (decided per #1446, documented in code): beside the referencing note** — basename from the link target, directory from the note that contains the link. `notes/topic/a.md` with `[[Concept X]]` → `notes/topic/Concept X.md`.
- Applied via a new **dialog-free** `createNoteFromReference` in `note-ops` (reuses `api.notebase.createFile` → `notebase.refresh()` → `editor.openFile`). Creating the note makes the originating link resolve.
- Data-flow compliant: the panel calls a prop callback; the `createFile` mutation lives in note-ops, not the component.

## Files
- `shared/types.ts` — `InspectionFix`
- `main/graph/health-checks.ts` — `Inspection.fix`; `createNoteTargetPath`
- `renderer/lib/app/note-ops.ts` — `createNoteFromReference`
- `InspectionsPanel.svelte` — deterministic-first `handleClick`; row extracted to a `{#snippet}` + fix pill
- `App.svelte` / `RightSidebar.svelte` — thread `onApplyInspectionFix`
- `ipc-contract.ts` / `client.ts` — `fix?` on the `inspections:list` / `:run` return shapes

## Scope notes
- Only `broken_note_link` grows a fix here; the other 14 inspection types are unchanged and keep the conversation fallback. Adding more fixes is now a per-check `fix:` assignment + (if a new kind) one `applyInspectionFix` branch.
- Detection is unchanged — `checkBrokenLinks` still uses exact-match, not the editor's fuzzy resolver. Aligning them is a separate follow-up flagged in #1446.

## Testing
- `pnpm lint` clean (tsc · svelte-check · eslint).
- `pnpm test` — added cases: fix payload + target path at root and in a subfolder (`[[Concept X]]` → `topic/deep/Concept X.md`), and that a broken *anchor* link (note exists) carries **no** fix. Graph/dataflow/registration/preload suites: 461 pass.
- Manual: open **Activity → Inspections**, a `[[missing]]` link shows a **Create Note** pill; clicking creates the note beside its referencer and opens it, and the link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)