### PR TITLE
feat(objects): emoji + colour pickers in the type editor

### DIFF
--- a/src/main/ipc/register-shell.ts
+++ b/src/main/ipc/register-shell.ts
@@ -1,4 +1,4 @@
-import { shell, dialog } from 'electron';
+import { app, shell, dialog } from 'electron';
 import { handle } from './typed-ipc';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
@@ -80,5 +80,15 @@ export function registerShell(): void {
     }
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return;
     await shell.openExternal(parsed.toString());
+  });
+
+  // Native emoji picker for the object-type icon field. The panel types into
+  // whatever text field has focus, so the renderer focuses the input first and
+  // we just raise the panel. macOS-only — `showEmojiPanel` doesn't exist on
+  // other platforms, and there's no Electron equivalent to fall back to, so
+  // this is a deliberate no-op there rather than a throw: the renderer already
+  // hides the button off-macOS, and a stray call shouldn't reject.
+  handle(Channels.SHELL_SHOW_EMOJI_PANEL, () => {
+    if (process.platform === 'darwin') app.showEmojiPanel();
   });
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -251,6 +251,7 @@ contextBridge.exposeInMainWorld('api', {
       invoke(Channels.SHELL_OPEN_IN_TERMINAL, relativePath),
     openExternal: (url: string) =>
       invoke(Channels.SHELL_OPEN_EXTERNAL, url),
+    showEmojiPanel: () => invoke(Channels.SHELL_SHOW_EMOJI_PANEL),
   },
   conversations: {
     create: (contextBundle: Parameters<ChannelMap['conversation:create']>[0], triggerNodeUri?: string, options?: Parameters<ChannelMap['conversation:create']>[2]) =>

--- a/src/renderer/lib/app/project-ops.ts
+++ b/src/renderer/lib/app/project-ops.ts
@@ -18,6 +18,7 @@ import { getEditorStore } from '../stores/editor.svelte';
 import { getConversationsStore } from '../stores/conversations.svelte';
 import { getDialogStore } from '../stores/dialogs.svelte';
 import { slugifyForPath, countNotes } from './text-helpers';
+import { IS_MAC } from '../utils/platform';
 import { ENTRYPOINT_TAG } from '../../../shared/entrypoint';
 import { WELCOME_NOTE_PATH, welcomeNoteContent } from '../../../shared/welcome-note';
 import { THOUGHTBASE_DOC_FILENAME, THOUGHTBASE_DOC_TEMPLATE } from '../../../shared/thoughtbase';
@@ -107,9 +108,8 @@ export function createProjectOps(ctx: ProjectOpsCtx) {
   async function maybeSeedWelcomeNote(): Promise<void> {
     if (!notebase.meta) return;
     if (countNotes(notebase.files) > 0) return;
-    const isMac = /Mac|iPhone|iPad/i.test(navigator.platform || navigator.userAgent || '');
     try {
-      await api.notebase.writeFile(WELCOME_NOTE_PATH, welcomeNoteContent(isMac));
+      await api.notebase.writeFile(WELCOME_NOTE_PATH, welcomeNoteContent(IS_MAC));
       await notebase.refresh();
       await editor.openFile(WELCOME_NOTE_PATH);
     } catch (e) {

--- a/src/renderer/lib/command-palette/format-accelerator.ts
+++ b/src/renderer/lib/command-palette/format-accelerator.ts
@@ -5,11 +5,7 @@
  * keybindings next to each command. (#463)
  */
 
-/** Whether to use macOS glyphs (⌘ / ⌥ / ⇧ / ⌃). Determined once at
- *  module load; tests can override by passing `isMac` directly. */
-const IS_MAC = typeof navigator !== 'undefined'
-  ? /Mac|iPhone|iPad/i.test(navigator.platform || navigator.userAgent || '')
-  : process.platform === 'darwin';
+import { IS_MAC } from '../utils/platform';
 
 /** Map of token (lowercased) → its display form on macOS. */
 const MAC_GLYPHS: Record<string, string> = {

--- a/src/renderer/lib/components/TypeEditorDialog.svelte
+++ b/src/renderer/lib/components/TypeEditorDialog.svelte
@@ -13,6 +13,8 @@
   import { api } from '../ipc/client';
   import { objectTypesStore } from '../stores/object-types.svelte';
   import { PROPERTY_TYPES, titleCase, type PropertyDef, type PropertyType } from '../../../shared/objects/type-def';
+  import { COLOR_SWATCHES, DEFAULT_SWATCH, toHex6 } from '../../../shared/color-swatches';
+  import { IS_MAC } from '../utils/platform';
   import type { TypeEditorInitial } from './type-editor-value';
 
   interface Props {
@@ -118,6 +120,25 @@
   }
 
   function overlayKey(e: KeyboardEvent): void { if (e.key === 'Escape') onClose(); }
+
+  // ── Icon + colour pickers ──────────────────────────────────────────────
+  let iconInput = $state<HTMLInputElement | undefined>();
+
+  /**
+   * Raise the OS emoji picker (macOS). It types into whatever field has focus,
+   * so focus + SELECT the icon input first: picking then replaces the current
+   * icon rather than appending a second glyph after it.
+   */
+  function pickEmoji(): void {
+    iconInput?.focus();
+    iconInput?.select();
+    void api.shell.showEmojiPanel();
+  }
+
+  /** `<input type="color">` only accepts `#rrggbb`; show the default until the
+   *  field holds something it can parse, so a half-typed hex doesn't blank it. */
+  const colorWell = $derived(toHex6(color) ?? DEFAULT_SWATCH);
+  const selectedSwatch = $derived(toHex6(color));
 </script>
 
 <div class="overlay" onkeydown={overlayKey} onmousedown={(e) => { if (e.target === e.currentTarget) onClose(); }} role="presentation">
@@ -128,12 +149,52 @@
       <label class="field grow"><span>Name</span>
         <input bind:value={label} placeholder="Book" />
       </label>
-      <label class="field narrow"><span>Icon</span>
-        <input bind:value={icon} placeholder="📖" maxlength="4" />
-      </label>
-      <label class="field narrow"><span>Color</span>
-        <input bind:value={color} placeholder="#89b4fa" />
-      </label>
+
+      <div class="field icon-field">
+        <label for="te-icon">Icon</label>
+        <div class="combo">
+          <!-- maxlength fits a full ZWJ sequence (👨‍👩‍👧‍👦 is 11 UTF-16 units);
+               the old cap of 4 truncated those mid-sequence into mojibake. -->
+          <input id="te-icon" bind:this={iconInput} bind:value={icon} placeholder="📖" maxlength="16" />
+          {#if IS_MAC}
+            <button class="adorn" title="Choose an emoji…" aria-label="Choose an emoji" onclick={pickEmoji}>☺</button>
+          {/if}
+        </div>
+      </div>
+
+      <div class="field color-field">
+        <label for="te-color">Color</label>
+        <div class="combo">
+          <input
+            class="well"
+            type="color"
+            value={colorWell}
+            aria-label="Pick a color"
+            oninput={(e) => { color = e.currentTarget.value; }}
+          />
+          <input id="te-color" bind:value={color} placeholder="#89b4fa" spellcheck="false" />
+          {#if color.trim()}
+            <button class="adorn" title="Clear color" aria-label="Clear color" onclick={() => { color = ''; }}>×</button>
+          {/if}
+        </div>
+      </div>
+    </div>
+
+    <!-- The app's own accent vocabulary (same family as the link-type
+         palette), so a hand-typed hex is never the only way to get a colour
+         that fits. Typing one still works — this just seeds the field. -->
+    <div class="swatches" role="group" aria-label="Color presets">
+      {#each COLOR_SWATCHES as sw (sw.hex)}
+        <button
+          class="swatch"
+          class:on={selectedSwatch === sw.hex}
+          style:background={sw.hex}
+          title={sw.name}
+          aria-label={sw.name}
+          aria-pressed={selectedSwatch === sw.hex}
+          onclick={() => { color = sw.hex; }}
+        ></button>
+      {/each}
     </div>
 
     <div class="props-head">
@@ -202,15 +263,56 @@
     box-shadow: 0 12px 48px rgba(0,0,0,0.45);
   }
   .title { margin: 0 0 14px; font-size: 15px; color: var(--text); }
-  .meta { display: flex; gap: 10px; margin-bottom: 16px; }
+  .meta { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-end; }
   .field { display: flex; flex-direction: column; gap: 4px; }
-  .field span { font-size: 11px; color: var(--text-muted); }
+  .field span, .field label { font-size: 11px; color: var(--text-muted); }
   .field.grow { flex: 1; }
-  .field.narrow { width: 90px; }
+  .field.icon-field { width: 92px; }
+  .field.color-field { width: 168px; }
   .field input, .field select, .prop-row input, .prop-row select {
     padding: 5px 8px; border: 1px solid var(--border); border-radius: 5px;
     background: var(--bg-inset); color: var(--text); font-family: inherit; font-size: 13px;
   }
+
+  /* Text field + its adornments share one bordered box, so the picker reads as
+     part of the field rather than a button parked beside it. */
+  .combo {
+    display: flex; align-items: stretch; gap: 0;
+    border: 1px solid var(--border); border-radius: 5px;
+    background: var(--bg-inset); overflow: hidden;
+  }
+  .combo:focus-within { border-color: var(--accent); }
+  .combo input { border: none; border-radius: 0; background: transparent; min-width: 0; flex: 1; }
+  .combo input:focus { outline: none; }
+  .adorn {
+    flex-shrink: 0; width: 26px; border: none; border-left: 1px solid var(--border);
+    background: var(--bg-button); color: var(--text-muted);
+    font-size: 13px; line-height: 1; cursor: pointer;
+  }
+  .adorn:hover { color: var(--text); background: var(--bg-button-hover); }
+
+  /* Native colour well, stripped of its chrome so it reads as a swatch. */
+  .well {
+    flex: 0 0 auto; width: 28px; padding: 0; border: none; border-radius: 0;
+    background: transparent; cursor: pointer; align-self: stretch;
+  }
+  .well::-webkit-color-swatch-wrapper { padding: 3px; }
+  .well::-webkit-color-swatch { border: 1px solid var(--border); border-radius: 3px; }
+
+  .swatches { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 16px; }
+  .swatch {
+    width: 17px; height: 17px; padding: 0; border-radius: 50%;
+    border: 1px solid color-mix(in oklch, var(--text) 25%, transparent);
+    cursor: pointer;
+  }
+  .swatch:hover { transform: scale(1.15); }
+  /* Selected reads as a ring rather than a colour change — the swatch IS its
+     colour, so it can't recolour to signal state. */
+  .swatch.on {
+    border-color: var(--text);
+    box-shadow: 0 0 0 2px var(--bg), 0 0 0 3.5px var(--accent);
+  }
+  .swatch:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
   .props-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
   .props-title { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
   .muted { font-size: 12px; color: var(--text-faint); margin: 2px 0 8px; }

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -497,6 +497,12 @@ export interface ShellApi {
   openInDefault(relativePath: string): Promise<void>;
   openInTerminal(relativePath?: string): Promise<void>;
   openExternal(url: string): Promise<void>;
+  /** Open the OS emoji picker over the focused text field; it types the chosen
+   *  emoji into that field as if the user had. macOS-only — resolves without
+   *  doing anything elsewhere, so gate the UI on `IS_MAC` rather than relying
+   *  on this to report failure. A stateless OS side-effect: callable from a
+   *  component directly. */
+  showEmojiPanel(): Promise<void>;
 }
 
 /** App + build metadata for the About dialog (#803). */

--- a/src/renderer/lib/utils/platform.ts
+++ b/src/renderer/lib/utils/platform.ts
@@ -1,0 +1,11 @@
+/**
+ * Renderer-side platform detection.
+ *
+ * The renderer has no `process.platform`, so this sniffs the UA. Determined
+ * once at module load — it can't change within a session. Callers that need to
+ * vary behaviour in tests should take the flag as a parameter rather than
+ * re-reading this.
+ */
+export const IS_MAC = typeof navigator !== 'undefined'
+  ? /Mac|iPhone|iPad/i.test(navigator.platform || navigator.userAgent || '')
+  : process.platform === 'darwin';

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -666,6 +666,9 @@ export const Channels = {
   SHELL_OPEN_IN_DEFAULT: 'shell:openInDefault',
   SHELL_OPEN_IN_TERMINAL: 'shell:openInTerminal',
   SHELL_OPEN_EXTERNAL: 'shell:openExternal',
+  /** Open the OS emoji picker over the focused text field. macOS-only; a
+   *  no-op elsewhere (Electron exposes no equivalent). */
+  SHELL_SHOW_EMOJI_PANEL: 'shell:showEmojiPanel',
   GRAPH_EXPORT: 'graph:export',
 
   // Privileged sites (per-machine domains the user has logged in to so

--- a/src/shared/color-swatches.ts
+++ b/src/shared/color-swatches.ts
@@ -1,0 +1,49 @@
+/**
+ * The app's shared accent-colour vocabulary, as pickable swatches.
+ *
+ * These are the same Catppuccin accents the link-type palette already draws
+ * from (`link-types.ts`), so a user-chosen type colour sits in the same family
+ * as the colours Minerva assigns itself. Hex rather than the theme's `oklch`
+ * tokens on purpose: a type's colour is durable user content written to
+ * frontmatter and fed to `<input type="color">`, not a theme token that should
+ * shift between light and dark.
+ */
+export interface ColorSwatch {
+  /** Human name, used as the swatch's tooltip + accessible label. */
+  name: string;
+  /** Lowercase `#rrggbb`. */
+  hex: string;
+}
+
+export const COLOR_SWATCHES: readonly ColorSwatch[] = [
+  { name: 'Rosewater', hex: '#f5e0dc' },
+  { name: 'Flamingo', hex: '#f2cdcd' },
+  { name: 'Pink', hex: '#f5c2e7' },
+  { name: 'Mauve', hex: '#cba6f7' },
+  { name: 'Red', hex: '#f38ba8' },
+  { name: 'Maroon', hex: '#eba0ac' },
+  { name: 'Peach', hex: '#fab387' },
+  { name: 'Yellow', hex: '#f9e2af' },
+  { name: 'Green', hex: '#a6e3a1' },
+  { name: 'Teal', hex: '#94e2d5' },
+  { name: 'Sky', hex: '#89dceb' },
+  { name: 'Sapphire', hex: '#74c7ec' },
+  { name: 'Blue', hex: '#89b4fa' },
+  { name: 'Lavender', hex: '#b4befe' },
+  { name: 'Grey', hex: '#9399b2' },
+];
+
+/** The swatch shown by `<input type="color">` when no colour is set yet. */
+export const DEFAULT_SWATCH = '#89b4fa';
+
+/**
+ * Normalize a user-typed colour to the `#rrggbb` an `<input type="color">`
+ * requires, or null if it isn't one. Accepts the `#rgb` shorthand (expanding
+ * it) and tolerates surrounding whitespace / a missing `#`.
+ */
+export function toHex6(value: string): string | null {
+  const v = value.trim().toLowerCase().replace(/^#/, '');
+  if (/^[0-9a-f]{3}$/.test(v)) return `#${v[0]}${v[0]}${v[1]}${v[1]}${v[2]}${v[2]}`;
+  if (/^[0-9a-f]{6}$/.test(v)) return `#${v}`;
+  return null;
+}

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -183,6 +183,7 @@ export interface ChannelMap {
   'shell:openInDefault': (relativePath: string) => void;
   'shell:openInTerminal': (relativePath?: string) => void;
   'shell:openExternal': (url: string) => void;
+  'shell:showEmojiPanel': () => void;
 
   // Bookmarks
   'bookmarks:load': () => BookmarkNode[];

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -179,6 +179,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "shell:openInDefault",
   "shell:openInTerminal",
   "shell:revealFile",
+  "shell:showEmojiPanel",
   "sites:add",
   "sites:list",
   "sites:login",

--- a/tests/main/ipc/register-shell.test.ts
+++ b/tests/main/ipc/register-shell.test.ts
@@ -20,14 +20,16 @@ import path from 'node:path';
 const ROOT = '/minerva-shell-guard-root-8f3a';
 
 type Handler = (event: unknown, ...args: unknown[]) => unknown;
-const { handlers, shellCalls, spawnCalls } = vi.hoisted(() => ({
+const { handlers, shellCalls, spawnCalls, emojiPanelCalls } = vi.hoisted(() => ({
   handlers: new Map<string, Handler>(),
   shellCalls: { reveal: [] as string[], openPath: [] as string[] },
   spawnCalls: [] as unknown[][],
+  emojiPanelCalls: { n: 0 },
 }));
 
 vi.mock('electron', () => ({
   ipcMain: { handle: (channel: string, fn: Handler) => { handlers.set(channel, fn); } },
+  app: { showEmojiPanel: () => { emojiPanelCalls.n += 1; } },
   shell: {
     showItemInFolder: (p: string) => { shellCalls.reveal.push(p); },
     openPath: (p: string) => { shellCalls.openPath.push(p); return Promise.resolve(''); },
@@ -61,7 +63,16 @@ beforeEach(() => {
   shellCalls.reveal = [];
   shellCalls.openPath = [];
   spawnCalls.length = 0;
+  emojiPanelCalls.n = 0;
 });
+
+/** Run `fn` with `process.platform` forced — it's a plain value property, so
+ *  `vi.spyOn(…, 'get')` can't stub it. */
+function withPlatform(value: string, fn: () => void): void {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  Object.defineProperty(process, 'platform', { ...original, value });
+  try { fn(); } finally { Object.defineProperty(process, 'platform', original); }
+}
 
 const TRAVERSAL = '../../../../etc/passwd';
 
@@ -97,5 +108,23 @@ describe('shell handlers — path-traversal guard (#1328)', () => {
     const h = handlers.get(Channels.SHELL_REVEAL_FILE)!;
     h({});
     expect(shellCalls.reveal).toEqual([ROOT]);
+  });
+});
+
+describe('SHELL_SHOW_EMOJI_PANEL', () => {
+  it('raises the native panel on macOS', () => {
+    const h = handlers.get(Channels.SHELL_SHOW_EMOJI_PANEL)!;
+    withPlatform('darwin', () => { h({}); });
+    expect(emojiPanelCalls.n).toBe(1);
+  });
+
+  it('is a silent no-op off macOS — no throw, so a stray call cannot reject', () => {
+    // Electron only defines showEmojiPanel on darwin, and there's no
+    // cross-platform equivalent; the renderer hides the button elsewhere.
+    const h = handlers.get(Channels.SHELL_SHOW_EMOJI_PANEL)!;
+    for (const p of ['win32', 'linux']) {
+      withPlatform(p, () => { expect(() => h({})).not.toThrow(); });
+    }
+    expect(emojiPanelCalls.n).toBe(0);
   });
 });

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -315,6 +315,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "openInDefault",
     "openInTerminal",
     "revealFile",
+    "showEmojiPanel",
   ],
   "sites": [
     "add",

--- a/tests/renderer/components/TypeEditorDialog.test.ts
+++ b/tests/renderer/components/TypeEditorDialog.test.ts
@@ -8,17 +8,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
 
-const { saveMock, listMock } = vi.hoisted(() => ({ saveMock: vi.fn(), listMock: vi.fn() }));
+const { saveMock, listMock, emojiPanelMock, platform } = vi.hoisted(() => ({
+  saveMock: vi.fn(), listMock: vi.fn(), emojiPanelMock: vi.fn(),
+  // Mutable so a test can render both the macOS and the non-macOS form.
+  platform: { IS_MAC: true },
+}));
 vi.mock('../../../src/renderer/lib/stores/object-types.svelte', () => ({
   objectTypesStore: { save: saveMock },
 }));
-vi.mock('../../../src/renderer/lib/ipc/client', () => ({ api: { types: { list: listMock } } }));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { types: { list: listMock }, shell: { showEmojiPanel: emojiPanelMock } },
+}));
+vi.mock('../../../src/renderer/lib/utils/platform', () => ({ get IS_MAC() { return platform.IS_MAC; } }));
 
 import TypeEditorDialog from '../../../src/renderer/lib/components/TypeEditorDialog.svelte';
 
 beforeEach(() => {
+  platform.IS_MAC = true;
   saveMock.mockResolvedValue({ id: 'book', filePath: '.minerva/types/book.md' });
   listMock.mockResolvedValue({ types: [{ id: 'person' }, { id: 'book' }], errors: [] });
+  emojiPanelMock.mockResolvedValue(undefined);
 });
 afterEach(() => { cleanup(); vi.clearAllMocks(); });
 
@@ -111,5 +120,84 @@ describe('TypeEditorDialog (#1585)', () => {
     // The Create button is disabled with an empty name.
     expect(screen.getByText('Create').hasAttribute('disabled')).toBe(true);
     expect(saveMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TypeEditorDialog — icon picker', () => {
+  it('focuses and selects the icon field before raising the OS panel, so a pick replaces', async () => {
+    // The native panel types into whatever field has focus. Without the
+    // select(), picking would append a second glyph after the existing one.
+    render(TypeEditorDialog, { initial: { label: 'Book', icon: '📖', properties: [] }, onSaved: vi.fn(), onClose: vi.fn() });
+    const field = screen.getByDisplayValue('📖');
+    const selectSpy = vi.spyOn(field, 'select');
+
+    await fireEvent.click(screen.getByLabelText('Choose an emoji'));
+
+    expect(document.activeElement).toBe(field);
+    expect(selectSpy).toHaveBeenCalled();
+    expect(emojiPanelMock).toHaveBeenCalled();
+  });
+
+  it('hides the picker button off macOS, leaving the field typable', async () => {
+    // No cross-platform equivalent exists, so the plain text field is the
+    // fallback rather than a button that would do nothing.
+    platform.IS_MAC = false;
+    render(TypeEditorDialog, { initial: { label: 'Book', icon: '📖', properties: [] }, onSaved: vi.fn(), onClose: vi.fn() });
+
+    expect(screen.queryByLabelText('Choose an emoji')).toBeNull();
+    expect(screen.getByDisplayValue('📖')).toBeTruthy();
+  });
+
+  it('accepts a multi-codepoint ZWJ emoji without truncating it', async () => {
+    // 👨‍👩‍👧‍👦 is 11 UTF-16 units — the old maxlength of 4 cut it into mojibake.
+    const family = '👨‍👩‍👧‍👦';
+    render(TypeEditorDialog, { initial: { label: 'Family', properties: [] }, onSaved: vi.fn(), onClose: vi.fn() });
+    await fireEvent.input(screen.getByPlaceholderText('📖'), { target: { value: family } });
+    await fireEvent.click(screen.getByText('Create'));
+
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(saveMock.mock.calls[0]![0].icon).toBe(family);
+  });
+});
+
+describe('TypeEditorDialog — color picker', () => {
+  it('sets the color from a preset swatch and saves it', async () => {
+    render(TypeEditorDialog, { initial: { label: 'Book', properties: [] }, onSaved: vi.fn(), onClose: vi.fn() });
+    await fireEvent.click(screen.getByLabelText('Green'));
+
+    expect((screen.getByPlaceholderText('#89b4fa')).value).toBe('#a6e3a1');
+    await fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(saveMock.mock.calls[0]![0].color).toBe('#a6e3a1');
+  });
+
+  it('marks the swatch matching the current color, matching case-insensitively', async () => {
+    render(TypeEditorDialog, { initial: { label: 'Book', color: '#A6E3A1', properties: [] }, onSaved: vi.fn(), onClose: vi.fn() });
+    expect(screen.getByLabelText('Green').getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByLabelText('Blue').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('drives the native color well, and holds its last good value while a hex is half-typed', async () => {
+    const { container } = render(TypeEditorDialog, { initial: { label: 'Book', color: '#a6e3a1', properties: [] }, onSaved: vi.fn(), onClose: vi.fn() });
+    const well = container.querySelector('input[type="color"]') as HTMLInputElement;
+    expect(well.value).toBe('#a6e3a1');
+
+    await fireEvent.input(screen.getByPlaceholderText('#89b4fa'), { target: { value: '#89b4f' } });
+    expect(well.value).toBe('#89b4fa'); // the default, not a blank
+  });
+
+  it('clears the color, and omits it from the saved type', async () => {
+    render(TypeEditorDialog, { initial: { label: 'Book', color: '#a6e3a1', properties: [] }, onSaved: vi.fn(), onClose: vi.fn() });
+    await fireEvent.click(screen.getByLabelText('Clear color'));
+
+    expect((screen.getByPlaceholderText('#89b4fa')).value).toBe('');
+    await fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(saveMock.mock.calls[0]![0].color).toBeUndefined();
+  });
+
+  it('has no clear button when no color is set', async () => {
+    render(TypeEditorDialog, { initial: { label: 'Book', properties: [] }, onSaved: vi.fn(), onClose: vi.fn() });
+    expect(screen.queryByLabelText('Clear color')).toBeNull();
   });
 });

--- a/tests/renderer/dataflow-rule-coverage.test.ts
+++ b/tests/renderer/dataflow-rule-coverage.test.ts
@@ -42,6 +42,9 @@ const READ_ALLOWLIST = new Set<string>([
   // app / shell / view / export — OS + window reads and stateless side-effects
   'getInfo', 'getShortcuts', 'openExternal', 'openInDefault', 'openInTerminal',
   'revealFile', 'revealFolder', 'revealAuditLog', 'csv', 'getZoomFactor',
+  // Raises the OS emoji picker over the focused field; the emoji arrives as
+  // ordinary typed input, so no in-app state changes behind the component.
+  'showEmojiPanel',
   // graph / links reads
   'query', 'aliasMap', 'frontmatterKeys', 'inspections', 'schemaForCompletion',
   'sourceDetail', 'citationsForNote', 'expandNode', 'neighborhood',

--- a/tests/shared/color-swatches.test.ts
+++ b/tests/shared/color-swatches.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Colour-swatch palette + hex normalization for the type editor's colour
+ * picker. `toHex6` is what stands between a hand-typed colour and
+ * `<input type="color">`, which silently ignores anything that isn't #rrggbb.
+ */
+import { describe, it, expect } from 'vitest';
+import { COLOR_SWATCHES, DEFAULT_SWATCH, toHex6 } from '../../src/shared/color-swatches';
+
+describe('COLOR_SWATCHES', () => {
+  it('is all lowercase #rrggbb, so a swatch compares equal to a normalized field', () => {
+    for (const sw of COLOR_SWATCHES) {
+      expect(sw.hex).toMatch(/^#[0-9a-f]{6}$/);
+      expect(toHex6(sw.hex)).toBe(sw.hex);
+    }
+  });
+
+  it('has no duplicate colours or names', () => {
+    expect(new Set(COLOR_SWATCHES.map((s) => s.hex)).size).toBe(COLOR_SWATCHES.length);
+    expect(new Set(COLOR_SWATCHES.map((s) => s.name)).size).toBe(COLOR_SWATCHES.length);
+  });
+
+  it('offers the default swatch as a pickable colour', () => {
+    expect(COLOR_SWATCHES.some((s) => s.hex === DEFAULT_SWATCH)).toBe(true);
+  });
+});
+
+describe('toHex6', () => {
+  it('passes through a full hex, lowercasing it', () => {
+    expect(toHex6('#89B4FA')).toBe('#89b4fa');
+    expect(toHex6('#89b4fa')).toBe('#89b4fa');
+  });
+
+  it('expands the #rgb shorthand', () => {
+    expect(toHex6('#fff')).toBe('#ffffff');
+    expect(toHex6('#0a3')).toBe('#00aa33');
+  });
+
+  it('tolerates whitespace and a missing #', () => {
+    expect(toHex6('  #89b4fa  ')).toBe('#89b4fa');
+    expect(toHex6('89b4fa')).toBe('#89b4fa');
+  });
+
+  it('returns null for anything it cannot parse — including a half-typed hex', () => {
+    // The half-typed case is the one that matters: the well must hold its last
+    // good value rather than blanking on every keystroke.
+    expect(toHex6('#89b4f')).toBeNull();
+    expect(toHex6('')).toBeNull();
+    expect(toHex6('rebeccapurple')).toBeNull();
+    expect(toHex6('#gggggg')).toBeNull();
+    expect(toHex6('#89b4fa80')).toBeNull(); // 8-digit alpha hex
+  });
+});


### PR DESCRIPTION
The type editor's **Icon** and **Color** fields were raw text inputs — you had to already know an emoji to paste, and type a hex by hand. Both now have a picker, and both keep the text field as the precise path.

## Icon → native OS emoji panel

A button raises the macOS emoji panel via `app.showEmojiPanel()`. Full Unicode set, the system's own search and recents, and no emoji dataset for us to carry or keep current as Unicode revs.

The renderer focuses **and selects** the input before raising it, so a pick *replaces* the existing icon instead of appending a second glyph after it.

**macOS-only, deliberately.** Electron defines `showEmojiPanel` on darwin alone and there's no cross-platform equivalent. The button is hidden off macOS and the main handler is a silent no-op there, so the plain typable field remains the fallback rather than a button that would do nothing. Both halves are tested.

Also raises the icon field's `maxlength` from 4 to 16 — a ZWJ sequence exceeds 4 UTF-16 units (👨‍👩‍👧‍👦 is 11), so the old cap truncated those into mojibake.

## Color → native well + preset swatches

- A native `<input type="color">` well, chrome stripped so it reads as a swatch.
- A row of preset swatches drawn from the **same Catppuccin accents `link-types.ts` already uses**, so a user-chosen type colour lands in the same family as the ones Minerva assigns itself — rather than a second, unrelated palette.
- New `shared/color-swatches.ts` holds the palette plus `toHex6`, which normalizes a typed value (accepts the `#rgb` shorthand, a missing `#`, stray whitespace) to the `#rrggbb` the native well requires.

The well **holds its last good value while a hex is half-typed** rather than blanking on every keystroke — that's the case `toHex6` returning `null` is really there for. A clear button appears only when a colour is actually set.

Field and adornments now share one bordered box, so the pickers read as part of the field rather than buttons parked beside it.

## Notes for review

- **`IS_MAC` was triplicated** (`format-accelerator.ts`, `project-ops.ts`, and this change) — extracted to `renderer/lib/utils/platform.ts` and the two existing copies re-pointed. That's the only change outside the feature.
- **Data-flow rule:** `showEmojiPanel` is a stateless OS side-effect — the emoji arrives as ordinary typed input, no in-app state changes behind the component — so it sits under `api.shell.*` and is called from the component directly. The fail-closed `dataflow-rule-coverage` test flagged it as unclassified and I added it to that test's `READ_ALLOWLIST` with the rationale inline. Worth a second opinion on that classification.
- Snapshot churn in `registration.test.ts.snap` / `preload-bridge.test.ts.snap` is just the one new channel.

## Tests

- 7 — palette invariants + `toHex6` (including the half-typed hex that must not blank the well)
- 9 — the dialog: focus/select before raising the panel, button hidden off macOS, ZWJ emoji round-trip, swatch pick → save, case-insensitive selected state, clear → colour omitted, well fallback
- 2 — the platform-gated main handler

`pnpm lint` clean; 566 test files / 5611 tests passing.

## Not verified by me

I tested this through the suite rather than launching the app, so I have **not** seen the native panel actually type into the field on a running build — that interaction crosses into AppKit and no test can cover it. Worth one manual check that picking an emoji lands in the icon field and replaces what was there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
