### PR TITLE
feat(preview): broken-link squiggle in the Preview pane (#1446)

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -36,6 +36,7 @@
     } from '../preview/compute-output-render';
     import { applyCslMarkers, resolveCiteQuoteLabels, type CitationRenderDeps } from '../preview/citation-render';
     import { hydrateTypedCards, type TypedCardDeps } from '../preview/typed-link-render';
+    import { markBrokenWikiLinks } from '../preview/broken-links';
     import { buildObjectCardHtml } from '../preview/typed-card';
     import { resolveWikiLinkTarget } from '../../../shared/wiki-link-resolver';
     import type { NoteTypedProperties } from '../../../shared/objects/type-def';
@@ -431,6 +432,10 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         requestAnimationFrame(() => {
             // Syntax-highlight fences off the critical render path (#1114).
             highlightCodeBlocks(hydrateCtx);
+            // Broken-link squiggle (#1446): mark unresolved note links so the
+            // Preview mirrors the editor. Synchronous DOM pass; runs before the
+            // async typed-card hydration (which only ever touches resolved links).
+            markBrokenWikiLinks(previewEl ?? null, typedCardDeps().resolvePath);
             const blocks = previewEl?.querySelectorAll('.query-block');
             blocks?.forEach((el) => executeQueryBlock(queryDeps(), el as HTMLElement));
             void resolveCiteQuoteLabels(citeDeps());

--- a/src/renderer/lib/preview/broken-links.ts
+++ b/src/renderer/lib/preview/broken-links.ts
@@ -1,0 +1,24 @@
+/**
+ * Mark unresolved wiki-links in the rendered preview so a broken `[[link]]`
+ * reads the same in the Preview pane as in the editor squiggle (#1446).
+ *
+ * Scope mirrors the editor: plain (untyped) note links only. `cite::`/`quote::`
+ * (`.typed-link`) resolve to sources/excerpts, not notes, so they'd false-flag
+ * through the note resolver and are skipped. A `#heading` anchor is stripped
+ * before resolving — a missing heading isn't a missing note (note-existence
+ * only, matching the editor).
+ */
+export function markBrokenWikiLinks(
+  previewEl: HTMLElement | null,
+  resolvePath: (target: string) => string | null,
+): void {
+  if (!previewEl) return;
+  for (const a of previewEl.querySelectorAll<HTMLElement>('.wiki-link:not(.typed-link)')) {
+    const target = a.dataset.target;
+    if (!target) continue;
+    const notePart = (target.split('#')[0] ?? target).trim();
+    // Empty target (a bare `[[#anchor]]`) isn't a broken note; leave it.
+    const broken = notePart.length > 0 && resolvePath(notePart) === null;
+    a.classList.toggle('wiki-link-broken', broken);
+  }
+}

--- a/src/renderer/styles/preview-content.css
+++ b/src/renderer/styles/preview-content.css
@@ -95,6 +95,21 @@
         text-decoration: none;
     }
 
+/* Broken link (#1446) — mirrors the editor squiggle: a --rust wavy underline,
+   with the chip tinted rust instead of accent so an unresolved link reads as a
+   diagnostic (not alarm-red, per the UI philosophy). */
+.preview .wiki-link.wiki-link-broken {
+        background: color-mix(in oklch, var(--rust) 12%, transparent);
+        color: var(--rust);
+        text-decoration: underline wavy var(--rust);
+        text-decoration-skip-ink: none;
+        text-underline-offset: 2px;
+    }
+.preview .wiki-link.wiki-link-broken:hover {
+        background: color-mix(in oklch, var(--rust) 18%, transparent);
+        text-decoration: underline wavy var(--rust);
+    }
+
 /* Type-keyed cards (#1071) — a block-level `[[TypedNote]]` / `[[quote::id]]`
        promoted from a chip to a card. Shared by the preview block and the hover
        tooltip (via .oc-tooltip). */

--- a/tests/renderer/preview-broken-links.test.ts
+++ b/tests/renderer/preview-broken-links.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect } from 'vitest';
+import { markBrokenWikiLinks } from '../../src/renderer/lib/preview/broken-links';
+
+// Only `raft` resolves; everything else is "missing".
+const resolvePath = (t: string): string | null => (t === 'raft' ? 'notes/raft.md' : null);
+
+function render(html: string): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'preview';
+  el.innerHTML = html;
+  return el;
+}
+
+describe('markBrokenWikiLinks (#1446)', () => {
+  it('marks an unresolved note link and leaves a resolved one alone', () => {
+    const el = render(
+      '<a class="wiki-link" data-target="missing">missing</a>' +
+      '<a class="wiki-link" data-target="raft">raft</a>',
+    );
+    markBrokenWikiLinks(el, resolvePath);
+    const [a, b] = [...el.querySelectorAll('.wiki-link')];
+    expect(a!.classList.contains('wiki-link-broken')).toBe(true);
+    expect(b!.classList.contains('wiki-link-broken')).toBe(false);
+  });
+
+  it('strips a #heading anchor — a missing heading on an existing note is not broken', () => {
+    const el = render('<a class="wiki-link" data-target="raft#gone">raft</a>');
+    markBrokenWikiLinks(el, resolvePath);
+    expect(el.querySelector('.wiki-link')!.classList.contains('wiki-link-broken')).toBe(false);
+  });
+
+  it('skips typed (cite/quote) links — they resolve to sources/excerpts, not notes', () => {
+    const el = render('<a class="wiki-link typed-link" data-target="some-source-id">cite</a>');
+    markBrokenWikiLinks(el, resolvePath);
+    expect(el.querySelector('.wiki-link')!.classList.contains('wiki-link-broken')).toBe(false);
+  });
+
+  it('clears the broken class when a link now resolves (re-render safety)', () => {
+    const el = render('<a class="wiki-link wiki-link-broken" data-target="raft">raft</a>');
+    markBrokenWikiLinks(el, resolvePath);
+    expect(el.querySelector('.wiki-link')!.classList.contains('wiki-link-broken')).toBe(false);
+  });
+
+  it('is a no-op on a null container', () => {
+    expect(() => markBrokenWikiLinks(null, resolvePath)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Mirrors the editor's broken-link squiggle into the rendered **Preview** pane. An unresolved `[[note]]` chip now gets a `--rust` wavy underline (and a rust tint instead of the accent chip), so a broken link reads the same in both panes.

## How

- **`preview/broken-links.ts`** — `markBrokenWikiLinks(previewEl, resolvePath)`: a synchronous post-render DOM pass that toggles `wiki-link-broken` on unresolved links. Reuses the Preview's existing `resolveWikiLinkTarget`-backed `resolvePath`.
- **Scope matches the editor**: plain (untyped) note links only. A `#heading` anchor is stripped before resolving (note-existence only — a missing heading isn't a missing note); `cite::`/`quote::` (`.typed-link`) resolve to sources/excerpts so they're skipped (they'd false-flag through the note resolver).
- **`Preview.svelte`** runs it right after render, before the async typed-card hydration — which only ever promotes *resolved* links to cards, so there's no conflict with a broken chip.
- **`preview-content.css`** — `.wiki-link-broken` styling matching the editor's `--rust` squiggle.

## Not included (say the word)
Just the squiggle, as asked. The editor's **hover lightbulb** / **Alt-Enter** quick-fix aren't mirrored into the Preview here — the Preview already has its own hover tooltip and a read-only right-click menu, so wiring the create-note fix there is a separate, larger step if you want it.

## Testing
- `pnpm lint` clean; full `pnpm test` — 5588 pass.
- happy-dom unit tests: marks an unresolved link, leaves a resolved one / an anchored-but-existing note / a typed cite link alone, and clears the class when a link resolves.
- **Manual (dev):** in Preview, a `[[missing]]` chip shows the rust wavy underline; `[[existing]]` and `[[existing#anymissingheading]]` don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)