### PR TITLE
fix(nav): record history for merge + safe-delete note jumps (#1446)

### DIFF
--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -110,6 +110,26 @@ export function createNoteOps(ctx: NoteOpsCtx) {
   }
 
   /**
+   * Open `relativePath` and record nav history so Back returns to the current
+   * position — mirroring the two-step record every nav-view handler does
+   * (record where you are, open, record the destination). Programmatic openers
+   * (create-note, safe-delete open-reference, merge) opened via `editor.openFile`
+   * directly and so left Back dead (#1446).
+   *
+   * `excludeCurrent` skips recording the from-position when the caller is about
+   * to delete that note (merge's source), so Back never targets a dead note.
+   */
+  async function openNoteRecordingHistory(relativePath: string, opts?: { excludeCurrent?: string }) {
+    const nav = getNavigationStore();
+    const from = editor.activeFilePath;
+    if (editor.activeTab?.type === 'note' && from && from !== relativePath && from !== opts?.excludeCurrent) {
+      nav.record({ type: 'note', relativePath: from, offset: ctx.getEditorComponent()?.getOffset() ?? 0 });
+    }
+    await editor.openFile(relativePath);
+    nav.record({ type: 'note', relativePath, offset: 0 });
+  }
+
+  /**
    * Deterministic "Create Note From Reference" (#1446) — the quick-fix behind a
    * `broken_note_link` inspection. No dialog: main already resolved the canonical
    * `relativePath` (beside the referencing note), so we just create the empty
@@ -122,16 +142,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       await api.notebase.createFile(relativePath);
       await notebase.refresh();
     }
-    // Record nav history like the other navigation entry points (nav-view): push
-    // the current (referencing) note so Back returns to it, then record the new
-    // note as the destination. Opening directly via editor.openFile bypassed
-    // this, so Back was dead after a Create-Note-From-Reference jump (#1446).
-    const nav = getNavigationStore();
-    if (editor.activeTab?.type === 'note' && editor.activeFilePath) {
-      nav.record({ type: 'note', relativePath: editor.activeFilePath, offset: ctx.getEditorComponent()?.getOffset() ?? 0 });
-    }
-    await editor.openFile(relativePath);
-    nav.record({ type: 'note', relativePath, offset: 0 });
+    await openNoteRecordingHistory(relativePath);
     ctx.getSidebar()?.refreshTags();
     ctx.getSidebar()?.refreshObjects?.();
   }
@@ -321,7 +332,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
    */
   async function openFirstReferenceFromSafeDelete(source: string, target: string): Promise<void> {
     ctx.setSafeDeleteState(null);
-    await editor.openFile(source);
+    await openNoteRecordingHistory(source);
     try {
       const content = await api.notebase.readFile(source);
       const basename = target.replace(/\.md$/, '').split('/').pop() ?? '';
@@ -521,8 +532,10 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       );
       // Open the target and scroll to the merge point. The
       // NOTEBASE_RENAMED / NOTEBASE_REWRITTEN broadcasts handle tab
-      // cleanup for the source and any open referrers.
-      await editor.openFile(result.targetPath);
+      // cleanup for the source and any open referrers. Record nav history so
+      // Back returns to where the user was — but never to the just-deleted
+      // source note (excludeCurrent).
+      await openNoteRecordingHistory(result.targetPath, { excludeCurrent: sourceRelPath });
       requestAnimationFrame(() => {
         ctx.getEditorComponent()?.gotoLineColumn(result.mergeLine, 1);
       });

--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -21,7 +21,8 @@ const h = vi.hoisted(() => {
   const notebase = { meta: { rootPath: '/p', name: 'p' } as unknown, files: [] as NoteFile[], refresh: vi.fn() };
   const editor = {
     openFile: vi.fn(), tabs: [] as unknown[], closeTabsForDeletedPath: vi.fn(), flushAutoSave: vi.fn(),
-    activeFilePath: 'Note.md' as string | null, content: '', setContent: vi.fn(),
+    activeFilePath: 'Note.md' as string | null, activeTab: { type: 'note' } as { type: string } | null,
+    content: '', setContent: vi.fn(),
     applyRenameTransitions: vi.fn(),
   };
   const dialog = {
@@ -49,7 +50,7 @@ function file(relativePath: string): NoteFile {
 }
 
 const sidebar = { getSelectionPaths: vi.fn(() => [] as string[]), refreshTags: vi.fn(), clearSelection: vi.fn() };
-const editorComp = { restorePosition: vi.fn(), gotoLineColumn: vi.fn() };
+const editorComp = { restorePosition: vi.fn(), gotoLineColumn: vi.fn(), getOffset: vi.fn(() => 0) };
 let editorCompRef: typeof editorComp | undefined;
 let ctx: NoteOpsCtx;
 let ops: ReturnType<typeof createNoteOps>;
@@ -66,6 +67,8 @@ beforeEach(() => {
   h.notebase.meta = { rootPath: '/p', name: 'p' };
   h.notebase.files = [];
   h.editor.tabs = [];
+  h.editor.activeFilePath = 'Note.md';
+  h.editor.activeTab = { type: 'note' };
   sidebar.getSelectionPaths.mockReturnValue([]);
   editorCompRef = undefined;
   getClipboardStore().clear();
@@ -453,6 +456,15 @@ describe('openFirstReferenceFromSafeDelete', () => {
     expect(h.editor.openFile).toHaveBeenCalledWith('notes/y.md');
     expect(editorComp.gotoLineColumn).not.toHaveBeenCalled();
   });
+
+  it('records nav history so Back returns to where the user was (#1446)', async () => {
+    const nav = getNavigationStore();
+    nav.clear(); nav.doneNavigating();
+    h.editor.activeFilePath = 'notes/current.md';
+    h.api.notebase.readFile.mockResolvedValue('see [[x]]');
+    await ops.openFirstReferenceFromSafeDelete('notes/y.md', 'notes/x.md');
+    expect(nav.goBack()).toEqual({ type: 'note', relativePath: 'notes/current.md', offset: 0 });
+  });
 });
 
 describe('handleCut / handleCopy', () => {
@@ -611,6 +623,26 @@ describe('handleMerge / performMerge', () => {
     expect(h.editor.openFile).toHaveBeenCalledWith('notes/target.md');
     expect(editorComp.gotoLineColumn).toHaveBeenCalledWith(12, 1);
     expect(h.notebase.refresh).toHaveBeenCalled();
+  });
+
+  it('performMerge records nav history, but never Back to the deleted source (#1446)', async () => {
+    const nav = getNavigationStore();
+    h.api.notebase.mergePreview.mockResolvedValue({ linkOccurrences: 0, affectedFiles: 0 });
+    h.dialog.showConfirm.mockResolvedValue(true);
+    h.api.notebase.merge.mockResolvedValue({ targetPath: 'notes/target.md', mergeLine: 1 });
+
+    // From an unrelated note → Back returns to it.
+    nav.clear(); nav.doneNavigating();
+    h.editor.activeFilePath = 'notes/elsewhere.md';
+    await ops.performMerge('notes/src.md', 'notes/target.md');
+    expect(nav.goBack()).toEqual({ type: 'note', relativePath: 'notes/elsewhere.md', offset: 0 });
+
+    // From the source being merged (deleted) → its from-position is NOT recorded,
+    // so Back has no dead-note entry to land on.
+    nav.clear(); nav.doneNavigating();
+    h.editor.activeFilePath = 'notes/src.md';
+    await ops.performMerge('notes/src.md', 'notes/target.md');
+    expect(nav.canGoBack).toBe(false);
   });
 
   it('performMerge handles the no-incoming-links preview branch', async () => {


### PR DESCRIPTION
## Follow-up to #1730

Same bug class: programmatic note openers called `editor.openFile` directly and skipped the two-step nav recording every `nav-view` handler does, so **Back was dead** after the jump.

## Audit

I checked every `editor.openFile` call outside `nav-view`. Two are genuine "navigate to an existing note" jumps that were missing history — the ones flagged after #1730:

| Path | Before | After |
|---|---|---|
| `openFirstReferenceFromSafeDelete` (safe-delete dialog → "Open first reference") | Back dead | Back returns to where you were |
| `performMerge` (merge → jump to target) | Back dead | Back returns to your prior note; **never** to the just-deleted source |

## Fix

Extract a shared **`openNoteRecordingHistory(relativePath, { excludeCurrent? })`** — record current position → open → record destination, mirroring `nav-view`. `createNoteFromReference` (the #1730 inline copy) now uses it too, so the pattern lives in one place. `excludeCurrent` handles merge's edge case: if you were viewing the source note (which the merge deletes), its from-position isn't recorded, so Back never lands on a dead note.

## Deliberately **not** changed

New-note **creation** paths — `handleNewNote`, `template-ops`, refactor extract/split — open a freshly-created note and were already not recording history. That's a separate UX category (create-and-open vs navigate), consistent across all creation, so I left it alone rather than silently changing creation behavior. Conversation/tool opens (`DraftCards`, `tools/output`) likewise out of scope. Happy to revisit any of these if you want creation to push history too.

## Testing
- `pnpm lint` clean; full `pnpm test` — 5567 pass.
- Added: safe-delete records the prior note (`nav.goBack()` returns it); merge records an unrelated prior note but records **nothing** when you merge the note you were viewing (`canGoBack === false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)