### PR TITLE
fix(objects): Duplicate in the Type Manager silently did nothing

### DIFF
--- a/src/renderer/lib/components/ObjectTypesSettings.svelte
+++ b/src/renderer/lib/components/ObjectTypesSettings.svelte
@@ -48,6 +48,14 @@
   }
   onMount(refresh);
 
+  /** Report a failed mutation. These calls used to be `try/finally` with no
+   *  `catch`, so a rejection became an unhandled promise rejection and the
+   *  button simply appeared inert — which is how Duplicate's broken IPC went
+   *  unnoticed. Anything that can fail says so. */
+  function reportFailure(action: string, t: TypeInfo, e: unknown): void {
+    toasts.push({ message: `Couldn’t ${action} “${t.label}” — ${e instanceof Error ? e.message : String(e)}` });
+  }
+
   async function duplicate(t: TypeInfo): Promise<void> {
     busy = true;
     try {
@@ -56,6 +64,8 @@
         properties: t.properties,
         ...optionalTypeFields(t),
       });
+    } catch (e) {
+      reportFailure('duplicate', t, e);
     } finally { busy = false; }
   }
 
@@ -80,6 +90,8 @@
       await loadCounts();
       if (cleared.length > 0) toasts.push({ message: `Deleted “${t.label}” and cleared it from ${cleared.length} note${cleared.length === 1 ? '' : 's'}.` });
       if (failed.length > 0) toasts.push({ message: `Deleted “${t.label}”, but ${failed.length} note${failed.length === 1 ? '' : 's'} couldn’t be cleared — ${failed.length === 1 ? 'it' : 'they'} still list this type.` });
+    } catch (e) {
+      reportFailure('delete', t, e);
     } finally { busy = false; }
   }
 
@@ -97,6 +109,8 @@
           ? `Renamed to “${newName}” — migrated ${migrated.length} note${migrated.length === 1 ? '' : 's'}.`
           : `Renamed to “${newName}”.` });
       }
+    } catch (e) {
+      reportFailure('rename', t, e);
     } finally { busy = false; }
   }
 </script>

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -683,9 +683,15 @@ export function getEditorStore() {
 
   function persistTabs() {
     // Persist the whole split arrangement (#816): every group's tabs +
-    // active tab + view mode, the focused group, and the layout tree. The
-    // layout is reactive ($state) — snapshot it to a plain object so the
-    // structured-clone IPC boundary doesn't choke on the Svelte proxy.
+    // active tab + view mode, the focused group, and the layout tree.
+    //
+    // Snapshot the whole session rather than just `layout` (which was already
+    // snapshotted for the reason below). Defence in depth, not a known break:
+    // `toSavedTab` copies some fields off `$state` tabs by reference — a
+    // type-view tab's `columns`, for one — and whether such a value comes back
+    // as a Svelte Proxy is subtle enough that it isn't worth betting session
+    // restore on. The structured-clone IPC boundary rejects a Proxy outright,
+    // and one slipping through would silently lose the whole save.
     const session: LayoutSession = {
       version: 2,
       activeGroupId,
@@ -695,9 +701,12 @@ export function getEditorStore() {
         viewMode: g.viewMode,
         tabs: g.tabs.map(toSavedTab),
       })),
-      layout: $state.snapshot(layout),
+      layout,
     };
-    void api.tabs.save(session);
+    // Surfacing beats a silent `void`: a rejected save means the session won't
+    // come back next launch, and losing that quietly is how this went unseen.
+    void api.tabs.save($state.snapshot(session))
+      .catch((e: unknown) => { console.error('[tabs] failed to persist session:', e); });
   }
 
   /** Reconstruct a live tab from its persisted form. Notes read their file

--- a/src/renderer/lib/stores/object-types.svelte.ts
+++ b/src/renderer/lib/stores/object-types.svelte.ts
@@ -43,7 +43,13 @@ function typeForNote(relativePath: string | null | undefined): TypeInfo | null {
 }
 
 async function save(input: SaveInput): Promise<{ id: string; filePath: string }> {
-  const result = await api.types.save(input);
+  // Snapshot at the IPC boundary. Callers legitimately build the input from
+  // values read out of `types` — which is deeply-reactive `$state`, so nested
+  // arrays/objects come back as Svelte Proxies, and Electron's structured
+  // clone refuses to serialize a Proxy ("could not be cloned"). The Type
+  // Manager's Duplicate did exactly that and failed before reaching main.
+  // Doing it here rather than per-caller means the next caller can't reopen it.
+  const result = await api.types.save($state.snapshot(input));
   await refresh();
   return result;
 }

--- a/tests/renderer/components/ObjectTypesSettings-duplicate.test.ts
+++ b/tests/renderer/components/ObjectTypesSettings-duplicate.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * "Duplicate" in the Type Manager silently did nothing.
+ *
+ * The list it renders comes from `objectTypesStore.types`, a deeply-reactive
+ * `$state` — so `t.properties` / `t.card` read back as Svelte Proxies. Duplicate
+ * forwarded those straight into `api.types.save`, and Electron's structured
+ * clone refuses to serialize a Proxy: the invoke rejected before reaching main,
+ * and with no `catch` on the call it surfaced as an unhandled rejection with
+ * nothing on screen.
+ *
+ * Edit was unaffected because TypeEditorDialog rebuilds its rows into fresh
+ * plain objects before saving, which is why only Duplicate broke.
+ *
+ * Unlike the sibling suite, this drives the REAL store — the bug lives in the
+ * hand-off between the component and the store, so mocking the store away
+ * would mock away the defect.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+
+const { saveMock, listMock, noteTypeMapMock, queryMock, toastMock } = vi.hoisted(() => ({
+  saveMock: vi.fn(), listMock: vi.fn(), noteTypeMapMock: vi.fn(), queryMock: vi.fn(), toastMock: vi.fn(),
+}));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    types: { list: listMock, save: saveMock, noteTypeMap: noteTypeMapMock },
+    graph: { query: queryMock },
+  },
+}));
+vi.mock('../../../src/renderer/lib/stores/dialogs.svelte', () => ({
+  getDialogStore: () => ({ showConfirm: vi.fn(), showPrompt: vi.fn() }),
+}));
+vi.mock('../../../src/renderer/lib/stores/toasts.svelte', () => ({
+  getToastStore: () => ({ push: toastMock }),
+}));
+
+import ObjectTypesSettings from '../../../src/renderer/lib/components/ObjectTypesSettings.svelte';
+import { objectTypesStore } from '../../../src/renderer/lib/stores/object-types.svelte';
+
+const GADGET = {
+  id: 'gadget', label: 'Gadget', classLocalName: 'Gadget', source: 'user', icon: '🔧',
+  card: ['maker'],
+  properties: [{ name: 'maker', type: 'text' }, { name: 'model', type: 'text' }],
+};
+
+beforeEach(() => {
+  listMock.mockResolvedValue({ types: [GADGET], errors: [] });
+  noteTypeMapMock.mockResolvedValue({});
+  queryMock.mockResolvedValue({ results: [], columns: [] });
+  saveMock.mockResolvedValue({ id: 'gadget-copy', filePath: '.minerva/types/gadget-copy.md' });
+});
+afterEach(async () => {
+  cleanup();
+  listMock.mockResolvedValue({ types: [], errors: [] });
+  noteTypeMapMock.mockResolvedValue({});
+  await objectTypesStore.refresh(); // module singleton — don't leak between suites
+  vi.clearAllMocks();
+});
+
+describe('Type Manager — Duplicate', () => {
+  it('sends a structured-cloneable payload, so the IPC actually reaches main', async () => {
+    render(ObjectTypesSettings, {});
+    await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
+
+    await fireEvent.click(screen.getByText('Duplicate'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+
+    const payload = saveMock.mock.calls[0]![0];
+    // The real assertion: Electron puts this through structured clone. A Svelte
+    // `$state` Proxy throws DataCloneError here exactly as it does over IPC.
+    expect(() => structuredClone(payload)).not.toThrow();
+  });
+
+  it('carries the source type’s properties and optional fields into the copy', async () => {
+    render(ObjectTypesSettings, {});
+    await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
+    await fireEvent.click(screen.getByText('Duplicate'));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+
+    const payload = saveMock.mock.calls[0]![0];
+    expect(payload.label).toBe('Gadget copy');
+    expect(payload.id).toBeUndefined(); // a copy derives a NEW id from its label
+    expect(payload.icon).toBe('🔧');
+    expect(payload.card).toEqual(['maker']);
+    expect(payload.properties).toEqual([
+      { name: 'maker', type: 'text' },
+      { name: 'model', type: 'text' },
+    ]);
+  });
+
+  it('surfaces a failed duplicate instead of swallowing it', async () => {
+    // Previously the call had no `catch`, so any failure was an invisible
+    // unhandled rejection — the reason the original bug showed no symptom.
+    saveMock.mockRejectedValue(new Error('disk full'));
+    render(ObjectTypesSettings, {});
+    await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
+
+    await fireEvent.click(screen.getByText('Duplicate'));
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalled());
+    expect(toastMock.mock.calls[0]![0].message).toMatch(/disk full/);
+    // The row's buttons must not be left disabled by a stuck `busy` flag.
+    expect((screen.getByText('Duplicate')).disabled).toBe(false);
+  });
+});

--- a/tests/renderer/stores/editor-store.test.ts
+++ b/tests/renderer/stores/editor-store.test.ts
@@ -676,3 +676,34 @@ describe('persist + restore across every tab kind', () => {
     expect(editor.tabs).toHaveLength(0);
   });
 });
+
+// ── Tab persistence must survive the structured-clone IPC boundary ──────────
+
+describe('persistTabs — structured-clone safety', () => {
+  it('sends a payload Electron can actually clone when a type-view tab has columns', async () => {
+    // `toSavedTab` copies a type-view tab's `columns` off `$state` by
+    // reference. It currently comes back as a plain array (verified — this
+    // test passes without the snapshot), but a Svelte Proxy would be rejected
+    // by the structured-clone IPC boundary and lose the whole session save
+    // silently. Pins the invariant so a future change to how tabs are stored
+    // can't quietly break session restore.
+    editor.openTypeView('book', { layout: 'table', columns: ['author', 'rating'] });
+    editor.persistTabs();
+
+    expect(h.tabsSave).toHaveBeenCalled();
+    const session = h.tabsSave.mock.calls[0]![0] as LayoutSession;
+    expect(() => structuredClone(session)).not.toThrow();
+  });
+
+  it('round-trips the type-view projection through the persisted session', async () => {
+    editor.openTypeView('book', { layout: 'gallery', sortColumn: 'rating', sortDir: 'desc', columns: ['author'] });
+    editor.persistTabs();
+
+    const session = h.tabsSave.mock.calls[0]![0] as LayoutSession;
+    const saved = session.groups.flatMap((g) => g.tabs).find((t) => t.type === 'type-view');
+    expect(saved).toMatchObject({
+      type: 'type-view', typeId: 'book', layout: 'gallery',
+      sortColumn: 'rating', sortDir: 'desc', columns: ['author'],
+    });
+  });
+});


### PR DESCRIPTION
You were right that Duplicate is just broken. It's not a hidden panel — the button was genuinely inert.

## Cause

The Type Manager's list renders from `objectTypesStore.types`, which is deeply-reactive `$state`. So `t.properties` and `t.card` read back as **Svelte Proxies**. `duplicate()` forwarded them straight into `api.types.save`, and Electron's structured clone refuses to serialize a Proxy:

```
DataCloneError: [object Array] could not be cloned.
```

The invoke rejected before ever reaching main. And because the call had **no `catch`**, it became an unhandled promise rejection — no copy, no error, nothing on screen.

`Edit` was unaffected because `TypeEditorDialog` rebuilds its rows into fresh plain objects before saving. That's why only Duplicate broke.

## Fixes

**1. Snapshot at the IPC boundary.** `objectTypesStore.save` now does `$state.snapshot(input)`. Callers legitimately build their input from values read out of `types`, so putting this in the store rather than in `duplicate()` means the next caller can't reopen the same hole.

**2. Stop swallowing failures.** `duplicate` / `rename` / `remove` were all `try/finally` with no `catch`. Each now reports the failure as a toast. The missing `catch` is *why this was invisible rather than merely broken* — and it would have hidden any future failure equally well.

## Tests

The new suite drives the **real store**, not a mock — the defect lived in the hand-off between component and store, so mocking the store away would have mocked away the bug. The key assertion runs the captured payload through `structuredClone`, which throws on a Proxy exactly as the IPC boundary does.

Verified by mutation: reverting the snapshot reproduces `DataCloneError` in the new test.

## One change that is *not* a bug fix — flagging honestly

While tracing this I hypothesised the same defect in `persistTabs`: `toSavedTab` copies a type-view tab's `columns` off `$state` by reference, so hiding a table column looked like it should break session persistence the same way.

**I checked, and I was wrong** — that value comes back as a plain array, and the test I added passes without the fix. I've kept a whole-session `$state.snapshot` there anyway as defence in depth (the previous code already snapshotted `layout` for this exact reason), plus a `.catch` replacing a bare `void` so a failed persist logs instead of vanishing. The code comment and the test both state plainly that this is precautionary, not a repair.

Worth knowing for review: whether a given read off `$state` yields a Proxy is subtle, and I would not trust reasoning alone on it again — both claims here were settled by running `structuredClone` against the real value.

`pnpm lint` clean; 569 test files / 5633 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
