### PR TITLE
feat(objects): let a thoughtbase customize stock object types

### DIFF
--- a/docs/vision/objects.md
+++ b/docs/vision/objects.md
@@ -87,8 +87,19 @@ extra `rdf:type`" — is already precedented in the tree.
   (`.minerva` is filtered from file views). This differs deliberately from
   skills (`~/.minerva/skills/`, per-machine): a type is part of _this library's_
   vocabulary, not a machine setting.
-- **Loading is additive; stock wins id collisions** (a user type can't shadow a
-  stock type), exactly as the skills catalog does.
+- **Loading is additive; an in-tree file of a stock id overrides it.** This is
+  how a thoughtbase customizes Book or Meeting — add a property, change the
+  icon — without forking the bundle. The override is a full local copy, marked
+  `overridesStock`, and deleting it reverts to the bundled definition (which is
+  still loaded underneath). The id carries the override and `classLocalName`
+  derives from the id, so a customized Book keeps its `types:Book` class and
+  every existing instance stays valid. Two ids colliding within the SAME source
+  is still an error — those are mistakes, not overrides.
+
+  This deliberately diverges from the skills catalog, which stays additive-only
+  (`docs/authoring-skills.md`): a skill is a prompt you can disable and replace
+  wholesale, whereas a type is a schema that existing notes are already
+  instances of, so editing in place has to preserve identity.
 - **Format**: a type definition is a `.md` file — YAML frontmatter (`label`,
   `properties[]`, optional `icon` / `color`) plus an optional template body,
   matching the skills authoring model.

--- a/src/main/types/loader.ts
+++ b/src/main/types/loader.ts
@@ -5,8 +5,17 @@
  * in docs/vision/objects.md). Unlike skills, the catalog is PER-PROJECT — the
  * user portion is a property of this thoughtbase's vocabulary, not the machine.
  *
- * Loading is additive and stock wins id collisions: a user type can't shadow a
- * stock type.
+ * Loading is additive, and an in-tree file of the same id OVERRIDES the stock
+ * type it shadows — that's how a thoughtbase customizes Book or Meeting
+ * (add a property, change the icon) without forking the bundle. The override is
+ * a full local copy, marked `overridesStock` so the UI can offer "revert to
+ * stock": deleting the in-tree file restores the bundled definition, because
+ * the stock set is still loaded underneath. The id is what carries the override,
+ * and `classLocalName` derives from the id, so a customized Book keeps its
+ * `types:Book` class and every existing instance stays valid.
+ *
+ * Two ids colliding within the SAME source is still an error (a duplicate stock
+ * id, or two user files claiming one id) — those are mistakes, not overrides.
  *
  * Process / test note (#1630): the stock set is a build-time module-global — the
  * `?raw` glob below, one immutable copy per process. Crucially, unlike the tool
@@ -91,11 +100,16 @@ export async function loadTypeCatalog(rootPath: string): Promise<TypeCatalog> {
   }
   for (const t of user.types) {
     const existing = byId.get(t.id);
+    if (existing && existing.source === 'stock') {
+      // A local customization of a stock type — the in-tree file wins, and the
+      // stock definition stays available underneath to revert to.
+      byId.set(t.id, { ...t, overridesStock: true });
+      continue;
+    }
     if (existing) {
-      const clash = existing.source === 'stock'
-        ? `id "${t.id}" is already a stock type; user types can't override stock`
-        : `duplicate user type id "${t.id}"`;
-      errors.push({ source: 'user', filePath: t.filePath, label: t.label, message: clash });
+      // Two user files claiming the same id is a genuine mistake: there's no
+      // "underneath" to fall back to, so first-loaded wins and we say so.
+      errors.push({ source: 'user', filePath: t.filePath, label: t.label, message: `duplicate user type id "${t.id}"` });
       continue;
     }
     byId.set(t.id, t);

--- a/src/main/types/write.ts
+++ b/src/main/types/write.ts
@@ -67,7 +67,12 @@ export async function saveType(rootPath: string, input: SaveTypeInput): Promise<
 }
 
 /** Delete a USER type by id (removes `.minerva/types/<id>.md`). A no-op for a
- *  stock-only id (stock types live in the bundle, not the thoughtbase). */
+ *  stock-only id (stock types live in the bundle, not the thoughtbase).
+ *
+ *  This is also "revert to stock": when the file being removed was a local
+ *  customization of a stock type, the bundled definition is still loaded
+ *  underneath and simply reappears on the next catalog load. Nothing else has
+ *  to happen — the id and class name are unchanged, so instances never notice. */
 export async function deleteType(rootPath: string, id: string): Promise<void> {
   const cleaned = slugify(id);
   if (!cleaned) return;

--- a/src/renderer/lib/components/ObjectTypesSettings.svelte
+++ b/src/renderer/lib/components/ObjectTypesSettings.svelte
@@ -2,10 +2,12 @@
   /**
    * Object Types settings panel (#1584) — an in-app home to see and manage
    * object types, so a user no longer hand-authors `.minerva/types/*.md`. Lists
-   * stock (read-only) + user types with their icon, property count, and live
-   * instance count; user types can be duplicated or deleted. Mutations route
-   * through the object-types store (renderer data-flow rule); editing a type's
-   * fields lands with the type editor (#1585).
+   * stock + user types with their icon, property count, and live instance
+   * count. Every type is editable: editing a stock one writes a local copy into
+   * `.minerva/types/` that shadows the bundled definition, and Revert deletes
+   * that copy to get the stock one back. Mutations route through the
+   * object-types store (renderer data-flow rule); editing a type's fields lands
+   * with the type editor (#1585).
    */
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
@@ -30,6 +32,8 @@
     editorInitial = {
       id: t.id, label: t.label, properties: t.properties,
       ...optionalTypeFields(t),
+      // Stock with no local copy yet → saving forks it into this thoughtbase.
+      ...(t.source === 'stock' ? { forksStock: true } : {}),
     };
     editorOpen = true;
   }
@@ -95,6 +99,26 @@
     } finally { busy = false; }
   }
 
+  /**
+   * Drop a customized stock type's local copy so the bundled definition takes
+   * over again. Genuine data loss (the customization is gone), so it confirms —
+   * with the usual "don't ask again" key. Deliberately NOT `removeSafely`: the
+   * type continues to exist, so clearing `type:` off its instances would be
+   * exactly wrong.
+   */
+  async function revert(t: TypeInfo): Promise<void> {
+    const msg = `Revert “${t.label}” to the stock definition? Your local changes to it are discarded; notes using it are unaffected.`;
+    if (!(await showConfirm(msg, 'revert-object-type', 'Revert'))) return;
+    busy = true;
+    try {
+      await objectTypesStore.revertToStock(t.id);
+      await loadCounts();
+      toasts.push({ message: `“${t.label}” reverted to the stock definition.` });
+    } catch (e) {
+      reportFailure('revert', t, e);
+    } finally { busy = false; }
+  }
+
   async function rename(t: TypeInfo): Promise<void> {
     const newName = (await showPrompt('Rename type to:', { initial: t.label }))?.trim();
     if (!newName || newName === t.label) return;
@@ -119,7 +143,8 @@
   <div class="head">
     <p class="hint">
       Object types let notes act as first-class objects (Book, Person, Meeting…). Create one here or from any
-      note with <strong>File → Save Note as Object Type</strong>; stock types are read-only.
+      note with <strong>File → Save Note as Object Type</strong>. Editing a stock type keeps a customized copy
+      in this thoughtbase; <strong>Revert</strong> restores the stock definition.
     </p>
     <button class="new-btn" onclick={openNew}>+ New type</button>
   </div>
@@ -146,17 +171,27 @@
               · {counts[t.id] ?? 0} instance{(counts[t.id] ?? 0) === 1 ? '' : 's'}
             </span>
           </span>
-          <span class="type-src" class:user={t.source === 'user'}>{t.source}</span>
-          {#if t.source === 'user'}
-            <span class="type-actions">
-              <button class="link-btn" disabled={busy} onclick={() => openEdit(t)}>Edit</button>
+          <!-- Three states, not two: stock, a stock type this thoughtbase has
+               customized, and a wholly user-authored type. Editing a stock type
+               writes a local copy that shadows the bundle; Revert deletes that
+               copy and the bundled definition takes over again. -->
+          <span class="type-src" class:user={t.source === 'user' && !t.overridesStock} class:custom={t.overridesStock}>
+            {t.overridesStock ? 'customized' : t.source}
+          </span>
+          <span class="type-actions">
+            <button class="link-btn" disabled={busy} onclick={() => openEdit(t)}>Edit</button>
+            <button class="link-btn" disabled={busy} onclick={() => { void duplicate(t); }}>Duplicate</button>
+            {#if t.overridesStock}
+              <button class="link-btn" disabled={busy} onclick={() => { void revert(t); }}>Revert</button>
+            {:else if t.source === 'user'}
+              <!-- Rename changes the id (and migrates instances). Meaningless
+                   for a stock id: the bundled type would just reappear under
+                   the old id alongside the renamed copy. Edit still changes a
+                   stock type's label — the id is what stays fixed. -->
               <button class="link-btn" disabled={busy} onclick={() => { void rename(t); }}>Rename</button>
-              <button class="link-btn" disabled={busy} onclick={() => { void duplicate(t); }}>Duplicate</button>
               <button class="link-btn" disabled={busy} onclick={() => { void remove(t); }}>Delete</button>
-            </span>
-          {:else}
-            <span class="type-actions muted">read-only</span>
-          {/if}
+            {/if}
+          </span>
         </li>
       {/each}
     </ul>
@@ -198,8 +233,11 @@
     background: color-mix(in oklch, var(--text) 6%, transparent);
   }
   .type-src.user { color: var(--accent); background: color-mix(in oklch, var(--accent) 12%, transparent); }
+  /* Customized stock reads as its own state — neither the neutral "stock" chip
+     nor the accent "user" one. Sage, not a warning colour: customizing is a
+     normal thing to do, not a problem. */
+  .type-src.custom { color: var(--sage); background: color-mix(in oklch, var(--sage) 14%, transparent); }
   .type-actions { display: flex; gap: 8px; flex-shrink: 0; }
-  .type-actions.muted { color: var(--text-faint); font-size: 11px; }
   .link-btn {
     border: none; background: none; color: var(--accent); font-family: inherit; font-size: 12px; cursor: pointer; padding: 0;
   }

--- a/src/renderer/lib/components/TypeEditorDialog.svelte
+++ b/src/renderer/lib/components/TypeEditorDialog.svelte
@@ -144,6 +144,14 @@
 <div class="overlay" onkeydown={overlayKey} onmousedown={(e) => { if (e.target === e.currentTarget) onClose(); }} role="presentation">
   <div class="dialog" role="dialog" aria-modal="true" aria-label="Edit object type">
     <h3 class="title">{initial?.id ? 'Edit' : 'New'} object type</h3>
+    {#if seed?.forksStock}
+      <!-- "Edit" on a stock type reads as editing the bundle; say what it
+           actually does before the user commits to it. -->
+      <p class="fork-note">
+        <strong>{seed.label}</strong> is a stock type. Saving keeps a customized copy in this
+        thoughtbase — the stock definition stays available to revert to.
+      </p>
+    {/if}
 
     <div class="meta">
       <label class="field grow"><span>Name</span>
@@ -263,6 +271,13 @@
     box-shadow: 0 12px 48px rgba(0,0,0,0.45);
   }
   .title { margin: 0 0 14px; font-size: 15px; color: var(--text); }
+  .fork-note {
+    margin: -8px 0 14px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text-muted);
+  }
+  .fork-note strong { color: var(--text); font-weight: 600; }
   .meta { display: flex; gap: 10px; margin-bottom: 8px; align-items: flex-end; }
   .field { display: flex; flex-direction: column; gap: 4px; }
   .field span, .field label { font-size: 11px; color: var(--text-muted); }

--- a/src/renderer/lib/components/type-editor-value.ts
+++ b/src/renderer/lib/components/type-editor-value.ts
@@ -17,6 +17,10 @@ export interface TypeEditorInitial {
   parent?: string;
   properties: PropertyDef[];
   template?: string;
+  /** Editing a STOCK type that has no local copy yet. Saving will create one
+   *  in `.minerva/types/`, shadowing the bundled definition — the dialog says
+   *  so, since "Edit" otherwise reads as editing the bundle itself. */
+  forksStock?: boolean;
 }
 
 /** A type's optional carry-over fields (icon / color / cover / card / parent /

--- a/src/renderer/lib/stores/object-types.svelte.ts
+++ b/src/renderer/lib/stores/object-types.svelte.ts
@@ -59,6 +59,19 @@ async function remove(id: string): Promise<void> {
   await refresh();
 }
 
+/**
+ * Drop a locally-customized stock type's in-tree file so the bundled
+ * definition takes over again. Mechanically the same call as `remove` — the
+ * override IS the file — but named for the intent, because the outcome is
+ * opposite: the type survives, it just stops being customized. Never use
+ * `removeSafely` here; clearing `type:` off instances would be wrong when the
+ * type is about to still exist.
+ */
+async function revertToStock(id: string): Promise<void> {
+  await api.types.delete(id);
+  await refresh();
+}
+
 async function removeSafely(id: string, clearInstances: boolean): Promise<{ cleared: string[]; failed: { path: string; error: string }[] }> {
   const result = await api.types.deleteSafely(id, clearInstances);
   await refresh();
@@ -79,6 +92,7 @@ export const objectTypesStore = {
   refresh,
   save,
   remove,
+  revertToStock,
   removeSafely,
   rename,
 };

--- a/src/shared/objects/type-def.ts
+++ b/src/shared/objects/type-def.ts
@@ -51,6 +51,11 @@ export interface TypeDef {
    *  type also count as the parent (#1586). Single inheritance for v1. */
   parent?: string | undefined;
   source: TypeSource;
+  /** True when this is a stock type the thoughtbase has locally customized —
+   *  `source` is `'user'` (the in-tree file is what loaded), but a stock
+   *  definition of the same id exists to revert to. Drives the "customized"
+   *  badge and the Revert action; a plain user type has no stock fallback. */
+  overridesStock?: boolean | undefined;
   /** Absolute path for user types; the glob key for stock types. */
   filePath: string;
 }
@@ -76,6 +81,8 @@ export interface TypeInfo {
    *  type also count as the parent (#1586). Single inheritance for v1. */
   parent?: string | undefined;
   source: TypeSource;
+  /** See `TypeDef.overridesStock` — a locally customized stock type. */
+  overridesStock?: boolean | undefined;
 }
 
 export interface TypeLoadError {
@@ -110,6 +117,7 @@ export function toTypeInfo(t: TypeDef): TypeInfo {
     card: t.card,
     parent: t.parent,
     source: t.source,
+    overridesStock: t.overridesStock,
   };
 }
 

--- a/tests/main/graph/customized-stock-type.test.ts
+++ b/tests/main/graph/customized-stock-type.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A locally customized stock type has to behave like any other type end to end:
+ * its added property indexes, and its instances stay on the SAME ontology class
+ * as before the customization (`classLocalName` derives from the id, which the
+ * override keeps). If that ever drifted, customizing Book would silently orphan
+ * every existing Book note.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexAllNotes, queryGraph, getNoteTypedProperties, reloadTypeCatalog } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+function write(rel: string, content: string): void {
+  const fp = path.join(root, rel);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content, 'utf-8');
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-custstock-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+});
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('customized stock type', () => {
+  it('indexes a note under types:Book and reads back the added property', async () => {
+    // Book customized with an extra `shelf` field.
+    write('.minerva/types/book.md', [
+      '---', 'label: Book', 'id: book',
+      'properties:',
+      '  - name: author', '    type: text',
+      '  - name: shelf', '    type: text',
+      '---', '',
+    ].join('\n'));
+    write('Dune.md', `---\ntitle: Dune\ntype: book\nauthor: Frank Herbert\nshelf: A3\n---\n`);
+    await reloadTypeCatalog(ctx);
+    await indexAllNotes(ctx);
+
+    // Same class as an uncustomized Book would have used.
+    const { results } = await queryGraph(
+      ctx,
+      `SELECT ?path WHERE { ?n a types:Book ; minerva:relativePath ?path }`,
+    );
+    expect((results as Array<{ path: string }>).map((r) => r.path)).toEqual(['Dune.md']);
+
+    const read = await getNoteTypedProperties(ctx, 'Dune.md');
+    expect(read.type?.id).toBe('book');
+    const byName = Object.fromEntries(read.properties.map((p) => [p.name, p.value]));
+    expect(byName.shelf).toBe('A3');       // the customization
+    expect(byName.author).toBe('Frank Herbert'); // carried-over stock field
+  });
+
+  it('leaves existing instances on the same class when the label is customized', async () => {
+    write('Dune.md', `---\ntitle: Dune\ntype: book\n---\n`);
+    await indexAllNotes(ctx);
+
+    // Now customize only the label.
+    write('.minerva/types/book.md', `---\nlabel: Tome\nid: book\nproperties: []\n---\n`);
+    await reloadTypeCatalog(ctx);
+    await indexAllNotes(ctx);
+
+    const { results } = await queryGraph(ctx, `SELECT ?path WHERE { ?n a types:Book ; minerva:relativePath ?path }`);
+    expect((results as Array<{ path: string }>).map((r) => r.path)).toEqual(['Dune.md']);
+    expect((await getNoteTypedProperties(ctx, 'Dune.md')).type?.label).toBe('Tome');
+  });
+});

--- a/tests/main/types/loader.test.ts
+++ b/tests/main/types/loader.test.ts
@@ -1,6 +1,7 @@
 /**
  * Type-registry loader + parser (#1062). Stock loads; in-tree user types load
- * additively; user can't shadow stock; malformed defs fail soft.
+ * additively; an in-tree file of a stock id OVERRIDES it (local
+ * customization, revertible by deleting the file); malformed defs fail soft.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
@@ -45,13 +46,55 @@ describe('loadTypeCatalog (#1062)', () => {
     expect(recipe?.properties[0]).toMatchObject({ name: 'servings', type: 'number' });
   });
 
-  it("rejects a user type that shadows a stock id (stock wins)", async () => {
-    writeUserType('book.md', `---\nlabel: Book\n---\n`);
+  it('lets an in-tree file override a stock type, marked as customized', async () => {
+    // Local customization of a stock type: the thoughtbase's copy wins, and is
+    // flagged so the UI can offer "revert to stock".
+    writeUserType('book.md', `---\nlabel: Book\nid: book\nicon: 📕\nproperties:\n  - name: author\n    type: text\n  - name: shelf\n    type: text\n---\n`);
     const cat = await loadTypeCatalog(root);
+
     const books = cat.types.filter((t) => t.id === 'book');
-    expect(books).toHaveLength(1);
-    expect(books[0]!.source).toBe('stock'); // stock kept
-    expect(cat.errors.some((e) => /already a stock type/.test(e.message))).toBe(true);
+    expect(books).toHaveLength(1); // one effective type, not two
+    const book = books[0]!;
+    expect(book.icon).toBe('📕');
+    expect(book.properties.map((p) => p.name)).toContain('shelf'); // the added field
+    expect(book.overridesStock).toBe(true);
+    expect(cat.errors).toEqual([]); // an override is not an error
+  });
+
+  it('keeps the class name of an overridden stock type, so instances stay valid', async () => {
+    // classLocalName derives from the id, not the label — renaming the label of
+    // a customized Book must not move it off `types:Book`.
+    writeUserType('book.md', `---\nlabel: Tome\nid: book\nproperties: []\n---\n`);
+    const cat = await loadTypeCatalog(root);
+    const book = cat.types.find((t) => t.id === 'book')!;
+    expect(book.label).toBe('Tome');
+    expect(book.classLocalName).toBe('Book');
+  });
+
+  it('restores the stock definition when the override file is removed', async () => {
+    // This is what "revert to stock" does — nothing more than deleting the file.
+    writeUserType('book.md', `---\nlabel: My Book\nid: book\nproperties: []\n---\n`);
+    expect((await loadTypeCatalog(root)).types.find((t) => t.id === 'book')!.label).toBe('My Book');
+
+    fs.rmSync(path.join(root, '.minerva', 'types', 'book.md'));
+    const after = (await loadTypeCatalog(root)).types.find((t) => t.id === 'book')!;
+    expect(after.label).toBe('Book');
+    expect(after.source).toBe('stock');
+    expect(after.overridesStock).toBeUndefined();
+  });
+
+  it('still errors on two USER files claiming one id — there is no stock underneath', async () => {
+    writeUserType('recipe.md', `---\nlabel: Recipe\nid: recipe\nproperties: []\n---\n`);
+    writeUserType('recipe-two.md', `---\nlabel: Recipe Again\nid: recipe\nproperties: []\n---\n`);
+    const cat = await loadTypeCatalog(root);
+    expect(cat.types.filter((t) => t.id === 'recipe')).toHaveLength(1);
+    expect(cat.errors.some((e) => /duplicate user type id/.test(e.message))).toBe(true);
+  });
+
+  it('a plain user type is not marked as overriding stock', async () => {
+    writeUserType('gadget.md', `---\nlabel: Gadget\nproperties: []\n---\n`);
+    const cat = await loadTypeCatalog(root);
+    expect(cat.types.find((t) => t.id === 'gadget')!.overridesStock).toBeUndefined();
   });
 
   it('fails soft on a malformed user type (logged, skipped, stock intact)', async () => {

--- a/tests/main/types/write.test.ts
+++ b/tests/main/types/write.test.ts
@@ -91,3 +91,66 @@ describe('saveType (#save-as-type)', () => {
     await expect(deleteType(root, 'nonexistent')).resolves.toBeUndefined();
   });
 });
+
+// ── Customizing a stock type ────────────────────────────────────────────────
+//
+// "Add a field to Book" — Edit a stock type and the save writes an in-tree copy
+// that shadows the bundled one. Revert is nothing more than deleting that file.
+
+describe('customizing a stock type', () => {
+  let root: string;
+  beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-stockedit-')); });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  /** The Type Manager's Edit path: the stock definition, plus a change. */
+  async function customizeBook(): Promise<void> {
+    const stockBook = (await loadTypeCatalog(root)).types.find((t) => t.id === 'book')!;
+    await saveType(root, {
+      id: stockBook.id,
+      label: stockBook.label,
+      properties: [...stockBook.properties, { name: 'shelf', type: 'text' }],
+      ...(stockBook.icon ? { icon: stockBook.icon } : {}),
+    });
+  }
+
+  it('writes the override next to the user types, keyed by the stock id', async () => {
+    await customizeBook();
+    expect(fs.existsSync(path.join(root, '.minerva', 'types', 'book.md'))).toBe(true);
+  });
+
+  it('the added field is live on the next catalog load', async () => {
+    await customizeBook();
+    const book = (await loadTypeCatalog(root)).types.find((t) => t.id === 'book')!;
+    expect(book.properties.map((p) => p.name)).toContain('shelf');
+    expect(book.properties.map((p) => p.name)).toContain('author'); // stock fields kept
+    expect(book.overridesStock).toBe(true);
+  });
+
+  it('does not disturb the other stock types', async () => {
+    await customizeBook();
+    const cat = await loadTypeCatalog(root);
+    for (const id of ['person', 'meeting', 'project', 'idea', 'article']) {
+      expect(cat.types.find((t) => t.id === id)!.source).toBe('stock');
+    }
+    expect(cat.errors).toEqual([]);
+  });
+
+  it('deleteType reverts it — the bundled definition comes back intact', async () => {
+    await customizeBook();
+    await deleteType(root, 'book');
+
+    const book = (await loadTypeCatalog(root)).types.find((t) => t.id === 'book')!;
+    expect(book.source).toBe('stock');
+    expect(book.overridesStock).toBeUndefined();
+    expect(book.properties.map((p) => p.name)).not.toContain('shelf');
+  });
+
+  it('an edited label leaves the class name alone, so instances survive', async () => {
+    const stockBook = (await loadTypeCatalog(root)).types.find((t) => t.id === 'book')!;
+    await saveType(root, { id: 'book', label: 'Tome', properties: stockBook.properties });
+
+    const book = (await loadTypeCatalog(root)).types.find((t) => t.id === 'book')!;
+    expect(book.label).toBe('Tome');
+    expect(book.classLocalName).toBe('Book'); // `types:Book` — unchanged
+  });
+});

--- a/tests/renderer/components/ObjectTypesSettings.test.ts
+++ b/tests/renderer/components/ObjectTypesSettings.test.ts
@@ -1,12 +1,12 @@
 /**
  * @vitest-environment happy-dom
  *
- * Object Types settings panel (#1584): lists stock (read-only) + user types with
+ * Object Types settings panel (#1584): lists stock + user types with
  * property + instance counts; user types can be duplicated and deleted (with a
  * confirm), routed through the object-types store. Stock types show no actions.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup, waitFor, screen } from '@testing-library/svelte';
+import { render, fireEvent, cleanup, waitFor, screen, within } from '@testing-library/svelte';
 
 const { listMock, saveMock, deleteMock, deleteSafelyMock, renameMock, noteTypeMapMock, queryMock, confirmMock, promptMock } = vi.hoisted(() => ({
   listMock: vi.fn(), saveMock: vi.fn(), deleteMock: vi.fn(), deleteSafelyMock: vi.fn(), renameMock: vi.fn(),
@@ -30,6 +30,17 @@ import ObjectTypesSettings from '../../../src/renderer/lib/components/ObjectType
 const BOOK = { id: 'book', label: 'Book', classLocalName: 'Book', source: 'stock', icon: '📖', properties: [{ name: 'author', type: 'text' }] };
 const GADGET = { id: 'gadget', label: 'Gadget', classLocalName: 'Gadget', source: 'user', icon: '🔧', properties: [{ name: 'maker', type: 'text' }, { name: 'model', type: 'text' }] };
 
+/** The type list only — the panel's intro copy names the same words the action
+ *  buttons use ("Revert", "stock"), so an unscoped query matches the prose. */
+function list(): HTMLElement {
+  return document.querySelector('.type-list') as HTMLElement;
+}
+/** Actions for one type's row, so "Duplicate" is unambiguous now that stock
+ *  types have their own action buttons too. */
+function row(label: string): HTMLElement {
+  return screen.getByText(label).closest('.type-row') as HTMLElement;
+}
+
 beforeEach(() => {
   listMock.mockResolvedValue({ types: [BOOK, GADGET], errors: [] });
   noteTypeMapMock.mockResolvedValue({});
@@ -52,17 +63,58 @@ describe('ObjectTypesSettings (#1584)', () => {
     expect(screen.getByText(/2 properties · 1 instance/)).toBeTruthy();  // Gadget
   });
 
-  it('shows actions only on user types (stock is read-only)', async () => {
+  it('offers Edit + Duplicate on a stock type, but not Rename or Delete', async () => {
+    // A stock type is customizable now — editing it forks a local copy — but
+    // Delete/Rename are meaningless against the bundle: there is no in-tree
+    // file to remove, and a renamed id would just resurrect the stock type
+    // alongside the copy.
     render(ObjectTypesSettings);
-    await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
-    expect(screen.getAllByText('Delete')).toHaveLength(1); // only the user type
-    expect(screen.getByText('read-only')).toBeTruthy();    // the stock type
+    await waitFor(() => expect(screen.getByText('Book')).toBeTruthy());
+    expect(within(list()).getAllByText('Edit')).toHaveLength(2);      // both types
+    expect(within(list()).getAllByText('Duplicate')).toHaveLength(2);
+    expect(within(list()).getAllByText('Delete')).toHaveLength(1);    // the user type only
+    expect(within(list()).getAllByText('Rename')).toHaveLength(1);
+    expect(within(row('Book')).getByText('stock')).toBeTruthy();
+    expect(within(list()).queryByText('Revert')).toBeNull();          // nothing customized yet
+  });
+
+  it('marks a customized stock type and offers Revert instead of Delete', async () => {
+    listMock.mockResolvedValue({ types: [{ ...BOOK, source: 'user', overridesStock: true }], errors: [] });
+    render(ObjectTypesSettings);
+    await waitFor(() => expect(screen.getByText('Book')).toBeTruthy());
+    expect(within(list()).getByText('customized')).toBeTruthy();
+    expect(within(list()).getByText('Revert')).toBeTruthy();
+    expect(within(list()).queryByText('Delete')).toBeNull();
+    expect(within(list()).queryByText('Rename')).toBeNull();
+  });
+
+  it('revert drops the local copy without touching the instances', async () => {
+    // Crucially `delete`, not `deleteSafely`: the type still exists after a
+    // revert, so clearing `type:` off its notes would be wrong.
+    listMock.mockResolvedValue({ types: [{ ...BOOK, source: 'user', overridesStock: true }], errors: [] });
+    render(ObjectTypesSettings);
+    await waitFor(() => expect(within(list()).getByText('Revert')).toBeTruthy());
+
+    await fireEvent.click(within(list()).getByText('Revert'));
+    await waitFor(() => expect(deleteMock).toHaveBeenCalledWith('book'));
+    expect(deleteSafelyMock).not.toHaveBeenCalled();
+  });
+
+  it('revert does nothing when the confirm is dismissed', async () => {
+    confirmMock.mockResolvedValue(false);
+    listMock.mockResolvedValue({ types: [{ ...BOOK, source: 'user', overridesStock: true }], errors: [] });
+    render(ObjectTypesSettings);
+    await waitFor(() => expect(within(list()).getByText('Revert')).toBeTruthy());
+
+    await fireEvent.click(within(list()).getByText('Revert'));
+    await waitFor(() => expect(confirmMock).toHaveBeenCalled());
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 
   it('duplicate saves a copy of the user type', async () => {
     render(ObjectTypesSettings);
     await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
-    await fireEvent.click(screen.getByText('Duplicate'));
+    await fireEvent.click(within(row('Gadget')).getByText('Duplicate'));
     await waitFor(() => expect(saveMock).toHaveBeenCalled());
     expect(saveMock.mock.calls[0]![0]).toMatchObject({ label: 'Gadget copy', icon: '🔧' });
   });
@@ -70,7 +122,7 @@ describe('ObjectTypesSettings (#1584)', () => {
   it('delete warns with the count, then offers to clear the instances (#1588)', async () => {
     render(ObjectTypesSettings);
     await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
-    await fireEvent.click(screen.getByText('Delete'));
+    await fireEvent.click(within(row('Gadget')).getByText('Delete'));
     await waitFor(() => expect(deleteSafelyMock).toHaveBeenCalled());
     // First confirm = the count warning; second = the clear-from-notes choice.
     expect(confirmMock.mock.calls[0]![0]).toMatch(/1 note still references it/);
@@ -83,7 +135,7 @@ describe('ObjectTypesSettings (#1584)', () => {
     confirmMock.mockResolvedValue(false);
     render(ObjectTypesSettings);
     await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
-    await fireEvent.click(screen.getByText('Delete'));
+    await fireEvent.click(within(row('Gadget')).getByText('Delete'));
     await waitFor(() => expect(confirmMock).toHaveBeenCalled());
     expect(deleteSafelyMock).not.toHaveBeenCalled();
   });
@@ -92,7 +144,7 @@ describe('ObjectTypesSettings (#1584)', () => {
     confirmMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false); // delete yes, clear no
     render(ObjectTypesSettings);
     await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
-    await fireEvent.click(screen.getByText('Delete'));
+    await fireEvent.click(within(row('Gadget')).getByText('Delete'));
     await waitFor(() => expect(deleteSafelyMock).toHaveBeenCalled());
     expect(deleteSafelyMock).toHaveBeenCalledWith('gadget', false);
   });
@@ -101,7 +153,7 @@ describe('ObjectTypesSettings (#1584)', () => {
     promptMock.mockResolvedValue('Doohickey');
     render(ObjectTypesSettings);
     await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
-    await fireEvent.click(screen.getByText('Rename'));
+    await fireEvent.click(within(row('Gadget')).getByText('Rename'));
     await waitFor(() => expect(renameMock).toHaveBeenCalled());
     expect(renameMock).toHaveBeenCalledWith('gadget', 'Doohickey');
   });
@@ -110,7 +162,7 @@ describe('ObjectTypesSettings (#1584)', () => {
     promptMock.mockResolvedValue('Gadget'); // same label
     render(ObjectTypesSettings);
     await waitFor(() => expect(screen.getByText('Gadget')).toBeTruthy());
-    await fireEvent.click(screen.getByText('Rename'));
+    await fireEvent.click(within(row('Gadget')).getByText('Rename'));
     await waitFor(() => expect(promptMock).toHaveBeenCalled());
     expect(renameMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Stock types were read-only, so adding a `shelf` field to Book meant duplicating it into a near-identical "Book copy" — which existing Book notes weren't instances of.

## Approach: in-tree override

An in-tree `.minerva/types/<id>.md` now **overrides** the stock type of the same id instead of erroring. Editing a stock type writes that file as a full local copy with the change applied; the bundled definition stays loaded underneath, so **Revert is nothing more than deleting the file**.

The **id** carries the override, and `classLocalName` derives from the id rather than the label — so a customized Book keeps its `types:Book` class and every existing instance stays valid, even after changing the label to "Tome". That's the property the whole design rests on, so it's tested at the graph level (`tests/main/graph/customized-stock-type.test.ts`) and not just at the loader.

Two ids colliding within the **same** source is still an error — a duplicate stock id, or two user files claiming one id. Those are mistakes, not overrides: there's no definition underneath to fall back to.

## Type Manager: three states, not two

| state | actions |
|---|---|
| `stock` | Edit · Duplicate |
| `customized` | Edit · Duplicate · **Revert** |
| `user` | Edit · Duplicate · Rename · Delete |

**Rename stays off stock ids deliberately.** It changes the id and migrates instances, so a renamed stock type would resurrect the bundled one under the old id *alongside* the renamed copy. Edit still changes a stock type's label — the id is what's fixed.

**Revert routes through `delete`, never `deleteSafely`.** The type continues to exist afterwards, so offering to clear `type:` off its instances would be exactly wrong — there's a test pinning that. It confirms first (the customization is discarded), with the usual "don't ask again" key.

"Edit" on a stock type otherwise reads as editing the bundle, so the dialog states what it will actually do before the user commits to it.

## Docs

`docs/vision/objects.md` recorded the old decision ("a user type can't shadow a stock type"), so it's updated with the new rule and the reasoning for diverging from skills here: a skill is a prompt you disable and replace wholesale, whereas a type is a schema that existing notes are already instances of — editing in place has to preserve identity.

## Test churn worth a look

Four pre-existing tests changed meaning rather than just moving:

- `loader.test.ts`'s "rejects a user type that shadows a stock id" encoded the rule this PR reverses. Replaced with five cases covering the override, class-name stability, revert-by-deletion, the still-an-error duplicate-user-id case, and that a plain user type isn't mis-marked.
- `ObjectTypesSettings.test.ts`'s "shows actions only on user types (stock is read-only)" likewise. Its siblings needed scoping to a specific row, since `getByText('Duplicate')` is now ambiguous once stock types have their own buttons — and the panel's intro copy contains the words "Revert" and "stock", so unscoped queries were matching the prose.

`pnpm lint` clean; 569 test files / 5653 tests passing.

## Not verified by me

Tested through the suite, not by launching the app — so I haven't watched the round trip in a real Settings panel (edit Book → "customized" badge → Revert → back to stock). The logic is covered end to end at the main-process level, but the badge/action rendering is only asserted in jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
