### PR TITLE
fix(preview): open every note at the top

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -491,6 +491,23 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         }
     }
 
+    // Open every note at its top (#1718). Unlike the editor — which App.svelte
+    // keys on the note path, so it remounts scrolled to zero — one Preview
+    // element serves every note in the group, and a scroll container keeps its
+    // offset when its contents are replaced. The reader would land partway down
+    // a note they'd never opened, at whatever offset the PREVIOUS note was left
+    // at. Keyed on the path alone, so editing the note you're reading (the
+    // split editor-preview view re-renders on every keystroke) doesn't yank you
+    // back to the top. Runs before the pending-anchor jump below, which scrolls
+    // in a rAF and so still wins for a `[[note#section]]` navigation.
+    let lastScrolledNotePath: string | null | undefined = undefined;
+    $effect(() => {
+        const path = notePath;
+        if (!previewEl || path === lastScrolledNotePath) return;
+        lastScrolledNotePath = path;
+        previewEl.scrollTop = 0;
+    });
+
     // After render, if the caller asked us to jump to a heading or block, do it.
     $effect(() => {
         if (!pendingAnchor || !previewEl) return;

--- a/tests/renderer/components/Preview.test.ts
+++ b/tests/renderer/components/Preview.test.ts
@@ -135,6 +135,35 @@ describe('Preview (render/smoke)', () => {
     expect(container.textContent).not.toContain('Hello World');
   });
 
+  it('scrolls back to the top when the note changes (#1718)', async () => {
+    // The preview pane is NOT keyed on the note path the way the editor is —
+    // one element serves every note — so without an explicit reset the next
+    // note opens at the previous note's scroll offset.
+    const { container, rerender } = render(Preview, props({
+      content: `# Long\n\n${'Filler paragraph.\n\n'.repeat(80)}`,
+    }));
+    const preview = container.querySelector<HTMLElement>('.preview')!;
+    preview.scrollTop = 900;
+    expect(preview.scrollTop).toBe(900);
+
+    await rerender(props({ notePath: 'notes/other.md', content: '# Other\n\nA different note.\n' }));
+    expect(preview.scrollTop).toBe(0);
+  });
+
+  it('leaves the scroll alone while the SAME note is edited', async () => {
+    // Typing in the split editor-preview view re-renders the pane on every
+    // keystroke; yanking the reader back to the top each time would be worse
+    // than the bug being fixed.
+    const { container, rerender } = render(Preview, props({
+      content: `# Long\n\n${'Filler paragraph.\n\n'.repeat(80)}`,
+    }));
+    const preview = container.querySelector<HTMLElement>('.preview')!;
+    preview.scrollTop = 900;
+
+    await rerender(props({ content: `# Long\n\n${'Filler paragraph.\n\n'.repeat(80)}More.\n` }));
+    expect(preview.scrollTop).toBe(900);
+  });
+
   it('opens the read-only note context menu and wires tool entries through onToolInvoke', async () => {
     h.getToolInfosByCategory.mockImplementation((category: string) =>
       category === 'learning' ? [tool('learn.summarize', 'Summarize', 'learning')] : [],


### PR DESCRIPTION
Closes #1718.

## What was happening

App.svelte keys the `Editor` on `groupId + ':' + relativePath`, so switching notes remounts it and the editor starts at the top. The `Preview` next to it is **not** keyed — one element serves every note in the group — and a scroll container keeps its offset when its contents are replaced. So the preview opened each note at whatever offset the *previous* note was left at.

Reported against a thoughtbase of long generated notes, where it means scrolling up before every single read.

## The fix

Reset `previewEl.scrollTop` when `notePath` changes.

Keyed on the **path alone**, deliberately: the split editor-preview view re-renders the pane on every keystroke, and resetting on content change would yank the reader to the top mid-edit — worse than the bug. There's a test pinning each half of that.

The reset runs synchronously in the effect flush; the pending-anchor jump scrolls inside a `requestAnimationFrame`, so a `[[note#section]]` navigation still wins and lands on its heading.

## Why not `{#key}` the Preview

Keying it on the note path in App.svelte fixes the symptom too, but remounts the whole pane per note: markdown re-rendered from scratch, plus every hydration pass (mermaid, vega, local/remote images, citations, typed cards, query blocks) redone. A one-line scroll reset is the cheaper equivalent.

## Scope

Preview scroll is now *reset* on a note change, not *remembered* per tab the way the editor remembers its cursor and scroll. Switching back to a tab you'd scrolled through returns you to the top of it rather than where you were. That's what the issue asks for, and it beats today's behaviour (landing at an unrelated note's offset); per-tab preview scroll memory would need its own persisted field and is a separate change.

`pnpm lint` clean; `pnpm test` 5704 passing (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)