### PR TITLE
feat(graph): resolve wiki-links to non-markdown notes (#1446) — re-land of #1726

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -3,6 +3,7 @@ import type { ProjectContext } from '../project-context-types';
 import { LINK_TYPES } from '../../shared/link-types';
 import { DAY_MS } from './queries';
 import type { InspectionFix } from '../../shared/types';
+import { stripNoteExt, noteExtRank } from '../../shared/note-extensions';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -436,7 +437,18 @@ async function checkBrokenLinks(ctx: ProjectContext): Promise<Inspection[]> {
       SELECT ?id WHERE { ?e minerva:excerptId ?id }
     `),
   ]);
-  const validNotes = new Set((notesRes.results as { path: string }[]).map((r) => r.path));
+  // Note validity is keyed by STEM, not full path (#1446): a link `[[budget]]`
+  // resolves to `budget.csv`/`.ttl`/`.py`, not just `budget.md`. Map stem →
+  // real relativePath, keeping the highest-precedence extension (`.md` first)
+  // when several notes share a stem — mirrors the wiki-link resolver.
+  const validNoteStems = new Map<string, string>();
+  for (const r of notesRes.results as { path: string }[]) {
+    const stem = stripNoteExt(r.path);
+    const existing = validNoteStems.get(stem);
+    if (existing === undefined || noteExtRank(r.path) < noteExtRank(existing)) {
+      validNoteStems.set(stem, r.path);
+    }
+  }
   const validSources = new Set((sourcesRes.results as { id: string }[]).map((r) => r.id));
   const validExcerpts = new Set((excerptsRes.results as { id: string }[]).map((r) => r.id));
 
@@ -455,7 +467,7 @@ async function checkBrokenLinks(ctx: ProjectContext): Promise<Inspection[]> {
   for (const row of linksRes.results as { source: string; sourcePath: string; predicate: string; target: string }[]) {
     const classified = classifyTarget(row.target);
     if (!classified) continue;
-    const ins = inspectionForBrokenLink(ctx, row, classified, validNotes, validSources, validExcerpts, counter);
+    const ins = inspectionForBrokenLink(ctx, row, classified, validNoteStems, validSources, validExcerpts, counter);
     if (ins) {
       inspections.push(ins);
       counter++;
@@ -468,8 +480,9 @@ async function checkBrokenLinks(ctx: ProjectContext): Promise<Inspection[]> {
 /** A wiki-link target IRI parsed into kind + base + optional fragment. */
 interface ClassifiedTarget {
   kind: 'note' | 'source' | 'excerpt' | null;
-  /** The identifier portion — relativePath for notes (with `.md`),
-   *  sourceId / excerptId for the others. URL-decoded. */
+  /** The identifier portion — for notes, the extension-less STEM (so it matches
+   *  a note of any extension, #1446); sourceId / excerptId for the others.
+   *  URL-decoded. */
   id: string;
   /** Fragment after `#`, decoded; null when none. */
   anchor: string | null;
@@ -485,9 +498,9 @@ function classifyTarget(iri: string): ClassifiedTarget | null {
   const noteIdx = base.lastIndexOf('/note/');
   if (noteIdx >= 0) {
     const id = decodeSegmented(base.slice(noteIdx + '/note/'.length));
-    // Note URIs in the indexer carry a `.md` suffix on the path
-    // string (e.g. `path/foo.md`); add it for matching.
-    return { kind: 'note', id: id.endsWith('.md') ? id : `${id}.md`, anchor };
+    // Note URIs strip `.md`/`.ttl` but keep `.csv`/`.py` (uri-helpers noteUri),
+    // so normalise to a bare stem and match a note of ANY extension (#1446).
+    return { kind: 'note', id: stripNoteExt(id), anchor };
   }
   const sourceIdx = base.lastIndexOf('/source/');
   if (sourceIdx >= 0) {
@@ -527,7 +540,7 @@ function inspectionForBrokenLink(
   ctx: ProjectContext,
   row: { source: string; sourcePath: string; predicate: string; target: string },
   classified: ClassifiedTarget,
-  validNotes: Set<string>,
+  validNoteStems: Map<string, string>,
   validSources: Set<string>,
   validExcerpts: Set<string>,
   index: number,
@@ -557,8 +570,12 @@ function inspectionForBrokenLink(
     };
   }
   if (classified.kind === 'note') {
-    if (!validNotes.has(classified.id)) {
-      const stem = classified.id.replace(/\.md$/, '');
+    // `classified.id` is an extension-less stem; look it up against the
+    // stem→realPath map so a link to a `.csv`/`.ttl`/`.py` note counts as
+    // resolved, not broken (#1446).
+    const realPath = validNoteStems.get(classified.id);
+    if (realPath === undefined) {
+      const stem = classified.id;
       const linkText = classified.anchor ? `${stem}#${classified.anchor}` : stem;
       return {
         id: `broken-note-${index}`,
@@ -579,14 +596,16 @@ function inspectionForBrokenLink(
         },
       };
     }
-    // Note exists. Check anchor when one was specified.
-    // Block-id anchors (`#^id`) intentionally skipped — they're
+    // Note exists. Check anchor when one was specified — but only for markdown
+    // targets: `headingsFor` is populated only for `.md` notes, so a non-md
+    // target has no headings to check against and an anchor would always
+    // false-flag. Block-id anchors (`#^id`) are also skipped — they're
     // scattered through the note body, not stored as triples.
-    if (classified.anchor && !classified.anchor.startsWith('^')) {
-      const headings = headingsFor(ctx, classified.id);
+    if (classified.anchor && !classified.anchor.startsWith('^') && realPath.endsWith('.md')) {
+      const headings = headingsFor(ctx, realPath);
       const found = headings.some((h) => h.slug === classified.anchor);
       if (!found) {
-        const stem = classified.id.replace(/\.md$/, '');
+        const stem = classified.id;
         return {
           id: `broken-anchor-${index}`,
           type: 'broken_anchor_link',

--- a/src/main/graph/indexers.ts
+++ b/src/main/graph/indexers.ts
@@ -21,6 +21,7 @@ import { getLinkType } from '../../shared/link-types';
 import { mapFrontmatterKey, type FrontmatterPredicate } from './frontmatter-predicates';
 import { parseWikiInner } from '../../shared/wiki-link';
 import { slugify } from '../../shared/slug';
+import { stripNoteExt } from '../../shared/note-extensions';
 import { isIndexable } from '../notebase/indexable-files';
 
 import type { ProjectContext } from '../project-context-types';
@@ -98,7 +99,7 @@ function rebuildAliasMap(state: GraphState): void {
   // indexed note, not just those with aliases — a real file at
   // `JFK.md` should beat any other note's "JFK" alias.
   for (const path of state.indexedNotePaths) {
-    const stem = path.replace(/\.md$/i, '').toLowerCase();
+    const stem = stripNoteExt(path).toLowerCase();
     next.delete(stem);
     const basename = stem.split('/').pop() ?? '';
     if (basename) next.delete(basename);
@@ -571,7 +572,8 @@ function indexNoteAliases(
   skipAliasRebuild: boolean,
 ): void {
   const { store } = state;
-  state.indexedNotePaths.add(relativePath);
+  // (Path registration hoisted to the top of indexNote so non-md notes register
+  // too; #1446.)
   const validAliases = parsed.aliases.filter(isAliasNameValid);
   if (validAliases.length > 0) state.aliasesPerNote.set(relativePath, validAliases);
   else state.aliasesPerNote.delete(relativePath);
@@ -617,6 +619,13 @@ export async function indexNote(
 
   const subject = noteUri(state, relativePath);
   const graph = subject; // named graph = note URI, for clean removal on re-index
+
+  // Register the note path up front — for ALL note extensions (#1446), before the
+  // `.ttl`/`.csv`/`.py` early-returns below. This feeds the wiki-link resolver
+  // index (buildLinkResolveCtx) + alias canonical-name set, so a bare `[[budget]]`
+  // resolves to a `budget.csv` even on the incremental (single-note) path, not
+  // just a full rebuild. Idempotent (`indexedNotePaths` is a Set).
+  state.indexedNotePaths.add(relativePath);
 
   // Remove ALL triples from this note's graph (handles arbitrary turtle subjects)
   store.removeMatches(undefined, undefined, undefined, graph);
@@ -924,8 +933,9 @@ export async function indexAllNotes(ctx: ProjectContext, opts?: IndexAllNotesOpt
         // Register every note path up front so the main pass resolves bare
         // `[[basename]]` links against the COMPLETE file set — otherwise a note
         // indexed early couldn't resolve a link to one indexed later (#1142).
-        // Mirrors the alias pre-pass rationale (#469).
-        if (relativePath.endsWith('.md')) state!.indexedNotePaths.add(relativePath);
+        // Mirrors the alias pre-pass rationale (#469). All note extensions, so
+        // `[[budget]]` resolves to a `budget.csv`/`.ttl`/`.py` too (#1446).
+        state!.indexedNotePaths.add(relativePath);
         try {
           const content = await fs.readFile(fullPath, 'utf-8');
           const parsed = parseMarkdown(content);

--- a/src/main/graph/queries.ts
+++ b/src/main/graph/queries.ts
@@ -13,6 +13,7 @@
 import * as $rdf from 'rdflib';
 import type { ProjectContext } from '../project-context-types';
 import { LINK_TYPES, type LinkType } from '../../shared/link-types';
+import { stripNoteExt } from '../../shared/note-extensions';
 import type {
   TagInfo, TaggedNote, TaggedSource,
   OutgoingLink, Backlink, SafeDeleteBlocker,
@@ -73,7 +74,7 @@ export function getAliasEntries(ctx: ProjectContext): AliasEntry[] {
   // canonical name — matches rebuildAliasMap's second pass.
   const canonicals = new Set<string>();
   for (const path of state.indexedNotePaths) {
-    const stem = path.replace(/\.md$/i, '').toLowerCase();
+    const stem = stripNoteExt(path).toLowerCase();
     canonicals.add(stem);
     const basename = stem.split('/').pop() ?? '';
     if (basename) canonicals.add(basename);

--- a/src/main/notebase/indexable-files.ts
+++ b/src/main/notebase/indexable-files.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { THOUGHTBASE_DOC_FILENAME } from '../../shared/thoughtbase';
+import { NOTE_EXTENSIONS } from '../../shared/note-extensions';
 
 /**
  * Canonical set of file extensions that Minerva indexes + lists as
@@ -7,11 +8,12 @@ import { THOUGHTBASE_DOC_FILENAME } from '../../shared/thoughtbase';
  * watcher only re-indexes changes to these, and `graph.indexNote`
  * dispatches on the extension within it.
  *
- * Adding a new extension here is the single change needed to wire it
- * through sidebar listing, watcher reindex, rename/link-rewrites, and
- * the bulk index-all-notes walker.
+ * Derived from the shared `NOTE_EXTENSIONS` (the single source of truth shared
+ * with the renderer + the pure wiki-link resolver). Adding a new extension there
+ * wires it through sidebar listing, watcher reindex, rename/link-rewrites, the
+ * bulk index-all-notes walker, and wiki-link resolution in one place.
  */
-export const INDEXABLE_EXTS: ReadonlySet<string> = new Set(['.md', '.ttl', '.csv', '.py']);
+export const INDEXABLE_EXTS: ReadonlySet<string> = new Set(NOTE_EXTENSIONS);
 
 export function isIndexable(relativePath: string): boolean {
   // The thoughtbase guide (thoughtbase.md) is meta, not knowledge — it feeds the

--- a/src/renderer/lib/app/text-helpers.ts
+++ b/src/renderer/lib/app/text-helpers.ts
@@ -4,6 +4,7 @@
  * trivially unit-testable and don't belong inline in the root component.
  */
 import { slugify } from '../../../shared/slug';
+import { isNotePath } from '../../../shared/note-extensions';
 import type { NoteFile } from '../../../shared/types';
 
 /** Cheap slug for path placeholders (e.g. onboarding system-prompt paths).
@@ -65,13 +66,16 @@ export function lineBookmarkName(text: string, offset: number): string {
   return `Line ${offsetToLineCol(text, clamped).line}`;
 }
 
-/** Flatten a NoteFile tree to the relative paths of indexable leaf files. */
+/** Flatten a NoteFile tree to the relative paths of indexable leaf files. Uses
+ *  the shared note-extension set so the renderer's note list (hover-preview,
+ *  wiki-link autocomplete) agrees with the main-side resolver on every format,
+ *  including `.py` (#1446). */
 export function flattenNotePaths(files: NoteFile[]): string[] {
   const out: string[] = [];
   const walk = (xs: NoteFile[]) => {
     for (const f of xs) {
       if (f.isDirectory) walk(f.children ?? []);
-      else if (/\.(md|ttl|csv)$/.test(f.relativePath)) out.push(f.relativePath);
+      else if (isNotePath(f.relativePath)) out.push(f.relativePath);
     }
   };
   walk(files);

--- a/src/shared/note-extensions.ts
+++ b/src/shared/note-extensions.ts
@@ -1,0 +1,41 @@
+/**
+ * The file extensions Minerva treats as first-class notes — everything that is
+ * indexed as `a minerva:Note` and is a valid wiki-link target. Kept in `shared/`
+ * (no `main/` imports) so the renderer, the pure wiki-link resolver, and the
+ * main-side indexer all agree on one list.
+ *
+ * ORDER IS PRECEDENCE: when a bare wiki-link like `[[budget]]` could match more
+ * than one file with the same stem (`budget.md` vs `budget.csv`), the earliest
+ * extension here wins — `.md` first. An explicitly-extended link (`[[budget.csv]]`)
+ * bypasses this via an exact-path match in the resolver.
+ *
+ * `main/notebase/indexable-files.ts` derives `INDEXABLE_EXTS` from this, so
+ * adding a note format is a one-line change here.
+ */
+export const NOTE_EXTENSIONS = ['.md', '.ttl', '.csv', '.py'] as const;
+
+export type NoteExtension = (typeof NOTE_EXTENSIONS)[number];
+
+const NOTE_EXT_RE = new RegExp(`(${NOTE_EXTENSIONS.map((e) => `\\${e}`).join('|')})$`, 'i');
+
+/** True when `relativePath` ends in a note extension (case-insensitive). */
+export function isNotePath(relativePath: string): boolean {
+  return NOTE_EXT_RE.test(relativePath);
+}
+
+/** Strip a trailing note extension, leaving the stem. Non-note paths (and paths
+ *  with some other extension) are returned unchanged. */
+export function stripNoteExt(s: string): string {
+  return s.replace(NOTE_EXT_RE, '');
+}
+
+/** Precedence rank of a path's note extension (lower = higher priority, `.md`
+ *  = 0). A path with no note extension sorts last. Used for the md-first stable
+ *  sort that makes bare-link resolution deterministic regardless of caller order. */
+export function noteExtRank(relativePath: string): number {
+  const lower = relativePath.toLowerCase();
+  for (let i = 0; i < NOTE_EXTENSIONS.length; i++) {
+    if (lower.endsWith(NOTE_EXTENSIONS[i]!)) return i;
+  }
+  return NOTE_EXTENSIONS.length;
+}

--- a/src/shared/wiki-link-resolver.ts
+++ b/src/shared/wiki-link-resolver.ts
@@ -1,11 +1,18 @@
 /**
- * Resolve a wiki-link target string to an actual project-relative `.md`
- * path, and canonicalise a target to a chosen path style. Pure — only needs
- * the note list (+ optional frontmatter alias map) — so both the renderer
- * (navigation) and the main-side formatter orchestrator (#778) use it.
+ * Resolve a wiki-link target string to an actual project-relative note path,
+ * and canonicalise a target to a chosen path style. Pure — only needs the note
+ * list (+ optional frontmatter alias map) — so both the renderer (navigation)
+ * and the main-side formatter orchestrator (#778) use it.
+ *
+ * Targets resolve to any note extension (`.md`/`.ttl`/`.csv`/`.py`), not just
+ * markdown (#1446). A bare `[[budget]]` prefers `.md` when several stems
+ * collide (see `noteExtRank`); an explicit `[[budget.csv]]` bypasses that via an
+ * exact-path match (step 0 below).
  *
  * Resolution priority:
- *   1. Exact relativePath match (with or without .md)
+ *   0. Explicit extension — exact relativePath match (so `[[budget.csv]]` reaches
+ *      the CSV even when `budget.md` exists)
+ *   1. Exact relativePath match (with or without a note extension)
  *   2. Basename match — case-sensitive
  *   3. Frontmatter alias (case-insensitive), if a map is provided (#469)
  *   4. Slugified basename match (case-insensitive, punctuation-fuzzy)
@@ -14,6 +21,7 @@
  */
 
 import type { NoteFile } from './types';
+import { isNotePath, stripNoteExt, noteExtRank } from './note-extensions';
 
 export function flattenNoteFiles(tree: NoteFile[]): NoteFile[] {
   const out: NoteFile[] = [];
@@ -30,16 +38,25 @@ export function flattenNoteFiles(tree: NoteFile[]): NoteFile[] {
   return out;
 }
 
-const stripMd = (s: string) => s.replace(/\.md$/i, '');
 const slug = (s: string): string =>
   s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 
 type NoteFileLike = Pick<NoteFile, 'relativePath' | 'isDirectory'>;
 
+/** Note files only, sorted so a lower `noteExtRank` (`.md` = 0) comes first.
+ *  `Array.prototype.sort` is stable, so files of the same extension keep their
+ *  input order — this makes bare-link precedence (`budget.md` over `budget.csv`)
+ *  deterministic regardless of the order the caller passes files in. */
+function orderedNoteFiles(files: NoteFileLike[]): NoteFileLike[] {
+  return files
+    .filter((f) => !f.isDirectory && isNotePath(f.relativePath))
+    .sort((a, b) => noteExtRank(a.relativePath) - noteExtRank(b.relativePath));
+}
+
 /**
- * Returns the project-relative path of the matched note (with .md), or
- * null when nothing matches. Targets ending in `.md` are tried as-is
- * first, otherwise treated as a stem.
+ * Returns the project-relative path of the matched note (with its real
+ * extension), or null when nothing matches. A target carrying an explicit note
+ * extension is honored first (step 0); otherwise it's treated as a stem.
  *
  * `aliases` is a frontmatter alias → relativePath map (#469). Title /
  * filename matches always win over aliases — the indexer's
@@ -52,19 +69,34 @@ export function resolveWikiLinkTarget(
   files: NoteFileLike[],
   aliases?: Record<string, string>,
 ): string | null {
-  const targetStem = stripMd(target);
-  const targetSlug = slug(targetStem);
+  const noteFiles = orderedNoteFiles(files);
 
-  const noteFiles = files.filter((f) => !f.isDirectory && f.relativePath.endsWith('.md'));
+  // 0. Explicit extension: a deliberately-typed `[[budget.csv]]` honors the
+  //    extension, reaching the CSV even when a same-stem `.md` exists (which
+  //    step 1's md-first precedence would otherwise pick). A slashed target is a
+  //    full path (exact match only); a bare one matches by basename-with-ext.
+  if (isNotePath(target)) {
+    for (const f of noteFiles) {
+      if (f.relativePath === target) return f.relativePath;
+    }
+    if (!target.includes('/')) {
+      for (const f of noteFiles) {
+        if ((f.relativePath.split('/').pop() ?? '') === target) return f.relativePath;
+      }
+    }
+  }
+
+  const targetStem = stripNoteExt(target);
+  const targetSlug = slug(targetStem);
 
   // 1. Exact relativePath
   for (const f of noteFiles) {
-    if (stripMd(f.relativePath) === targetStem) return f.relativePath;
+    if (stripNoteExt(f.relativePath) === targetStem) return f.relativePath;
   }
 
   // 2. Basename exact (case-sensitive)
   for (const f of noteFiles) {
-    const base = stripMd(f.relativePath.split('/').pop() ?? '');
+    const base = stripNoteExt(f.relativePath.split('/').pop() ?? '');
     if (base === targetStem) return f.relativePath;
   }
 
@@ -76,14 +108,14 @@ export function resolveWikiLinkTarget(
 
   // 4. Basename slug match
   for (const f of noteFiles) {
-    const base = stripMd(f.relativePath.split('/').pop() ?? '');
+    const base = stripNoteExt(f.relativePath.split('/').pop() ?? '');
     if (slug(base) === targetSlug) return f.relativePath;
   }
 
   // 5. Full-stem slug match (target like "notes/topic/raft" against the
   //    file's full stem slug)
   for (const f of noteFiles) {
-    if (slug(stripMd(f.relativePath)) === targetSlug) return f.relativePath;
+    if (slug(stripNoteExt(f.relativePath)) === targetSlug) return f.relativePath;
   }
 
   // 6. Path-suffix slug match — target slug ends a file's full-stem slug at
@@ -92,7 +124,7 @@ export function resolveWikiLinkTarget(
   //    caught by step 4). Useful for "[[journey/raft]]"-style tail links.
   if (targetSlug.length > 0) {
     for (const f of noteFiles) {
-      const fullSlug = slug(stripMd(f.relativePath));
+      const fullSlug = slug(stripNoteExt(f.relativePath));
       if (fullSlug === targetSlug) continue; // already covered by step 5
       if (fullSlug.endsWith(`-${targetSlug}`) || fullSlug.endsWith(`/${targetSlug}`)) {
         return f.relativePath;
@@ -112,6 +144,10 @@ export function resolveWikiLinkTarget(
  * in `files` order for a given key, matching the loops' first-match-wins.
  */
 export interface WikiLinkIndex {
+  /** Exact relativePath identity map (step 0) — an explicit `[[reports/budget.csv]]`. */
+  byRelPath: Map<string, string>;
+  /** Basename-with-extension → relativePath (step 0) — a bare `[[budget.csv]]`. */
+  byBasenameExt: Map<string, string>;
   byStem: Map<string, string>;
   byBasename: Map<string, string>;
   bySlugBase: Map<string, string>;
@@ -122,18 +158,23 @@ export interface WikiLinkIndex {
 }
 
 export function buildWikiLinkIndex(files: NoteFileLike[], aliases: Record<string, string> = {}): WikiLinkIndex {
+  const byRelPath = new Map<string, string>();
+  const byBasenameExt = new Map<string, string>();
   const byStem = new Map<string, string>();
   const byBasename = new Map<string, string>();
   const bySlugBase = new Map<string, string>();
   const bySlugStem = new Map<string, string>();
   const bySuffixSlug = new Map<string, string>();
   const set = (m: Map<string, string>, k: string, v: string) => { if (k && !m.has(k)) m.set(k, v); };
-  for (const f of files) {
-    if (f.isDirectory || !f.relativePath.endsWith('.md')) continue;
+  // md-first order so first-writer-wins yields `.md` precedence, matching the
+  // loop resolver's `orderedNoteFiles` scan (verified equivalent in tests).
+  for (const f of orderedNoteFiles(files)) {
     const rel = f.relativePath;
-    const stem = stripMd(rel);
+    const stem = stripNoteExt(rel);
     const base = stem.split('/').pop() ?? '';
     const sStem = slug(stem);
+    set(byRelPath, rel, rel);
+    set(byBasenameExt, rel.split('/').pop() ?? '', rel);
     set(byStem, stem, rel);
     set(byBasename, base, rel);
     set(bySlugBase, slug(base), rel);
@@ -145,13 +186,20 @@ export function buildWikiLinkIndex(files: NoteFileLike[], aliases: Record<string
       for (let k = 1; k < parts.length; k++) set(bySuffixSlug, parts.slice(parts.length - k).join('-'), rel);
     }
   }
-  return { byStem, byBasename, bySlugBase, bySlugStem, bySuffixSlug, aliases };
+  return { byRelPath, byBasenameExt, byStem, byBasename, bySlugBase, bySlugStem, bySuffixSlug, aliases };
 }
 
 /** O(1) equivalent of `resolveWikiLinkTarget` using a prebuilt `WikiLinkIndex`.
  *  Verified to match the loop-based resolver in wiki-link-resolver.test.ts. */
 export function resolveWikiLinkTargetWithIndex(target: string, index: WikiLinkIndex): string | null {
-  const stem = stripMd(target);
+  // Step 0: explicit extension → exact path, or basename-with-ext for a bare
+  //         target (mirrors the loop resolver).
+  if (isNotePath(target)) {
+    const hit = index.byRelPath.get(target)
+      ?? (target.includes('/') ? undefined : index.byBasenameExt.get(target));
+    if (hit) return hit;
+  }
+  const stem = stripNoteExt(target);
   const s = slug(stem);
   return index.byStem.get(stem)
     ?? index.byBasename.get(stem)
@@ -183,12 +231,12 @@ export function canonicalizeWikiLinkTarget(
 ): string | null {
   const full = resolveWikiLinkTarget(target, files, aliases);
   if (!full) return null;
-  const stem = stripMd(full);
+  const stem = stripNoteExt(full);
   if (style === 'absolute') return stem;
 
   const noteStems = files
-    .filter((f) => !f.isDirectory && f.relativePath.endsWith('.md'))
-    .map((f) => stripMd(f.relativePath));
+    .filter((f) => !f.isDirectory && isNotePath(f.relativePath))
+    .map((f) => stripNoteExt(f.relativePath));
   const suffix = (s: string, t: number) => s.split('/').slice(-t).join('/');
   const segs = stem.split('/');
   for (let t = 1; t <= segs.length; t++) {

--- a/tests/main/graph/broken-link-inspection.test.ts
+++ b/tests/main/graph/broken-link-inspection.test.ts
@@ -8,7 +8,7 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { initGraph, indexNote, indexSource, indexExcerpt } from '../../../src/main/graph/index';
+import { initGraph, indexNote, indexSource, indexExcerpt, findNotesLinkingTo } from '../../../src/main/graph/index';
 import { runAllChecks } from '../../../src/main/graph/health-checks';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 
@@ -146,5 +146,67 @@ describe('broken-link inspection (#140)', () => {
     await indexNote(ctx, 'a.md', '[[quote::p42-graphs]]\n');
     const inspections = await runAllChecks(ctx);
     expect(inspections.some((i) => i.type === 'broken_cite_quote')).toBe(false);
+  });
+});
+
+// ─── links to non-markdown notes (#1446) ────────────────────────────────────
+describe('broken-link inspection — non-markdown note targets (#1446)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-nonmd-links-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('does not flag [[budget]] when a budget.csv note exists', async () => {
+    await indexNote(ctx, 'budget.csv', 'month,spend\njan,10\n');
+    await indexNote(ctx, 'a.md', 'See [[budget]] for the numbers.\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_note_link')).toBe(false);
+  });
+
+  it('does not flag links to .ttl or .py notes', async () => {
+    await indexNote(ctx, 'data.ttl', '@prefix ex: <https://ex/> .\n');
+    await indexNote(ctx, 'script.py', 'print("hi")\n');
+    await indexNote(ctx, 'a.md', 'Links [[data]] and [[script]].\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_note_link')).toBe(false);
+  });
+
+  it('still flags a genuinely-missing note with a create-note fix to <stem>.md', async () => {
+    await indexNote(ctx, 'budget.csv', 'month,spend\njan,10\n');
+    await indexNote(ctx, 'a.md', '[[budget]] and [[ghost]]\n');
+    const [broken] = (await runAllChecks(ctx)).filter((i) => i.type === 'broken_note_link');
+    expect(broken.message).toContain('ghost');
+    expect(broken.fix).toEqual({ kind: 'create-note', label: 'Create Note', targetPath: 'ghost.md' });
+  });
+
+  it('does not flag an anchor link to a non-md note (no markdown headings to check)', async () => {
+    await indexNote(ctx, 'budget.csv', 'month,spend\njan,10\n');
+    await indexNote(ctx, 'a.md', 'See [[budget#totals]]\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_anchor_link')).toBe(false);
+    expect(inspections.some((i) => i.type === 'broken_note_link')).toBe(false);
+  });
+
+  it('records a backlink edge from a note that links a .csv note', async () => {
+    await indexNote(ctx, 'budget.csv', 'month,spend\njan,10\n');
+    await indexNote(ctx, 'a.md', 'See [[budget]].\n');
+    expect(findNotesLinkingTo(ctx, 'budget.csv')).toContain('a.md');
+  });
+
+  it('resolves a non-md target indexed incrementally (no full rebuild)', async () => {
+    // budget.csv is indexed on its own; a later single-note index of a.md must
+    // still resolve [[budget]] against it (exercises the indexedNotePaths hoist).
+    await indexNote(ctx, 'budget.csv', 'month,spend\njan,10\n');
+    await indexNote(ctx, 'a.md', 'See [[budget]].\n');
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'broken_note_link')).toBe(false);
+    expect(findNotesLinkingTo(ctx, 'budget.csv')).toContain('a.md');
   });
 });

--- a/tests/shared/wiki-link-resolver.test.ts
+++ b/tests/shared/wiki-link-resolver.test.ts
@@ -55,7 +55,14 @@ describe('buildWikiLinkIndex / resolveWikiLinkTargetWithIndex equivalence (#1473
     { relativePath: 'deep/nested/journey/consensus.md', isDirectory: false },
     { relativePath: 'a/b/c/x.md', isDirectory: false },
     { relativePath: 'x.md', isDirectory: false },
-    { relativePath: 'assets/pic.png', isDirectory: false }, // non-md, ignored
+    // Non-md notes (#1446). The csv is listed BEFORE its same-stem md twin so
+    // the equivalence check also proves md-first precedence is enforced INSIDE
+    // the resolvers, not by caller order.
+    { relativePath: 'reports/budget.csv', isDirectory: false },
+    { relativePath: 'reports/budget.md', isDirectory: false }, // same stem → md wins for bare [[budget]]
+    { relativePath: 'data/records.ttl', isDirectory: false },
+    { relativePath: 'scripts/run.py', isDirectory: false },
+    { relativePath: 'assets/pic.png', isDirectory: false }, // non-note ext, ignored
     { relativePath: 'notes', isDirectory: true },           // dir, ignored
   ];
   const aliases = { 'rowing boat': 'notes/topic/raft.md', consensus: 'journal/raft.md' };
@@ -66,6 +73,9 @@ describe('buildWikiLinkIndex / resolveWikiLinkTargetWithIndex equivalence (#1473
     'ideas & plans', 'consensus', 'journey/consensus', 'nested/journey/consensus',
     'rowing boat', 'ROWING BOAT', 'x', 'c/x', 'b/c/x', 'nonexistent',
     '', 'raft.md', 'RAFT', 'topic/raft', 'deep/nested/journey/consensus',
+    // non-md + explicit-ext + precedence targets (#1446)
+    'budget', 'reports/budget', 'budget.csv', 'reports/budget.csv', 'budget.md',
+    'records', 'data/records', 'records.ttl', 'run', 'scripts/run', 'run.py',
   ];
 
   const index = buildWikiLinkIndex(files, aliases);
@@ -81,5 +91,42 @@ describe('buildWikiLinkIndex / resolveWikiLinkTargetWithIndex equivalence (#1473
     for (const t of targets) {
       expect(resolveWikiLinkTargetWithIndex(t, idx)).toBe(resolveWikiLinkTarget(t, files));
     }
+  });
+});
+
+// ── Non-markdown note resolution (#1446) ─────────────────────────────────────
+describe('resolveWikiLinkTarget — non-markdown notes (#1446)', () => {
+  it('resolves a bare link to a .csv / .ttl / .py note', () => {
+    const f = [{ relativePath: 'reports/budget.csv', isDirectory: false }];
+    expect(resolveWikiLinkTarget('budget', f)).toBe('reports/budget.csv');
+    expect(resolveWikiLinkTarget('reports/budget', f)).toBe('reports/budget.csv');
+
+    const t = [{ relativePath: 'data/records.ttl', isDirectory: false }];
+    expect(resolveWikiLinkTarget('records', t)).toBe('data/records.ttl');
+
+    const p = [{ relativePath: 'scripts/run.py', isDirectory: false }];
+    expect(resolveWikiLinkTarget('run', p)).toBe('scripts/run.py');
+  });
+
+  it('prefers .md when a bare link collides across extensions (md-first)', () => {
+    // csv listed first — precedence must come from noteExtRank, not order.
+    const f = [
+      { relativePath: 'reports/budget.csv', isDirectory: false },
+      { relativePath: 'reports/budget.md', isDirectory: false },
+    ];
+    expect(resolveWikiLinkTarget('budget', f)).toBe('reports/budget.md');
+  });
+
+  it('honors an explicit extension over precedence (regression guard)', () => {
+    const f = [
+      { relativePath: 'reports/budget.csv', isDirectory: false },
+      { relativePath: 'reports/budget.md', isDirectory: false },
+    ];
+    // [[budget.csv]] must reach the CSV even though budget.md exists.
+    expect(resolveWikiLinkTarget('budget.csv', f)).toBe('reports/budget.csv');
+    expect(resolveWikiLinkTarget('reports/budget.csv', f)).toBe('reports/budget.csv');
+    // …and the index fast-path agrees.
+    const idx = buildWikiLinkIndex(f);
+    expect(resolveWikiLinkTargetWithIndex('budget.csv', idx)).toBe('reports/budget.csv');
   });
 });


### PR DESCRIPTION
## Why this exists

#1726 was **stacked on #1724's branch** and got merged into that base branch — but #1724 had already squash-merged into `main` first, so #1726's changes landed on a now-dead branch and **never reached `main`**. `main` has the Create-Note affordance (#1724) but none of the non-md wiki-link work.

This re-lands the exact #1726 commit onto `main` (cherry-picked cleanly; the diff vs `main` is precisely the non-md changes). Content is unchanged from the reviewed #1726 — see that PR for full discussion.

## What it does (recap)

Wiki-links resolve to non-markdown notes (`.ttl`/`.csv`/`.py`) end-to-end, fixing the false `broken_note_link` flag + navigation dead-end, and stopping the #1724 Create-Note fix from offering a spurious `budget.md` beside an existing `budget.csv`.

- **`shared/note-extensions.ts`** (new) — one source of truth (`NOTE_EXTENSIONS`, md-first precedence; `stripNoteExt`/`isNotePath`/`noteExtRank`); `INDEXABLE_EXTS` derives from it.
- **`wiki-link-resolver.ts`** — ext-aware; md-first precedence enforced *inside* both resolvers; explicit-extension step 0 (`byRelPath`/`byBasenameExt`) so `[[budget.csv]]` still reaches the CSV.
- **Indexer** — registers non-md paths on both full-rebuild and incremental paths; alias canonical-stem passes strip any note ext.
- **`health-checks.ts`** — stem-keyed validity; `classifyTarget` returns a stem; anchor heading-check only for `.md`.
- **`text-helpers.ts`** — `flattenNotePaths` derives from `NOTE_EXTENSIONS` (adds `.py`).

`noteUri` untouched (link IRI and subject IRI both go through `noteUri(resolvedRealPath)`). Non-md rename/link-rewrite and link-shortening remain md-only (follow-ups).

## Testing
- `pnpm lint` clean; targeted resolver + broken-link suites pass (62 tests); full `pnpm test` was green on the identical content in #1726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)