### PR TITLE
feat(editor): in-editor broken wiki-link squiggle + Alt-Enter quick-fix (#1446 Phase 2)

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -4,6 +4,7 @@ import { LINK_TYPES } from '../../shared/link-types';
 import { DAY_MS } from './queries';
 import type { InspectionFix } from '../../shared/types';
 import { stripNoteExt, noteExtRank } from '../../shared/note-extensions';
+import { noteTargetPathBeside } from '../../shared/wiki-link-resolver';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -523,18 +524,6 @@ function decodeSegmented(s: string): string {
   return s.split('/').map(decode).join('/');
 }
 
-/**
- * Where "Create Note From Reference" (#1446) puts the new note: beside the
- * referencing note. The basename is the link target's own basename (any
- * directory part of the target is dropped — wiki-links are basename-scoped);
- * the directory is the referencing note's folder.
- */
-function createNoteTargetPath(referencingPath: string, targetStem: string): string {
-  const base = targetStem.split('/').pop() ?? targetStem;
-  const slashIdx = referencingPath.lastIndexOf('/');
-  const dir = slashIdx >= 0 ? referencingPath.slice(0, slashIdx) : '';
-  return dir ? `${dir}/${base}.md` : `${base}.md`;
-}
 
 function inspectionForBrokenLink(
   ctx: ProjectContext,
@@ -592,7 +581,7 @@ function inspectionForBrokenLink(
         fix: {
           kind: 'create-note',
           label: 'Create Note',
-          targetPath: createNoteTargetPath(row.sourcePath, stem),
+          targetPath: noteTargetPathBeside(row.sourcePath, stem),
         },
       };
     }

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -85,6 +85,7 @@
     lineBookmarkName,
     formatCappedList,
   } from './lib/app/text-helpers';
+  import { noteTargetPathBeside } from '../shared/wiki-link-resolver';
   import { initAppearance } from './lib/appearance/settings';
   import { applyStoredZoom } from './lib/appearance/zoom';
   import { clampFontSize } from './lib/editor/font-size';
@@ -1194,6 +1195,7 @@
                           getNotePaths={() => flattenNotePaths(notebase.files)}
                           getSources={() => sourcesCache}
                           getAliases={() => aliasEntries}
+                          onCreateNoteFromReference={(target) => void createNoteFromReference(noteTargetPathBeside(note.relativePath, target))}
                           resolveInlineTypeCreate={handleInlineTypeCreate}
                           bookmarks={collectBookmarksForPath(bookmarkStore.tree, note.relativePath)}
                           onUploadError={(message) => {

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
   import EditorContextMenu from './EditorContextMenu.svelte';
+  import QuickFixMenu, { type QuickFix } from './QuickFixMenu.svelte';
   import { installDismissOnClickOutside } from '../dismiss-menu';
   import { EditorView, keymap } from '@codemirror/view';
   import { basicSetup } from 'codemirror';
@@ -27,6 +28,7 @@
   import { toggleEditorDictation } from '../editor/dictation';
   import { linkDecorations, findLinkAt, type LinkRange } from '../editor/link-decorations';
   import { highlightDecorations } from '../editor/highlight-decorations';
+  import { brokenLinkDecorations, brokenNoteLinkAt } from '../editor/broken-link-decorations';
   import { computeCellsExtension, type RunAllRef } from '../editor/compute-cells';
   import {
     bookmarkGutterExtension,
@@ -115,6 +117,10 @@
     /** Live list of frontmatter alias entries so wiki-link autocomplete
      *  can suggest aliases alongside note paths (#492). */
     getAliases?: () => readonly { alias: string; relativePath: string }[];
+    /** Alt-Enter quick-fix "Create Note From Reference" (#1446 Phase 2): the
+     *  raw wiki-link target under the cursor. The host creates the note beside
+     *  this one (via note-ops) and opens it. */
+    onCreateNoteFromReference?: (target: string) => void;
     /** Inline `/book` typed-creation (#1065): given the picked type, prompt for
      *  a title, create (or link an existing) typed note, and return the
      *  wiki-link target — or null if cancelled. Wired by the host to note-ops. */
@@ -167,6 +173,7 @@
     getNotePaths,
     getSources,
     getAliases,
+    onCreateNoteFromReference,
     resolveInlineTypeCreate,
     initialHistory,
     onUploadError,
@@ -196,6 +203,8 @@
   let ignoreNextUpdate = false;
   let contextMenu = $state<EditorContextMenuState | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
+  // Alt-Enter quick-fix popup (#1446 Phase 2): position + the fixes to offer.
+  let quickFix = $state<{ x: number; y: number; fixes: QuickFix[] } | null>(null);
   // Separate from the main context menu: right-click anywhere in the
   // gutter opens a tiny toggle for line-number visibility. Keeps the
   // content-area menu from growing a gutter-only option that'd only
@@ -496,6 +505,10 @@
         getNotePaths: () => getNotePaths?.() ?? [],
         getAliases: () => getAliases?.() ?? [],
         readNote: (p) => api.notebase.readFile(p),
+      }),
+      brokenLinkDecorations({
+        getNotePaths: () => getNotePaths?.() ?? [],
+        getAliases: () => getAliases?.() ?? [],
       }),
       footnoteDecorations(),
       highlightDecorations(),
@@ -810,10 +823,37 @@
     view.focus();
   }
 
+  /** Alt-Enter quick-fix (#1446 Phase 2). When the cursor sits on a broken note
+   *  wiki-link and the host wired a create-note handler, open the quick-fix menu
+   *  at the cursor with "Create Note From Reference". Returns false otherwise so
+   *  Alt-Enter falls through. */
+  function openQuickFix(v: EditorView): boolean {
+    if (!onCreateNoteFromReference) return false;
+    const pos = v.state.selection.main.head;
+    const link = brokenNoteLinkAt(v.state, pos, {
+      getNotePaths: () => getNotePaths?.() ?? [],
+      getAliases: () => getAliases?.() ?? [],
+    });
+    if (!link) return false;
+    const coords = v.coordsAtPos(pos);
+    if (!coords) return false;
+    const target = link.href;
+    quickFix = {
+      x: coords.left,
+      y: coords.bottom + 2,
+      fixes: [{
+        label: 'Create Note From Reference',
+        apply: () => onCreateNoteFromReference?.(target),
+      }],
+    };
+    return true;
+  }
+
   onMount(() => {
     const resolved = resolveKeyBindings();
     const appKeymap = Prec.highest(keymap.of([
       { key: 'Mod-s', run: () => { onSave(); return true; } },
+      { key: 'Alt-Enter', run: openQuickFix },
       // Tab accepts the active completion; acceptCompletion returns false
       // when no completion panel is open, so Tab-for-indent still works
       // everywhere else.
@@ -1029,6 +1069,15 @@
     onMenuAction={handleMenuAction}
     onClose={closeMenu}
     onDictate={() => void toggleEditorDictation(view)}
+  />
+{/if}
+
+{#if quickFix}
+  <QuickFixMenu
+    x={quickFix.x}
+    y={quickFix.y}
+    fixes={quickFix.fixes}
+    onClose={() => { quickFix = null; view?.focus(); }}
   />
 {/if}
 

--- a/src/renderer/lib/components/QuickFixMenu.svelte
+++ b/src/renderer/lib/components/QuickFixMenu.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  // Alt-Enter quick-fix popup for the editor (#1446 Phase 2). A minimal
+  // keyboard-driven menu of applicable fixes for the token under the cursor —
+  // currently "Create Note From Reference" for a broken wiki-link. Deliberately
+  // NOT the big EditorContextMenu (that's right-click-only and coupled to a
+  // large op set); this is a focused, extensible list.
+  import { installDismissOnClickOutside } from '../dismiss-menu';
+
+  export interface QuickFix {
+    label: string;
+    apply: () => void;
+  }
+
+  interface Props {
+    /** Viewport coordinates to anchor the menu at (the cursor, via coordsAtPos). */
+    x: number;
+    y: number;
+    fixes: QuickFix[];
+    /** Close without applying — the parent nulls its state and refocuses the editor. */
+    onClose: () => void;
+  }
+
+  let { x, y, fixes, onClose }: Props = $props();
+
+  let selected = $state(0);
+  let menuEl = $state<HTMLDivElement | undefined>();
+
+  // Focus the menu so it owns the keyboard while open; dismiss on outside click
+  // (deferred one tick so the opening interaction doesn't self-close).
+  $effect(() => {
+    menuEl?.focus();
+    installDismissOnClickOutside(onClose, '.quick-fix-menu');
+  });
+
+  function run(i: number) {
+    const fix = fixes[i];
+    onClose();
+    fix?.apply();
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      selected = (selected + 1) % fixes.length;
+      e.preventDefault();
+    } else if (e.key === 'ArrowUp') {
+      selected = (selected - 1 + fixes.length) % fixes.length;
+      e.preventDefault();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      run(selected);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div
+  class="quick-fix-menu"
+  bind:this={menuEl}
+  tabindex="-1"
+  role="menu"
+  style:left="{x}px"
+  style:top="{y}px"
+  onkeydown={onKeydown}
+>
+  {#each fixes as fix, i}
+    <button
+      class="quick-fix-item"
+      class:active={i === selected}
+      role="menuitem"
+      onmousemove={() => { selected = i; }}
+      onclick={() => run(i)}
+    >{fix.label}</button>
+  {/each}
+</div>
+
+<style>
+  .quick-fix-menu {
+    position: fixed;
+    z-index: 1000;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    min-width: 180px;
+    outline: none;
+  }
+
+  .quick-fix-item {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 12px;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .quick-fix-item.active,
+  .quick-fix-item:hover {
+    background: var(--bg-button);
+  }
+</style>

--- a/src/renderer/lib/editor/broken-link-decorations.ts
+++ b/src/renderer/lib/editor/broken-link-decorations.ts
@@ -1,0 +1,156 @@
+/**
+ * In-editor broken wiki-link squiggle (#1446 Phase 2). A ViewPlugin that
+ * underlines any `[[note]]` whose target doesn't resolve, following the same
+ * pattern as `link-decorations.ts` / `highlight-decorations.ts` (scan visible
+ * ranges → RangeSetBuilder of Decoration.mark). Detection reuses the shared
+ * wiki-link resolver — a link is "broken" exactly when `resolveWikiLinkTarget`
+ * finds nothing — so the editor and the graph inspection agree.
+ *
+ * Scope: note wiki-links only (untyped `[[x]]` and note-kind typed links).
+ * `cite::`/`quote::` point at sources/excerpts and are left alone. Anchors are
+ * stripped before resolving — a missing heading isn't a missing note.
+ */
+import {
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+  Decoration,
+  type DecorationSet,
+} from '@codemirror/view';
+import { RangeSetBuilder, StateEffect, type EditorState } from '@codemirror/state';
+import { scanLinks, findLinkAt, type LinkRange } from './link-decorations';
+import {
+  buildWikiLinkIndex,
+  resolveWikiLinkTargetWithIndex,
+  type WikiLinkIndex,
+} from '../../../shared/wiki-link-resolver';
+import { getLinkType } from '../../../shared/link-types';
+
+export interface BrokenLinkDeps {
+  /** Live list of note relative paths (same source as autocomplete/preview). */
+  getNotePaths: () => string[];
+  /** Live frontmatter alias entries. */
+  getAliases: () => readonly { alias: string; relativePath: string }[];
+}
+
+/**
+ * Dispatch this effect to force the squiggle to re-resolve against a fresh note
+ * set — the note list can change (create / rename / delete elsewhere) without a
+ * doc or viewport change, and the quick-fix creating the target must clear the
+ * underline. `null` payload; presence is the whole signal.
+ */
+export const refreshBrokenLinks = StateEffect.define<null>();
+
+/** A wiki link that targets a NOTE (so its resolution is note-existence):
+ *  untyped, or a typed link whose `targetKind` is note (undefined). `cite`
+ *  (source) / `quote` (excerpt) links resolve differently and are excluded. */
+function isNoteWikiLink(link: LinkRange): boolean {
+  if (link.kind !== 'wiki') return false;
+  if (link.linkType === null) return true;
+  return getLinkType(link.linkType).targetKind === undefined;
+}
+
+const stripAnchor = (href: string): string => href.split('#')[0] ?? href;
+
+/** A note wiki-link whose target doesn't resolve — the single-link predicate
+ *  behind both the squiggle and the Alt-Enter quick-fix. */
+export function isBrokenNoteLink(link: LinkRange, index: WikiLinkIndex): boolean {
+  if (!isNoteWikiLink(link)) return false;
+  const target = stripAnchor(link.href).trim();
+  if (!target) return false;
+  return resolveWikiLinkTargetWithIndex(target, index) === null;
+}
+
+/**
+ * Pure core (unit-tested): the note wiki-link ranges in `text` — offset into
+ * the doc by `offset` — whose target does not resolve. Empty targets and
+ * cite/quote links are skipped.
+ */
+export function findBrokenWikiRanges(
+  text: string,
+  offset: number,
+  index: WikiLinkIndex,
+): LinkRange[] {
+  return scanLinks(text, offset).filter((l) => isBrokenNoteLink(l, index));
+}
+
+/** Build the resolver index from live deps (note list + aliases), matching how
+ *  `linkPreview`/autocomplete adapt the same getters. */
+export function buildBrokenLinkIndex(deps: BrokenLinkDeps): WikiLinkIndex {
+  const files = deps.getNotePaths().map((relativePath) => ({ relativePath, isDirectory: false }));
+  const aliases = Object.fromEntries(deps.getAliases().map((a) => [a.alias.toLowerCase(), a.relativePath]));
+  return buildWikiLinkIndex(files, aliases);
+}
+
+/** The broken note wiki-link under `pos`, or null. Used by the Alt-Enter
+ *  quick-fix to decide whether it has anything to offer. */
+export function brokenNoteLinkAt(
+  state: EditorState,
+  pos: number,
+  deps: BrokenLinkDeps,
+): LinkRange | null {
+  const link = findLinkAt(state, pos);
+  if (!link) return null;
+  return isBrokenNoteLink(link, buildBrokenLinkIndex(deps)) ? link : null;
+}
+
+const brokenMark = Decoration.mark({ class: 'cm-broken-link' });
+
+function buildDecorations(view: EditorView, index: WikiLinkIndex): DecorationSet {
+  const all: LinkRange[] = [];
+  for (const { from, to } of view.visibleRanges) {
+    all.push(...findBrokenWikiRanges(view.state.doc.sliceString(from, to), from, index));
+  }
+  // RangeSetBuilder requires sorted, non-overlapping ranges. scanLinks yields
+  // well-separated wiki matches, but sort + guard defensively.
+  all.sort((a, b) => a.from - b.from || a.to - b.to);
+  const builder = new RangeSetBuilder<Decoration>();
+  let lastTo = -1;
+  for (const r of all) {
+    if (r.from < lastTo) continue;
+    builder.add(r.from, r.to, brokenMark);
+    lastTo = r.to;
+  }
+  return builder.finish();
+}
+
+/** Subdued warm underline — `--rust` is the theme's established signal color for
+ *  "warning/failure" (callouts use it). A broken link is a diagnostic, not a
+ *  destructive action, so we avoid alarm-red per the app's UI philosophy. */
+const brokenLinkTheme = EditorView.theme({
+  '.cm-broken-link': {
+    textDecoration: 'underline wavy var(--rust)',
+    textDecorationSkipInk: 'none',
+    textUnderlineOffset: '2px',
+  },
+});
+
+export function brokenLinkDecorations(deps: BrokenLinkDeps) {
+  const plugin = ViewPlugin.fromClass(
+    class {
+      index: WikiLinkIndex;
+      decorations: DecorationSet;
+      constructor(view: EditorView) {
+        this.index = buildBrokenLinkIndex(deps);
+        this.decorations = buildDecorations(view, this.index);
+      }
+      update(update: ViewUpdate) {
+        const forced = update.transactions.some((tr) =>
+          tr.effects.some((e) => e.is(refreshBrokenLinks)),
+        );
+        // The note set can change without touching THIS doc (a note created —
+        // e.g. by the quick-fix — renamed, or deleted elsewhere). Rebuild the
+        // resolver index on an explicit refresh or when the editor regains focus
+        // (covers returning to the tab after creating the target); a plain edit
+        // to this note doesn't change resolution, so it just re-scans.
+        const refocused = update.focusChanged && update.view.hasFocus;
+        if (forced || refocused) this.index = buildBrokenLinkIndex(deps);
+        if (forced || refocused || update.docChanged || update.viewportChanged) {
+          this.decorations = buildDecorations(update.view, this.index);
+        }
+      }
+    },
+    { decorations: (v) => v.decorations },
+  );
+  return [plugin, brokenLinkTheme];
+}

--- a/src/renderer/lib/editor/link-decorations.ts
+++ b/src/renderer/lib/editor/link-decorations.ts
@@ -75,7 +75,10 @@ function trimUrlTail(url: string): string {
   return url.replace(/[.,;:!?)\]}'"]+$/, '');
 }
 
-function scanLinks(text: string, offset: number): LinkRange[] {
+/** Parse every link (wiki / markdown / bare URL) in `text`, whose ranges are
+ *  offset by `offset` (the slice's start in the doc). Exported so the
+ *  broken-link decoration layer (#1446) reuses one wiki-link parser. */
+export function scanLinks(text: string, offset: number): LinkRange[] {
   const ranges: LinkRange[] = [];
 
   // Markdown links first — they need to shadow any bare URL that lives inside.

--- a/src/shared/wiki-link-resolver.ts
+++ b/src/shared/wiki-link-resolver.ts
@@ -248,3 +248,19 @@ export function canonicalizeWikiLinkTarget(
   }
   return stem;
 }
+
+/**
+ * The canonical path for "Create Note From Reference" (#1446): the new `.md`
+ * note lands **beside the referencing note**. The basename is the link target's
+ * own basename (any directory part is dropped — wiki-links are basename-scoped;
+ * any `#anchor` and note extension are stripped); the directory is the
+ * referencing note's folder. Shared by the inspection quick-fix (main) and the
+ * in-editor Alt-Enter quick-fix (renderer) so both create at the same place.
+ */
+export function noteTargetPathBeside(referencingPath: string, target: string): string {
+  const noAnchor = target.split('#')[0] ?? target;
+  const base = stripNoteExt(noAnchor.split('/').pop() ?? noAnchor);
+  const slashIdx = referencingPath.lastIndexOf('/');
+  const dir = slashIdx >= 0 ? referencingPath.slice(0, slashIdx) : '';
+  return dir ? `${dir}/${base}.md` : `${base}.md`;
+}

--- a/tests/renderer/editor/broken-link-decorations.test.ts
+++ b/tests/renderer/editor/broken-link-decorations.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { buildWikiLinkIndex } from '../../../src/shared/wiki-link-resolver';
+import {
+  findBrokenWikiRanges,
+  isBrokenNoteLink,
+} from '../../../src/renderer/lib/editor/broken-link-decorations';
+import { scanLinks } from '../../../src/renderer/lib/editor/link-decorations';
+
+// One `raft.md` note exists; everything else is missing.
+const index = buildWikiLinkIndex([
+  { relativePath: 'notes/raft.md', isDirectory: false },
+], {});
+
+/** Convenience: the single link in a one-link string. */
+function onlyLink(text: string) {
+  const [link] = scanLinks(text, 0);
+  return link!;
+}
+
+describe('findBrokenWikiRanges (#1446 Phase 2)', () => {
+  it('flags an unresolved note wiki-link', () => {
+    const ranges = findBrokenWikiRanges('see [[missing]] here', 0, index);
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0]!.from).toBe(4); // start of `[[`
+  });
+
+  it('does not flag a link that resolves (fuzzy basename)', () => {
+    expect(findBrokenWikiRanges('see [[raft]]', 0, index)).toHaveLength(0);
+  });
+
+  it('strips the #anchor before resolving — a missing heading is not a missing note', () => {
+    expect(findBrokenWikiRanges('see [[raft#nonexistent-heading]]', 0, index)).toHaveLength(0);
+    // …but a missing note WITH an anchor is still broken.
+    expect(findBrokenWikiRanges('see [[ghost#intro]]', 0, index)).toHaveLength(1);
+  });
+
+  it('ignores cite:: / quote:: links (they target sources / excerpts, not notes)', () => {
+    expect(findBrokenWikiRanges('[[cite::unknown-src]] [[quote::unknown-x]]', 0, index)).toHaveLength(0);
+  });
+
+  it('still flags a note-kind typed link (e.g. supports::)', () => {
+    expect(findBrokenWikiRanges('[[supports::missing]]', 0, index)).toHaveLength(1);
+  });
+
+  it('ignores markdown links and bare URLs', () => {
+    expect(findBrokenWikiRanges('[text](./x.md) and https://example.com', 0, index)).toHaveLength(0);
+  });
+
+  it('offsets ranges by the slice start', () => {
+    const [r] = findBrokenWikiRanges('[[missing]]', 100, index);
+    expect(r!.from).toBe(100);
+  });
+});
+
+describe('isBrokenNoteLink', () => {
+  it('is true for an unresolved untyped wiki-link', () => {
+    expect(isBrokenNoteLink(onlyLink('[[missing]]'), index)).toBe(true);
+  });
+  it('is false for a resolved one', () => {
+    expect(isBrokenNoteLink(onlyLink('[[raft]]'), index)).toBe(false);
+  });
+  it('is false for a cite:: link', () => {
+    expect(isBrokenNoteLink(onlyLink('[[cite::x]]'), index)).toBe(false);
+  });
+  it('is false for a markdown link', () => {
+    expect(isBrokenNoteLink(onlyLink('[t](u)'), index)).toBe(false);
+  });
+});

--- a/tests/shared/wiki-link-resolver.test.ts
+++ b/tests/shared/wiki-link-resolver.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { canonicalizeWikiLinkTarget } from '../../src/shared/wiki-link-resolver';
+import { canonicalizeWikiLinkTarget, noteTargetPathBeside } from '../../src/shared/wiki-link-resolver';
+
+describe('noteTargetPathBeside (#1446 create-note path)', () => {
+  it('creates beside a root note', () => {
+    expect(noteTargetPathBeside('a.md', 'budget')).toBe('budget.md');
+  });
+  it('creates in the referencing note\'s folder', () => {
+    expect(noteTargetPathBeside('topic/deep/a.md', 'Concept X')).toBe('topic/deep/Concept X.md');
+  });
+  it('drops any path + note extension from the target, keeps the basename', () => {
+    expect(noteTargetPathBeside('topic/a.md', 'sub/budget.csv')).toBe('topic/budget.md');
+  });
+  it('strips an #anchor from the target', () => {
+    expect(noteTargetPathBeside('topic/a.md', 'budget#totals')).toBe('topic/budget.md');
+  });
+});
 
 const files = [
   { relativePath: 'notes/topic/raft.md', isDirectory: false },


### PR DESCRIPTION
## What

Brings the broken-link inspection *into the editor* (IDE-style), so you see and fix a dangling `[[link]]` where you're writing — not only in the right-sidebar panel.

- **Wavy underline** under any note `[[link]]` whose target doesn't resolve.
- **Alt-Enter** on a broken link opens a small **quick-fix menu** → **Create Note From Reference** (creates the note beside the current one and opens it, reusing the #1724 note-op).

## How

- **`broken-link-decorations.ts`** — a `ViewPlugin` following the existing `link-decorations`/`highlight-decorations` pattern (scan visible ranges → `Decoration.mark`). Detection **reuses the shared `resolveWikiLinkTarget`**, so the editor and the graph inspection agree on what's broken. `cite::`/`quote::` are skipped (they target sources/excerpts); `#anchors` are stripped before resolving (a missing heading isn't a missing note). The resolver index rebuilds on an explicit refresh **or on focus-gain**, so the underline clears when you return after creating the target.
- **`QuickFixMenu.svelte`** — a minimal keyboard-driven popup (↑/↓/Enter/Esc, click-away dismiss). Deliberately not the big right-click `EditorContextMenu`.
- **`Editor.svelte`** — an `Alt-Enter` command that opens the menu when the cursor sits on a broken note link; new `onCreateNoteFromReference` prop.
- **`wiki-link-resolver.ts`** — the "path beside the referencing note" rule is now a shared `noteTargetPathBeside()`, replacing the `health-checks`-local copy (one rule, two callers: the panel quick-fix and the editor quick-fix).

**Styling note:** the underline uses `--rust` (the theme's established warning/failure signal color, also used by callouts), not alarm-red — a broken link is a diagnostic, not a destructive action, per the app's UI philosophy.

## Scope (deferred follow-ups)
- Preview-mode mirror of the squiggle/quick-fix.
- Broken **anchor** squiggle (`[[note#missing-heading]]`) and broken `cite::`/`quote::`.
- Gutter **lightbulb** affordance (model exists in `bookmark-gutter.ts`).

## Testing
- `pnpm lint` clean; full `pnpm test` — 5563 pass.
- Unit: `findBrokenWikiRanges` / `isBrokenNoteLink` (unresolved flagged, resolved/fuzzy ignored, `cite::`/`quote::` skipped, `#anchor` stripped, offset honored); `noteTargetPathBeside` (root/subfolder/anchor/ext).
- **Manual (recommended):** type `[[missing]]` → wavy underline; put the cursor on it → **Alt-Enter** → menu → **Create Note From Reference** → note is created beside this one, opens in a tab, underline clears. `[[existing]]` and `[[cite::id]]` are not underlined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)