### PR TITLE
fix(editor): seat the broken-link gutter stripe next to the line numbers (#1446)

### DIFF
--- a/src/renderer/lib/editor/broken-link-decorations.ts
+++ b/src/renderer/lib/editor/broken-link-decorations.ts
@@ -19,7 +19,7 @@ import {
   gutter,
   GutterMarker,
 } from '@codemirror/view';
-import { RangeSetBuilder, StateEffect, type EditorState } from '@codemirror/state';
+import { RangeSetBuilder, StateEffect, Prec, type EditorState } from '@codemirror/state';
 import { scanLinks, findLinkAt, type LinkRange } from './link-decorations';
 import {
   buildWikiLinkIndex,
@@ -125,9 +125,12 @@ const brokenLinkTheme = EditorView.theme({
     textDecorationSkipInk: 'none',
     textUnderlineOffset: '2px',
   },
-  // Gutter stripe column — no fixed width, so it disappears on clean notes.
+  // Gutter stripe column, kept snug against the line-number gutter (it's given
+  // high precedence below so it renders as the leftmost gutter). No fixed width
+  // + tight padding so it's a thin rail, not a floating bar, and it collapses to
+  // nothing on clean notes.
   '.cm-broken-gutter': { minWidth: '0' },
-  '.cm-broken-gutter .cm-gutterElement': { display: 'flex', justifyContent: 'center' },
+  '.cm-broken-gutter .cm-gutterElement': { display: 'flex', justifyContent: 'center', padding: '0 1px' },
   '.cm-broken-line-bar': {
     width: '3px',
     alignSelf: 'stretch',
@@ -200,5 +203,7 @@ export function brokenLinkDecorations(deps: BrokenLinkDeps) {
     },
   });
 
-  return [plugin, brokenLinkTheme, brokenGutter];
+  // High precedence so this gutter sorts ahead of the fold / bookmark gutters
+  // and sits right next to the line-number gutter, rather than out by the text.
+  return [plugin, brokenLinkTheme, Prec.high(brokenGutter)];
 }


### PR DESCRIPTION
## What

Follow-up to #1738. The gutter stripe was registering **after** the fold and bookmark gutters, so it rendered as the rightmost gutter column — out by the text, "far from" the line-number gutter.

- Wrap the broken-link gutter in `Prec.high(...)` so it sorts ahead of the fold/bookmark gutters and sits **adjacent to the line-number gutter**.
- Tighten the column padding (`0 1px`) so it reads as a thin rail rather than a bar floating in a padded column.

## On the color

The stripe and the squiggle are **both `var(--rust)`** already — same value. If they look mismatched in practice it's a perceptual thing (a solid 3px bar reads bolder than a thin wavy underline of the same hue). Easy to tone the bar down (thinner / slight opacity) if you want them to match more closely — say the word.

## Note on placement

`Prec.high` seats the stripe as the **leftmost** gutter (just left of the line numbers). If you'd rather it sit *between* the line numbers and the code, that's a one-line precedence tweak — let me know which reads better once you see it.

## Testing
- `pnpm lint` clean; broken-link detection tests still pass. This is a CSS/ordering change with no logic impact — worth an eyeball in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)