### PR TITLE
fix(nav): Back history for note-creation paths + shared recorder (#1446)

### DIFF
--- a/src/renderer/lib/app/nav-record.ts
+++ b/src/renderer/lib/app/nav-record.ts
@@ -1,0 +1,56 @@
+/**
+ * Nav-history recording for programmatic note opens (#1446). The nav-view
+ * handlers do a two-step record around every user navigation — capture where
+ * you are, open, record the destination — so Back/Forward work. Openers in
+ * other op clusters (note-ops create/merge/safe-delete, template-ops and
+ * refactor-ops note creation) called `editor.openFile` directly and so left
+ * Back dead. This shares the recording so every one of them participates.
+ */
+import { getEditorStore } from '../stores/editor.svelte';
+import { getNavigationStore, type NavPosition } from '../stores/navigation.svelte';
+
+/** The current editor location as a NavPosition — note (with caret offset),
+ *  query, or source/pdf. `null` when there's nothing recordable. Mirrors
+ *  nav-view's `recordCurrentPosition`, extended to source/pdf so Back returns
+ *  to a source you created a note from. */
+function currentPosition(getOffset: () => number | undefined): NavPosition | null {
+  const editor = getEditorStore();
+  const tab = editor.activeTab;
+  if (!tab) return null;
+  switch (tab.type) {
+    case 'note':
+      return editor.activeFilePath
+        ? { type: 'note', relativePath: editor.activeFilePath, offset: getOffset() ?? 0 }
+        : null;
+    case 'query':
+      return { type: 'query', tabId: tab.id };
+    case 'source':
+    case 'pdf':
+      return { type: 'source', sourceId: tab.sourceId };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Open `relativePath`, recording nav history so Back returns to the current
+ * position. `getOffset` reads the active editor caret for a note from-position.
+ * `excludeCurrent` skips recording the from-position when the caller is about
+ * to delete that note (merge's source), so Back never targets a dead note.
+ */
+export async function openNoteRecordingHistory(
+  relativePath: string,
+  getOffset: () => number | undefined,
+  opts?: { excludeCurrent?: string },
+): Promise<void> {
+  const editor = getEditorStore();
+  const nav = getNavigationStore();
+  const cur = currentPosition(getOffset);
+  // Don't record a note from-position that's the destination itself or a note
+  // being deleted; other kinds (query/source) always record.
+  const skip = cur?.type === 'note'
+    && (cur.relativePath === relativePath || cur.relativePath === opts?.excludeCurrent);
+  if (cur && !skip) nav.record(cur);
+  await editor.openFile(relativePath);
+  nav.record({ type: 'note', relativePath, offset: 0 });
+}

--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -9,7 +9,7 @@
 import { api } from '../ipc/client';
 import { getNotebaseStore } from '../stores/notebase.svelte';
 import { getEditorStore } from '../stores/editor.svelte';
-import { getNavigationStore } from '../stores/navigation.svelte';
+import { openNoteRecordingHistory } from './nav-record';
 import { getDialogStore } from '../stores/dialogs.svelte';
 import { getBusyStore } from '../stores/busy.svelte';
 import { getClipboardStore } from '../stores/clipboard.svelte';
@@ -48,6 +48,9 @@ export function createNoteOps(ctx: NoteOpsCtx) {
   const busy = getBusyStore();
   const clipboard = getClipboardStore();
   const { showPrompt, showConfirm, showNewNoteDialog, showTypePicker } = dialogs;
+
+  /** The active editor caret, for recording a note from-position in nav history. */
+  const getOffset = () => ctx.getEditorComponent()?.getOffset();
 
   async function handleNewNote(directory: string = '') {
     if (!notebase.meta) return;
@@ -96,7 +99,9 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       await api.notebase.createFile(relativePath);
     }
     await notebase.refresh();
-    await editor.openFile(relativePath);
+    // Record nav history so Back returns to the note you were on before
+    // creating this one (#1446 — creation paths were dead for Back).
+    await openNoteRecordingHistory(relativePath, getOffset);
     if (caretOffset !== null) {
       // Wait one frame so the editor has mounted the file before we
       // restore the position — restorePosition is a no-op against an
@@ -107,26 +112,6 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     }
     ctx.getSidebar()?.refreshTags();
     ctx.getSidebar()?.refreshObjects?.();
-  }
-
-  /**
-   * Open `relativePath` and record nav history so Back returns to the current
-   * position — mirroring the two-step record every nav-view handler does
-   * (record where you are, open, record the destination). Programmatic openers
-   * (create-note, safe-delete open-reference, merge) opened via `editor.openFile`
-   * directly and so left Back dead (#1446).
-   *
-   * `excludeCurrent` skips recording the from-position when the caller is about
-   * to delete that note (merge's source), so Back never targets a dead note.
-   */
-  async function openNoteRecordingHistory(relativePath: string, opts?: { excludeCurrent?: string }) {
-    const nav = getNavigationStore();
-    const from = editor.activeFilePath;
-    if (editor.activeTab?.type === 'note' && from && from !== relativePath && from !== opts?.excludeCurrent) {
-      nav.record({ type: 'note', relativePath: from, offset: ctx.getEditorComponent()?.getOffset() ?? 0 });
-    }
-    await editor.openFile(relativePath);
-    nav.record({ type: 'note', relativePath, offset: 0 });
   }
 
   /**
@@ -142,7 +127,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       await api.notebase.createFile(relativePath);
       await notebase.refresh();
     }
-    await openNoteRecordingHistory(relativePath);
+    await openNoteRecordingHistory(relativePath, getOffset);
     ctx.getSidebar()?.refreshTags();
     ctx.getSidebar()?.refreshObjects?.();
   }
@@ -332,7 +317,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
    */
   async function openFirstReferenceFromSafeDelete(source: string, target: string): Promise<void> {
     ctx.setSafeDeleteState(null);
-    await openNoteRecordingHistory(source);
+    await openNoteRecordingHistory(source, getOffset);
     try {
       const content = await api.notebase.readFile(source);
       const basename = target.replace(/\.md$/, '').split('/').pop() ?? '';
@@ -535,7 +520,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       // cleanup for the source and any open referrers. Record nav history so
       // Back returns to where the user was — but never to the just-deleted
       // source note (excludeCurrent).
-      await openNoteRecordingHistory(result.targetPath, { excludeCurrent: sourceRelPath });
+      await openNoteRecordingHistory(result.targetPath, getOffset, { excludeCurrent: sourceRelPath });
       requestAnimationFrame(() => {
         ctx.getEditorComponent()?.gotoLineColumn(result.mergeLine, 1);
       });

--- a/src/renderer/lib/app/refactor-ops.svelte.ts
+++ b/src/renderer/lib/app/refactor-ops.svelte.ts
@@ -17,6 +17,7 @@ import { getDialogStore } from '../stores/dialogs.svelte';
 import { getBusyStore } from '../stores/busy.svelte';
 import { getRefactorFlowStore } from '../stores/refactor-flow.svelte';
 import { formatCappedList, type OperationFailure } from './text-helpers';
+import { openNoteRecordingHistory } from './nav-record';
 import {
   planExtract,
   planSplitHere,
@@ -61,6 +62,9 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
   const editor = getEditorStore();
   const dialogs = getDialogStore();
   const busy = getBusyStore();
+
+  /** The active editor caret, for recording a note from-position in nav history. */
+  const getOffset = () => ctx.getEditorComponent()?.getOffset();
   const flow = getRefactorFlowStore();
   const { showPrompt, showConfirm, showAddPropertyDialog } = dialogs;
 
@@ -119,7 +123,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     // doesn't overwrite our rewrite.
     await editor.reloadTabFromDisk(tab.relativePath);
     await notebase.refresh();
-    await editor.openFile(plan.newNotePath);
+    await openNoteRecordingHistory(plan.newNotePath, getOffset);
     ctx.getSidebar()?.refreshTags();
   }
 
@@ -178,7 +182,7 @@ export function createRefactorOps(ctx: RefactorOpsCtx) {
     await api.notebase.writeFile(tab.relativePath, plan.updatedSourceContent);
     await editor.reloadTabFromDisk(tab.relativePath);
     await notebase.refresh();
-    await editor.openFile(plan.newNotePath);
+    await openNoteRecordingHistory(plan.newNotePath, getOffset);
     ctx.getSidebar()?.refreshTags();
   }
 

--- a/src/renderer/lib/app/template-ops.ts
+++ b/src/renderer/lib/app/template-ops.ts
@@ -20,11 +20,13 @@ import {
 import { getRefactorSettings } from '../refactor/settings';
 import { todayDateString } from '../refactor/extract';
 import { CONFIRM_KEYS } from '../confirm-keys';
+import { openNoteRecordingHistory } from './nav-record';
 import type { Conversation, SourceExcerpt } from '../../../shared/types';
 
 interface EditorRef {
   getSelectedText: () => string;
   insertText: (s: string, offset?: number | null) => void;
+  getOffset: () => number;
 }
 interface SidebarRef {
   refreshTags: () => void;
@@ -41,6 +43,9 @@ export function createTemplateOps(ctx: TemplateOpsCtx) {
   const editor = getEditorStore();
   const dialogs = getDialogStore();
   const { showPrompt, showConfirm, showSnippetPicker } = dialogs;
+
+  /** The active editor caret, for recording a note from-position in nav history. */
+  const getOffset = () => ctx.getEditorComponent()?.getOffset();
 
   async function handleCreateNoteFromConversation(args: {
     conversation: Conversation;
@@ -86,7 +91,7 @@ export function createTemplateOps(ctx: TemplateOpsCtx) {
       }
       await api.notebase.writeFile(path, plan.newNoteContent);
       await notebase.refresh();
-      await editor.openFile(path);
+      await openNoteRecordingHistory(path, getOffset);
       ctx.getSidebar()?.refreshTags();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -155,7 +160,7 @@ export function createTemplateOps(ctx: TemplateOpsCtx) {
     const initialContent = `---\nabout: [[sources/${sourceId}]]\n---\n\n# ${titleStem}\n\n`;
     await api.notebase.writeFile(relativePath, initialContent);
     await notebase.refresh();
-    await editor.openFile(relativePath);
+    await openNoteRecordingHistory(relativePath, getOffset);
     ctx.getSidebar()?.refreshTags();
     return relativePath;
   }
@@ -192,7 +197,7 @@ export function createTemplateOps(ctx: TemplateOpsCtx) {
     }).content;
     await api.notebase.writeFile(relativePath, finalContent);
     await notebase.refresh();
-    await editor.openFile(relativePath);
+    await openNoteRecordingHistory(relativePath, getOffset);
     ctx.getSidebar()?.refreshTags();
     return relativePath;
   }

--- a/tests/renderer/app/nav-record.test.ts
+++ b/tests/renderer/app/nav-record.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The shared nav-history recorder behind every programmatic note open
+ * (create-note, merge, safe-delete, and the note-creation paths). Mocks the
+ * editor store; uses the real navigation singleton.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const editor = {
+    activeTab: null as { type: string; id?: string; sourceId?: string } | null,
+    activeFilePath: null as string | null,
+    openFile: vi.fn(),
+  };
+  return { editor };
+});
+vi.mock('../../../src/renderer/lib/stores/editor.svelte', () => ({ getEditorStore: () => h.editor }));
+
+import { openNoteRecordingHistory } from '../../../src/renderer/lib/app/nav-record';
+import { getNavigationStore } from '../../../src/renderer/lib/stores/navigation.svelte';
+
+const nav = getNavigationStore();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  nav.clear();
+  nav.doneNavigating();
+  h.editor.openFile.mockResolvedValue(undefined);
+  h.editor.activeTab = null;
+  h.editor.activeFilePath = null;
+});
+
+describe('openNoteRecordingHistory (#1446)', () => {
+  it('opens the target and records the current note so Back returns to it (with its caret offset)', async () => {
+    h.editor.activeTab = { type: 'note' };
+    h.editor.activeFilePath = 'a.md';
+    await openNoteRecordingHistory('b.md', () => 42);
+    expect(h.editor.openFile).toHaveBeenCalledWith('b.md');
+    expect(nav.goBack()).toEqual({ type: 'note', relativePath: 'a.md', offset: 42 });
+  });
+
+  it('records a source from-position — creating a note from a source view returns Back to the source', async () => {
+    h.editor.activeTab = { type: 'source', sourceId: 'url-abc' };
+    await openNoteRecordingHistory('b.md', () => undefined);
+    expect(nav.goBack()).toEqual({ type: 'source', sourceId: 'url-abc' });
+  });
+
+  it('records a query from-position', async () => {
+    h.editor.activeTab = { type: 'query', id: 'q1' };
+    await openNoteRecordingHistory('b.md', () => 0);
+    expect(nav.goBack()).toEqual({ type: 'query', tabId: 'q1' });
+  });
+
+  it('never records the from-position when it is the note being deleted (merge source)', async () => {
+    h.editor.activeTab = { type: 'note' };
+    h.editor.activeFilePath = 'src.md';
+    await openNoteRecordingHistory('target.md', () => 0, { excludeCurrent: 'src.md' });
+    expect(nav.canGoBack).toBe(false);
+  });
+
+  it('skips recording when the current note is already the destination', async () => {
+    h.editor.activeTab = { type: 'note' };
+    h.editor.activeFilePath = 'same.md';
+    await openNoteRecordingHistory('same.md', () => 0);
+    expect(nav.canGoBack).toBe(false);
+  });
+
+  it('records only the destination when there is no recordable tab', async () => {
+    h.editor.activeTab = null;
+    await openNoteRecordingHistory('b.md', () => 0);
+    expect(h.editor.openFile).toHaveBeenCalledWith('b.md');
+    expect(nav.canGoBack).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Completes the nav-history thread (#1730 → #1731 → this): **creating a new note now pushes Back history**, so after the jump Back returns to the note (or source) you created it from. Before, every creation opener called `editor.openFile` directly and left Back dead.

## Centralized recorder

The recorder had been living inside `note-ops`. Promoted it to a shared **`src/renderer/lib/app/nav-record.ts`** (`openNoteRecordingHistory`) so all three op clusters share one implementation — and **extended it** to capture the current position for `note`, `query`, **and `source`/`pdf`** tabs (nav-view's `recordCurrentPosition` only handled note/query). So creating a note from a source viewer returns Back to the source.

## Paths now recording

| Cluster | Paths |
|---|---|
| `note-ops` | `handleNewNote` (+ `createNoteFromReference` / `performMerge` / `openFirstReferenceFromSafeDelete` migrated off the local copy) |
| `template-ops` | new-note-from-conversation, new-note-about-source, create-note-from-excerpt |
| `refactor-ops` | extract-selection, split-here |

`handleSplitByHeading` opens nothing (creates multiple notes, stays on the source), so it's untouched.

## Testing
- `pnpm lint` clean; full `pnpm test` — 5573 pass.
- New `nav-record` suite: note / query / source from-positions recorded; `excludeCurrent` (deleted merge-source) never recorded; current==destination skipped; no-recordable-tab records only the destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)