### PR TITLE
feat(inspections): surface source inspections + Mark-read / Resolve-stub fixes (#1446)

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -309,6 +309,8 @@ async function checkLongUnresolvedStubs(ctx: ProjectContext, thresholdDays: numb
       nodeLabel: label,
       message: `Stub "${label}" has been unresolved since ${r.modified!.split('T')[0]}.`,
       suggestedAction: 'Right-click the source and run "Resolve to full source", or hand-edit meta.ttl.',
+      // Deterministic quick-fix (#1446): resolve the stub against CrossRef.
+      fix: { kind: 'resolve-source-stub', label: 'Resolve source', sourceId: r.sourceId! },
     };
   });
 }
@@ -344,6 +346,8 @@ async function checkCitedUnreadSources(ctx: ProjectContext): Promise<Inspection[
       nodeLabel: label,
       message: `"${label}" is cited ${count === 1 ? 'once' : `${count} times`} but you haven't marked it Reading or Read.`,
       suggestedAction: 'Open the source and set its reading status, or right-click → Mark reading.',
+      // Deterministic quick-fix (#1446): mark the cited source read.
+      fix: { kind: 'set-read-status', label: 'Mark read', sourceId: r.sourceId!, status: 'read' },
     };
   });
 }

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -23,6 +23,7 @@
   import { savedViewsStore } from './lib/stores/saved-views.svelte';
   import { getBusyStore } from './lib/stores/busy.svelte';
   import { getClipboardStore } from './lib/stores/clipboard.svelte';
+  import { getSourceDataStore } from './lib/stores/source-data.svelte';
   import { getSourceFlowStore } from './lib/stores/source-flow.svelte';
   import { getRefactorFlowStore } from './lib/stores/refactor-flow.svelte';
   import { createNoteOps, type NoteOpsCtx } from './lib/app/note-ops';
@@ -721,10 +722,22 @@
   } = createNoteOps(noteOpsCtx);
 
   /** Apply an inspection's deterministic quick-fix (#1446). Maps the fix kind
-   *  to its note-ops handler; conversation is only the panel's fallback for
-   *  inspections that carry no fix. */
-  function applyInspectionFix(fix: InspectionFix) {
-    if (fix.kind === 'create-note') void createNoteFromReference(fix.targetPath);
+   *  to its store / ops handler (the mutation never lives in the panel);
+   *  conversation is only the panel's fallback for inspections with no fix. The
+   *  returned promise lets the panel re-run the checks once the fix has applied.
+   */
+  async function applyInspectionFix(fix: InspectionFix): Promise<void> {
+    switch (fix.kind) {
+      case 'create-note':
+        await createNoteFromReference(fix.targetPath);
+        break;
+      case 'set-read-status':
+        await getSourceDataStore().setReadStatus(fix.sourceId, fix.status);
+        break;
+      case 'resolve-source-stub':
+        await handleResolveStub(fix.sourceId);
+        break;
+    }
   }
 
   // Nav-ops + source-view-ops handler cluster (#670): position history

--- a/src/renderer/lib/components/RightSidebar.svelte
+++ b/src/renderer/lib/components/RightSidebar.svelte
@@ -106,8 +106,9 @@
     onScrollToLine: (line: number) => void;
     onOpenConversation?: (message: string) => void;
     /** Apply an inspection's deterministic quick-fix (#1446). Routed to the
-     *  Inspections panel; App owns the note-ops mutation it triggers. */
-    onApplyInspectionFix?: (fix: InspectionFix) => void;
+     *  Inspections panel; App owns the store/ops mutation it triggers. Returns a
+     *  promise so the panel can re-run the checks once the fix has applied. */
+    onApplyInspectionFix?: (fix: InspectionFix) => void | Promise<void>;
     onOpenQuery: (sql: string) => void;
     onOpenSource: (sourceId: string) => void;
     onOpenExcerpt: (excerptId: string) => void;

--- a/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/InspectionsPanel.svelte
@@ -27,8 +27,9 @@
     onOpenConversation?: (message: string) => void;
     /** Apply an inspection's deterministic quick-fix (#1446). When present on a
      *  row, it's the primary action — conversation is only the fallback for
-     *  inspections that carry no fix. */
-    onApplyFix?: (fix: InspectionFix) => void;
+     *  inspections that carry no fix. Returns a promise so the panel can re-run
+     *  the checks once the fix has applied and clear the fixed row. */
+    onApplyFix?: (fix: InspectionFix) => void | Promise<void>;
   }
 
   let { revision, activeFilePath, onOpenConversation, onApplyFix }: Props = $props();
@@ -37,6 +38,10 @@
   let loading = $state(false);
   let search = $state('');
   let sortId = $state<'severity' | 'type'>('severity');
+  // Scope (#1446): 'note' (default) keeps the note-context filter; 'project'
+  // shows every inspection — the only way source-scoped inspections (unread
+  // sources, aged stubs, dupes) surface, since they aren't anchored to a note.
+  let scope = $state<'note' | 'project'>('note');
 
   async function refresh() {
     loading = true;
@@ -54,18 +59,20 @@
 
   $effect(() => { revision; void refresh(); });
 
-  // Scope to the active note (#1446): the panel lives in the note-context right
-  // sidebar, so it shows only inspections anchored to the open note, not the
-  // whole project. Inspections without a notePath (source dupes/metadata,
-  // standalone claim components) aren't "on" a note and are excluded.
-  const noteScoped = $derived(
-    activeFilePath ? inspections.filter(i => i.notePath === activeFilePath) : [],
+  // Scope to the active note (#1446): in 'note' scope the panel lives in the
+  // note-context right sidebar, so it shows only inspections anchored to the
+  // open note (those without a notePath — source dupes/metadata, standalone
+  // claim components — aren't "on" a note). 'project' scope shows everything.
+  const scoped = $derived(
+    scope === 'project'
+      ? inspections
+      : (activeFilePath ? inspections.filter(i => i.notePath === activeFilePath) : []),
   );
 
   const filtered = $derived(() => {
     const q = search.trim().toLowerCase();
-    if (!q) return noteScoped;
-    return noteScoped.filter(i =>
+    if (!q) return scoped;
+    return scoped.filter(i =>
       i.nodeLabel.toLowerCase().includes(q) ||
       i.message.toLowerCase().includes(q) ||
       i.type.toLowerCase().includes(q)
@@ -92,11 +99,14 @@
     return '\u00B7'; // ·
   }
 
-  function handleClick(inspection: Inspection) {
+  async function handleClick(inspection: Inspection) {
     // Deterministic-first (#1446): a fixable inspection applies its fix; only
     // inspections with no fix fall back to opening a conversation.
     if (inspection.fix) {
-      onApplyFix?.(inspection.fix);
+      // Re-run the checks after the fix applies so the fixed row clears — the
+      // main-side results are cached and aren't recomputed on a graph write.
+      await onApplyFix?.(inspection.fix);
+      void runNow();
       return;
     }
     if (onOpenConversation) {
@@ -118,9 +128,10 @@
     onSort={(id: string) => { sortId = id as 'severity' | 'type'; }}
   />
   <div class="panel-header">
-    <span class="count">
-      {filtered().length} inspection{filtered().length !== 1 ? 's' : ''}
-    </span>
+    <div class="scope-toggle" role="group" aria-label="Inspection scope">
+      <button class:active={scope === 'note'} onclick={() => { scope = 'note'; }} title="Inspections on the current note">This note</button>
+      <button class:active={scope === 'project'} onclick={() => { scope = 'project'; }} title="Every inspection in the thoughtbase, including source-level ones">Project</button>
+    </div>
     <button class="refresh-btn" onclick={runNow} disabled={loading} title="Re-run health checks">
       {loading ? '...' : 'Run'}
     </button>
@@ -131,7 +142,7 @@
        conversation fallback. The row is a single button, so the pill is a
        non-interactive span (no nested interactive element). -->
   {#snippet row(insp: Inspection)}
-    <button class="inspection-item {insp.severity}" onclick={() => handleClick(insp)} title={insp.fix ? insp.fix.label : (insp.suggestedAction ?? '')}>
+    <button class="inspection-item {insp.severity}" onclick={() => void handleClick(insp)} title={insp.fix ? insp.fix.label : (insp.suggestedAction ?? '')}>
       <span class="insp-icon">{severityIcon(insp.severity)}</span>
       <div class="insp-body">
         <span class="insp-label">{insp.nodeLabel}</span>
@@ -142,7 +153,7 @@
   {/snippet}
 
   {#if filtered().length === 0}
-    <p class="empty">{loading ? 'Checking...' : (noteScoped.length === 0 ? 'No inspections for this note' : 'No matches')}</p>
+    <p class="empty">{loading ? 'Checking...' : (scoped.length === 0 ? (scope === 'project' ? 'No inspections' : 'No inspections for this note') : 'No matches')}</p>
   {:else if sortId === 'type'}
     <div class="inspection-list">
       {#each byType() as [typeName, items]}
@@ -201,9 +212,26 @@
     flex-shrink: 0;
   }
 
-  .count {
-    font-size: 11px;
+  /* Segmented This note / Project scope switch (#1446). */
+  .scope-toggle {
+    display: inline-flex;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .scope-toggle button {
+    padding: 2px 8px;
+    border: none;
+    background: none;
     color: var(--text-muted);
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .scope-toggle button:first-child { border-right: 1px solid var(--border); }
+  .scope-toggle button:hover { color: var(--text); }
+  .scope-toggle button.active {
+    background: var(--bg-button);
+    color: var(--text);
   }
 
   .refresh-btn {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,9 +7,16 @@
  *   `targetPath` (a project-relative `.md` path the check already resolved,
  *   e.g. beside the referencing note). Applied via `note-ops`
  *   `createNoteFromReference`.
+ * - `set-read-status` — set a source's `minerva:readStatus` (e.g. mark a cited
+ *   but unread source as read). Applied via the source-data store.
+ * - `resolve-source-stub` — resolve an aged unresolved source stub against
+ *   CrossRef. Applied via `source-ops` `handleResolveStub` (auto-applies a
+ *   confident match, else opens the picker).
  */
 export type InspectionFix =
-  | { kind: 'create-note'; label: string; targetPath: string };
+  | { kind: 'create-note'; label: string; targetPath: string }
+  | { kind: 'set-read-status'; label: string; sourceId: string; status: ReadStatus }
+  | { kind: 'resolve-source-stub'; label: string; sourceId: string };
 
 export interface NoteFile {
   name: string;

--- a/tests/main/graph/source-health-checks.test.ts
+++ b/tests/main/graph/source-health-checks.test.ts
@@ -91,6 +91,8 @@ describe('source health checks (#119)', () => {
     const aged = inspections.filter((i) => i.type === 'stub_aged');
     expect(aged).toHaveLength(1);
     expect(aged[0].message).toContain('Aged stub');
+    // Deterministic quick-fix: resolve the stub against CrossRef (#1446).
+    expect(aged[0].fix).toEqual({ kind: 'resolve-source-stub', label: 'Resolve source', sourceId: 'aged-stub' });
   });
 
   it('does not flag freshly-created stubs', async () => {
@@ -112,6 +114,8 @@ describe('source health checks (#119)', () => {
     const flagged = inspections.filter((i) => i.type === 'source_cited_unread');
     expect(flagged).toHaveLength(1);
     expect(flagged[0].nodeLabel).toBe('Cited paper');
+    // Deterministic quick-fix: mark the cited source read (#1446).
+    expect(flagged[0].fix).toEqual({ kind: 'set-read-status', label: 'Mark read', sourceId: 'cited-paper', status: 'read' });
   });
 
   it('does not flag a cited source that\'s marked reading', async () => {


### PR DESCRIPTION
## What

#1728 scoped the Inspections panel to the active note — which hid **source-level** inspections entirely (they have no `notePath`, and the panel is the only inspections surface). This brings them back and gives the two cleanly-deterministic ones quick-fixes.

- **Scope toggle** in the panel header: **This note** (default — keeps #1728's behavior) | **Project** (every inspection, including source-level).
- Two new `InspectionFix` kinds (carry `sourceId`): `set-read-status`, `resolve-source-stub`.
- Fixes attached in `health-checks`:
  - `source_cited_unread` → **Mark read** → source-data store `setReadStatus(id, 'read')`.
  - `stub_aged` → **Resolve source** → the existing `handleResolveStub(id)` op (auto-applies a confident CrossRef match, else opens the picker).

## Row refresh (also fixes a create-note papercut)

The main-side results are **cached** and aren't recomputed on a graph write, so applying a fix didn't clear its row. `onApplyFix` now returns a promise and the panel **re-runs the checks** once it resolves. This also fixes the pre-existing case where create-note left its `broken_note_link` row visible until the next timer/Run.

## Deliberately deferred
- **Duplicates → Merge** (`source_duplicate_doi`/`_uri`): `merge(src, dest)` exists, but picking the canonical of a dup group is a user choice, not deterministic — needs a target picker.
- `source_missing_metadata` / `invalid_doi`: remedy is hand-editing meta.ttl — no deterministic fix; they show in Project scope with the conversation fallback.

## Testing
- `pnpm lint` clean; full `pnpm test` — 5573 pass.
- `source_cited_unread` carries the `set-read-status` fix (right `sourceId`); `stub_aged` carries `resolve-source-stub`.
- **Manual (dev):** in a base with an unread cited source + an aged stub → switch panel to **Project** → both appear; **Mark read** clears the unread row; **Resolve source** runs CrossRef. Back on **This note**, only the active note's inspections show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)