### PR TITLE
feat(inspections): scope the right-sidebar panel to the active note (#1446)

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -20,6 +20,12 @@ export interface Inspection {
   /** Optional deterministic quick-fix the panel can apply directly instead of
    *  opening a conversation (#1446). Absent when the only remedy is prose. */
   fix?: InspectionFix;
+  /** The note this inspection is anchored to, as a project-relative path, when
+   *  it belongs to one — the referencing note for a broken link, the stale note
+   *  itself, a claim's own note. Lets the right-sidebar panel scope to the
+   *  active note (#1446). Absent for source-scoped inspections (dupes, metadata)
+   *  and standalone claim components, which aren't "on" a note. */
+  notePath?: string;
 }
 
 const lastResultsByProject = new Map<string, Inspection[]>();
@@ -72,9 +78,10 @@ export async function runAllChecks(ctx: ProjectContext): Promise<Inspection[]> {
 
 async function checkUnsupportedClaims(ctx: ProjectContext): Promise<Inspection[]> {
   const results = await queryGraph(ctx, `
-    SELECT ?claim ?label WHERE {
+    SELECT ?claim ?label ?notePath WHERE {
       ?claim a thought:Claim .
       ?claim thought:label ?label .
+      OPTIONAL { ?claim minerva:relativePath ?notePath }
       FILTER NOT EXISTS { ?other thought:supports ?claim }
     }
   `);
@@ -87,6 +94,7 @@ async function checkUnsupportedClaims(ctx: ProjectContext): Promise<Inspection[]
     nodeLabel: r.label!,
     message: `Claim "${r.label}" has no supporting evidence`,
     suggestedAction: 'Add grounds or evidence that supports this claim',
+    ...(r.notePath ? { notePath: r.notePath } : {}),
   }));
 }
 
@@ -94,8 +102,9 @@ async function checkStaleness(ctx: ProjectContext, thresholdDays: number): Promi
   const cutoff = new Date(Date.now() - thresholdDays * DAY_MS).toISOString();
 
   const results = await queryGraph(ctx, `
-    SELECT ?note ?title ?modified WHERE {
+    SELECT ?note ?path ?title ?modified WHERE {
       ?note a minerva:Note .
+      ?note minerva:relativePath ?path .
       ?note dc:title ?title .
       ?note dc:modified ?modified .
       FILTER(?modified < "${cutoff}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
@@ -112,6 +121,7 @@ async function checkStaleness(ctx: ProjectContext, thresholdDays: number): Promi
     nodeLabel: r.title!,
     message: `"${r.title}" hasn't been modified since ${r.modified!.split('T')[0]}`,
     suggestedAction: 'Review whether this note is still current',
+    ...(r.path ? { notePath: r.path } : {}),
   }));
 }
 
@@ -120,11 +130,12 @@ async function checkEvidenceGaps(ctx: ProjectContext): Promise<Inspection[]> {
 
   // Claims with grounds but no warrant
   const noWarrant = await queryGraph(ctx, `
-    SELECT ?claim ?label WHERE {
+    SELECT ?claim ?label ?notePath WHERE {
       ?claim a thought:Claim .
       ?claim thought:label ?label .
       ?grounds thought:supports ?claim .
       ?grounds a thought:Grounds .
+      OPTIONAL { ?claim minerva:relativePath ?notePath }
       FILTER NOT EXISTS {
         ?warrant thought:supports ?claim .
         ?warrant a thought:Warrant .
@@ -141,14 +152,16 @@ async function checkEvidenceGaps(ctx: ProjectContext): Promise<Inspection[]> {
       nodeLabel: r.label!,
       message: `Claim "${r.label}" has grounds but no warrant connecting them`,
       suggestedAction: 'Add a warrant explaining why the grounds support this claim',
+      ...(r.notePath ? { notePath: r.notePath } : {}),
     });
   }
 
   // Warrants with no backing
   const noBacking = await queryGraph(ctx, `
-    SELECT ?warrant ?label WHERE {
+    SELECT ?warrant ?label ?notePath WHERE {
       ?warrant a thought:Warrant .
       ?warrant thought:label ?label .
+      OPTIONAL { ?warrant minerva:relativePath ?notePath }
       FILTER NOT EXISTS {
         ?backing thought:supports ?warrant .
         ?backing a thought:Backing .
@@ -165,6 +178,7 @@ async function checkEvidenceGaps(ctx: ProjectContext): Promise<Inspection[]> {
       nodeLabel: r.label!,
       message: `Warrant "${r.label}" has no backing — why should we accept this reasoning principle?`,
       suggestedAction: 'Add backing that supports this warrant',
+      ...(r.notePath ? { notePath: r.notePath } : {}),
     });
   }
 
@@ -205,12 +219,13 @@ async function checkInvalidDois(ctx: ProjectContext): Promise<Inspection[]> {
 
 async function checkContradictions(ctx: ProjectContext): Promise<Inspection[]> {
   const results = await queryGraph(ctx, `
-    SELECT ?a ?aLabel ?b ?bLabel WHERE {
+    SELECT ?a ?aLabel ?b ?bLabel ?notePath WHERE {
       ?a thought:contradicts ?b .
       ?a thought:hasStatus thought:established .
       ?b thought:hasStatus thought:established .
       ?a thought:label ?aLabel .
       ?b thought:label ?bLabel .
+      OPTIONAL { ?a minerva:relativePath ?notePath }
     }
   `);
 
@@ -222,6 +237,7 @@ async function checkContradictions(ctx: ProjectContext): Promise<Inspection[]> {
     nodeLabel: r.aLabel!,
     message: `Established claim "${r.aLabel}" contradicts established claim "${r.bLabel}"`,
     suggestedAction: 'Review both claims — at least one needs to be revised or its status changed',
+    ...(r.notePath ? { notePath: r.notePath } : {}),
   }));
 }
 
@@ -553,6 +569,7 @@ function inspectionForBrokenLink(
       severity: 'warning',
       nodeUri: row.source,
       nodeLabel: row.sourcePath,
+      notePath: row.sourcePath,
       message: `Note "${row.sourcePath}" cites an unknown source: ${classified.id}`,
       suggestedAction: 'Ingest the source via Ingest Identifier… or fix the `[[cite::id]]` target.',
     };
@@ -565,6 +582,7 @@ function inspectionForBrokenLink(
       severity: 'warning',
       nodeUri: row.source,
       nodeLabel: row.sourcePath,
+      notePath: row.sourcePath,
       message: `Note "${row.sourcePath}" quotes an unknown excerpt: ${classified.id}`,
       suggestedAction: 'Create the excerpt from the source viewer, or fix the `[[quote::id]]` target.',
     };
@@ -583,6 +601,7 @@ function inspectionForBrokenLink(
         severity: 'warning',
         nodeUri: row.source,
         nodeLabel: row.sourcePath,
+        notePath: row.sourcePath,
         message: `Note "${row.sourcePath}" links to a missing note: [[${linkText}]]`,
         suggestedAction: 'Create the target note, fix the spelling, or remove the link.',
         // Deterministic quick-fix (#1446): create the missing note beside the
@@ -612,6 +631,7 @@ function inspectionForBrokenLink(
           severity: 'warning',
           nodeUri: row.source,
           nodeLabel: row.sourcePath,
+          notePath: row.sourcePath,
           message: `Note "${row.sourcePath}" links to a missing heading: [[${stem}#${classified.anchor}]]`,
           suggestedAction: 'Add the heading to the target note, fix the anchor slug, or remove the `#…` part.',
         };

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -277,7 +277,7 @@
     {:else if activePanel === 'bookmarks'}
       <BookmarksPanel {activeFilePath} {onFileSelect} {...(onNavigate !== undefined ? { onNavigate } : {})} {...(onOpenAtOffset !== undefined ? { onOpenAtOffset } : {})} />
     {:else if activePanel === 'inspections'}
-      <InspectionsPanel {revision} {...(onOpenConversation !== undefined ? { onOpenConversation } : {})} {...(onApplyInspectionFix !== undefined ? { onApplyFix: onApplyInspectionFix } : {})} />
+      <InspectionsPanel {revision} {activeFilePath} {...(onOpenConversation !== undefined ? { onOpenConversation } : {})} {...(onApplyInspectionFix !== undefined ? { onApplyFix: onApplyInspectionFix } : {})} />
     {/if}
   </div>
 </aside>

--- a/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
@@ -16,10 +16,14 @@
     message: string;
     suggestedAction?: string;
     fix?: InspectionFix;
+    notePath?: string;
   }
 
   interface Props {
     revision: number;
+    /** The active note's relative path. The panel scopes to inspections anchored
+     *  to this note (#1446) — this is a note-context sidebar, not a project view. */
+    activeFilePath: string | null;
     onOpenConversation?: (message: string) => void;
     /** Apply an inspection's deterministic quick-fix (#1446). When present on a
      *  row, it's the primary action — conversation is only the fallback for
@@ -27,7 +31,7 @@
     onApplyFix?: (fix: InspectionFix) => void;
   }
 
-  let { revision, onOpenConversation, onApplyFix }: Props = $props();
+  let { revision, activeFilePath, onOpenConversation, onApplyFix }: Props = $props();
 
   let inspections = $state<Inspection[]>([]);
   let loading = $state(false);
@@ -50,10 +54,18 @@
 
   $effect(() => { revision; void refresh(); });
 
+  // Scope to the active note (#1446): the panel lives in the note-context right
+  // sidebar, so it shows only inspections anchored to the open note, not the
+  // whole project. Inspections without a notePath (source dupes/metadata,
+  // standalone claim components) aren't "on" a note and are excluded.
+  const noteScoped = $derived(
+    activeFilePath ? inspections.filter(i => i.notePath === activeFilePath) : [],
+  );
+
   const filtered = $derived(() => {
     const q = search.trim().toLowerCase();
-    if (!q) return inspections;
-    return inspections.filter(i =>
+    if (!q) return noteScoped;
+    return noteScoped.filter(i =>
       i.nodeLabel.toLowerCase().includes(q) ||
       i.message.toLowerCase().includes(q) ||
       i.type.toLowerCase().includes(q)
@@ -130,7 +142,7 @@
   {/snippet}
 
   {#if filtered().length === 0}
-    <p class="empty">{loading ? 'Checking...' : (inspections.length === 0 ? 'No inspections' : 'No matches')}</p>
+    <p class="empty">{loading ? 'Checking...' : (noteScoped.length === 0 ? 'No inspections for this note' : 'No matches')}</p>
   {:else if sortId === 'type'}
     <div class="inspection-list">
       {#each byType() as [typeName, items]}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -140,8 +140,8 @@ export interface GraphApi {
   /** Rebase to a new base IRI + rebuild indexes (#1443 Part B). */
   setBaseUri(uri: string): Promise<{ ok: true } | { ok: false; error: string }>;
   groundCheck(claimText: string): Promise<{ node: string; label: string; type: string }[]>;
-  inspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix }[]>;
-  runInspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix }[]>;
+  inspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix; notePath?: string }[]>;
+  runInspections(): Promise<{ id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix; notePath?: string }[]>;
   export(): Promise<void>;
   sourceDetail(sourceId: string): Promise<SourceDetail | null>;
   excerptSource(excerptId: string): Promise<{ sourceId: string } | null>;

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -248,8 +248,8 @@ export interface ChannelMap {
   'graph:frontmatterKeys': () => string[];
 
   // Inspections (graph health checks)
-  'inspections:list': () => { id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix }[];
-  'inspections:run': () => { id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix }[];
+  'inspections:list': () => { id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix; notePath?: string }[];
+  'inspections:run': () => { id: string; type: string; severity: string; nodeUri: string; nodeLabel: string; message: string; suggestedAction?: string; fix?: InspectionFix; notePath?: string }[];
 
   // Tables (DuckDB)
   'tables:query': (sql: string) =>

--- a/tests/main/graph/broken-link-inspection.test.ts
+++ b/tests/main/graph/broken-link-inspection.test.ts
@@ -66,6 +66,13 @@ describe('broken-link inspection (#140)', () => {
     expect(inspections.some((i) => i.type === 'broken_note_link')).toBe(true);
   });
 
+  it('anchors the inspection to the referencing note via notePath (#1446)', async () => {
+    // Used by the right-sidebar panel to scope inspections to the open note.
+    await indexNote(ctx, 'topic/a.md', 'Links [[missing-note]].\n');
+    const [broken] = (await runAllChecks(ctx)).filter((i) => i.type === 'broken_note_link');
+    expect(broken.notePath).toBe('topic/a.md');
+  });
+
   // ─── deterministic create-note fix (#1446) ──────────────────────────────
 
   it('carries a create-note fix targeting a path beside the referencing note', async () => {


### PR DESCRIPTION
## What

The Inspections panel lives in the **note-context right sidebar** (alongside Outline, Properties, Backlinks) but was showing every project-wide inspection. This scopes it to the note you're viewing.

## How

- **`Inspection.notePath`** (new field) anchors an inspection to a note:
  - `broken_*` → the referencing note's path (`row.sourcePath`)
  - `stale_note` → the note itself
  - `unsupported_claim` / `missing_warrant` / `missing_backing` / `contradiction` → via `OPTIONAL { ?node minerva:relativePath ?notePath }` (embedded-turtle claims are their own note; standalone claim components stay unanchored)
  - source-scoped inspections (duplicate DOI/URI, missing metadata, invalid DOI, unread) leave it **unset** — they aren't "on" a note
- **`InspectionsPanel`** takes `activeFilePath` and shows only inspections whose `notePath` matches. Empty state reads "No inspections for this note". Scoping is reactive on the active note, so switching tabs re-scopes the already-loaded list with no re-query.

## Design note

The right sidebar is note-scoped by nature, so source/project-level inspections simply don't appear here. If a project-wide inspections view is wanted later, that's a separate surface — this change deliberately doesn't add a "whole project" toggle.

## Testing
- `pnpm lint` clean; full `pnpm test` — 5549 pass.
- Added: `broken_note_link` carries `notePath` = the referencing note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)