### PR TITLE
docs: document File → Thoughtbase Properties…

### DIFF
--- a/src/renderer/lib/components/ThoughtbaseProperties.svelte
+++ b/src/renderer/lib/components/ThoughtbaseProperties.svelte
@@ -2,11 +2,16 @@
   /**
    * Thoughtbase Properties dialog (#1443). Rename (safe, instant) plus an
    * Advanced breakout to set the knowledge-graph base IRI — which rewrites every
-   * graph identifier via a full re-index, so it's tucked away, warned, and
-   * disabled while the review queue is non-empty (pending proposals hold
-   * absolute IRIs that a rebuild can't re-derive). Reads its values directly
-   * (reads are allowed in components); mutations route through the notebase
-   * store via the `onSave` callback.
+   * graph identifier via a full re-index, so it's tucked away and warned about.
+   *
+   * It is NOT gated on an empty review queue: that was the original design (a
+   * pending proposal holds absolute IRIs a rebuild can't re-derive), but
+   * `indexAllNotes`' `rebaseFrom` now rewrites proposal IRIs old→new during the
+   * rebuild, so the guard was dropped. `checkRebase` is the only refusal left —
+   * an absolute http(s) URL ending in '/'.
+   *
+   * Reads its values directly (reads are allowed in components); mutations
+   * route through the notebase store via the `onSave` callback.
    */
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';

--- a/tests/scripts/__snapshots__/help-docs-corpus-staleness.test.ts.snap
+++ b/tests/scripts/__snapshots__/help-docs-corpus-staleness.test.ts.snap
@@ -451,6 +451,8 @@ exports[`help-docs corpus staleness (#1288) > chunk ids freshly extracted from w
   "thoughtbase-operations.html#closing",
   "thoughtbase-operations.html#creating",
   "thoughtbase-operations.html#guide",
+  "thoughtbase-operations.html#properties",
+  "thoughtbase-operations.html#properties",
   "thoughtbase-operations.html#related",
   "thoughtbase-operations.html#rename-delete",
   "thoughtbase-operations.html#switching",

--- a/website/docs/thoughtbase-operations.html
+++ b/website/docs/thoughtbase-operations.html
@@ -127,8 +127,27 @@
       </div>
     </div>
 
+    <h2 id="properties">Thoughtbase properties</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Thoughtbase Properties…</div>
+        <div class="v"><b>File → Thoughtbase Properties…</b> opens a small dialog for the two things a thoughtbase itself carries: what it's called, and — tucked under <b>Advanced</b> — the base address its knowledge graph uses.</div>
+      </div>
+    </div>
+
+    <p>The <b>Name</b> is a display label, kept separately from the folder on disk. Set it to whatever reads best and the folder keeps its own name; leave it blank and Minerva falls back to the folder's name. This is the friendly way to fix a thoughtbase called <code>notes-final-v2</code> without renaming anything on your file system.</p>
+
+    <div class="box">
+      <span class="label">Advanced: the graph base IRI</span>
+      <p>Every fact in your <a href="notes-rdf.html">knowledge graph</a> is identified by an address built on a common prefix — the base IRI. You'd change it if you're publishing your graph and want its identifiers to live under a domain you control.</p>
+      <p>Saving a new base rebuilds every index so all those identifiers regenerate. It has to be an absolute <code>http://</code> or <code>https://</code> address ending in a slash; anything else is refused with the reason shown in the dialog. Your <a href="right-sidebar-proposals.html">proposals</a> are carried over automatically, and <a href="navigation-wiki-links.html">wiki-links</a> between notes aren't affected — they don't use the base at all. What does break is anything outside Minerva that referred to the old addresses: exports you've already published, and any identifiers you'd copied elsewhere by hand.</p>
+      <p>Most thoughtbases never need this. If you're not publishing the graph, the default is fine.</p>
+    </div>
+
     <h2 id="rename-delete">Renaming, moving, or deleting a thoughtbase</h2>
-    <p>Because a thoughtbase is an ordinary folder, there's no separate command to rename or delete one — you do it in Finder or your file manager, like any folder. Rename or move the folder, then open it again from its new location; delete the folder to remove the thoughtbase. (Renaming, moving, and deleting individual <a href="notes.html#lifecycle">notes</a> <em>is</em> handled inside Minerva, from the sidebar.)</p>
+    <p>There are two different things you might mean by renaming a thoughtbase. To change what it's <em>called</em> in Minerva, set its Name in <a href="#properties">Thoughtbase Properties</a> — that's instant and touches nothing on disk. To change the <em>folder</em>, do it in Finder or your file manager like any other folder, then open it again from its new location.</p>
+
+    <p>Deleting works the same way: a thoughtbase is an ordinary folder, so removing the folder removes the thoughtbase. There's no command inside Minerva for it. (Renaming, moving, and deleting individual <a href="notes.html#lifecycle">notes</a> <em>is</em> handled inside Minerva, from the sidebar.)</p>
 
     <h2 id="related">Related</h2>
     <p>Once a thoughtbase is open, these cover what you do next:</p>


### PR DESCRIPTION
Adds a **Thoughtbase properties** section to `thoughtbase-operations.html`, placed after the guide to match the File menu's own order: the Name as a display label kept separate from the folder on disk, and the Advanced base-IRI field in a box of its own.

## It corrects the page, not just extends it

"Renaming, moving, or deleting a thoughtbase" opened by stating flatly:

> Because a thoughtbase is an ordinary folder, there's no separate command to rename or delete one — you do it in Finder or your file manager

The Properties dialog contradicts that. Rewritten around the distinction that actually matters: renaming what it's **called** is instant and in-app; renaming the **folder** is still a file-manager job. Deleting is unchanged.

## On the base IRI

Deliberately concrete about consequences, since it's the one destructive-ish action on the page — what it's for (publishing under a domain you control), the format it insists on, what survives (proposals migrate automatically, wiki-links never used the base), and what doesn't (already-published exports, identifiers copied elsewhere by hand). Plus a plain "most thoughtbases never need this."

## A stale comment I had to resolve first

The dialog component's doc comment says the rebase is *"disabled while the review queue is non-empty"* — so my first draft documented that restriction.

It isn't true. That was the original design, dropped once `indexAllNotes`' `rebaseFrom` began rewriting proposal IRIs during the rebuild. Neither `register-graph.ts` nor `rebase-guard.ts` refuses on that basis — `rebase-guard.ts` explicitly documents the reversal — and the dialog has no such gate. `checkRebase` (absolute http(s) URL ending in `/`) is the only refusal left.

The component comment was the last place still asserting it, so it's corrected here. Worth a look in review: I'd have shipped wrong docs if I'd trusted it, and it's the kind of thing that misleads the next person to touch that file.

## Checks

- 0 broken internal links, 0 dangling in-page anchors across all 114 docs pages
- tag balance verified on the edited page
- help-corpus snapshot regenerated, so in-app help search finds the new section
- `pnpm lint` clean; 569 test files / 5658 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
