### PR TITLE
feat(llm): batch folder moves into one proposal

### DIFF
--- a/src/main/ipc/register-conversation-drafts.ts
+++ b/src/main/ipc/register-conversation-drafts.ts
@@ -174,9 +174,12 @@ export function registerConversationDrafts(): void {
       }
       const { ordered } = orderRefactors(selected);
       const ctx = projectContext(rootPath);
+      // A folder batch files `folder-refactor` payloads — same bundle, same
+      // ordered apply and reverse-order rollback, different payload kind.
+      const kind = draft.isFolder ? ('folder-refactor' as const) : ('note-refactor' as const);
       const proposal = await approval.proposeWrite(ctx, {
         operationType: 'note_refactor',
-        payloads: ordered.map((i) => ({ kind: 'note-refactor' as const, fromPath: i.fromPath, toPath: i.toPath })),
+        payloads: ordered.map((i) => ({ kind, fromPath: i.fromPath, toPath: i.toPath })),
         note: draft.note,
         ...conversationProvenance(draft.conversationId),
       });

--- a/src/main/llm/tools/propose-folder-move.ts
+++ b/src/main/llm/tools/propose-folder-move.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import { planFolderRename, RefactorError } from '../../notebase/rename';
-import type { ConversationRefactorDraft } from '../../../shared/conversation-refactor-drafts';
+import { planFolderReorg } from '../../notebase/reorg';
+import type {
+  ConversationRefactorDraft,
+  ConversationReorgDraft,
+} from '../../../shared/conversation-refactor-drafts';
 import type { NotebaseTool, ToolContext, ToolCallbacks } from './types';
 
 /**
@@ -11,20 +15,92 @@ import type { NotebaseTool, ToolContext, ToolCallbacks } from './types';
  * `isFolder` for review. Never moves anything — on Approve the renderer files a
  * `folder-refactor` proposal.
  */
+/** One folder move, normalized to bare relative paths. */
+interface FolderPair { from: string; to: string }
+
+function parsePairs(input: unknown): { pairs: FolderPair[] } | { error: string } {
+  const { moves } = input as { moves?: unknown };
+  if (!Array.isArray(moves) || moves.length === 0) {
+    return { error: 'moves is required: a non-empty array of { path, newPath } objects.' };
+  }
+  const pairs: FolderPair[] = [];
+  for (const m of moves) {
+    const { path: folderPath, newPath } = (m ?? {}) as { path?: unknown; newPath?: unknown };
+    if (typeof folderPath !== 'string' || !folderPath.trim()) {
+      return { error: 'each move needs a non-empty string `path`.' };
+    }
+    if (typeof newPath !== 'string' || !newPath.trim()) {
+      return { error: 'each move needs a non-empty string `newPath` (the folder\'s full destination path).' };
+    }
+    pairs.push({
+      from: folderPath.trim().replace(/^\/+|\/+$/g, ''),
+      to: newPath.trim().replace(/^\/+|\/+$/g, ''),
+    });
+  }
+  return { pairs };
+}
+
+/**
+ * propose_folder_move — the folder counterpart to propose_note_move/rename.
+ * Dry-runs each folder move via `planFolderRename` (validates guardrails +
+ * computes the blast radius: every note that relocates + every note whose
+ * inbound links get rewritten), then forwards a draft for review. Never moves
+ * anything — on Approve the renderer files `folder-refactor` proposals.
+ *
+ * One folder keeps the single refactor card (its blast-radius view reads better
+ * for one move). A batch routes through the reorg draft, exactly as batched
+ * note moves do, so many folders are one card and one all-or-nothing bundle.
+ */
 async function runProposeFolderMove(
   ctx: ToolContext, input: unknown, callbacks: ToolCallbacks,
 ): Promise<{ content: string; isError: boolean }> {
-  if (!callbacks.onRefactorDraft) {
-    return { content: 'propose_folder_move is only available in conversation contexts.', isError: true };
-  }
   if (!ctx.conversationId) {
     return { content: 'propose_folder_move requires a bound conversation id.', isError: true };
   }
-  const { path: folderPath, newPath } = input as { path?: string; newPath?: string };
-  if (typeof folderPath !== 'string' || !folderPath.trim()) return { content: 'path is required.', isError: true };
-  if (typeof newPath !== 'string' || !newPath.trim()) return { content: 'newPath is required (the folder\'s full destination path).', isError: true };
-  const from = folderPath.trim().replace(/^\/+|\/+$/g, '');
-  const to = newPath.trim().replace(/^\/+|\/+$/g, '');
+  const parsed = parsePairs(input);
+  if ('error' in parsed) return { content: parsed.error, isError: true };
+  const { pairs } = parsed;
+
+  if (pairs.length > 1) {
+    if (!callbacks.onReorgDraft) {
+      return { content: 'propose_folder_move is only available in conversation contexts.', isError: true };
+    }
+    const plan = await planFolderReorg(ctx.rootPath, pairs.map((p) => ({ path: p.from, newPath: p.to })));
+    if (plan.items.length === 0) {
+      return { content: `No folder moves could be planned. ${plan.warnings.join(' ')}`.trim(), isError: true };
+    }
+    const draft: ConversationReorgDraft = {
+      draftId: `reorg-${randomUUID()}`,
+      conversationId: ctx.conversationId,
+      note: `Move ${plan.items.length} folders`,
+      items: plan.items.map((i) => ({ fromPath: i.fromPath, toPath: i.toPath, affectedNotes: i.affectedNotes })),
+      warnings: plan.warnings,
+      isFolder: true,
+      createdAt: new Date().toISOString(),
+    };
+    callbacks.onReorgDraft(draft);
+
+    const notesMoved = new Set(plan.items.flatMap((i) => i.affectedNotes.filter((a) => a.isMoved).map((a) => a.path)));
+    const linkRewrites = new Set(plan.items.flatMap((i) => i.affectedNotes.filter((a) => !a.isMoved).map((a) => a.path)));
+    return {
+      content: JSON.stringify({
+        status: 'drafted',
+        draftId: draft.draftId,
+        foldersMoved: plan.items.length,
+        notesMoved: notesMoved.size,
+        notesWithLinkRewrites: linkRewrites.size,
+        ...(plan.warnings.length > 0 ? { warnings: plan.warnings } : {}),
+        hint: 'STOP. The folder moves are queued for the user to review (per-item) and approve — nothing has moved. ' +
+          'End the turn with one short acknowledgement and do NOT call this tool again this turn.',
+      }),
+      isError: false,
+    };
+  }
+
+  if (!callbacks.onRefactorDraft) {
+    return { content: 'propose_folder_move is only available in conversation contexts.', isError: true };
+  }
+  const { from, to } = pairs[0]!;
 
   let plan: Awaited<ReturnType<typeof planFolderRename>>;
   try {
@@ -68,21 +144,36 @@ export const proposeFolderMove: NotebaseTool = {
   definition: {
     name: 'propose_folder_move',
     description:
-      'Propose moving OR renaming a whole folder (and everything under it) for the ' +
+      'Propose moving OR renaming whole folders (and everything under them) for the ' +
       'user to review. Use this instead of moving notes one-by-one when a folder ' +
       'belongs somewhere else or should be renamed. Every note inside relocates and ' +
       'all inbound wiki-links + relative paths are rewritten automatically on ' +
-      'approval; the user reviews a card showing the destination and the affected ' +
-      'notes. To move, give a `newPath` under a different parent (keep the last ' +
-      'segment); to rename, give a `newPath` with a different last segment. Use ' +
-      'list_notes first to see the folder structure. NOTHING moves until approved.',
+      'approval; the user reviews a card showing the destinations and the affected ' +
+      'notes. For each entry: to move, give a `newPath` under a different parent ' +
+      '(keep the last segment); to rename, give a `newPath` with a different last ' +
+      'segment. Use list_notes first to see the folder structure. ' +
+      'Call this ONCE per turn with ALL the folders you want to move in `moves` — ' +
+      'a batch becomes a single review card and a single all-or-nothing change, ' +
+      'so do not call it once per folder. NOTHING moves until approved.',
     input_schema: {
       type: 'object',
       properties: {
-        path: { type: 'string', description: 'The folder\'s current thoughtbase-relative path (e.g. "notes/old-topic").' },
-        newPath: { type: 'string', description: 'The folder\'s full destination path (e.g. "notes/archive/old-topic" to move, or "notes/new-topic" to rename).' },
+        moves: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 100,
+          description: 'One entry per folder to move or rename. Include every folder in this one call.',
+          items: {
+            type: 'object',
+            properties: {
+              path: { type: 'string', description: 'The folder\'s current thoughtbase-relative path (e.g. "notes/old-topic").' },
+              newPath: { type: 'string', description: 'The folder\'s full destination path (e.g. "notes/archive/old-topic" to move, or "notes/new-topic" to rename).' },
+            },
+            required: ['path', 'newPath'],
+          },
+        },
       },
-      required: ['path', 'newPath'],
+      required: ['moves'],
     },
   },
   run: (ctx, input, callbacks) => runProposeFolderMove(ctx, input, callbacks),

--- a/src/main/notebase/reorg.ts
+++ b/src/main/notebase/reorg.ts
@@ -15,7 +15,7 @@
  *    so it's reported rather than silently mis-applied.
  */
 
-import { planRename, RefactorError, type RenamePlan } from './rename';
+import { planRename, planFolderRename, RefactorError, type RenamePlan } from './rename';
 
 export interface ReorgOperation {
   path: string;
@@ -103,4 +103,71 @@ export function orderRefactors<T extends { fromPath: string; toPath: string }>(
   }
   if (ordered.length < n) return { ordered: [...pairs], cycle: true };
   return { ordered, cycle: false };
+}
+
+/**
+ * Folder counterpart to {@link planReorg} (#1778) — dry-run a batch of whole-folder
+ * moves/renames so many folders are one review card and one bundled proposal.
+ *
+ * Same drop-with-a-warning contract as `planReorg`: a folder that can't be
+ * planned (missing, collision, into-itself) is skipped with a message rather
+ * than failing the batch.
+ *
+ * One hazard is specific to folders and worth naming. Each folder is planned
+ * against the CURRENT tree, so when one requested move's source or destination
+ * sits inside another's, the previews can't both be right — moving `a/` into
+ * `b/` while also moving `b/` is the simple case. Apply is still safe: the
+ * `folder-refactor` payload re-runs `planFolderRename` at apply time and throws
+ * on a guardrail violation, which rolls the whole bundle back. So this warns
+ * rather than rejects — the preview may understate what happens, the commit
+ * cannot silently do the wrong thing.
+ */
+export async function planFolderReorg(
+  rootPath: string,
+  operations: ReorgOperation[],
+): Promise<ReorgPlan> {
+  const items: ReorgItem[] = [];
+  const warnings: string[] = [];
+  const seenDest = new Map<string, string>();
+
+  const trim = (p: string): string => p.trim().replace(/^\/+|\/+$/g, '');
+
+  for (const op of operations) {
+    const from = trim(op.path);
+    const to = trim(op.newPath);
+
+    const clash = seenDest.get(to);
+    if (clash !== undefined) {
+      warnings.push(`Skipped ${from}: ${clash} is already being moved to ${to}.`);
+      continue;
+    }
+
+    try {
+      const plan = await planFolderRename(rootPath, from, to);
+      seenDest.set(to, from);
+      items.push({ fromPath: from, toPath: to, affectedNotes: plan.affectedNotes });
+    } catch (e) {
+      if (e instanceof RefactorError) {
+        warnings.push(`Skipped ${from}: ${e.message}`);
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  // Nesting check across the planned set (see the hazard note above).
+  const inside = (child: string, parent: string): boolean => child.startsWith(`${parent}/`);
+  for (const a of items) {
+    for (const b of items) {
+      if (a === b) continue;
+      if (inside(a.fromPath, b.fromPath) || inside(a.toPath, b.fromPath)) {
+        warnings.push(
+          `${a.fromPath} → ${a.toPath} overlaps the move of ${b.fromPath}; `
+          + 'the preview for it may not reflect the other move.',
+        );
+      }
+    }
+  }
+
+  return { items, warnings };
 }

--- a/src/renderer/lib/components/ReorgDraftCard.svelte
+++ b/src/renderer/lib/components/ReorgDraftCard.svelte
@@ -53,8 +53,14 @@
 
 <div class="draft-card">
   <div class="draft-summary">
-    <strong>Reorganize</strong>
-    <span class="draft-note">{selectedItems.length} of {draft.items.length} notes · {linkRewrites} note{linkRewrites === 1 ? '' : 's'}' links rewritten</span>
+    <!-- A folder batch moves whole trees, so the item count is folders; the
+         link-rewrite count stays notes either way (that's what gets rewritten). -->
+    <strong>{draft.isFolder ? 'Move folders' : 'Reorganize'}</strong>
+    <span class="draft-note">
+      {selectedItems.length} of {draft.items.length}
+      {draft.isFolder ? 'folder' : 'note'}{draft.items.length === 1 ? '' : 's'}
+      · {linkRewrites} note{linkRewrites === 1 ? '' : 's'}' links rewritten
+    </span>
   </div>
 
   {#if draft.warnings.length > 0}

--- a/src/shared/conversation-refactor-drafts.ts
+++ b/src/shared/conversation-refactor-drafts.ts
@@ -54,6 +54,12 @@ export interface ConversationReorgDraft extends ConversationToolDraft {
   items: ReorgDraftItem[];
   /** Plan-level problems surfaced before apply (collisions, cycles, skips). */
   warnings: string[];
+  /** True when every item is a whole FOLDER move (batched propose_folder_move,
+   *  #1778) rather than a note move. The card says "folders" and the file
+   *  handler emits `folder-refactor` payloads instead of `note-refactor`.
+   *  `affectedNotes` still lists notes either way — for a folder that's the
+   *  notes inside it plus the referrers whose links get rewritten. */
+  isFolder?: boolean;
 }
 
 /** One note proposed for deletion within a `propose_note_delete` batch

--- a/tests/main/llm/folder-move-delete-proposal.test.ts
+++ b/tests/main/llm/folder-move-delete-proposal.test.ts
@@ -102,6 +102,47 @@ describe('folder-refactor proposal (#911 follow-up)', () => {
     expect(await readBytes('topic/pic.png')).toEqual(Buffer.from(PNG_BYTES));
   });
 
+  it('moves MANY folders from one bundle, and rolls them all back on failure', async () => {
+    // The batched `propose_folder_move` path (#1778) files one proposal with a
+    // folder-refactor payload per folder. Each payload re-plans at apply time,
+    // so the bundle is safe; what this pins is that a mid-bundle failure leaves
+    // NO folder half-moved.
+    await seed('other/b.md', '# B\n\nbody');
+
+    const ok = await proposeWrite(ctx(), {
+      operationType: 'note_refactor',
+      payloads: [
+        { kind: 'folder-refactor', fromPath: 'topic', toPath: 'archive/topic' },
+        { kind: 'folder-refactor', fromPath: 'other', toPath: 'archive/other' },
+      ],
+      note: 'Move 2 folders',
+      proposedBy: 'unit-test',
+    });
+    await approveProposal(ctx(), ok.uri);
+    expect(exists('archive/topic/a.md')).toBe(true);
+    expect(exists('archive/other/b.md')).toBe(true);
+    expect(exists('topic/a.md')).toBe(false);
+    expect(exists('other/b.md')).toBe(false);
+
+    // A broken triples payload after the moves fails the bundle; both folders
+    // must go back.
+    const bad = await proposeWrite(ctx(), {
+      operationType: 'note_refactor',
+      payloads: [
+        { kind: 'folder-refactor', fromPath: 'archive/topic', toPath: 'topic' },
+        { kind: 'folder-refactor', fromPath: 'archive/other', toPath: 'other' },
+        { kind: 'graph-triples', turtle: '<https://ex/z> ;;;; .', affectsNodeUris: ['https://ex/z'] },
+      ],
+      note: 'Move 2 folders back (fails)',
+      proposedBy: 'unit-test',
+    });
+    await expect(approveProposal(ctx(), bad.uri)).rejects.toThrow();
+    expect(exists('archive/topic/a.md')).toBe(true);
+    expect(exists('archive/other/b.md')).toBe(true);
+    expect(exists('topic/a.md')).toBe(false);
+    expect(exists('other/b.md')).toBe(false);
+  });
+
   it('rejects a colliding destination at approval time', async () => {
     await fsp.mkdir(path.join(root, 'archive/topic'), { recursive: true });
     const p = await moveFolder('topic', 'archive/topic');

--- a/tests/main/llm/folder-move-tool.test.ts
+++ b/tests/main/llm/folder-move-tool.test.ts
@@ -1,0 +1,190 @@
+/**
+ * `propose_folder_move` — single and batched (#1778).
+ *
+ * The tool had no coverage of its own: `folder-move-delete-proposal.test.ts`
+ * tests the `folder-refactor` payload, not the tool that produces the draft.
+ * Batching it is the moment to fix that, because the routing decision — one
+ * folder keeps the single refactor card, many route through the reorg draft —
+ * is exactly the kind of thing that regresses silently.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { executeNotebaseTool, type ToolCallbacks } from '../../../src/main/llm/tools';
+import { initGraph, indexNote, disposeProject } from '../../../src/main/graph/index';
+import { projectContext } from '../../../src/main/project-context-types';
+import type {
+  ConversationRefactorDraft,
+  ConversationReorgDraft,
+} from '../../../src/shared/conversation-refactor-drafts';
+
+let root: string;
+const ctx = () => projectContext(root);
+const toolCtx = () => ({ rootPath: root, conversationId: 'conv-1' });
+
+async function seed(rel: string, body: string): Promise<void> {
+  const abs = path.join(root, rel);
+  await fsp.mkdir(path.dirname(abs), { recursive: true });
+  await fsp.writeFile(abs, body, 'utf-8');
+  await indexNote(ctx(), rel, body);
+}
+
+function capture(): {
+  single: ConversationRefactorDraft[];
+  batch: ConversationReorgDraft[];
+  callbacks: ToolCallbacks;
+} {
+  const single: ConversationRefactorDraft[] = [];
+  const batch: ConversationReorgDraft[] = [];
+  return {
+    single,
+    batch,
+    callbacks: { onRefactorDraft: (d) => single.push(d), onReorgDraft: (d) => batch.push(d) },
+  };
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-folder-move-tool-'));
+  await initGraph(ctx());
+  await seed('topics/raft/raft.md', '# Raft\n\nThe Raft algorithm.');
+  await seed('topics/paxos/paxos.md', '# Paxos\n\nThe Paxos algorithm.');
+  // An outside referrer using PATH-qualified links — a bare `[[raft]]` resolves
+  // by basename and survives a folder move untouched, so it would show no blast
+  // radius at all.
+  await seed('index.md', '# Index\n\nSee [[topics/raft/raft]] and [[topics/paxos/paxos]].');
+});
+afterEach(async () => {
+  disposeProject(ctx());
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+describe('propose_folder_move — one folder', () => {
+  it('emits a refactor draft flagged isFolder, without moving anything', async () => {
+    const { single, batch, callbacks } = capture();
+    const out = await executeNotebaseTool(toolCtx(), 'propose_folder_move', {
+      moves: [{ path: 'topics/raft', newPath: 'archive/raft' }],
+    }, callbacks);
+
+    expect(out.isError).toBe(false);
+    expect(batch).toHaveLength(0); // a single folder keeps the single card
+    expect(single).toHaveLength(1);
+    expect(single[0]).toMatchObject({
+      fromPath: 'topics/raft',
+      toPath: 'archive/raft',
+      isFolder: true,
+    });
+    // Nothing moved.
+    expect(fs.existsSync(path.join(root, 'topics/raft/raft.md'))).toBe(true);
+    expect(fs.existsSync(path.join(root, 'archive/raft/raft.md'))).toBe(false);
+  });
+
+  it('errors on an unplannable move (into itself)', async () => {
+    const { single, callbacks } = capture();
+    const out = await executeNotebaseTool(toolCtx(), 'propose_folder_move', {
+      moves: [{ path: 'topics', newPath: 'topics/nested' }],
+    }, callbacks);
+    expect(out.isError).toBe(true);
+    expect(single).toHaveLength(0);
+  });
+});
+
+describe('propose_folder_move — batched', () => {
+  it('routes many folders into ONE reorg draft, not N refactor cards', async () => {
+    const { single, batch, callbacks } = capture();
+    const out = await executeNotebaseTool(toolCtx(), 'propose_folder_move', {
+      moves: [
+        { path: 'topics/raft', newPath: 'archive/raft' },
+        { path: 'topics/paxos', newPath: 'archive/paxos' },
+      ],
+    }, callbacks);
+
+    expect(out.isError).toBe(false);
+    expect(single).toHaveLength(0);
+    expect(batch).toHaveLength(1);
+    expect(batch[0].isFolder).toBe(true);
+    expect(batch[0].items.map((i) => [i.fromPath, i.toPath])).toEqual([
+      ['topics/raft', 'archive/raft'],
+      ['topics/paxos', 'archive/paxos'],
+    ]);
+    expect(batch[0].note).toBe('Move 2 folders');
+    // The blast radius is still notes either way — the ones relocating, plus
+    // any referrer whose links need rewriting.
+    const affected = batch[0].items.flatMap((i) => i.affectedNotes.map((a) => a.path));
+    expect(affected).toContain('topics/raft/raft.md');
+    expect(affected).toContain('topics/paxos/paxos.md');
+    expect(affected).toContain('index.md');
+    // Still nothing moved.
+    expect(fs.existsSync(path.join(root, 'topics/raft/raft.md'))).toBe(true);
+  });
+
+  it('keeps the plannable folders and warns about the rest', async () => {
+    const { batch, callbacks } = capture();
+    const out = await executeNotebaseTool(toolCtx(), 'propose_folder_move', {
+      moves: [
+        { path: 'topics/raft', newPath: 'archive/raft' },
+        { path: 'topics/ghost', newPath: 'archive/ghost' }, // no such folder
+        { path: 'topics/paxos', newPath: 'archive/paxos' },
+      ],
+    }, callbacks);
+
+    expect(out.isError).toBe(false);
+    expect(batch[0].items.map((i) => i.fromPath)).toEqual(['topics/raft', 'topics/paxos']);
+    expect(batch[0].warnings.join(' ')).toMatch(/ghost/);
+  });
+
+  it('warns when one move overlaps another, rather than silently mispreviewing', async () => {
+    // Moving `topics/raft` while also moving its parent `topics`: each folder is
+    // planned against the CURRENT tree, so the previews can't both be right.
+    // Apply re-plans and would roll back, but the user should be told.
+    const { batch, callbacks } = capture();
+    await executeNotebaseTool(toolCtx(), 'propose_folder_move', {
+      moves: [
+        { path: 'topics/raft', newPath: 'archive/raft' },
+        { path: 'topics', newPath: 'old-topics' },
+      ],
+    }, callbacks);
+
+    expect(batch[0].warnings.join(' ')).toMatch(/overlaps the move of/i);
+  });
+
+  it('errors (no draft) when no folder in the batch can be planned', async () => {
+    const { single, batch, callbacks } = capture();
+    const out = await executeNotebaseTool(toolCtx(), 'propose_folder_move', {
+      moves: [
+        { path: 'ghost-a', newPath: 'archive/a' },
+        { path: 'ghost-b', newPath: 'archive/b' },
+      ],
+    }, callbacks);
+    expect(out.isError).toBe(true);
+    expect(single).toHaveLength(0);
+    expect(batch).toHaveLength(0);
+  });
+
+  it('validates required input', async () => {
+    const { callbacks } = capture();
+    const bad: unknown[] = [
+      {},
+      { moves: [] },
+      { moves: [{ newPath: 'archive/x' }] },
+      { moves: [{ path: 'topics/raft' }] },
+    ];
+    for (const input of bad) {
+      expect((await executeNotebaseTool(toolCtx(), 'propose_folder_move', input, callbacks)).isError).toBe(true);
+    }
+  });
+
+  it('requires a conversation context for both the single and batch paths', async () => {
+    expect((await executeNotebaseTool(toolCtx(), 'propose_folder_move', {
+      moves: [{ path: 'topics/raft', newPath: 'archive/raft' }],
+    }, {})).isError).toBe(true);
+
+    expect((await executeNotebaseTool(toolCtx(), 'propose_folder_move', {
+      moves: [
+        { path: 'topics/raft', newPath: 'archive/raft' },
+        { path: 'topics/paxos', newPath: 'archive/paxos' },
+      ],
+    }, {})).isError).toBe(true);
+  });
+});


### PR DESCRIPTION
Finishes the batching sweep. `propose_folder_move` takes a `moves` array, so moving three folders into `archive/` is one call, one card, and one all-or-nothing proposal instead of three of each.

A folder move is one `folder-refactor` payload covering a whole tree, so a batch is N of those in one bundle.

## The engine needed nothing

`folder-refactor` re-runs `planFolderRename` **inside `apply`** — exactly as `note-refactor` re-plans — so each payload applies against the state the previous one left, and a guardrail violation throws and rolls the bundle back. I checked this before designing anything, because if it had captured paths at propose time a bundle of interacting folder moves would have been unsafe.

## Reuses the batch surface rather than adding one

- `planFolderReorg` mirrors `planReorg`'s drop-with-a-warning contract, for folders.
- A batch emits the same `ConversationReorgDraft` (now carrying `isFolder`) that batched note moves use, with the same per-item checkboxes.
- The reorg file-handler emits `folder-refactor` payloads instead of `note-refactor` when the draft is a folder batch.
- `orderRefactors` is already generic over `{fromPath, toPath}`, so vacate-before-fill ordering works for folders unchanged.
- A single folder keeps the existing refactor card, matching how single note moves behave.

The card's only note-specific wording ("N of M notes") becomes folder-aware; the link-rewrite count stays notes, because notes are what get rewritten either way.

## One hazard that's genuinely folder-specific

Each folder is planned against the **current** tree, so when one requested move sits inside another — moving `a/` into `b/` while also moving `b/` — the previews can't both be right.

Apply is still safe: it re-plans and rolls back. So `planFolderReorg` **warns** on overlapping moves rather than rejecting them. The preview may understate what happens; the commit cannot silently do the wrong thing. There's a test for the warning.

## A coverage gap this exposed

`propose_folder_move` had **no tests of its own** — `folder-move-delete-proposal.test.ts` covers the `folder-refactor` payload, not the tool that produces the draft. Added a suite, since the routing decision (one folder → refactor card, many → reorg draft) is exactly what regresses silently. Plus the engine case the batch depends on: many folders in one bundle, all moved, all rolled back together on failure.

One test caught a wrong assumption of mine rather than a bug: I first asserted a referrer using `[[raft]]` would appear in the blast radius. It doesn't — a bare basename link resolves the same after a folder move and needs no rewrite. The fixture now uses path-qualified links, which genuinely relocate.

`pnpm lint` clean; 571 test files / 5686 tests passing.

## Not verified by me

Tested through the suite, not by launching the app, so I haven't watched a multi-folder card render. The reorg card is unchanged apart from wording, and the single-folder path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
