### PR TITLE
feat(inspections): duplicates-merge quick-fix with a keep-picker (#1446)

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -385,6 +385,8 @@ async function checkDuplicateSources(ctx: ProjectContext): Promise<Inspection[]>
       nodeLabel: ids[0] ?? r.keyDoi!,
       message: `Duplicate DOI ${r.keyDoi}: ${ids.length} sources (${ids.join(', ')}).`,
       suggestedAction: 'Right-click one and choose "Merge into…" to consolidate.',
+      // Quick-fix (#1446): pick which duplicate to keep, merge the rest into it.
+      fix: { kind: 'merge-sources', label: 'Merge…', sourceIds: ids },
     });
   }
 
@@ -411,6 +413,8 @@ async function checkDuplicateSources(ctx: ProjectContext): Promise<Inspection[]>
       nodeLabel: ids[0] ?? r.keyUri!,
       message: `Duplicate URL ${r.keyUri}: ${ids.length} sources (${ids.join(', ')}).`,
       suggestedAction: 'Right-click one and choose "Merge into…" to consolidate.',
+      // Quick-fix (#1446): pick which duplicate to keep, merge the rest into it.
+      fix: { kind: 'merge-sources', label: 'Merge…', sourceIds: ids },
     });
   }
 

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -737,6 +737,28 @@
       case 'resolve-source-stub':
         await handleResolveStub(fix.sourceId);
         break;
+      case 'merge-sources': {
+        // Pick which duplicate to keep, then merge the rest into it. Not a
+        // silent fix — the canonical source is the user's choice.
+        const dupes = sourcesCache.filter((s) => fix.sourceIds.includes(s.sourceId));
+        if (dupes.length < 2) break;
+        const keepId = await dialogs.showMergeSourcesPicker(dupes);
+        if (!keepId) break;
+        const sd = getSourceDataStore();
+        for (const other of fix.sourceIds) {
+          if (other === keepId) continue;
+          try {
+            await sd.merge(other, keepId);
+          } catch (err) {
+            await showConfirm(
+              `Couldn't merge "${other}": ${err instanceof Error ? err.message : String(err)}`,
+              CONFIRM_KEYS.mergeSourcesFailed,
+              'OK',
+            );
+          }
+        }
+        break;
+      }
     }
   }
 

--- a/src/renderer/lib/components/DialogHost.svelte
+++ b/src/renderer/lib/components/DialogHost.svelte
@@ -9,6 +9,7 @@
   import NewNoteDialog from './NewNoteDialog.svelte';
   import SnippetPickerDialog from './SnippetPickerDialog.svelte';
   import TypePickerDialog from './TypePickerDialog.svelte';
+  import MergeSourcesDialog from './MergeSourcesDialog.svelte';
   import ConfirmDialog from './ConfirmDialog.svelte';
   import OpenTargetDialog from './OpenTargetDialog.svelte';
   import AddPropertyDialog from './AddPropertyDialog.svelte';
@@ -49,6 +50,14 @@
     types={dialogs.typePicker.types}
     onPick={(t) => dialogs.pickType(t)}
     onCancel={() => dialogs.cancelTypePicker()}
+  />
+{/if}
+
+{#if dialogs.mergeSources}
+  <MergeSourcesDialog
+    sources={dialogs.mergeSources.sources}
+    onPick={(keepId) => dialogs.pickMergeSource(keepId)}
+    onCancel={() => dialogs.cancelMergeSources()}
   />
 {/if}
 

--- a/src/renderer/lib/components/MergeSourcesDialog.svelte
+++ b/src/renderer/lib/components/MergeSourcesDialog.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  /**
+   * Duplicate-source merge picker (#1446). Several sources share a DOI/URL; the
+   * user chooses which one to KEEP and the rest are merged into it. Modeled on
+   * TypePickerDialog. Merging isn't a silent deterministic fix — which source is
+   * canonical is a judgment call, so we ask.
+   */
+  import type { SourceMetadata } from '../../../shared/types';
+  import { displaySourceTitle } from '../../../shared/source-display';
+
+  interface Props {
+    sources: SourceMetadata[];
+    /** The kept source's id; the caller merges the others into it. */
+    onPick: (keepId: string) => void;
+    onCancel: () => void;
+  }
+
+  let { sources, onPick, onCancel }: Props = $props();
+
+  let selectedIndex = $state(0);
+  let dialogEl = $state<HTMLDivElement>();
+
+  $effect(() => { dialogEl?.focus(); });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectedIndex = (selectedIndex + 1) % sources.length;
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectedIndex = (selectedIndex - 1 + sources.length) % sources.length;
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const pick = sources[selectedIndex];
+      if (pick) onPick(pick.sourceId);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onCancel();
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="overlay" onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <div class="dialog" role="dialog" aria-modal="true" tabindex="-1" bind:this={dialogEl} onkeydown={handleKeydown}>
+    <header class="card-header">
+      <div class="eyebrow">Merge duplicates</div>
+      <h2 class="title">Which source should be kept?</h2>
+      <p class="subtitle">The other {sources.length - 1} will be merged into it — their excerpts and citations move over, then they're removed.</p>
+    </header>
+
+    <div class="body">
+      <div class="ms-results" role="listbox" aria-label="Duplicate sources">
+        {#each sources as s, i (s.sourceId)}
+          {@const selected = i === selectedIndex}
+          <button
+            type="button"
+            class="ms-row"
+            class:selected
+            role="option"
+            aria-selected={selected}
+            onmousemove={() => { selectedIndex = i; }}
+            onclick={() => onPick(s.sourceId)}
+          >
+            <span class="ms-dot" aria-hidden="true">{selected ? '●' : '○'}</span>
+            <span class="ms-body">
+              <span class="ms-name">{displaySourceTitle(s)}</span>
+              <span class="ms-id">{s.sourceId}</span>
+            </span>
+            {#if selected}<span class="ms-keep">keep</span>{/if}
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    <footer class="card-footer">
+      <span class="kbd-hint">esc · cancel · ↑↓ · ↵ merge others in</span>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(20, 14, 6, 0.5);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+  }
+  .dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: 12px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
+    width: 460px;
+    max-width: 100%;
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-sans);
+    color: var(--text);
+    overflow: hidden;
+    outline: none;
+  }
+  .card-header { padding: 18px 22px 0; }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--text-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 5px;
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--text);
+  }
+  .subtitle { margin: 6px 0 0; font-size: 12px; color: var(--text-muted); line-height: 1.4; }
+  .body { padding: 14px 22px 16px; }
+  .ms-results {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-height: 320px;
+    overflow-y: auto;
+  }
+  .ms-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+  .ms-row.selected { background: color-mix(in oklch, var(--accent) 14%, transparent); color: var(--accent); }
+  .ms-dot { width: 14px; font-size: 12px; line-height: 1; text-align: center; flex-shrink: 0; }
+  .ms-body { display: flex; flex-direction: column; gap: 1px; overflow: hidden; flex: 1; }
+  .ms-name { font-size: 13px; font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ms-id { font-family: var(--font-mono); font-size: 10px; color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ms-keep {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--accent);
+    flex-shrink: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .card-footer {
+    display: flex;
+    align-items: center;
+    padding: 10px 18px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+  }
+  .kbd-hint { font-size: 10.5px; color: var(--text-faint); font-family: var(--font-mono); }
+</style>

--- a/src/renderer/lib/confirm-keys.ts
+++ b/src/renderer/lib/confirm-keys.ts
@@ -87,6 +87,8 @@ export const CONFIRM_KEYS = {
   mergeNote: 'merge-note',
   /** Surfaced when the merge IPC throws after the user confirmed (rare). */
   mergeFailed: 'merge-failed',
+  /** Surfaced when a duplicate-source merge (inspection quick-fix) fails (#1446). */
+  mergeSourcesFailed: 'merge-sources-failed',
   bibliographyResult: 'bibliography-result',
   bibliographyFailed: 'bibliography-failed',
   /** Shown when an LLM-backed action runs without an Anthropic API key
@@ -398,6 +400,12 @@ export const CONFIRM_REGISTRY: ConfirmRegistryEntry[] = [
     title: 'Merge note failed',
     description:
       'Shown when "Merge note into…" errors out after the user confirmed — read failure, write failure mid-rewrite, etc. Recovery is `git reset --hard HEAD`.',
+  },
+  {
+    key: CONFIRM_KEYS.mergeSourcesFailed,
+    title: 'Merge sources failed',
+    description:
+      'Shown when the duplicate-source merge quick-fix (Inspections panel, #1446) fails to merge one of the duplicates into the kept source.',
   },
   {
     key: CONFIRM_KEYS.bibliographyResult,

--- a/src/renderer/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/lib/stores/dialogs.svelte.ts
@@ -17,6 +17,7 @@ import { getConfirmSuppressionStore } from './confirm-suppression.svelte';
 import type { NoteExt, NewNoteResult } from '../components/new-note-dialog-types';
 import type { TemplateInfo } from '../ipc/client';
 import type { TypeInfo } from '../../../shared/objects/type-def';
+import type { SourceMetadata } from '../../../shared/types';
 
 export interface PromptState {
   message: string;
@@ -73,10 +74,18 @@ export interface TypePickerState {
   resolve: (value: TypeInfo | null) => void;
 }
 
+/** Duplicate-source merge picker (#1446): choose which of the duplicates to
+ *  keep; resolves to its sourceId, or null on cancel. */
+export interface MergeSourcesState {
+  sources: SourceMetadata[];
+  resolve: (keepId: string | null) => void;
+}
+
 let prompt = $state<PromptState | null>(null);
 let newNote = $state<NewNoteState | null>(null);
 let snippet = $state<SnippetPickerState | null>(null);
 let typePicker = $state<TypePickerState | null>(null);
+let mergeSources = $state<MergeSourcesState | null>(null);
 let confirm = $state<ConfirmState | null>(null);
 let computeConsent = $state<ComputeConsentState | null>(null);
 let openTarget = $state<OpenTargetState | null>(null);
@@ -170,6 +179,13 @@ export function getDialogStore() {
   function pickType(t: TypeInfo) { const r = typePicker?.resolve; typePicker = null; r?.(t); }
   function cancelTypePicker() { const r = typePicker?.resolve; typePicker = null; r?.(null); }
 
+  /** Show the duplicate-source merge picker; resolves to the kept sourceId (#1446). */
+  function showMergeSourcesPicker(sources: SourceMetadata[]): Promise<string | null> {
+    return new Promise((resolve) => { mergeSources = { sources, resolve }; });
+  }
+  function pickMergeSource(keepId: string) { const r = mergeSources?.resolve; mergeSources = null; r?.(keepId); }
+  function cancelMergeSources() { const r = mergeSources?.resolve; mergeSources = null; r?.(null); }
+
   function confirmConfirm(dontAskAgain: boolean) {
     if (dontAskAgain && confirm) confirmSuppression.suppress(confirm.key);
     confirm?.resolve(true);
@@ -189,6 +205,7 @@ export function getDialogStore() {
     get newNote() { return newNote; },
     get snippet() { return snippet; },
     get typePicker() { return typePicker; },
+    get mergeSources() { return mergeSources; },
     get confirm() { return confirm; },
     get computeConsent() { return computeConsent; },
     get openTarget() { return openTarget; },
@@ -211,6 +228,9 @@ export function getDialogStore() {
     showTypePicker,
     pickType,
     cancelTypePicker,
+    showMergeSourcesPicker,
+    pickMergeSource,
+    cancelMergeSources,
     confirmConfirm,
     cancelConfirm,
     resolveOpenTarget,
@@ -225,6 +245,7 @@ export function __resetDialogsForTests(): void {
   newNote = null;
   snippet = null;
   typePicker = null;
+  mergeSources = null;
   confirm = null;
   openTarget = null;
   addProperty = null;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,11 +12,15 @@
  * - `resolve-source-stub` — resolve an aged unresolved source stub against
  *   CrossRef. Applied via `source-ops` `handleResolveStub` (auto-applies a
  *   confident match, else opens the picker).
+ * - `merge-sources` — several sources share a DOI/URL; `sourceIds` are the
+ *   duplicates. Opens a picker to choose which to keep, then merges the rest
+ *   into it (not deterministic-silent — the canonical is the user's choice).
  */
 export type InspectionFix =
   | { kind: 'create-note'; label: string; targetPath: string }
   | { kind: 'set-read-status'; label: string; sourceId: string; status: ReadStatus }
-  | { kind: 'resolve-source-stub'; label: string; sourceId: string };
+  | { kind: 'resolve-source-stub'; label: string; sourceId: string }
+  | { kind: 'merge-sources'; label: string; sourceIds: string[] };
 
 export interface NoteFile {
   name: string;

--- a/tests/main/graph/source-health-checks.test.ts
+++ b/tests/main/graph/source-health-checks.test.ts
@@ -150,6 +150,9 @@ describe('source health checks (#119)', () => {
     expect(dup).toHaveLength(1);
     expect(dup[0].message).toContain('dup-a');
     expect(dup[0].message).toContain('dup-b');
+    // Merge quick-fix carries every duplicate id so the picker can offer them (#1446).
+    expect(dup[0].fix?.kind).toBe('merge-sources');
+    expect(dup[0].fix && 'sourceIds' in dup[0].fix ? [...dup[0].fix.sourceIds].sort() : []).toEqual(['dup-a', 'dup-b']);
   });
 
   it('flags two sources sharing the same URL (trailing-slash normalised)', async () => {


### PR DESCRIPTION
## What

`source_duplicate_doi` / `source_duplicate_uri` inspections now carry a **Merge…** quick-fix. Clicking it opens a picker of the duplicate sources; the user chooses which one to **keep** and the rest are merged into it.

Merge isn't a silent deterministic fix — which source is canonical is a judgment call — so unlike Mark-read/Resolve-stub, this one asks. That's the "with a picker" part.

## How

- **`InspectionFix`**: new `merge-sources` kind carrying every duplicate `sourceId` in the group.
- **`health-checks`**: both dup checks attach the fix with the group's ids (the check already GROUP_CONCATs them).
- **`MergeSourcesDialog.svelte`**: a keyboard-nav keep-picker (↑/↓/Enter/Esc), modeled on `TypePickerDialog`, wired through the dialogs store's existing promise-picker pattern (`showMergeSourcesPicker`) + `DialogHost`.
- **`App.applyInspectionFix`**: `merge-sources` → picker → merge each *other* id into the kept one via the source-data store (`merge(other, keepId)`), with per-item failure surfaced.

The panel re-runs the checks after the fix resolves (the #1735 flow), so once merged the duplicate row clears.

## Testing
- `pnpm lint` clean; full `pnpm test` — 5573 pass.
- The dup inspection carries the `merge-sources` fix with all group ids; added the `CONFIRM_REGISTRY` entry for the new merge-failure key (the registry-parity test caught it).
- **Manual (dev):** two sources sharing a DOI → panel **Project** scope → the dup shows a **Merge…** pill → pick which to keep → the others merge in and the row clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)