### PR TITLE
feat(editor): Tab indents in the markdown editor; fix the macOS focus-mode key

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -15,7 +15,7 @@
   import { search, openSearchPanel, setSearchQuery, SearchQuery } from '@codemirror/search';
   import { autocompletion, acceptCompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
   import { acceptCompletionEatTail, completionKeymapNoEnter } from '../editor/accept-completion-eat-tail';
-  import { historyField } from '@codemirror/commands';
+  import { historyField, indentWithTab } from '@codemirror/commands';
   import { api } from '../ipc/client';
   import {
     uploadImage,
@@ -854,10 +854,13 @@
     const appKeymap = Prec.highest(keymap.of([
       { key: 'Mod-s', run: () => { onSave(); return true; } },
       { key: 'Alt-Enter', run: openQuickFix },
-      // Tab accepts the active completion; acceptCompletion returns false
-      // when no completion panel is open, so Tab-for-indent still works
-      // everywhere else.
+      // Tab accepts the active completion, else indents (Shift-Tab outdents).
+      // acceptCompletion returns false with no popup open, and same-key bindings
+      // run in array order, so the fall-through lands on indentWithTab. Both
+      // no-op while tab-focus mode is on (editor.toggleTabFocusMode, Ctrl-m),
+      // which is what still lets keyboard users move focus out of the editor.
       { key: 'Tab', run: acceptCompletion },
+      indentWithTab,
       // Enter accepts the active completion and eats the half-typed word tail
       // (#206) — only word chars, so `[[No|te]]` → `[[Notebook]]` keeps its
       // brackets. Returns false with no popup open, so Enter stays a newline /

--- a/src/renderer/lib/editor/command-registry.ts
+++ b/src/renderer/lib/editor/command-registry.ts
@@ -1,4 +1,5 @@
 import type { Command } from '@codemirror/view';
+import { toggleTabFocusMode } from '@codemirror/commands';
 import { toggleCase, joinLines, duplicateLine, sortLines, extendSelection, shrinkSelection } from './commands';
 import {
   toggleBold, toggleItalic, toggleCode, toggleStrikethrough, toggleHighlight,
@@ -32,6 +33,18 @@ export const COMMAND_REGISTRY: CommandEntry[] = [
   // Selection
   { id: 'editor.extendSelection', label: 'Extend Selection', defaultKey: 'Alt-ArrowUp', command: extendSelection },
   { id: 'editor.shrinkSelection', label: 'Shrink Selection', defaultKey: 'Alt-ArrowDown', command: shrinkSelection },
+
+  // Accessibility — releases Tab so keyboard users can move focus out of the
+  // editor now that Tab indents. CodeMirror's default is `Ctrl-m`, but its
+  // `mac: 'Shift-Alt-m'` override can never fire: Option composes characters on
+  // macOS, so the browser reports "Â" rather than "m". `Ctrl-m` everywhere is a
+  // no-op off macOS (defaultKeymap already binds it) and fixes it on macOS.
+  {
+    id: 'editor.toggleTabFocusMode',
+    label: 'Toggle Tab Moves Focus',
+    defaultKey: 'Ctrl-m',
+    command: toggleTabFocusMode,
+  },
 
   // Inline formatting
   { id: 'editor.toggleBold', label: 'Bold', defaultKey: 'Mod-b', command: toggleBold },

--- a/tests/renderer/editor-command-registry.test.ts
+++ b/tests/renderer/editor-command-registry.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Editor command registry — default keybindings and the override merge.
+ *
+ * The guard that matters here is the `Alt-<letter>` one. On macOS Option is the
+ * character-compose modifier, so the browser reports `event.key` as the composed
+ * glyph (Option-Shift-m → "Â") rather than a plain letter. CodeMirror matches
+ * bindings on that reported name, so an `Alt-<letter>` default silently never
+ * fires on macOS *and* types a stray character into the note. That is exactly
+ * how CodeMirror's own `Shift-Alt-m` default for `toggleTabFocusMode` became
+ * unreachable, which is why this registry rebinds it to `Ctrl-m`.
+ *
+ * `Alt-<non-letter>` is fine and stays allowed — Option-ArrowUp doesn't compose,
+ * which is why the existing Extend/Shrink Selection bindings are unaffected.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { COMMAND_REGISTRY, resolveKeyBindings, saveOverrides } from '../../src/renderer/lib/editor/command-registry';
+
+// Clean in-memory localStorage — the renderer harness only sets up a partial
+// stub (same approach as editor-settings.test.ts).
+function installFakeLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => { store.clear(); },
+      get length() { return store.size; },
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+    },
+    configurable: true,
+  });
+}
+installFakeLocalStorage();
+
+describe('editor command registry', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('binds a default key to something', () => {
+    // A guard over an empty registry would pass vacuously.
+    expect(COMMAND_REGISTRY.filter((e) => e.defaultKey).length).toBeGreaterThan(5);
+  });
+
+  it('never defaults to Alt-<letter>, which macOS Option-composes away', () => {
+    const trapped = COMMAND_REGISTRY
+      .filter((e) => /(^|-)Alt-[A-Za-z]$/.test(e.defaultKey))
+      .map((e) => `${e.id}: ${e.defaultKey}`);
+    expect(
+      trapped,
+      'On macOS, Option turns these into a composed character, so the binding ' +
+        'never fires and the glyph is typed into the note instead. Use Ctrl- or ' +
+        'Mod- for letter keys; Alt- is only safe with non-letters (arrows, Tab).',
+    ).toEqual([]);
+  });
+
+  it('keeps Tab-moves-focus reachable — the escape hatch for Tab-indents', () => {
+    const entry = COMMAND_REGISTRY.find((e) => e.id === 'editor.toggleTabFocusMode');
+    expect(entry, 'editor.toggleTabFocusMode must stay registered').toBeDefined();
+    expect(entry!.defaultKey).toBe('Ctrl-m');
+    expect(resolveKeyBindings().some((b) => b.key === 'Ctrl-m')).toBe(true);
+  });
+
+  it('assigns each default key to exactly one command', () => {
+    const keys = COMMAND_REGISTRY.map((e) => e.defaultKey).filter(Boolean);
+    expect([...new Set(keys)]).toHaveLength(keys.length);
+  });
+
+  it('lets a user override replace a default key', () => {
+    saveOverrides([{ key: 'Ctrl-Alt-m', command: 'editor.toggleTabFocusMode' }]);
+    const keys = resolveKeyBindings().map((b) => b.key);
+    expect(keys).toContain('Ctrl-Alt-m');
+    expect(keys).not.toContain('Ctrl-m');
+  });
+
+  it('drops a command whose default key is empty until it is bound', () => {
+    const unbound = COMMAND_REGISTRY.find((e) => !e.defaultKey);
+    expect(unbound, 'expected at least one intentionally unbound command').toBeDefined();
+    saveOverrides([{ key: 'Ctrl-Alt-9', command: unbound!.id }]);
+    expect(resolveKeyBindings().some((b) => b.key === 'Ctrl-Alt-9')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1733.

Tab was bound only to `acceptCompletion`, which returns `false` when no completion popup is open — so the key fell through to native focus navigation and never indented. Two small changes:

- **`Editor.svelte`** — add `indentWithTab` immediately after the existing Tab binding. Same-key bindings in one `keymap.of([...])` run in array order, so completion keeps first refusal and Tab/Shift-Tab indent/outdent otherwise. No new precedence tier needed.
- **`command-registry.ts`** — register `toggleTabFocusMode` at `Ctrl-m`. Claiming Tab needs a working escape hatch for keyboard-only users, and CodeMirror's own `mac: 'Shift-Alt-m'` default can never fire: Option composes characters on macOS, so the browser reports `event.key` as `Â` rather than `m`. `Ctrl-m` is a no-op off macOS (where `defaultKeymap` already binds it) and restores the shortcut on macOS. Going through the registry means it's reboundable like every other editor command.

Indent width follows the existing **Tab size** setting, since `indentUnit` is already wired to it — so this inserts spaces, not `\t`, and nesting a list item respects the configured width.

### Tests

`command-registry.ts` had no test file, so this adds one covering the default keys and the override merge. The load-bearing case asserts no default binds `Alt-<letter>`, which encodes the macOS compose trap as an invariant rather than a comment. `Alt-<non-letter>` stays legal, so the existing `Alt-ArrowUp`/`Alt-ArrowDown` Extend/Shrink Selection bindings are unaffected.

`pnpm lint` clean (`tsc`, `svelte-check` 0 errors/0 warnings, `eslint .`). Full `pnpm test`: 5573 passed. One unrelated failure, `tests/main/compute/audit.test.ts`, times out only under full-suite parallel load and passes in isolation in 1.85s against a 5s limit — it's pre-existing on `main` and untouched here.

Verified by hand on macOS: Tab indents, Shift-Tab outdents, Tab still accepts a wiki-link completion, and `Ctrl-m` toggles cleanly between "Tab indents" and "Tab moves focus" with no stray character inserted.

### On intent

Happy to adjust or close this if it doesn't match the intended design — Tab-releases-focus is a legitimate accessibility default, and the keybinding registry has no settings UI wired to it yet, so I may be reading an intentional choice as an oversight. The macOS `Shift-Alt-m` half is a plain bug either way; the Tab-indents half is the opinionated part, and it's easy to drop if you'd rather keep Tab free.
