### PR TITLE
feat(inspections): remove-anchor quick-fix for broken_anchor_link (#1446)

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -631,6 +631,16 @@ function inspectionForBrokenLink(
           notePath: row.sourcePath,
           message: `Note "${row.sourcePath}" links to a missing heading: [[${stem}#${classified.anchor}]]`,
           suggestedAction: 'Add the heading to the target note, fix the anchor slug, or remove the `#…` part.',
+          // Deterministic quick-fix (#1446): drop the broken `#heading` so the
+          // link points at the note itself. targetPath is the resolved note;
+          // classified.anchor is the (slugified) missing heading.
+          fix: {
+            kind: 'remove-anchor',
+            label: 'Remove anchor',
+            notePath: row.sourcePath,
+            targetPath: realPath,
+            anchor: classified.anchor,
+          },
         };
       }
     }

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -716,7 +716,7 @@
     openTypeEditor: (initial, promoteNotePath) => { typeEditorState = { initial, promoteNotePath }; },
   };
   const {
-    handleNewNote, createNoteFromReference, handleInlineTypeCreate, handlePromoteToType, handleSaveNoteAsObjectType, handleNewFolder, handleDelete, openFirstReferenceFromSafeDelete,
+    handleNewNote, createNoteFromReference, removeBrokenAnchor, handleInlineTypeCreate, handlePromoteToType, handleSaveNoteAsObjectType, handleNewFolder, handleDelete, openFirstReferenceFromSafeDelete,
     handleCut, handleCopy, handleMove, handlePaste, handleMerge, performMerge,
     handleRename, handleCopyWithPrompt, handleMoveWithPrompt,
   } = createNoteOps(noteOpsCtx);
@@ -736,6 +736,9 @@
         break;
       case 'resolve-source-stub':
         await handleResolveStub(fix.sourceId);
+        break;
+      case 'remove-anchor':
+        await removeBrokenAnchor(fix.notePath, fix.targetPath, fix.anchor);
         break;
       case 'merge-sources': {
         // Pick which duplicate to keep, then merge the rest into it. Not a

--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -16,6 +16,7 @@ import { getClipboardStore } from '../stores/clipboard.svelte';
 import { resolveSelectionTargets, expandSelectionToNoteFiles, pathExistsInTree } from '../sidebar-tree-utils';
 import { describeDeleteNoun, describeDeleteMessage, offsetToLineCol, flattenNotePaths, formatCappedList, type OperationFailure } from './text-helpers';
 import { resolveWikiLinkTarget } from '../../../shared/wiki-link-resolver';
+import { removeBrokenAnchorLinks } from '../../../shared/refactor/remove-broken-anchor';
 import { setFrontmatterProperty, getFrontmatterValues } from '../../../shared/frontmatter-edit';
 import { deriveTypeProperties } from '../../../shared/objects/derive-type';
 import type { TypeInfo, PropertyDef } from '../../../shared/objects/type-def';
@@ -130,6 +131,28 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     await openNoteRecordingHistory(relativePath, getOffset);
     ctx.getSidebar()?.refreshTags();
     ctx.getSidebar()?.refreshObjects?.();
+  }
+
+  /**
+   * broken_anchor_link quick-fix (#1446): strip the missing `#heading` from
+   * links in `notePath` that resolve to `targetPath`. Edits the live editor
+   * buffer when the referencing note is open (auto-saves + re-indexes), else
+   * writes to disk. `anchor` is the slugified missing heading.
+   */
+  async function removeBrokenAnchor(notePath: string, targetPath: string, anchor: string) {
+    if (!notebase.meta) return;
+    const files = flattenNotePaths(notebase.files).map((relativePath) => ({ relativePath, isDirectory: false }));
+    if (notePath === editor.activeFilePath) {
+      const next = removeBrokenAnchorLinks(editor.content, files, undefined, targetPath, anchor);
+      if (next !== editor.content) editor.setContent(next);
+      return;
+    }
+    const content = await api.notebase.readFile(notePath);
+    const next = removeBrokenAnchorLinks(content, files, undefined, targetPath, anchor);
+    if (next !== content) {
+      await api.notebase.writeFile(notePath, next);
+      await notebase.refresh();
+    }
   }
 
   /**
@@ -620,5 +643,5 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     await handleMove(relativePath, destDir);
   }
 
-  return { handleNewNote, createNoteFromReference, handleInlineTypeCreate, handlePromoteToType, handleSaveNoteAsObjectType, handleNewFolder, handleDelete, executeDeletes, openFirstReferenceFromSafeDelete, handleCut, handleCopy, handleMove, handlePaste, handleMerge, performMerge, handleRename, handleCopyWithPrompt, handleMoveWithPrompt };
+  return { handleNewNote, createNoteFromReference, removeBrokenAnchor, handleInlineTypeCreate, handlePromoteToType, handleSaveNoteAsObjectType, handleNewFolder, handleDelete, executeDeletes, openFirstReferenceFromSafeDelete, handleCut, handleCopy, handleMove, handlePaste, handleMerge, performMerge, handleRename, handleCopyWithPrompt, handleMoveWithPrompt };
 }

--- a/src/shared/refactor/remove-broken-anchor.ts
+++ b/src/shared/refactor/remove-broken-anchor.ts
@@ -1,0 +1,34 @@
+/**
+ * Strip a broken heading anchor from wiki-links (#1446 — the broken_anchor_link
+ * quick-fix). `[[note#missing-heading]]` → `[[note]]`, so the link resolves to
+ * the note itself instead of a heading that doesn't exist.
+ *
+ * Only links that actually resolve to `targetPath` AND whose anchor slugifies to
+ * `anchorSlug` are touched — so a `#intro` that's broken on note A never strips
+ * a valid `#intro` on note B. Type prefix and display text are preserved.
+ */
+import { WIKI_LINK_RE, parseWikiInner, reassembleWikiLink } from '../wiki-link';
+import { resolveWikiLinkTarget, type NoteFileLike } from '../wiki-link-resolver';
+import { getLinkType } from '../link-types';
+import { slugify } from '../slug';
+
+export function removeBrokenAnchorLinks(
+  content: string,
+  files: NoteFileLike[],
+  aliases: Record<string, string> | undefined,
+  targetPath: string,
+  anchorSlug: string,
+): string {
+  return content.replace(WIKI_LINK_RE, (whole, inner: string) => {
+    const p = parseWikiInner(inner);
+    if (!p.anchor) return whole;
+    // `p.anchor` keeps its leading '#'; the inspection's anchor is already a slug.
+    const raw = p.anchor.slice(1);
+    if (raw.startsWith('^')) return whole; // block-id, not a heading
+    if (slugify(raw) !== anchorSlug) return whole;
+    // cite:: / quote:: target sources / excerpts, not notes — leave them.
+    if (p.type && getLinkType(p.type).targetKind !== undefined) return whole;
+    if (resolveWikiLinkTarget(p.target, files, aliases) !== targetPath) return whole;
+    return reassembleWikiLink({ ...p, anchor: null }, p.target);
+  });
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,12 +15,17 @@
  * - `merge-sources` — several sources share a DOI/URL; `sourceIds` are the
  *   duplicates. Opens a picker to choose which to keep, then merges the rest
  *   into it (not deterministic-silent — the canonical is the user's choice).
+ * - `remove-anchor` — a `[[note#heading]]` whose heading is missing; strip the
+ *   `#heading` in `notePath` (the referencing note) from links that resolve to
+ *   `targetPath` and whose anchor slug is `anchor`, so the link points at the
+ *   note itself. Applied via `note-ops`.
  */
 export type InspectionFix =
   | { kind: 'create-note'; label: string; targetPath: string }
   | { kind: 'set-read-status'; label: string; sourceId: string; status: ReadStatus }
   | { kind: 'resolve-source-stub'; label: string; sourceId: string }
-  | { kind: 'merge-sources'; label: string; sourceIds: string[] };
+  | { kind: 'merge-sources'; label: string; sourceIds: string[] }
+  | { kind: 'remove-anchor'; label: string; notePath: string; targetPath: string; anchor: string };
 
 export interface NoteFile {
   name: string;

--- a/src/shared/wiki-link-resolver.ts
+++ b/src/shared/wiki-link-resolver.ts
@@ -41,7 +41,7 @@ export function flattenNoteFiles(tree: NoteFile[]): NoteFile[] {
 const slug = (s: string): string =>
   s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 
-type NoteFileLike = Pick<NoteFile, 'relativePath' | 'isDirectory'>;
+export type NoteFileLike = Pick<NoteFile, 'relativePath' | 'isDirectory'>;
 
 /** Note files only, sorted so a lower `noteExtRank` (`.md` = 0) comes first.
  *  `Array.prototype.sort` is stable, so files of the same extension keep their

--- a/tests/main/graph/broken-link-inspection.test.ts
+++ b/tests/main/graph/broken-link-inspection.test.ts
@@ -88,11 +88,17 @@ describe('broken-link inspection (#140)', () => {
     expect(broken.fix && 'targetPath' in broken.fix ? broken.fix.targetPath : null).toBe('topic/deep/Concept X.md');
   });
 
-  it('offers no create-note fix on a broken anchor link (the note exists)', async () => {
+  it('offers a remove-anchor fix on a broken anchor link (#1446)', async () => {
     await indexNote(ctx, 'target.md', '# Real heading\n\nbody\n');
     await indexNote(ctx, 'source.md', 'See [[target#missing-heading]]\n');
     const [broken] = (await runAllChecks(ctx)).filter((i) => i.type === 'broken_anchor_link');
-    expect(broken.fix).toBeUndefined();
+    expect(broken.fix).toEqual({
+      kind: 'remove-anchor',
+      label: 'Remove anchor',
+      notePath: 'source.md',
+      targetPath: 'target.md',
+      anchor: 'missing-heading',
+    });
   });
 
   // ─── broken anchor link ─────────────────────────────────────────────────

--- a/tests/shared/remove-broken-anchor.test.ts
+++ b/tests/shared/remove-broken-anchor.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { removeBrokenAnchorLinks } from '../../src/shared/refactor/remove-broken-anchor';
+
+const files = [
+  { relativePath: 'notes/topic/raft.md', isDirectory: false },
+  { relativePath: 'notes/other.md', isDirectory: false },
+];
+
+// Strip the broken `#consensus` anchor from links that resolve to raft.md.
+function strip(content: string): string {
+  return removeBrokenAnchorLinks(content, files, undefined, 'notes/topic/raft.md', 'consensus');
+}
+
+describe('removeBrokenAnchorLinks (#1446)', () => {
+  it('drops the anchor from a bare-basename link to the target note', () => {
+    expect(strip('see [[raft#consensus]] here')).toBe('see [[raft]] here');
+  });
+
+  it('drops the anchor from a full-path link', () => {
+    expect(strip('[[notes/topic/raft#consensus]]')).toBe('[[notes/topic/raft]]');
+  });
+
+  it('preserves display text and type prefix', () => {
+    expect(strip('[[raft#consensus|the paper]]')).toBe('[[raft|the paper]]');
+    expect(strip('[[supports::raft#consensus]]')).toBe('[[supports::raft]]');
+  });
+
+  it('matches the anchor by slug (raw heading text in the link)', () => {
+    // The link author wrote the human heading; the inspection anchor is a slug.
+    expect(strip('[[raft#Consensus]]')).toBe('[[raft]]');
+  });
+
+  it('leaves the same anchor on a DIFFERENT note untouched', () => {
+    expect(strip('[[other#consensus]]')).toBe('[[other#consensus]]');
+  });
+
+  it('leaves a different anchor on the target note untouched', () => {
+    expect(strip('[[raft#leader-election]]')).toBe('[[raft#leader-election]]');
+  });
+
+  it('leaves cite:: / quote:: links untouched', () => {
+    expect(strip('[[cite::raft#consensus]]')).toBe('[[cite::raft#consensus]]');
+  });
+
+  it('leaves block-id anchors untouched', () => {
+    expect(strip('[[raft#^blockid]]')).toBe('[[raft#^blockid]]');
+  });
+
+  it('strips every matching occurrence in the note', () => {
+    expect(strip('[[raft#consensus]] and again [[raft#consensus|x]]')).toBe('[[raft]] and again [[raft|x]]');
+  });
+
+  it('leaves anchorless links and non-target links alone', () => {
+    expect(strip('[[raft]] and [[other]] and text')).toBe('[[raft]] and [[other]] and text');
+  });
+});


### PR DESCRIPTION
## What

A `[[note#heading]]` whose heading is missing now offers a **Remove anchor** quick-fix — rewrite it to `[[note]]` so the link resolves to the note itself. This is one of the inspection's own suggested remedies ("remove the `#…` part"), and it's the cleanly-deterministic choice: it invents no content, unlike "add heading" (which would have to guess a heading level and de-slugify the anchor).

## How

- **`shared/refactor/remove-broken-anchor.ts`** — `removeBrokenAnchorLinks(content, files, aliases, targetPath, anchorSlug)`. Strips the `#heading` **only** from links that actually **resolve to `targetPath`** and whose anchor slugifies to `anchorSlug` — so a broken `#intro` on note A never strips a *valid* `#intro` on note B. Preserves the type prefix + display text; skips `cite::`/`quote::` and block-id (`#^`) anchors. Reuses `parseWikiInner` / `reassembleWikiLink` / `resolveWikiLinkTarget`.
- **`InspectionFix`**: new `remove-anchor` kind (`notePath`, `targetPath`, `anchor`).
- **`health-checks`**: the broken-anchor branch attaches the fix (`targetPath` = the resolved note, `anchor` = the slugified missing heading).
- **`note-ops.removeBrokenAnchor`**: edits the **live editor buffer** when the referencing note is open (auto-saves + re-indexes), else writes to disk.
- **`App.applyInspectionFix`**: `remove-anchor` branch. Panel re-runs after it resolves, so the row clears.

## Why resolution-aware matching

Link anchors are raw heading text (`[[raft#Consensus]]`) while the inspection anchor is a slug (`consensus`), and a link can use a short form (`[[raft]]` → `notes/topic/raft.md`). So the helper slugifies the link's anchor for comparison and resolves each link's target before matching — matching on plain string/regex would either miss short-form links or clobber same-named anchors on other notes.

## Testing
- `pnpm lint` clean; full `pnpm test` — 5583 pass.
- Pure-helper unit tests: bare/full-path/typed/display links; slug match on raw heading text; **other note untouched**, **other anchor untouched**, cite/quote + block-id skipped; all occurrences stripped.
- The `broken_anchor_link` inspection now carries the `remove-anchor` fix (updated the old #1724 "no fix" assertion).
- **Manual (dev):** `[[SomeNote#gone]]` → panel shows **Remove anchor** → click → link becomes `[[SomeNote]]`, row clears; a valid `#heading` elsewhere is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)