### PR TITLE
fix(nav): Back button after Create Note From Reference (#1446)

### DIFF
--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -9,6 +9,7 @@
 import { api } from '../ipc/client';
 import { getNotebaseStore } from '../stores/notebase.svelte';
 import { getEditorStore } from '../stores/editor.svelte';
+import { getNavigationStore } from '../stores/navigation.svelte';
 import { getDialogStore } from '../stores/dialogs.svelte';
 import { getBusyStore } from '../stores/busy.svelte';
 import { getClipboardStore } from '../stores/clipboard.svelte';
@@ -24,7 +25,7 @@ import { CONFIRM_KEYS } from '../confirm-keys';
 import type { SafeDeleteBlocker } from '../../../shared/types';
 
 /** Minimal structural views of the bind:this component refs the note-ops touch. */
-interface EditorRef { restorePosition(offset: number, scrollTop: number): void; gotoLineColumn(line: number, col: number): void; }
+interface EditorRef { restorePosition(offset: number, scrollTop: number): void; gotoLineColumn(line: number, col: number): void; getOffset(): number; }
 interface SidebarRef { getSelectionPaths(): string[]; refreshTags(): void; refreshObjects?(): void; clearSelection(): void; }
 interface SafeDeleteState { selectionCount: number; targets: string[]; blockers: SafeDeleteBlocker[]; proceed: () => void | Promise<void>; }
 
@@ -121,7 +122,16 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       await api.notebase.createFile(relativePath);
       await notebase.refresh();
     }
+    // Record nav history like the other navigation entry points (nav-view): push
+    // the current (referencing) note so Back returns to it, then record the new
+    // note as the destination. Opening directly via editor.openFile bypassed
+    // this, so Back was dead after a Create-Note-From-Reference jump (#1446).
+    const nav = getNavigationStore();
+    if (editor.activeTab?.type === 'note' && editor.activeFilePath) {
+      nav.record({ type: 'note', relativePath: editor.activeFilePath, offset: ctx.getEditorComponent()?.getOffset() ?? 0 });
+    }
     await editor.openFile(relativePath);
+    nav.record({ type: 'note', relativePath, offset: 0 });
     ctx.getSidebar()?.refreshTags();
     ctx.getSidebar()?.refreshObjects?.();
   }

--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../../src/renderer/lib/stores/editor.svelte', () => ({ getEditorStor
 vi.mock('../../../src/renderer/lib/stores/dialogs.svelte', () => ({ getDialogStore: () => h.dialog }));
 
 import { createNoteOps, type NoteOpsCtx } from '../../../src/renderer/lib/app/note-ops';
+import { getNavigationStore } from '../../../src/renderer/lib/stores/navigation.svelte';
 import { getClipboardStore } from '../../../src/renderer/lib/stores/clipboard.svelte';
 import { CONFIRM_KEYS } from '../../../src/renderer/lib/confirm-keys';
 
@@ -124,6 +125,25 @@ describe('handleNewNote', () => {
     h.dialog.showNewNoteDialog.mockResolvedValue(null);
     await ops.handleNewNote();
     expect(h.api.notebase.createFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('createNoteFromReference — nav history (#1446)', () => {
+  it('records the referencing note so Back returns to it after opening the new note', async () => {
+    const nav = getNavigationStore();
+    nav.clear();
+    nav.doneNavigating();
+    h.editor.activeFilePath = 'topic/Referrer.md';
+    (h.editor as unknown as { activeTab: { type: string } }).activeTab = { type: 'note' };
+    h.notebase.files = []; // target doesn't exist yet → gets created
+
+    await ops.createNoteFromReference('topic/New.md');
+
+    expect(h.api.notebase.createFile).toHaveBeenCalledWith('topic/New.md');
+    expect(h.editor.openFile).toHaveBeenCalledWith('topic/New.md');
+    // The referencing note is on the back stack, so Back returns to it — the
+    // bug was that createNoteFromReference bypassed nav recording entirely.
+    expect(nav.goBack()).toEqual({ type: 'note', relativePath: 'topic/Referrer.md', offset: 0 });
   });
 });
 


### PR DESCRIPTION
## Bug

Create Note From Reference correctly creates the note and jumps to it — but once there, **Back doesn't work**. Reported after #1729.

## Cause

`createNoteFromReference` (note-ops) opened the new note via `editor.openFile` directly, bypassing the two-step navigation recording that every `nav-view` handler performs: `recordCurrentPosition()` (push where you are) then `nav.record(destination)`. Nothing was pushed onto the back stack, so Back had no entry for the referencing note.

## Fix

Record nav history in `createNoteFromReference`, mirroring `handleFileSelect`: push the current (referencing) note + caret offset, open the new note, then record it as the destination. Back now returns to the note that had the broken link.

This covers **both** entry points that use the note-op — the editor Alt-Enter quick-fix (#1729) and the right-sidebar panel fix (#1724).

## Testing
- `pnpm lint` clean; note-ops + nav-view suites pass (90 tests).
- Added: after `createNoteFromReference`, `nav.goBack()` returns the referencing note.
- Manual: broken `[[link]]` → Alt-Enter → Create Note From Reference → lands on the new note → **Back returns to the referencing note**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)