### PR TITLE
feat(objects): show type icons on typed notes across the note lists

### DIFF
--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -31,7 +31,7 @@ export {
   getSourceDetail, getReadingQueueSourceIds, sourcesByReadStatus, citationsForNote, getExcerptSource,
 } from './queries';
 export type { AliasEntry, SchemaEntry, GraphSchema, ReadingQueueView } from './queries';
-export { getNoteTypedProperties, getTypeInstances } from './note-properties';
+export { getNoteTypedProperties, getTypeInstances, getNoteTypeMap } from './note-properties';
 export { neighborhood, expandNode } from './neighborhood';
 export type {
   NeighborhoodResult, NeighborhoodNode, NeighborhoodEdge, NeighborhoodOptions, NeighborhoodHop,

--- a/src/main/graph/note-properties.ts
+++ b/src/main/graph/note-properties.ts
@@ -68,6 +68,33 @@ export async function getNoteTypedProperties(
 }
 
 /**
+ * Which notes are typed, and as what — the whole thoughtbase in one projection.
+ *
+ * Every note list in the renderer (sidebar tree, tabs, quick-open, backlinks)
+ * wants a type icon per row, and `getNoteTypedProperties` is one-note-per-call:
+ * a tree of 2000 notes would mean 2000 round-trips. This is the bulk read
+ * instead — a `relativePath → typeId` map the renderer joins against the type
+ * catalog it already holds. Mirrors `graph:aliasMap`, the other bulk map the
+ * renderer caches and refreshes on reindex.
+ *
+ * Direct class only (no `rdfs:subClassOf*`): a row should show the note's OWN
+ * type's icon, not an ancestor's. First match wins for a multi-valued `type:`,
+ * matching `getNoteTypedProperties`.
+ */
+export async function getNoteTypeMap(ctx: ProjectContext): Promise<Record<string, string>> {
+  if (!getState(ctx)) return {};
+  const { results } = await queryGraph(
+    ctx,
+    `SELECT ?path ?id WHERE { ?n minerva:relativePath ?path ; a ?c . ?c minerva:typeId ?id }`,
+  );
+  const out: Record<string, string> = {};
+  for (const r of results as Array<{ path?: string; id?: string }>) {
+    if (r.path && r.id && !(r.path in out)) out[r.path] = r.id;
+  }
+  return out;
+}
+
+/**
  * Project every instance of a type with its declared-property values (#1070) —
  * the data behind the list/table/gallery multi-view. One SPARQL pass: each
  * declared property becomes an OPTIONAL column bound through the SAME predicate

--- a/src/main/ipc/register-types.ts
+++ b/src/main/ipc/register-types.ts
@@ -44,6 +44,16 @@ export function registerTypes(): void {
     ),
   );
 
+  // Which notes are typed, for the type icons on note rows. `{}` on no project
+  // is a legitimate "nothing is typed yet" answer, not a failure signal.
+  handle(
+    Channels.TYPES_NOTE_TYPE_MAP,
+    withRootPathOr<[], Record<string, string> | Promise<Record<string, string>>>(
+      {},
+      (rootPath) => graph.getNoteTypeMap(projectContext(rootPath)),
+    ),
+  );
+
   // Save a new user object type derived from a note ("Save Note as Object Type").
   // Writes `.minerva/types/<id>.md`, then reloads the graph's type catalog so the
   // new type is immediately usable for promotion + indexing.

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -476,6 +476,7 @@ contextBridge.exposeInMainWorld('api', {
     list: () => invoke(Channels.TYPES_LIST),
     noteProperties: (relativePath: string) => invoke(Channels.TYPES_NOTE_PROPERTIES, relativePath),
     instances: (typeId: string) => invoke(Channels.TYPES_INSTANCES, typeId),
+    noteTypeMap: () => invoke(Channels.TYPES_NOTE_TYPE_MAP),
     save: (input: Parameters<ChannelMap['types:save']>[0]) => invoke(Channels.TYPES_SAVE, input),
     delete: (id: string) => invoke(Channels.TYPES_DELETE, id),
     deleteSafely: (id: string, clearInstances: boolean) => invoke(Channels.TYPES_DELETE_SAFELY, id, clearInstances),

--- a/src/renderer/lib/components/BookmarksPanel.svelte
+++ b/src/renderer/lib/components/BookmarksPanel.svelte
@@ -4,6 +4,8 @@
   import { DRAG_MIME_NOTE } from '../editor/drag-link';
   import Ribbon from './right-sidebar/Ribbon.svelte';
   import Icon from './Icon.svelte';
+  import TypeIcon from './TypeIcon.svelte';
+  import { objectTypesStore } from '../stores/object-types.svelte';
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { installDismissOnClickOutside } from '../dismiss-menu';
 
@@ -193,6 +195,9 @@
       {/each}
     {/if}
   {:else}
+    <!-- An anchor bookmark points into a section, not the note as a whole, so
+         it keeps the generic glyph rather than claiming to be the object. -->
+    {@const noteType = node.anchor ? null : objectTypesStore.typeForNote(node.relativePath)}
     <div
       class="bm-item bookmark"
       style:padding-left="{8 + depth * 14}px"
@@ -205,7 +210,11 @@
       ondragstart={(e) => handleDragStart(e, node)}
     >
       <span class="chev"></span>
-      <Icon name={bmIcon(node)} size={13} color="var(--text-faint)" />
+      {#if noteType}
+        <TypeIcon type={noteType} size={13} />
+      {:else}
+        <Icon name={bmIcon(node)} size={13} color="var(--text-faint)" />
+      {/if}
       <span class="bm-body">
         <span class="bm-name">{node.name}</span>
         <span class="bm-path">{node.anchor ? `${node.relativePath} › §` : node.relativePath}</span>

--- a/src/renderer/lib/components/FileTree.svelte
+++ b/src/renderer/lib/components/FileTree.svelte
@@ -2,6 +2,8 @@
   import type { NoteFile } from '../../../shared/types';
   import FileTree from './FileTree.svelte';
   import Icon from './Icon.svelte';
+  import TypeIcon from './TypeIcon.svelte';
+  import { objectTypesStore } from '../stores/object-types.svelte';
   import { formatRelativeTime } from '../utils/format-relative-time';
   import { api } from '../ipc/client';
   import { clampMenuToViewport } from '../utils/menuClamp';
@@ -265,6 +267,7 @@
           />
         {/if}
       {:else}
+        {@const noteType = objectTypesStore.typeForNote(file.relativePath)}
         <button
           class="tree-item file"
           class:active={activeFilePath === file.relativePath}
@@ -278,11 +281,17 @@
           ondragstart={(e) => handleDragStart(e, file.relativePath, false)}
         >
           <span class="chev"></span>
-          <Icon
-            name={iconForFile(file.name)}
-            size={13}
-            color={activeFilePath === file.relativePath ? 'var(--accent)' : 'var(--text-faint)'}
-          />
+          {#if noteType}
+            <!-- A typed note shows its type's icon instead of the generic
+                 by-extension glyph: the type is the more specific fact. -->
+            <TypeIcon type={noteType} size={13} />
+          {:else}
+            <Icon
+              name={iconForFile(file.name)}
+              size={13}
+              color={activeFilePath === file.relativePath ? 'var(--accent)' : 'var(--text-faint)'}
+            />
+          {/if}
           <span class="row-label">{file.name.replace(/\.(md|ttl|csv|py)$/, '')}</span>
           {#if file.mtimeMs !== undefined}
             <span class="mtime">{formatRelativeTime(file.mtimeMs)}</span>

--- a/src/renderer/lib/components/GotoNoteDialog.svelte
+++ b/src/renderer/lib/components/GotoNoteDialog.svelte
@@ -2,6 +2,8 @@
   import type { NoteFile, SourceMetadata, SavedQuery } from '../../../shared/types';
   import { displaySourceTitle } from '../../../shared/source-display';
   import Icon from './Icon.svelte';
+  import TypeIcon from './TypeIcon.svelte';
+  import { objectTypesStore } from '../stores/object-types.svelte';
   import type { IconName } from './icons/registry';
   import { formatRelativeTime } from '../utils/format-relative-time';
 
@@ -277,6 +279,7 @@
           {@const folder = result.kind === 'note' && result.relativePath.includes('/')
             ? result.relativePath.slice(0, result.relativePath.lastIndexOf('/'))
             : ''}
+          {@const noteType = result.kind === 'note' ? objectTypesStore.typeForNote(result.relativePath) : null}
           <li>
             <button
               class="result-item"
@@ -284,7 +287,11 @@
               onclick={() => selectItem(result)}
               onmouseenter={() => { selectedIndex = i; }}
             >
-              <Icon name={kindIconName(result.kind)} size={13} color={i === selectedIndex ? 'var(--accent)' : 'var(--text-faint)'} />
+              {#if noteType}
+                <TypeIcon type={noteType} size={13} />
+              {:else}
+                <Icon name={kindIconName(result.kind)} size={13} color={i === selectedIndex ? 'var(--accent)' : 'var(--text-faint)'} />
+              {/if}
               <span class="result-body">
                 <span class="result-name">{result.name}</span>
                 {#if result.kind === 'note'}

--- a/src/renderer/lib/components/ObjectsPanel.svelte
+++ b/src/renderer/lib/components/ObjectsPanel.svelte
@@ -9,6 +9,8 @@
    * host calls `refresh()` on write/reindex (mirroring the Tags panel).
    */
   import { api } from '../ipc/client';
+  import TypeIcon from './TypeIcon.svelte';
+  import { objectTypesStore } from '../stores/object-types.svelte';
   import ExcerptsBrowser from './ExcerptsBrowser.svelte';
   import { savedViewsStore } from '../stores/saved-views.svelte';
   import type { TypeInfo } from '../../../shared/objects/type-def';
@@ -127,12 +129,18 @@
         <p class="no-instances">No {row.type.label.toLowerCase()} yet</p>
       {:else}
         {#each instances[row.type.id] ?? [] as inst (inst.path)}
+          <!-- The group is subclass-aware (#1587) — a Book group lists Novels
+               too — so a row carries its OWN type's icon, not the group's. -->
+          {@const instType = objectTypesStore.typeForNote(inst.path) ?? row.type}
           <button
             class="instance-row"
             onclick={() => onFileSelect(inst.path)}
             ondblclick={() => onFileSelect(inst.path)}
             title={inst.path}
-          >{inst.title}</button>
+          >
+            <TypeIcon type={instType} size={12} />
+            <span class="instance-name">{inst.title}</span>
+          </button>
         {/each}
       {/if}
     {/if}
@@ -221,7 +229,9 @@
     flex-shrink: 0;
   }
   .instance-row {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 7px;
     width: 100%;
     padding: 4px 8px 4px 30px;
     border: none;
@@ -232,6 +242,10 @@
     font-size: 12.5px;
     cursor: pointer;
     text-align: left;
+  }
+  /* Ellipsis moves to the label now that the row is a flex container. */
+  .instance-name {
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/renderer/lib/components/Sidebar.svelte
+++ b/src/renderer/lib/components/Sidebar.svelte
@@ -11,6 +11,7 @@
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { installDismissOnClickOutside } from '../dismiss-menu';
   import { getSidebarSelectionStore } from '../stores/sidebar-selection.svelte';
+  import { objectTypesStore } from '../stores/object-types.svelte';
   import { getProposalsStore } from '../stores/proposals.svelte';
   import { flattenVisible } from '../sidebar-tree-utils';
   import { getSidebarSettings, setSidebarSettings } from '../sidebar/settings';
@@ -111,6 +112,10 @@
   let sourcesPanel = $state<SourcesPanel>();
   let tablesPanel = $state<TablesPanel>();
   let objectsPanel = $state<ObjectsPanel>();
+  // Seed the note→type map once on mount so Notes-tree rows carry their type
+  // icons from the first paint. A project restored at startup doesn't go
+  // through the menu-open path that calls refreshObjects().
+  $effect(() => { void objectTypesStore.refresh(); });
   let contextMenu = $state<{ x: number; y: number } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | undefined>();
 
@@ -498,6 +503,10 @@
   }
 
   export function refreshObjects() {
+    // Unconditional: the note→type map drives the type icons on Notes-tree
+    // rows, so it has to stay fresh whether or not the Objects panel is the
+    // mounted one. The panel's own refresh is still a no-op when it isn't.
+    void objectTypesStore.refresh();
     void objectsPanel?.refresh();
   }
 

--- a/src/renderer/lib/components/TabBar.svelte
+++ b/src/renderer/lib/components/TabBar.svelte
@@ -6,6 +6,8 @@
   import { clampMenuToViewport } from '../utils/menuClamp';
   import { installDismissOnClickOutside } from '../dismiss-menu';
   import Icon from './Icon.svelte';
+  import TypeIcon from './TypeIcon.svelte';
+  import { objectTypesStore } from '../stores/object-types.svelte';
 
   interface Props {
     tabs: Tab[];
@@ -97,6 +99,7 @@
 <div class="tab-bar">
   {#each tabs as tab, i}
     {@const dirty = tab.type === 'note' && tab.content !== tab.savedContent}
+    {@const noteType = tab.type === 'note' ? objectTypesStore.typeForNote(tab.relativePath) : null}
     <!-- Presentational wrapper: carries the drag / middle-click / context-menu
          gestures for the whole tab. The switch and close controls live inside
          as siblings so no interactive element nests another (a11y #1005). The
@@ -149,6 +152,8 @@
             <Icon name="graph" size={13} color="var(--text-faint)" />
           {:else if tab.type === 'type-view'}
             <Icon name="objects" size={13} color="var(--text-faint)" />
+          {:else if noteType}
+            <TypeIcon type={noteType} size={13} />
           {:else}
             <Icon name="notes" size={13} color="var(--text-faint)" />
           {/if}

--- a/src/renderer/lib/components/TypeIcon.svelte
+++ b/src/renderer/lib/components/TypeIcon.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  /**
+   * A typed note's type icon, sized to drop into the same slot as an `<Icon>`
+   * in a list row (sidebar tree, tabs, quick-open, backlinks).
+   *
+   * A type's `icon` is a raw emoji/glyph string, not an SVG from the app's icon
+   * registry — so this is a text span boxed to `size` rather than an `<svg>`.
+   * `◆` is the shared fallback for an icon-less type, matching the Objects
+   * panel and the type pickers.
+   */
+  import type { TypeInfo } from '../../../shared/objects/type-def';
+
+  interface Props {
+    type: TypeInfo;
+    size?: number;
+    /** Tooltip/label. Defaults to the type's label ("Book"). */
+    title?: string | undefined;
+  }
+
+  let { type, size = 13, title }: Props = $props();
+</script>
+
+<span
+  class="type-icon"
+  style:width="{size}px"
+  style:height="{size}px"
+  style:font-size="{Math.round(size * 0.92)}px"
+  style:color={type.color ?? undefined}
+  role="img"
+  aria-label={title ?? type.label}
+  title={title ?? type.label}
+>{type.icon ?? '◆'}</span>
+
+<style>
+  /* Box to the same footprint as the <Icon> svg it replaces, so a typed and an
+     untyped row keep an aligned label column. Emoji overflow their em box at
+     small sizes; `overflow: visible` lets them render at full size without
+     widening the gutter. */
+  .type-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    line-height: 1;
+    overflow: visible;
+  }
+</style>

--- a/src/renderer/lib/components/TypeView.svelte
+++ b/src/renderer/lib/components/TypeView.svelte
@@ -14,6 +14,8 @@
    * #1066 is where values are edited); table cells never mutate the graph.
    */
   import { api } from '../ipc/client';
+  import TypeIcon from './TypeIcon.svelte';
+  import { objectTypesStore } from '../stores/object-types.svelte';
   import type { PropertyDef, TypeInfo, TypeInstanceRow } from '../../../shared/objects/type-def';
 
   type Layout = 'list' | 'table' | 'gallery';
@@ -116,6 +118,16 @@
     return !!v && /^https?:\/\//i.test(v);
   }
 
+  /**
+   * The icon for one row. This view is subclass-aware (#1587) — a Book view
+   * lists Novels too — so a row shows its OWN type's icon, not the view's.
+   * That makes the per-row icon informative rather than merely repeating the
+   * header. Falls back to the view's type if the map hasn't loaded yet.
+   */
+  function rowType(inst: TypeInstanceRow): TypeInfo | null {
+    return objectTypesStore.typeForNote(inst.path) ?? type;
+  }
+
   const LAYOUTS: { id: Layout; label: string }[] = [
     { id: 'list', label: 'List' },
     { id: 'table', label: 'Table' },
@@ -170,9 +182,13 @@
   {:else if layout === 'list'}
     <div class="tv-list">
       {#each instances as inst (inst.path)}
+        {@const rt = rowType(inst)}
         <button class="tv-list-row" onclick={() => onOpenNote(inst.path)} title={inst.path}>
-          <span class="tv-list-title">{inst.title}</span>
-          {#if summary(inst)}<span class="tv-list-summary">{summary(inst)}</span>{/if}
+          {#if rt}<span class="tv-list-icon"><TypeIcon type={rt} size={14} /></span>{/if}
+          <span class="tv-list-body">
+            <span class="tv-list-title">{inst.title}</span>
+            {#if summary(inst)}<span class="tv-list-summary">{summary(inst)}</span>{/if}
+          </span>
         </button>
       {/each}
     </div>
@@ -199,8 +215,14 @@
         </thead>
         <tbody>
           {#each sorted as inst (inst.path)}
+            {@const rt = rowType(inst)}
             <tr onclick={() => onOpenNote(inst.path)} title={inst.path}>
-              <td class="tv-cell-title">{inst.title}</td>
+              <td class="tv-cell-title">
+                <span class="tv-cell-title-inner">
+                  {#if rt}<TypeIcon type={rt} size={13} />{/if}
+                  <span>{inst.title}</span>
+                </span>
+              </td>
               {#each visibleColumns as col (col.name)}
                 <td>{display(col, inst.values[col.name] ?? null)}</td>
               {/each}
@@ -212,12 +234,13 @@
   {:else}
     <div class="tv-gallery">
       {#each instances as inst (inst.path)}
+        {@const rt = rowType(inst)}
         <button class="tv-card" onclick={() => onOpenNote(inst.path)} title={inst.path}>
           <div class="tv-card-cover">
             {#if isImageUrl(inst.cover)}
               <img src={inst.cover} alt="" loading="lazy" />
             {:else}
-              <span class="tv-card-icon" style={type.color ? `color:${type.color}` : undefined}>{type.icon ?? '◆'}</span>
+              <span class="tv-card-icon" style={rt?.color ? `color:${rt.color}` : undefined}>{rt?.icon ?? '◆'}</span>
             {/if}
           </div>
           <span class="tv-card-title">{inst.title}</span>
@@ -303,10 +326,13 @@
 
   /* List */
   .tv-list { overflow-y: auto; padding: 6px; }
+  /* Icon in a left gutter, title/summary stacked beside it. `align-items:
+     start` keeps the icon on the title's line rather than centred against a
+     two-line row. */
   .tv-list-row {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
+    align-items: flex-start;
+    gap: 8px;
     width: 100%;
     padding: 8px 10px;
     border: none;
@@ -318,6 +344,9 @@
     text-align: left;
   }
   .tv-list-row:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
+  /* Match the title's line box so the icon centres on the first line. */
+  .tv-list-icon { display: flex; align-items: center; height: 19px; flex-shrink: 0; }
+  .tv-list-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
   .tv-list-title { font-size: 13.5px; font-weight: 500; }
   .tv-list-summary { font-size: 11.5px; color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
@@ -345,6 +374,7 @@
   .tv-table tbody tr { cursor: pointer; }
   .tv-table tbody tr:hover { background: color-mix(in oklch, var(--text) 4%, transparent); }
   .tv-cell-title { font-weight: 500; color: var(--text); }
+  .tv-cell-title-inner { display: flex; align-items: center; gap: 7px; }
 
   /* Gallery */
   .tv-gallery {

--- a/src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte
@@ -4,6 +4,8 @@
   import LinkBadge from './LinkBadge.svelte';
   import Ribbon from './Ribbon.svelte';
   import Icon from '../Icon.svelte';
+  import TypeIcon from '../TypeIcon.svelte';
+  import { objectTypesStore } from '../../stores/object-types.svelte';
   import { getLinkDrag } from '../../stores/link-drag.svelte';
 
   const linkDrag = getLinkDrag();
@@ -106,13 +108,18 @@
           {/if}
           {#if type === '' || !collapsed}
             {#each typeLinks as link}
+              {@const noteType = objectTypesStore.typeForNote(link.source)}
               <button
                 class="link-item"
                 onclick={() => onFileSelect(link.source)}
                 onpointerdown={(e) => linkDrag.start({ kind: 'note', path: link.source, label: link.sourceTitle }, e)}
                 title={link.source}
               >
-                <Icon name="notes" size={12} color="var(--text-faint)" />
+                {#if noteType}
+                  <TypeIcon type={noteType} size={12} />
+                {:else}
+                  <Icon name="notes" size={12} color="var(--text-faint)" />
+                {/if}
                 <span class="link-title">{link.sourceTitle}</span>
                 {#if type === ''}
                   <LinkBadge label={link.linkLabel} color={link.linkColor} />

--- a/src/renderer/lib/components/right-sidebar/OutgoingLinksPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/OutgoingLinksPanel.svelte
@@ -4,6 +4,8 @@
   import LinkBadge from './LinkBadge.svelte';
   import Ribbon from './Ribbon.svelte';
   import Icon from '../Icon.svelte';
+  import TypeIcon from '../TypeIcon.svelte';
+  import { objectTypesStore } from '../../stores/object-types.svelte';
 
   interface Props {
     activeFilePath: string | null;
@@ -106,6 +108,7 @@
           {/if}
           {#if type === '' || !collapsed}
             {#each typeLinks as link}
+              {@const noteType = objectTypesStore.typeForNote(link.target)}
               <button
                 class="link-item"
                 class:dead={!link.exists}
@@ -114,6 +117,8 @@
               >
                 {#if !link.exists}
                   <Icon name="warn" size={12} color="var(--rust)" />
+                {:else if noteType}
+                  <TypeIcon type={noteType} size={12} />
                 {:else}
                   <Icon name="notes" size={12} color="var(--text-faint)" />
                 {/if}

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -782,6 +782,9 @@ export interface TypesApi {
   noteProperties(relativePath: string): Promise<import('../../../shared/objects/type-def').NoteTypedProperties>;
   /** Every instance of a type + its property values, for the multi-view (#1070). */
   instances(typeId: string): Promise<import('../../../shared/objects/type-def').TypeInstancesResult>;
+  /** Bulk `relativePath → typeId` map for the type icons on note rows. Empty
+   *  when no project is open — "nothing typed yet", never an error. */
+  noteTypeMap(): Promise<Record<string, string>>;
   /** Save a user object type — "Save Note as Object Type" + the Type Manager. */
   save(input: { label: string; id?: string; properties: import('../../../shared/objects/type-def').PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; parent?: string; template?: string }): Promise<{ id: string; filePath: string }>;
   /** Delete a user object type by id (#1584). */

--- a/src/renderer/lib/stores/object-types.svelte.ts
+++ b/src/renderer/lib/stores/object-types.svelte.ts
@@ -3,6 +3,12 @@
  * catalog list, so the Type Manager panel never calls them directly (renderer
  * data-flow rule #1086). Every mutation re-lists, and re-lists refresh the
  * reactive view the panel + pickers read.
+ *
+ * It also caches the bulk `relativePath → typeId` map behind `typeForNote()`,
+ * so every note list (sidebar tree, tabs, quick-open, backlinks) can badge a row
+ * with its type icon off one projection instead of an N-call fan-out. Catalog
+ * and map are fetched together, so a type whose icon is edited in the Type
+ * Manager repaints every row on the same `refresh()`.
  */
 import { api } from '../ipc/client';
 import type { TypeInfo, TypeLoadError } from '../../../shared/objects/type-def';
@@ -12,12 +18,28 @@ type SaveInput = Parameters<typeof api.types.save>[0];
 let types = $state<TypeInfo[]>([]);
 let errors = $state<TypeLoadError[]>([]);
 let loaded = $state(false);
+/** relativePath → TypeInfo, for O(1) per-row lookup while rendering a list. */
+let noteTypes = $state<Record<string, TypeInfo>>({});
 
 async function refresh(): Promise<void> {
-  const catalog = await api.types.list();
+  const [catalog, map] = await Promise.all([api.types.list(), api.types.noteTypeMap()]);
   types = catalog.types;
   errors = catalog.errors;
+  const byId = new Map(catalog.types.map((t) => [t.id, t]));
+  const next: Record<string, TypeInfo> = {};
+  for (const [path, typeId] of Object.entries(map)) {
+    // A stale `type:` pointing at a deleted type simply goes un-badged.
+    const def = byId.get(typeId);
+    if (def) next[path] = def;
+  }
+  noteTypes = next;
   loaded = true;
+}
+
+/** The type of the note at `relativePath`, or null if it isn't typed. */
+function typeForNote(relativePath: string | null | undefined): TypeInfo | null {
+  if (!relativePath) return null;
+  return noteTypes[relativePath] ?? null;
 }
 
 async function save(input: SaveInput): Promise<{ id: string; filePath: string }> {
@@ -47,6 +69,7 @@ export const objectTypesStore = {
   get types(): TypeInfo[] { return types; },
   get errors(): TypeLoadError[] { return errors; },
   get loaded(): boolean { return loaded; },
+  typeForNote,
   refresh,
   save,
   remove,

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -463,6 +463,9 @@ export const Channels = {
   TYPES_NOTE_PROPERTIES: 'types:noteProperties',
   /** Every instance of a type + its property values, for the multi-view (#1070). */
   TYPES_INSTANCES: 'types:instances',
+  /** Bulk `relativePath → typeId` map, so note lists can show a type icon per
+   *  row without an N-call `types:noteProperties` fan-out. */
+  TYPES_NOTE_TYPE_MAP: 'types:noteTypeMap',
   /** Save a new user object type derived from a note ("Save Note as Object Type"). */
   TYPES_SAVE: 'types:save',
   /** Delete a user object type by id (#1584). */

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -421,6 +421,7 @@ export interface ChannelMap {
   'types:list': () => TypeCatalogInfo;
   'types:noteProperties': (relativePath: string) => NoteTypedProperties;
   'types:instances': (typeId: string) => TypeInstancesResult;
+  'types:noteTypeMap': () => Record<string, string>;
   'types:save': (input: { label: string; id?: string; properties: PropertyDef[]; icon?: string; color?: string; cover?: string; card?: string[]; parent?: string; template?: string }) => { id: string; filePath: string };
   'types:delete': (id: string) => void;
   'types:deleteSafely': (id: string, clearInstances: boolean) => { cleared: string[]; failed: { path: string; error: string }[] };

--- a/tests/main/graph/note-type-map.test.ts
+++ b/tests/main/graph/note-type-map.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The bulk `relativePath → typeId` projection behind the type icons on note
+ * rows (sidebar tree, tabs, quick-open, backlinks). One read for the whole
+ * thoughtbase, so a list doesn't fan out to `getNoteTypedProperties` per row.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexAllNotes, getNoteTypeMap, reloadTypeCatalog } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+function writeNote(rel: string, content: string): void {
+  const fp = path.join(root, rel);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content, 'utf-8');
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-notetypemap-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('note→type map', () => {
+  it('maps each typed note to its type id, and omits untyped notes', async () => {
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: book\n---\n`);
+    writeNote('people/Ada.md', `---\ntitle: Ada\ntype: person\n---\n`);
+    writeNote('Scratch.md', `---\ntitle: Scratch\n---\njust a note\n`);
+    await indexAllNotes(ctx);
+
+    const map = await getNoteTypeMap(ctx);
+    expect(map['Dune.md']).toBe('book');
+    // Keyed by project-relative path, not basename — nested notes included.
+    expect(map['people/Ada.md']).toBe('person');
+    expect(map['Scratch.md']).toBeUndefined();
+  });
+
+  it('is empty for a thoughtbase with no typed notes', async () => {
+    writeNote('Scratch.md', `---\ntitle: Scratch\n---\n`);
+    await indexAllNotes(ctx);
+
+    expect(await getNoteTypeMap(ctx)).toEqual({});
+  });
+
+  it('an unknown `type:` yields no entry, so the row falls back to its file icon', async () => {
+    writeNote('Odd.md', `---\ntitle: Odd\ntype: not-a-real-type\n---\n`);
+    await indexAllNotes(ctx);
+
+    expect((await getNoteTypeMap(ctx))['Odd.md']).toBeUndefined();
+  });
+
+  it('reports a subtype instance as its OWN type, not its parent', async () => {
+    // A row should show the most specific icon the note declares.
+    fs.mkdirSync(path.join(root, '.minerva/types'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, '.minerva/types/novel.md'),
+      `---\nlabel: Novel\nparent: book\nicon: 📕\n---\n`,
+      'utf-8',
+    );
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: novel\n---\n`);
+    await reloadTypeCatalog(ctx); // the catalog was loaded before this type existed
+    await indexAllNotes(ctx);
+
+    expect((await getNoteTypeMap(ctx))['Dune.md']).toBe('novel');
+  });
+
+  it('drops a note from the map once its type is removed', async () => {
+    writeNote('Dune.md', `---\ntitle: Dune\ntype: book\n---\n`);
+    await indexAllNotes(ctx);
+    expect((await getNoteTypeMap(ctx))['Dune.md']).toBe('book');
+
+    writeNote('Dune.md', `---\ntitle: Dune\n---\n`);
+    await indexAllNotes(ctx);
+    expect((await getNoteTypeMap(ctx))['Dune.md']).toBeUndefined();
+  });
+});

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -238,6 +238,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "types:instances",
   "types:list",
   "types:noteProperties",
+  "types:noteTypeMap",
   "types:rename",
   "types:save",
   "views:delete",

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -404,6 +404,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "instances",
     "list",
     "noteProperties",
+    "noteTypeMap",
     "rename",
     "save",
   ],

--- a/tests/renderer/components/FileTree.test.ts
+++ b/tests/renderer/components/FileTree.test.ts
@@ -29,13 +29,33 @@ const h = vi.hoisted(() => ({
       openInDefault: vi.fn(),
       openInTerminal: vi.fn(),
     },
+    // A typed note's row shows its type's icon instead of the by-extension
+    // glyph; the store joins these two reads.
+    types: {
+      list: vi.fn().mockResolvedValue({ types: [], errors: [] }),
+      noteTypeMap: vi.fn().mockResolvedValue({}),
+    },
   },
 }));
 vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: h.api }));
 
 import FileTree from '../../../src/renderer/lib/components/FileTree.svelte';
+import { objectTypesStore } from '../../../src/renderer/lib/stores/object-types.svelte';
 
-afterEach(cleanup);
+const BOOK = { id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock', icon: '📖', properties: [] };
+
+/** Seed the module-singleton store, then reset it so tests stay independent. */
+async function seedTypes(map: Record<string, string>, types: unknown[] = [BOOK]) {
+  h.api.types.list.mockResolvedValue({ types, errors: [] });
+  h.api.types.noteTypeMap.mockResolvedValue(map);
+  await objectTypesStore.refresh();
+}
+
+afterEach(async () => {
+  cleanup();
+  // The store is a module singleton — empty it so a seeded map can't leak.
+  await seedTypes({}, []);
+});
 
 /** notes/ (dir) → alpha.md, beta.md ; plus a root-level readme.md. */
 function tree(): NoteFile[] {
@@ -98,6 +118,40 @@ describe('FileTree (#1002)', () => {
     expect(row(container, 'notes')).toBeTruthy();
     expect(row(container, 'notes/alpha.md')).toBeTruthy();
     expect(row(container, 'readme.md')).toBeTruthy();
+  });
+
+  it('shows a typed note’s type icon, and leaves untyped rows on the file glyph', async () => {
+    await seedTypes({ 'notes/alpha.md': 'book' });
+    const { container } = render(FileTree, props({ expanded: { notes: true } }));
+
+    const typed = row(container, 'notes/alpha.md')!;
+    expect(typed.querySelector('.type-icon')?.textContent).toBe('📖');
+    expect(typed.querySelector('.type-icon')?.getAttribute('aria-label')).toBe('Book');
+    // The generic svg glyph is replaced, not doubled up.
+    expect(typed.querySelectorAll('svg')).toHaveLength(0);
+
+    const untyped = row(container, 'notes/beta.md')!;
+    expect(untyped.querySelector('.type-icon')).toBeNull();
+    expect(untyped.querySelectorAll('svg').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the file glyph when a note’s type is no longer in the catalog', async () => {
+    // A `type:` left pointing at a deleted type must not render a blank slot.
+    await seedTypes({ 'readme.md': 'ghost-type' });
+    const { container } = render(FileTree, props());
+
+    const r = row(container, 'readme.md')!;
+    expect(r.querySelector('.type-icon')).toBeNull();
+    expect(r.querySelectorAll('svg').length).toBeGreaterThan(0);
+  });
+
+  it('repaints rows when the type catalog changes (an icon edit)', async () => {
+    await seedTypes({ 'readme.md': 'book' });
+    const { container } = render(FileTree, props());
+    expect(row(container, 'readme.md')!.querySelector('.type-icon')?.textContent).toBe('📖');
+
+    await seedTypes({ 'readme.md': 'book' }, [{ ...BOOK, icon: '📕' }]);
+    expect(row(container, 'readme.md')!.querySelector('.type-icon')?.textContent).toBe('📕');
   });
 
   it('marks the active file and moves the highlight when activeFilePath changes', async () => {

--- a/tests/renderer/components/ObjectTypesSettings.test.ts
+++ b/tests/renderer/components/ObjectTypesSettings.test.ts
@@ -8,12 +8,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
 
-const { listMock, saveMock, deleteMock, deleteSafelyMock, renameMock, queryMock, confirmMock, promptMock } = vi.hoisted(() => ({
+const { listMock, saveMock, deleteMock, deleteSafelyMock, renameMock, noteTypeMapMock, queryMock, confirmMock, promptMock } = vi.hoisted(() => ({
   listMock: vi.fn(), saveMock: vi.fn(), deleteMock: vi.fn(), deleteSafelyMock: vi.fn(), renameMock: vi.fn(),
+  // The store fetches the catalog and the note→type map together, so every
+  // `refresh()` here hits both.
+  noteTypeMapMock: vi.fn(),
   queryMock: vi.fn(), confirmMock: vi.fn(), promptMock: vi.fn(),
 }));
 vi.mock('../../../src/renderer/lib/ipc/client', () => ({
-  api: { types: { list: listMock, save: saveMock, delete: deleteMock, deleteSafely: deleteSafelyMock, rename: renameMock }, graph: { query: queryMock } },
+  api: { types: { list: listMock, save: saveMock, delete: deleteMock, deleteSafely: deleteSafelyMock, rename: renameMock, noteTypeMap: noteTypeMapMock }, graph: { query: queryMock } },
 }));
 vi.mock('../../../src/renderer/lib/stores/dialogs.svelte', () => ({
   getDialogStore: () => ({ showConfirm: confirmMock, showPrompt: promptMock }),
@@ -29,6 +32,7 @@ const GADGET = { id: 'gadget', label: 'Gadget', classLocalName: 'Gadget', source
 
 beforeEach(() => {
   listMock.mockResolvedValue({ types: [BOOK, GADGET], errors: [] });
+  noteTypeMapMock.mockResolvedValue({});
   saveMock.mockResolvedValue({ id: 'gadget-copy', filePath: '.minerva/types/gadget-copy.md' });
   deleteMock.mockResolvedValue(undefined);
   deleteSafelyMock.mockResolvedValue({ cleared: [], failed: [] });

--- a/tests/renderer/components/ObjectsPanel.test.ts
+++ b/tests/renderer/components/ObjectsPanel.test.ts
@@ -8,18 +8,32 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
 
-const { typesMock, queryMock, viewsListMock } = vi.hoisted(() => ({ typesMock: vi.fn(), queryMock: vi.fn(), viewsListMock: vi.fn() }));
+const { typesMock, queryMock, viewsListMock, noteTypeMapMock } = vi.hoisted(() => ({
+  typesMock: vi.fn(), queryMock: vi.fn(), viewsListMock: vi.fn(),
+  // Instance rows carry a per-row type icon read from the store's map.
+  noteTypeMapMock: vi.fn(),
+}));
 vi.mock('../../../src/renderer/lib/ipc/client', () => ({
-  api: { types: { list: typesMock }, graph: { query: queryMock }, views: { list: viewsListMock } },
+  api: { types: { list: typesMock, noteTypeMap: noteTypeMapMock }, graph: { query: queryMock }, views: { list: viewsListMock } },
 }));
 
 import ObjectsPanel from '../../../src/renderer/lib/components/ObjectsPanel.svelte';
+import { objectTypesStore } from '../../../src/renderer/lib/stores/object-types.svelte';
 
 const BOOK = { id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock', icon: '📖', properties: [] };
 const MEETING = { id: 'meeting', label: 'Meeting', classLocalName: 'Meeting', source: 'stock', icon: '🗓️', properties: [] };
+const NOVEL = { id: 'novel', label: 'Novel', classLocalName: 'Novel', parent: 'book', source: 'user', icon: '📕', properties: [] };
 
-beforeEach(() => {
+/** Seed the module-singleton note→type store used for the per-row icons. */
+async function seedTypes(map: Record<string, string>, types: unknown[] = [BOOK, MEETING, NOVEL]) {
+  typesMock.mockResolvedValue({ types, errors: [] });
+  noteTypeMapMock.mockResolvedValue(map);
+  await objectTypesStore.refresh();
+}
+
+beforeEach(async () => {
   typesMock.mockResolvedValue({ types: [BOOK, MEETING], errors: [] });
+  noteTypeMapMock.mockResolvedValue({});
   viewsListMock.mockResolvedValue([]); // saved-views store refresh (#1072)
   queryMock.mockImplementation((sparql: string) => {
     if (sparql.includes('thought:Excerpt')) return Promise.resolve({ results: [{ n: '7' }], columns: [] }); // excerpt count
@@ -30,7 +44,11 @@ beforeEach(() => {
     return Promise.resolve({ results: [], columns: [] });
   });
 });
-afterEach(() => { cleanup(); typesMock.mockReset(); queryMock.mockReset(); viewsListMock.mockReset(); });
+afterEach(async () => {
+  cleanup();
+  await seedTypes({}, []); // the store is a module singleton — don't leak a map
+  typesMock.mockReset(); queryMock.mockReset(); viewsListMock.mockReset(); noteTypeMapMock.mockReset();
+});
 
 describe('ObjectsPanel (#1068)', () => {
   it('lists types with instance counts, including a zero-instance type', async () => {
@@ -52,6 +70,28 @@ describe('ObjectsPanel (#1068)', () => {
     expect(screen.getByText('Neuromancer')).toBeTruthy();
     await fireEvent.click(dune);
     expect(onFileSelect).toHaveBeenCalledWith('Dune.md');
+  });
+
+  it('gives each instance row its OWN type icon, not the group’s', async () => {
+    // The group query is subclass-aware (#1587), so a Book group lists Novels.
+    // The per-row icon is what tells them apart.
+    await seedTypes({ 'Dune.md': 'book', 'Neuro.md': 'novel' });
+    const { container } = render(ObjectsPanel, { onFileSelect: vi.fn() });
+    await fireEvent.click(await screen.findByText('Book'));
+    await screen.findByText('Dune');
+
+    const icons = [...container.querySelectorAll('.instance-row .type-icon')].map((e) => e.textContent);
+    expect(icons).toEqual(['📖', '📕']);
+  });
+
+  it('falls back to the group’s type icon for a row missing from the note→type map', async () => {
+    await seedTypes({});
+    const { container } = render(ObjectsPanel, { onFileSelect: vi.fn() });
+    await fireEvent.click(await screen.findByText('Book'));
+    await screen.findByText('Dune');
+
+    const icons = [...container.querySelectorAll('.instance-row .type-icon')].map((e) => e.textContent);
+    expect(icons).toEqual(['📖', '📖']);
   });
 
   it('shows an empty state for an expanded type with no instances', async () => {

--- a/tests/renderer/components/TypeView.test.ts
+++ b/tests/renderer/components/TypeView.test.ts
@@ -9,10 +9,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
 
-const { instancesMock } = vi.hoisted(() => ({ instancesMock: vi.fn() }));
-vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: { types: { instances: instancesMock } } }));
+const { instancesMock, listMock, noteTypeMapMock } = vi.hoisted(() => ({
+  instancesMock: vi.fn(),
+  // The per-row type icon reads the store's note→type map (see the subclass test).
+  listMock: vi.fn(), noteTypeMapMock: vi.fn(),
+}));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { types: { instances: instancesMock, list: listMock, noteTypeMap: noteTypeMapMock } },
+}));
 
 import TypeView from '../../../src/renderer/lib/components/TypeView.svelte';
+import { objectTypesStore } from '../../../src/renderer/lib/stores/object-types.svelte';
 
 const TYPE = {
   id: 'book',
@@ -44,8 +51,20 @@ function props(over: Record<string, unknown> = {}) {
   };
 }
 
-beforeEach(() => { instancesMock.mockResolvedValue({ type: TYPE, instances: INSTANCES }); });
-afterEach(() => { cleanup(); instancesMock.mockReset(); });
+const NOVEL = { id: 'novel', label: 'Novel', classLocalName: 'Novel', icon: '📕', parent: 'book', source: 'user' as const, properties: [] };
+
+/** Seed the module-singleton note→type store used for per-row icons. */
+async function seedTypes(map: Record<string, string>, types: unknown[] = [TYPE, NOVEL]) {
+  listMock.mockResolvedValue({ types, errors: [] });
+  noteTypeMapMock.mockResolvedValue(map);
+  await objectTypesStore.refresh();
+}
+
+beforeEach(async () => {
+  instancesMock.mockResolvedValue({ type: TYPE, instances: INSTANCES });
+  await seedTypes({});
+});
+afterEach(async () => { cleanup(); await seedTypes({}, []); instancesMock.mockReset(); });
 
 describe('TypeView (#1070)', () => {
   it('renders the header (label + count) and a list of instances', async () => {
@@ -54,6 +73,27 @@ describe('TypeView (#1070)', () => {
     expect(screen.getByText('Neuromancer')).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Book' })).toBeTruthy();
     expect(screen.getByText('2')).toBeTruthy(); // instance count
+  });
+
+  it('gives each row its OWN type icon — a subclass instance is not shown as its parent', async () => {
+    // This view is subclass-aware (#1587): a Book view lists Novels too. The
+    // per-row icon is what distinguishes them, so it must not just repeat the
+    // header's type.
+    await seedTypes({ 'Neuro.md': 'novel' });
+    const { container } = render(TypeView, props({ layout: 'list' }));
+    await waitFor(() => expect(screen.getByText('Dune')).toBeTruthy());
+
+    const icons = [...container.querySelectorAll('.tv-list .type-icon')].map((e) => e.textContent);
+    expect(icons).toEqual(['📖', '📕']);
+  });
+
+  it('falls back to the view’s type icon before the note→type map has loaded', async () => {
+    await seedTypes({});
+    const { container } = render(TypeView, props({ layout: 'list' }));
+    await waitFor(() => expect(screen.getByText('Dune')).toBeTruthy());
+
+    const icons = [...container.querySelectorAll('.tv-list .type-icon')].map((e) => e.textContent);
+    expect(icons).toEqual(['📖', '📖']);
   });
 
   it('opens a note when an instance is clicked', async () => {
@@ -71,7 +111,8 @@ describe('TypeView (#1070)', () => {
     await waitFor(() => expect(screen.getByRole('columnheader', { name: /Author/ })).toBeTruthy());
     expect(screen.getByRole('columnheader', { name: /Rating/ })).toBeTruthy();
 
-    const titles = () => [...container.querySelectorAll('tbody .tv-cell-title')].map((e) => e.textContent);
+    // Last span in the cell is the title text — the first is the type icon.
+    const titles = () => [...container.querySelectorAll('tbody .tv-cell-title-inner > span:last-child')].map((e) => e.textContent);
     expect(titles()).toEqual(['Dune', 'Neuromancer']); // intrinsic order (sortColumn null)
 
     // Clicking a header requests a sort — it doesn't self-sort.


### PR DESCRIPTION
Typed notes carry an icon on their type definition (📖 for Book), but it only rendered in type-scoped UI — the Objects panel headers, the pickers, the type header. Every note list showed the same generic page glyph, so a thoughtbase of Books and People looked undifferentiated in the sidebar.

## The bulk read

There was no way to ask "which notes are typed?" in one shot — `types:noteProperties` is one call per note, so badging a 2000-note tree would have meant 2000 IPC round-trips.

`types:noteTypeMap` is one SPARQL pass returning `relativePath → typeId` for the whole thoughtbase, modeled on the existing `graph:aliasMap` bulk projection. It reads the **direct** class (no `rdfs:subClassOf*`), so a row shows the note's own type rather than an ancestor's.

`objectTypesStore` caches it behind `typeForNote(path)` rather than getting a new store of its own. It already re-lists on every type mutation, so catalog and map refresh together — editing a type's icon in the Type Manager repaints every row at once (covered by a test).

## Surfaces

All via a shared `TypeIcon.svelte`, boxed to the same footprint as `<Icon>` so typed and untyped rows keep an aligned label column:

- **sidebar Notes tree** (`FileTree`)
- tab bar — the dirty pip still wins, per §7.2
- quick-open / Goto Note
- backlinks + outgoing links
- bookmarks — anchor bookmarks keep the generic glyph, since they point into a section rather than at the object
- Objects panel instance rows
- TypeView list / table / gallery

The last two look redundant sitting under a type-scoped header, but both query with `a/rdfs:subClassOf*` (#1587): a Book group and a Book view **list Novel instances too**, and the header can only say "Book". Those rows resolve their own type and fall back to the group's, so 📖 Dune / 📕 Neuromancer distinguishes what the header cannot.

Untyped notes, and notes whose `type:` points at a deleted type, keep their by-extension glyph — no blank slots.

## Refresh timing

Rides `Sidebar.refreshObjects()`, which every graph-changed path already calls, plus a mount-time seed so a startup-restored project has icons on first paint.

Deliberately **not** wired to the file-watcher events: `watcher.ts:183` broadcasts before it reindexes, so a subscription there would read a stale graph.

## Layout changes

Two rows needed restructuring to take an icon at all:

- `.instance-row` (Objects panel) was `display: block` with its ellipsis on the row → flex, truncation moved to a new `.instance-name`.
- TypeView list rows were `flex-direction: column` (title stacked over summary), so an icon would have stacked *above* the title → icon gutter + `.tv-list-body` column, icon boxed to the title's line height so it centres on the first line rather than on a two-line row.

## Tests

- 5 for the projection — nesting, unknown type, subtype specificity, type removal
- 3 for FileTree rendering, including the icon-edit repaint and the deleted-type fallback
- 4 for the subclass distinction + pre-load fallback in ObjectsPanel / TypeView
- Fixed an existing `ObjectTypesSettings` test whose `api.types` stub predated the new method

One existing TypeView assertion broke legitimately: it read a title cell's `textContent`, which now includes the icon (`'📖 Dune'`). Retargeted to the title span — the failure also confirmed the `?? type` fallback fires before the map loads.

`pnpm lint` clean; 566 test files / 5606 tests passing.

## Reviewer notes

- Snapshot churn in `registration.test.ts.snap` and `preload-bridge.test.ts.snap` is just the one new channel.
- Per the IPC error-handling convention, `types:noteTypeMap` uses `withRootPathOr({})` — an empty map is a legitimate "nothing typed yet", not a failure signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
