### PR TITLE
feat(editor): broken-link gutter stripe + hover lightbulb quick-fix (#1446)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -505,6 +505,9 @@
         getNotePaths: () => getNotePaths?.() ?? [],
         getAliases: () => getAliases?.() ?? [],
         readNote: (p) => api.notebase.readFile(p),
+        // Broken-link hover lightbulb (#1446). Wrapped in a closure (not a bare
+        // prop reference) so it stays current in the once-built extension list.
+        onCreateNoteFromReference: (target: string) => onCreateNoteFromReference?.(target),
       }),
       brokenLinkDecorations({
         getNotePaths: () => getNotePaths?.() ?? [],

--- a/src/renderer/lib/editor/broken-link-decorations.ts
+++ b/src/renderer/lib/editor/broken-link-decorations.ts
@@ -16,6 +16,8 @@ import {
   type ViewUpdate,
   Decoration,
   type DecorationSet,
+  gutter,
+  GutterMarker,
 } from '@codemirror/view';
 import { RangeSetBuilder, StateEffect, type EditorState } from '@codemirror/state';
 import { scanLinks, findLinkAt, type LinkRange } from './link-decorations';
@@ -123,7 +125,32 @@ const brokenLinkTheme = EditorView.theme({
     textDecorationSkipInk: 'none',
     textUnderlineOffset: '2px',
   },
+  // Gutter stripe column — no fixed width, so it disappears on clean notes.
+  '.cm-broken-gutter': { minWidth: '0' },
+  '.cm-broken-gutter .cm-gutterElement': { display: 'flex', justifyContent: 'center' },
+  '.cm-broken-line-bar': {
+    width: '3px',
+    alignSelf: 'stretch',
+    background: 'var(--rust)',
+    borderRadius: '1px',
+  },
 });
+
+/** IntelliJ-style gutter stripe: a thin `--rust` bar in its own column on any
+ *  line that carries a broken link. Rendered as a GutterMarker (see the theme
+ *  block for the bar styling). */
+class BrokenLineMarker extends GutterMarker {
+  override toDOM(): HTMLElement {
+    const el = document.createElement('div');
+    el.className = 'cm-broken-line-bar';
+    el.title = 'Broken link on this line';
+    return el;
+  }
+  override eq(other: GutterMarker): boolean {
+    return other instanceof BrokenLineMarker;
+  }
+}
+const brokenLineMarker = new BrokenLineMarker();
 
 export function brokenLinkDecorations(deps: BrokenLinkDeps) {
   const plugin = ViewPlugin.fromClass(
@@ -152,5 +179,26 @@ export function brokenLinkDecorations(deps: BrokenLinkDeps) {
     },
     { decorations: (v) => v.decorations },
   );
-  return [plugin, brokenLinkTheme];
+
+  // Gutter reads the plugin's live broken-link decorations — no separate scan.
+  // The column collapses to nothing when a note has no broken links (no spacer).
+  const brokenGutter = gutter({
+    class: 'cm-broken-gutter',
+    lineMarker(view, line) {
+      const inst = view.plugin(plugin);
+      if (!inst || inst.decorations.size === 0) return null;
+      let has = false;
+      inst.decorations.between(line.from, line.to, () => { has = true; return false; });
+      return has ? brokenLineMarker : null;
+    },
+    lineMarkerChange(update) {
+      const forced = update.transactions.some((tr) =>
+        tr.effects.some((e) => e.is(refreshBrokenLinks)),
+      );
+      return forced || update.docChanged || update.viewportChanged ||
+        (update.focusChanged && update.view.hasFocus);
+    },
+  });
+
+  return [plugin, brokenLinkTheme, brokenGutter];
 }

--- a/src/renderer/lib/editor/link-preview.ts
+++ b/src/renderer/lib/editor/link-preview.ts
@@ -17,8 +17,39 @@ import { makeNotePreviewFetcher, type NotePreviewDeps } from './note-preview';
 // link-decorations.ts.
 const WIKI_RE = /\[\[([^[\]\n]+)\]\]/g;
 
-export function linkPreview(deps: NotePreviewDeps): Extension {
+const LIGHTBULB =
+  `<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 13h4M6.5 15h3"/><path d="M8 1a5 5 0 0 0-3 9c.5.4.8 1 .8 1.6h4.4c0-.6.3-1.2.8-1.6A5 5 0 0 0 8 1z"/></svg>`;
+
+/** Deps for the hover preview + its broken-link quick-fix (#1446). */
+export type LinkPreviewDeps = NotePreviewDeps & {
+  /** When a hovered link's target is missing, the tooltip offers a "Create Note
+   *  From Reference" lightbulb that calls this (the same fix as Alt-Enter). */
+  onCreateNoteFromReference?: (target: string) => void;
+};
+
+export function linkPreview(deps: LinkPreviewDeps): Extension {
   const fetchPreview = makeNotePreviewFetcher(deps);
+
+  /** Render the "not found" state, plus a lightbulb quick-fix when wired. This
+   *  is the in-editor hover affordance for a broken link (#1446) — one tooltip,
+   *  so it doesn't collide with the squiggle's own hover. */
+  function showMissing(dom: HTMLElement, target: string): void {
+    dom.className = 'cm-link-preview missing';
+    dom.textContent = '';
+    const msg = document.createElement('div');
+    msg.className = 'missing-msg';
+    msg.textContent = `“${target}” not found`;
+    dom.append(msg);
+    if (deps.onCreateNoteFromReference) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'cm-link-fix';
+      btn.innerHTML = `${LIGHTBULB}<span>Create Note From Reference</span>`;
+      btn.onmousedown = (e) => { e.preventDefault(); }; // keep editor focus
+      btn.onclick = () => deps.onCreateNoteFromReference!(target);
+      dom.append(btn);
+    }
+  }
 
   return hoverTooltip((view, pos): Tooltip | null => {
     const line = view.state.doc.lineAt(pos);
@@ -53,8 +84,7 @@ export function linkPreview(deps: NotePreviewDeps): Extension {
         dom.textContent = '…';
         void fetchPreview(target).then((preview) => {
           if (!preview) {
-            dom.className = 'cm-link-preview missing';
-            dom.textContent = `“${target}” not found`;
+            showMissing(dom, target);
             return;
           }
           dom.className = 'cm-link-preview';
@@ -67,8 +97,7 @@ export function linkPreview(deps: NotePreviewDeps): Extension {
           body.textContent = preview.snippet || '(empty note)';
           dom.append(titleEl, body);
         }).catch(() => {
-          dom.className = 'cm-link-preview missing';
-          dom.textContent = `“${target}” not found`;
+          showMissing(dom, target);
         });
         return { dom };
       },

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -609,3 +609,22 @@ mark.hl-orange { background: color-mix(in oklch, var(--hl-orange) 30%, transpare
   font-style: italic;
   font-size: 11px;
 }
+/* Broken-link hover quick-fix (#1446): a lightbulb "Create Note" action under
+   the "not found" message. Non-italic so it reads as an action, not prose. */
+.cm-link-preview.missing .missing-msg { margin-bottom: 6px; }
+.cm-link-fix {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg-button);
+  color: var(--text);
+  font-style: normal;
+  font-size: 11px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+.cm-link-fix:hover { border-color: var(--rust); color: var(--text); }
+.cm-link-fix svg { color: var(--rust); flex-shrink: 0; }


### PR DESCRIPTION
## What

The IntelliJ-style pair you asked for, complementing the #1729 squiggle + Alt-Enter:

- **Gutter color line** — a thin `--rust` stripe in its own gutter column on any line that carries a broken wiki-link, so problems are scannable down the margin. The column collapses to nothing on clean notes.
- **Hover lightbulb** — hovering a broken link shows a **Create Note From Reference** lightbulb button that applies the same fix as Alt-Enter.

## How

- **Gutter** (`broken-link-decorations.ts`): the gutter's `lineMarker` reads the existing broken-link `ViewPlugin`'s decoration set directly (via `view.plugin(...)` + `RangeSet.between`) — no second scan — and returns a `--rust` bar marker when a line overlaps a broken range. `lineMarkerChange` re-evaluates on the same triggers the plugin uses (doc/viewport/focus/refresh).
- **Hover** (`link-preview.ts`): `link-preview` already shows a "…not found" hover tooltip for broken links. Rather than add a *second* hover tooltip (which would collide with it), the lightbulb is integrated into that missing state — one tooltip: `"X" not found` + a **Create Note From Reference** action. Gated on a new `onCreateNoteFromReference` dep threaded from `Editor.svelte` (the same callback the Alt-Enter menu uses).

Both reuse the already-tested `findBrokenWikiRanges` detection. Colors use `--rust` (the theme's warning signal), keeping the diagnostic non-alarming per the UI philosophy.

## Deliberately not done
Kept the Alt-Enter quick-fix menu from #1729 as-is (the lightbulb and Alt-Enter are complementary discovery paths, as in IntelliJ).

## Testing
- `pnpm lint` clean (0 warnings); full `pnpm test` — 5583 pass. Detection logic (`findBrokenWikiRanges`) is unit-tested; the gutter/hover are thin CM/DOM layers over it.
- **Manual (recommended — this is visual):** type `[[missing]]` → a `--rust` stripe appears in the gutter on that line and the squiggle underlines it; hover the link → "…not found" tooltip with a lightbulb **Create Note From Reference** → click → note created, stripe + squiggle clear. Confirm the gutter column vanishes on a note with no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)