### PR TITLE
fix(editor): restore the broken-link gutter marker (#1446)

### DIFF
--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -491,6 +491,13 @@
           void api.shell.openExternal(url);
         },
       }),
+      // Registered before the bookmark gutter so the broken-link gutter stripe
+      // sits in the left gutter group (near the line numbers), not out by the
+      // text (#1446). Gutter columns render in registration order.
+      brokenLinkDecorations({
+        getNotePaths: () => getNotePaths?.() ?? [],
+        getAliases: () => getAliases?.() ?? [],
+      }),
       bookmarkGutterExtension(),
       computeCellsExtension({
         runCell: (language, code) => (
@@ -508,10 +515,6 @@
         // Broken-link hover lightbulb (#1446). Wrapped in a closure (not a bare
         // prop reference) so it stays current in the once-built extension list.
         onCreateNoteFromReference: (target: string) => onCreateNoteFromReference?.(target),
-      }),
-      brokenLinkDecorations({
-        getNotePaths: () => getNotePaths?.() ?? [],
-        getAliases: () => getAliases?.() ?? [],
       }),
       footnoteDecorations(),
       highlightDecorations(),

--- a/src/renderer/lib/editor/broken-link-decorations.ts
+++ b/src/renderer/lib/editor/broken-link-decorations.ts
@@ -19,7 +19,7 @@ import {
   gutter,
   GutterMarker,
 } from '@codemirror/view';
-import { RangeSetBuilder, StateEffect, Prec, type EditorState } from '@codemirror/state';
+import { RangeSetBuilder, StateEffect, type EditorState } from '@codemirror/state';
 import { scanLinks, findLinkAt, type LinkRange } from './link-decorations';
 import {
   buildWikiLinkIndex,
@@ -203,7 +203,10 @@ export function brokenLinkDecorations(deps: BrokenLinkDeps) {
     },
   });
 
-  // High precedence so this gutter sorts ahead of the fold / bookmark gutters
-  // and sits right next to the line-number gutter, rather than out by the text.
-  return [plugin, brokenLinkTheme, Prec.high(brokenGutter)];
+  // NOTE: don't wrap `brokenGutter` in a Prec — CM's `gutter()` bundles the
+  // shared gutter renderer, and re-precedencing the whole thing stops it
+  // rendering at all. Column order is set by registration order instead: this
+  // is registered ahead of the bookmark gutter in Editor.svelte so it sits in
+  // the left gutter group, not out by the text.
+  return [plugin, brokenLinkTheme, brokenGutter];
 }


### PR DESCRIPTION
## Regression fix

#1739's `Prec.high` on the gutter is what made the marker disappear. CM's `gutter()` bundles the shared gutter *renderer*, so wrapping the whole thing in a precedence override disrupts that shared setup and the gutter stops rendering entirely.

- **Drop the `Prec`** → the marker renders again.
- Instead, control the column position by **registration order**: register the broken-link gutter *ahead of* the bookmark gutter so it sits in the left gutter group (near the line numbers) rather than out by the text.

## Honest limitation

The **fold gutter** (bundled in `basicSetup`) still sits between the broken-link column and the line numbers, so this is "in the left gutter group," not literally flush against the numbers. Getting it truly adjacent means splitting the gutter out and registering it ahead of `basicSetup` — a slightly bigger change I've left out unless you want it. Say the word and I'll do it.

Color is unchanged: the bar and the squiggle are both `var(--rust)`.

## Testing
- `pnpm lint` clean; broken-link detection tests pass. Pure CSS/ordering — needs an eyeball, but the marker is back (this reverts the change that hid it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)