### PR TITLE
perf(llm): cache the conversation history, not just the system prompt

### DIFF
--- a/src/main/llm/provider/anthropic-cache.ts
+++ b/src/main/llm/provider/anthropic-cache.ts
@@ -1,0 +1,101 @@
+/**
+ * Prompt-cache breakpoint placement for the Anthropic provider (#1773).
+ *
+ * Caching is a PREFIX match: the cache key is the exact bytes of the rendered
+ * prompt up to each `cache_control` marker, and the render order is
+ * `tools` → `system` → `messages`. The provider already marks the system block,
+ * which covers tools + system — but the conversation history was never marked,
+ * so every iteration of the agentic loop re-sent the whole growing transcript
+ * at full input price. A tool-heavy turn pays that up to `maxIterations` times.
+ *
+ * The fix is a rolling breakpoint on the tail of the history. Iteration N marks
+ * its last messages, writing a cache entry for everything through them;
+ * iteration N+1 sends that same prefix unchanged, reads it back at ~0.1× input
+ * price, and writes only its own delta.
+ *
+ * Two constraints shape the implementation:
+ *
+ *  - **Four breakpoints per request, total.** The system block takes one, so
+ *    the history gets at most three. We use two, leaving one spare.
+ *  - **A breakpoint looks back at most 20 content blocks** for a prior entry.
+ *    One iteration can add many blocks at once (an assistant message plus one
+ *    `tool_result` per parallel tool call), so marking only the very last
+ *    message risks the next lookback overshooting the previous entry. Marking
+ *    the last two keeps a second anchor ~1 message back, well inside the window.
+ *
+ * A pure leaf module — no SDK client, no I/O — so the placement rules are
+ * unit-testable without a live API.
+ */
+import type Anthropic from '@anthropic-ai/sdk';
+
+/**
+ * Block types the API accepts `cache_control` on. Notably absent: `thinking`
+ * and `redacted_thinking`, which an assistant message can end with — marking
+ * one is rejected, so we walk back to the last block that can carry it.
+ */
+const CACHEABLE_BLOCK_TYPES: ReadonlySet<string> = new Set([
+  'text',
+  'image',
+  'tool_use',
+  'tool_result',
+  'document',
+]);
+
+/** History breakpoints to place. System takes a fourth; the API allows 4. */
+export const HISTORY_BREAKPOINTS = 2;
+
+const EPHEMERAL = { type: 'ephemeral' } as const;
+
+/** Index of the last block that can carry `cache_control`, or -1 if none can. */
+function lastCacheableIndex(content: readonly Anthropic.ContentBlockParam[]): number {
+  for (let i = content.length - 1; i >= 0; i--) {
+    const type = content[i]?.type;
+    if (type && CACHEABLE_BLOCK_TYPES.has(type)) return i;
+  }
+  return -1;
+}
+
+/**
+ * A copy of `message` with `cache_control` on its last cacheable block, or null
+ * when it has none to mark (an empty message, or one that is all thinking).
+ * String content is promoted to a single text block so it can carry the marker.
+ */
+function markMessage(message: Anthropic.MessageParam): Anthropic.MessageParam | null {
+  const { content } = message;
+
+  if (typeof content === 'string') {
+    if (content === '') return null;
+    return { ...message, content: [{ type: 'text', text: content, cache_control: EPHEMERAL }] };
+  }
+
+  if (content.length === 0) return null;
+  const at = lastCacheableIndex(content);
+  if (at === -1) return null;
+
+  const next: Anthropic.ContentBlockParam[] = [...content];
+  next[at] = { ...next[at], cache_control: EPHEMERAL } as Anthropic.ContentBlockParam;
+  return { ...message, content: next };
+}
+
+/**
+ * Return `history` with a rolling cache breakpoint on the last `limit`
+ * markable messages.
+ *
+ * Never mutates the input: the agentic loop reuses and appends to the same
+ * array across iterations, so stamping in place would accumulate stale
+ * breakpoints and blow the four-per-request budget after two iterations.
+ */
+export function withHistoryCacheBreakpoints(
+  history: readonly Anthropic.MessageParam[],
+  limit: number = HISTORY_BREAKPOINTS,
+): Anthropic.MessageParam[] {
+  const out = [...history];
+  let placed = 0;
+  for (let i = out.length - 1; i >= 0 && placed < limit; i--) {
+    const marked = markMessage(out[i]!);
+    if (!marked) continue; // nothing markable here — try the message before it
+    out[i] = marked;
+    placed++;
+  }
+  return out;
+}

--- a/src/main/llm/provider/anthropic.ts
+++ b/src/main/llm/provider/anthropic.ts
@@ -13,6 +13,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { Citation, TurnUsage } from '../../../shared/types';
 import type { ConnectionCheckResult } from '../../../shared/tools/types';
 import { toConnectionResult } from '../connection-error';
+import { withHistoryCacheBreakpoints } from './anthropic-cache';
 import type { Effort } from '../../../shared/tools/effort';
 import type {
   ChatMessage,
@@ -140,6 +141,8 @@ export class AnthropicProvider implements LLMProvider {
   }
 
   async runTurn(req: TurnRequest, hooks: TurnHooks): Promise<TurnResult> {
+    // Tools render before system, so this one marker caches BOTH — the tool
+    // schemas and the system prompt — as a single prefix.
     const system: Anthropic.TextBlockParam[] = [
       { type: 'text', text: req.system, cache_control: { type: 'ephemeral' } },
     ];
@@ -148,7 +151,9 @@ export class AnthropicProvider implements LLMProvider {
       max_tokens: req.maxTokens,
       system,
       tools: this.buildTools(req.tools, req.web),
-      messages: req.history as unknown as Anthropic.MessageParam[],
+      // Rolling breakpoints on the history tail so each loop iteration reads
+      // the transcript the previous one wrote instead of re-paying for it.
+      messages: withHistoryCacheBreakpoints(req.history as unknown as Anthropic.MessageParam[]),
       ...outputConfigFor(req.effort),
     };
     if (req.containerId) streamParams.container = req.containerId;
@@ -166,6 +171,17 @@ export class AnthropicProvider implements LLMProvider {
     if (hooks.onTextDelta) stream.on('text', (delta) => hooks.onTextDelta!(delta));
 
     const message = await stream.finalMessage();
+
+    if (process.env.MINERVA_LLM_DEBUG) {
+      // Caching fails silently — a stray timestamp in the system prompt just
+      // means `read` stays 0 forever, with no error. Surface the split so a
+      // regression is visible rather than merely expensive.
+      const u = message.usage;
+      console.log(
+        `[llm] cache read=${u?.cache_read_input_tokens ?? 0} `
+        + `write=${u?.cache_creation_input_tokens ?? 0} uncached=${u?.input_tokens ?? 0}`,
+      );
+    }
 
     // Fallback for any tool-use block the streaming event missed (SDK drift),
     // so the indicator still appears exactly once.
@@ -201,7 +217,16 @@ export class AnthropicProvider implements LLMProvider {
     const messages = req.messages as Anthropic.MessageParam[];
     const base = {
       model: req.model,
-      ...(req.system ? { system: req.system } : {}),
+      // Batch callers (auto-tag, auto-link) re-send an identical system prompt
+      // per note; marking it makes every call after the first a cache read.
+      // Below the model's minimum cacheable prefix this is silently a no-op.
+      ...(req.system
+        ? {
+            system: [
+              { type: 'text', text: req.system, cache_control: { type: 'ephemeral' } },
+            ] satisfies Anthropic.TextBlockParam[],
+          }
+        : {}),
       ...outputConfigFor(req.effort),
       messages,
     };

--- a/tests/main/llm/anthropic-cache.test.ts
+++ b/tests/main/llm/anthropic-cache.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Prompt-cache breakpoint placement (#1773).
+ *
+ * The failure mode this guards against is silent: a misplaced or missing
+ * `cache_control` marker produces no error, just a permanent 0% cache-read rate
+ * and a bill nobody notices. So the rules are pinned here rather than left to a
+ * live API call to reveal — the API's constraints (four markers per request,
+ * only certain block types, an untouched prefix) are all things a unit test can
+ * check and a running app cannot.
+ */
+import { describe, it, expect } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import {
+  withHistoryCacheBreakpoints,
+  HISTORY_BREAKPOINTS,
+} from '../../../src/main/llm/provider/anthropic-cache';
+
+type Msg = Anthropic.MessageParam;
+
+/** Every `cache_control` in a message list, as `messageIndex:blockIndex`. */
+function markers(messages: readonly Msg[]): string[] {
+  const out: string[] = [];
+  messages.forEach((m, mi) => {
+    if (typeof m.content === 'string') return;
+    m.content.forEach((b, bi) => {
+      if ((b as { cache_control?: unknown }).cache_control) out.push(`${mi}:${bi}`);
+    });
+  });
+  return out;
+}
+
+const user = (text: string): Msg => ({ role: 'user', content: text });
+const assistantText = (text: string): Msg => ({
+  role: 'assistant',
+  content: [{ type: 'text', text }],
+});
+const toolResults = (n: number): Msg => ({
+  role: 'user',
+  content: Array.from({ length: n }, (_, i) => ({
+    type: 'tool_result' as const,
+    tool_use_id: `toolu_${i}`,
+    content: 'ok',
+  })),
+});
+
+describe('withHistoryCacheBreakpoints', () => {
+  it('marks the last two messages, on their final block', () => {
+    const history = [user('one'), assistantText('two'), toolResults(3)];
+    const out = withHistoryCacheBreakpoints(history);
+    // Message 2's third tool_result and message 1's only text block.
+    expect(markers(out)).toEqual(['1:0', '2:2']);
+  });
+
+  it('leaves the input untouched — the loop appends to the same array', () => {
+    // Stamping in place would accumulate stale markers across iterations and
+    // blow the four-per-request budget by the third turn.
+    const history = [user('one'), assistantText('two')];
+    const before = JSON.stringify(history);
+    withHistoryCacheBreakpoints(history);
+    expect(JSON.stringify(history)).toBe(before);
+  });
+
+  it('stays within the API budget once the system marker is counted', () => {
+    const history = Array.from({ length: 30 }, (_, i) => assistantText(`m${i}`));
+    const out = withHistoryCacheBreakpoints(history);
+    // 4 allowed per request; the provider spends one on the system block.
+    expect(markers(out).length).toBe(HISTORY_BREAKPOINTS);
+    expect(markers(out).length).toBeLessThanOrEqual(3);
+  });
+
+  it('promotes string content to a text block so it can carry the marker', () => {
+    const out = withHistoryCacheBreakpoints([user('plain string')]);
+    expect(out[0]!.content).toEqual([
+      { type: 'text', text: 'plain string', cache_control: { type: 'ephemeral' } },
+    ]);
+  });
+
+  it('never marks a thinking block — the API rejects it', () => {
+    // Adaptive thinking is on by default for Claude Opus 5, so an assistant
+    // message can legitimately end with a block that cannot carry the marker.
+    const history: Msg[] = [
+      user('q'),
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'answer' },
+          { type: 'thinking', thinking: 'reasoning', signature: 'sig' },
+        ] as unknown as Anthropic.ContentBlockParam[],
+      },
+    ];
+    const out = withHistoryCacheBreakpoints(history);
+    const blocks = out[1]!.content as Anthropic.ContentBlockParam[];
+    expect((blocks[1] as { cache_control?: unknown }).cache_control).toBeUndefined();
+    expect((blocks[0] as { cache_control?: unknown }).cache_control).toBeDefined();
+  });
+
+  it('falls through to an earlier message when one has nothing markable', () => {
+    const unmarkable: Msg = { role: 'assistant', content: [] };
+    const out = withHistoryCacheBreakpoints([user('a'), assistantText('b'), unmarkable]);
+    // The empty message is skipped; both markers land on real content.
+    expect(markers(out)).toEqual(['0:0', '1:0']);
+  });
+
+  it('handles a history shorter than the breakpoint count', () => {
+    expect(markers(withHistoryCacheBreakpoints([user('only')]))).toEqual(['0:0']);
+    expect(withHistoryCacheBreakpoints([])).toEqual([]);
+  });
+
+  it('re-marks the new tail as the loop grows, so each turn reads the last write', () => {
+    // The mechanic the whole feature rests on: iteration N's markers move to
+    // the messages iteration N+1 appended, leaving N's prefix byte-identical
+    // and therefore readable.
+    const turn1 = [user('q'), assistantText('a1')];
+    const marked1 = withHistoryCacheBreakpoints(turn1);
+    expect(markers(marked1)).toEqual(['0:0', '1:0']);
+
+    const turn2 = [...turn1, toolResults(1), assistantText('a2')];
+    const marked2 = withHistoryCacheBreakpoints(turn2);
+    expect(markers(marked2)).toEqual(['2:0', '3:0']);
+
+    // The prefix iteration 1 cached is unchanged in iteration 2's request —
+    // this is what makes it a cache read rather than a fresh write.
+    expect(JSON.stringify(marked2.slice(0, 2))).toBe(JSON.stringify(turn1));
+  });
+});

--- a/tests/main/llm/provider-seam.test.ts
+++ b/tests/main/llm/provider-seam.test.ts
@@ -29,27 +29,40 @@ function collectTsFiles(dir: string): string[] {
   return out;
 }
 
-// Each provider SDK is confined to its own implementation file. A real
+// Each provider SDK is confined to its own implementation. A real
 // import/require (not a passing mention in a comment — types.ts names Anthropic
 // in prose while importing nothing) anywhere else breaks the seam. As providers
 // are added (BYOM #1492) each SDK gets a row here.
-const SDKS: { name: string; importRe: RegExp; sanctioned: string }[] = [
+//
+// `sanctioned` is a LIST because an implementation may span more than one file:
+// `anthropic-cache.ts` holds the prompt-cache breakpoint rules, factored out of
+// `anthropic.ts` so they're unit-testable without a live client. The invariant
+// this test defends is unchanged — every sanctioned path must live under
+// `src/main/llm/provider/`, so the conversation layer still can't reach the SDK.
+const SDKS: { name: string; importRe: RegExp; sanctioned: string[] }[] = [
   {
     name: '@anthropic-ai/sdk',
     importRe: /(?:from|require\()\s*['"]@anthropic-ai\/sdk['"]/,
-    sanctioned: path.join('src', 'main', 'llm', 'provider', 'anthropic.ts'),
+    sanctioned: [
+      path.join('src', 'main', 'llm', 'provider', 'anthropic-cache.ts'),
+      path.join('src', 'main', 'llm', 'provider', 'anthropic.ts'),
+    ],
   },
   {
     name: 'openai',
     importRe: /(?:from|require\()\s*['"]openai(?:\/[^'"]*)?['"]/,
-    sanctioned: path.join('src', 'main', 'llm', 'provider', 'openai.ts'),
+    sanctioned: [path.join('src', 'main', 'llm', 'provider', 'openai.ts')],
   },
   {
     name: '@google/genai',
     importRe: /(?:from|require\()\s*['"]@google\/genai['"]/,
-    sanctioned: path.join('src', 'main', 'llm', 'provider', 'google.ts'),
+    sanctioned: [path.join('src', 'main', 'llm', 'provider', 'google.ts')],
   },
 ];
+
+/** Every sanctioned file must be inside the provider directory — that, not the
+ *  file count, is what keeps the seam meaningful. */
+const PROVIDER_DIR = path.join('src', 'main', 'llm', 'provider');
 
 const NON_PROVIDER_FILES = [
   path.join('src', 'main', 'llm', 'index.ts'),
@@ -66,8 +79,16 @@ describe('provider seam (#1148, BYOM #1492)', () => {
       .sort();
 
   for (const sdk of SDKS) {
-    it(`confines ${sdk.name} to its single provider implementation`, () => {
-      expect(importersOf(sdk.importRe)).toEqual([sdk.sanctioned]);
+    it(`confines ${sdk.name} to its provider implementation`, () => {
+      expect(importersOf(sdk.importRe)).toEqual([...sdk.sanctioned].sort());
+    });
+
+    it(`keeps every sanctioned ${sdk.name} file inside the provider directory`, () => {
+      // Guards the guard: widening `sanctioned` to a path outside the provider
+      // directory would silently re-admit the SDK to the conversation layer.
+      for (const file of sdk.sanctioned) {
+        expect(file.startsWith(PROVIDER_DIR + path.sep)).toBe(true);
+      }
     });
   }
 


### PR DESCRIPTION
Minerva already had prompt caching — just not all of it.

The system block was marked with `cache_control`, and since `tools` render before `system`, that one marker covered **tools + system**. Cache reads/writes were already tracked in `TurnUsage` and priced correctly in `models.ts` (0.1× read, 1.25× write). What was missing was the **conversation history**: every iteration of the agentic loop re-sent the whole growing transcript at full input price — up to `maxIterations` times per user turn — and every new turn re-sent all prior turns.

## The change

A rolling breakpoint on the history tail. Iteration N marks its last messages, writing a cache entry for everything through them; iteration N+1 sends that prefix byte-identical and reads it back at ~0.1× instead of 1×, writing only its own delta.

Two API constraints shape the implementation:

- **Four breakpoints per request.** System takes one, history uses two, one spare.
- **A breakpoint looks back at most 20 content blocks** for a prior entry. One iteration can add many blocks at once (an assistant message plus one `tool_result` per parallel tool call), so marking only the last message risks the next lookback overshooting the previous entry. Two markers keep an anchor one message back.

The rules live in `anthropic-cache.ts` as a pure leaf module rather than inline. The failure mode here is **silent** — a misplaced marker produces no error, just a permanent 0% hit rate and a bill nobody notices — so the placement rules are worth pinning in a unit test that a running app can't give you. It never mutates the input: the loop appends to one array across iterations, so marking in place would accumulate stale markers and blow the four-per-request budget by the third turn (there's a test for that).

Also marks the system prompt on the one-shot `complete()` path — batch callers like auto-tag and auto-link re-send an identical system prompt per note — and logs the read/write/uncached split under `MINERVA_LLM_DEBUG`.

Anthropic-only by construction: it sits behind the provider seam, so the OpenAI and Google implementations are untouched.

## Seam-test change, called out explicitly

`provider-seam.test.ts` asserted that **exactly one** file may import `@anthropic-ai/sdk`. `sanctioned` becomes a list, since an implementation can legitimately span more than one file.

To avoid weakening the guard, I added a second assertion: every sanctioned path must live under `src/main/llm/provider/`. That's the property that actually matters — it's what keeps the conversation layer, tool dispatch, and the approval gate away from the SDK. Widening the list to a path outside that directory now fails.

## Audit findings

I ran the silent-invalidator checklist over the prefix. Three clean, one worth your judgment:

- ✅ **Tool order is deterministic** — `NOTEBASE_TOOLS` is a static array and `extraTools` is deduped in caller order.
- ✅ **No timestamps or UUIDs** in the prefix.
- ✅ **`currentDateContext()` is day-granular**, not per-request — it re-caches once a day, not every call.
- ⚠️ **`currentNotePath` sits in the system prompt.** Because system renders *before* messages, switching notes mid-conversation invalidates the whole prefix — tools, system, **and** the history cache this PR adds. `buildConversationSystemPrompt` already documents this as a known tradeoff ("it only re-caches when the date or open note changes"), so I've left it alone rather than change a deliberate design decision unasked.

The fix, if you want it, is to move the volatile per-turn lines (date, current note) out of `system` and into a `{role: "system"}` message appended to `messages` — which sits *after* the cached prefix and so leaves it intact. That's supported with no beta header on Claude Opus 5 (Minerva's default) and Opus 4.8, but **not on Sonnet 5**, where it returns a 400. So it needs model-capability gating and a fallback, which is why it's a separate piece of work rather than folded in here.

`pnpm lint` clean; 570 test files / 5669 tests passing.

## Not measured

I verified placement by unit test, not by watching real `cache_read_input_tokens` come back from the API — that needs a live key and a real conversation. `MINERVA_LLM_DEBUG=1` now prints the read/write/uncached split per turn, so one tool-heavy conversation will confirm it (or show a zero read rate, which would mean an invalidator I missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
