### PR TITLE
fix(objects): lock the Name field when editing a stock type

### DIFF
--- a/docs/vision/objects.md
+++ b/docs/vision/objects.md
@@ -96,6 +96,10 @@ extra `rdf:type`" — is already precedented in the tree.
   every existing instance stays valid. Two ids colliding within the SAME source
   is still an error — those are mistakes, not overrides.
 
+  A stock-derived type's **name and id are both fixed**: you customize its
+  properties, icon and colour, not its identity. Duplicate gives you an
+  independently-named type of your own.
+
   This deliberately diverges from the skills catalog, which stays additive-only
   (`docs/authoring-skills.md`): a skill is a prompt you can disable and replace
   wholesale, whereas a type is a schema that existing notes are already

--- a/src/renderer/lib/components/ObjectTypesSettings.svelte
+++ b/src/renderer/lib/components/ObjectTypesSettings.svelte
@@ -32,8 +32,10 @@
     editorInitial = {
       id: t.id, label: t.label, properties: t.properties,
       ...optionalTypeFields(t),
-      // Stock with no local copy yet → saving forks it into this thoughtbase.
-      ...(t.source === 'stock' ? { forksStock: true } : {}),
+      // Stock-derived either way: 'stock' forks on save, 'customized' already
+      // has its local copy. Both keep the stock name.
+      ...(t.overridesStock ? { stockOrigin: 'customized' as const }
+        : t.source === 'stock' ? { stockOrigin: 'stock' as const } : {}),
     };
     editorOpen = true;
   }
@@ -186,8 +188,10 @@
             {:else if t.source === 'user'}
               <!-- Rename changes the id (and migrates instances). Meaningless
                    for a stock id: the bundled type would just reappear under
-                   the old id alongside the renamed copy. Edit still changes a
-                   stock type's label — the id is what stays fixed. -->
+                   the old id alongside the renamed copy. The Edit dialog locks
+                   a stock type's Name to match — offering one rename and
+                   refusing the other read as a contradiction. Duplicate is the
+                   way to get one under your own name. -->
               <button class="link-btn" disabled={busy} onclick={() => { void rename(t); }}>Rename</button>
               <button class="link-btn" disabled={busy} onclick={() => { void remove(t); }}>Delete</button>
             {/if}

--- a/src/renderer/lib/components/TypeEditorDialog.svelte
+++ b/src/renderer/lib/components/TypeEditorDialog.svelte
@@ -27,6 +27,12 @@
   // live binding); untrack the read so it isn't flagged as reactive.
   const seed = untrack(() => initial);
 
+  /** A stock type's name is fixed, exactly as its id is. The Type Manager
+   *  offers no Rename for one, so an editable Name here just contradicted it —
+   *  and the two meant different things anyway (id vs. label). Customize the
+   *  fields, icon and colour; Duplicate if you want one under your own name. */
+  const nameLocked = seed?.stockOrigin !== undefined;
+
   interface Row {
     name: string;
     type: PropertyType;
@@ -144,18 +150,27 @@
 <div class="overlay" onkeydown={overlayKey} onmousedown={(e) => { if (e.target === e.currentTarget) onClose(); }} role="presentation">
   <div class="dialog" role="dialog" aria-modal="true" aria-label="Edit object type">
     <h3 class="title">{initial?.id ? 'Edit' : 'New'} object type</h3>
-    {#if seed?.forksStock}
+    {#if seed?.stockOrigin === 'stock'}
       <!-- "Edit" on a stock type reads as editing the bundle; say what it
            actually does before the user commits to it. -->
       <p class="fork-note">
         <strong>{seed.label}</strong> is a stock type. Saving keeps a customized copy in this
-        thoughtbase — the stock definition stays available to revert to.
+        thoughtbase — the stock definition stays available to revert to. Its name is fixed;
+        duplicate it instead to make one of your own.
       </p>
     {/if}
 
     <div class="meta">
       <label class="field grow"><span>Name</span>
-        <input bind:value={label} placeholder="Book" />
+        <!-- readonly, not disabled: the value still reads at full contrast and
+             stays selectable, and the field keeps its place in the row. -->
+        <input
+          bind:value={label}
+          placeholder="Book"
+          readonly={nameLocked}
+          class:locked={nameLocked}
+          title={nameLocked ? 'A stock type keeps its name — duplicate it to make one of your own' : undefined}
+        />
       </label>
 
       <div class="field icon-field">
@@ -285,6 +300,14 @@
     color: var(--text-muted);
   }
   .fork-note strong { color: var(--text); font-weight: 600; }
+  /* Reads as "fixed", not "broken": same text contrast, a flatter well and a
+     default cursor so it doesn't invite a click. No danger styling. */
+  .field input.locked {
+    background: color-mix(in oklch, var(--text) 5%, transparent);
+    border-color: transparent;
+    cursor: default;
+  }
+  .field input.locked:focus { outline: none; border-color: var(--border); }
   .meta { display: flex; gap: 10px; margin-bottom: 10px; align-items: flex-end; }
   .field { display: flex; flex-direction: column; gap: 4px; }
   .field span, .field label { font-size: 11px; color: var(--text-muted); }

--- a/src/renderer/lib/components/type-editor-value.ts
+++ b/src/renderer/lib/components/type-editor-value.ts
@@ -17,10 +17,18 @@ export interface TypeEditorInitial {
   parent?: string;
   properties: PropertyDef[];
   template?: string;
-  /** Editing a STOCK type that has no local copy yet. Saving will create one
-   *  in `.minerva/types/`, shadowing the bundled definition — the dialog says
-   *  so, since "Edit" otherwise reads as editing the bundle itself. */
-  forksStock?: boolean;
+  /**
+   * Set when editing a stock-derived type — `'stock'` for one with no local
+   * copy yet, `'customized'` for one already overridden in this thoughtbase.
+   * Absent for a wholly user-authored type.
+   *
+   * Two effects: `'stock'` warns that saving forks a local copy (otherwise
+   * "Edit" reads as editing the bundle itself), and BOTH lock the Name. A
+   * stock type's name is fixed the same way its id is — the Type Manager
+   * refuses to rename one, so letting the dialog change its label anyway just
+   * contradicted itself.
+   */
+  stockOrigin?: 'stock' | 'customized';
 }
 
 /** A type's optional carry-over fields (icon / color / cover / card / parent /

--- a/tests/renderer/components/TypeEditorDialog.test.ts
+++ b/tests/renderer/components/TypeEditorDialog.test.ts
@@ -124,6 +124,57 @@ describe('TypeEditorDialog (#1585)', () => {
   });
 });
 
+describe('TypeEditorDialog — stock types keep their name', () => {
+  // The Type Manager offers no Rename for a stock type, so an editable Name in
+  // the dialog contradicted it. (They also meant different things: Rename
+  // changes the id, the Name field changes the label.)
+
+  it('locks the Name when editing a stock type, and says why', async () => {
+    render(TypeEditorDialog, {
+      initial: { id: 'book', label: 'Book', properties: [], stockOrigin: 'stock' },
+      onSaved: vi.fn(), onClose: vi.fn(),
+    });
+    const name = screen.getByDisplayValue('Book');
+    expect(name.readOnly).toBe(true);
+    expect(screen.getByText(/is a stock type/)).toBeTruthy();
+    expect(screen.getByText(/name is fixed/)).toBeTruthy();
+  });
+
+  it('locks the Name on an already-customized stock type too', async () => {
+    // It's still stock-derived — the local copy doesn't make the name yours.
+    render(TypeEditorDialog, {
+      initial: { id: 'book', label: 'Book', properties: [], stockOrigin: 'customized' },
+      onSaved: vi.fn(), onClose: vi.fn(),
+    });
+    expect((screen.getByDisplayValue('Book')).readOnly).toBe(true);
+    // Already forked, so the "saving forks a copy" note is not repeated.
+    expect(screen.queryByText(/is a stock type/)).toBeNull();
+  });
+
+  it('leaves the Name editable on a user type', async () => {
+    render(TypeEditorDialog, {
+      initial: { id: 'gadget', label: 'Gadget', properties: [] },
+      onSaved: vi.fn(), onClose: vi.fn(),
+    });
+    expect((screen.getByDisplayValue('Gadget')).readOnly).toBe(false);
+    expect(screen.queryByText(/is a stock type/)).toBeNull();
+  });
+
+  it('still saves the stock name through unchanged, alongside the real edits', async () => {
+    // Locking the field must not drop the label from the payload — the local
+    // copy needs it, since the override is a full definition.
+    render(TypeEditorDialog, {
+      initial: { id: 'book', label: 'Book', icon: '📖', properties: [{ name: 'author', type: 'text' }], stockOrigin: 'stock' },
+      onSaved: vi.fn(), onClose: vi.fn(),
+    });
+    await fireEvent.click(screen.getByLabelText('Green'));
+    await fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect(saveMock.mock.calls[0]![0]).toMatchObject({ id: 'book', label: 'Book', color: '#a6e3a1' });
+  });
+});
+
 describe('TypeEditorDialog — icon picker', () => {
   it('focuses and selects the icon field before raising the OS panel, so a pick replaces', async () => {
     // The native panel types into whatever field has focus. Without the


### PR DESCRIPTION
The Type Manager offers no **Rename** for a stock type, but its Edit dialog let you change the **Name** anyway — the UI contradicting itself.

The two also meant different things under the hood: Rename changes the id and migrates instances; the Name field only changes the label. That distinction isn't visible to anyone actually using it, which is what made the inconsistency read as a bug.

## Change

The Name is read-only for any **stock-derived** type — whether or not this thoughtbase has already customized it. The local copy doesn't make the name yours. A stock type's identity is fixed; you customize its properties, icon and colour. **Duplicate** is the way to get one under your own name, and it already produces a fully renamable user type.

`forksStock: boolean` becomes `stockOrigin: 'stock' | 'customized'` — the boolean only covered the not-yet-customized case, and the lock has to apply to both.

`readonly` rather than `disabled`: the value keeps full text contrast, stays selectable, and the field holds its place in the row. Styled as *fixed* rather than *broken* — flatter well, default cursor, no danger colour.

## Worth checking in review

The label still travels in the save payload. The override is a **full** definition, so dropping it would write a nameless type — there's a test asserting a stock edit still sends `label: 'Book'` alongside the real change.

## Also

- Corrects a comment in `ObjectTypesSettings.svelte` that asserted the opposite ("Edit still changes a stock type's label — the id is what stays fixed"). That was accurate when I wrote it in #1766 and is now backwards.
- Records the fixed-identity rule in `docs/vision/objects.md` next to the override design.

`pnpm lint` clean; 569 test files / 5658 tests passing.

## The tradeoff

This does remove the ability to locally relabel a stock type — "I want to call these Tomes" now means Duplicate, which yields a type with a *different* id, so existing Book notes aren't instances of it. I think that's the right trade for a consistent rule, and it matches how stock skills work (author your own rather than edit the bundled one), but it is a real capability lost rather than a pure cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
