### PR TITLE
feat(editor): put the cursor in the editor when a note is created

### DIFF
--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -24,9 +24,10 @@ import { substituteTemplate } from '../../../shared/templates';
 import { buildTypedNoteScaffold } from '../../../shared/objects/scaffold';
 import { CONFIRM_KEYS } from '../confirm-keys';
 import type { SafeDeleteBlocker } from '../../../shared/types';
+import { tick } from 'svelte';
 
 /** Minimal structural views of the bind:this component refs the note-ops touch. */
-interface EditorRef { restorePosition(offset: number, scrollTop: number): void; gotoLineColumn(line: number, col: number): void; getOffset(): number; }
+interface EditorRef { restorePosition(offset: number, scrollTop: number): void; gotoLineColumn(line: number, col: number): void; getOffset(): number; focus(): void; }
 interface SidebarRef { getSelectionPaths(): string[]; refreshTags(): void; refreshObjects?(): void; clearSelection(): void; }
 interface SafeDeleteState { selectionCount: number; targets: string[]; blockers: SafeDeleteBlocker[]; proceed: () => void | Promise<void>; }
 
@@ -52,6 +53,29 @@ export function createNoteOps(ctx: NoteOpsCtx) {
 
   /** The active editor caret, for recording a note from-position in nav history. */
   const getOffset = () => ctx.getEditorComponent()?.getOffset();
+
+  /**
+   * Land the caret in the editor after creating a note (#1561). Creating a note
+   * is an authoring action — the user's next move is to type, and having to
+   * click into the pane first is pure friction.
+   *
+   * A group in pure `preview` mode has no editor to focus at all, so a new note
+   * opens as a blank rendered page with nowhere to type. Give it one, keeping
+   * the reading pane the user chose (`editor-preview` rather than `source`).
+   *
+   * `tick()` lets the note (and, if we just switched, the editor) mount; the
+   * extra frame lets CodeMirror finish its own setup before we take focus.
+   */
+  async function focusNewNote(caretOffset: number | null): Promise<void> {
+    if (editor.viewMode === 'preview') editor.setViewMode('editor-preview');
+    await tick();
+    requestAnimationFrame(() => {
+      const component = ctx.getEditorComponent();
+      if (!component) return;
+      if (caretOffset !== null) component.restorePosition(caretOffset, 0);
+      else component.focus();
+    });
+  }
 
   async function handleNewNote(directory: string = '') {
     if (!notebase.meta) return;
@@ -103,14 +127,9 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     // Record nav history so Back returns to the note you were on before
     // creating this one (#1446 — creation paths were dead for Back).
     await openNoteRecordingHistory(relativePath, getOffset);
-    if (caretOffset !== null) {
-      // Wait one frame so the editor has mounted the file before we
-      // restore the position — restorePosition is a no-op against an
-      // empty doc otherwise. Capture in a const so TS keeps the
-      // narrowing past the closure boundary.
-      const offset = caretOffset;
-      requestAnimationFrame(() => ctx.getEditorComponent()?.restorePosition(offset, 0));
-    }
+    // A template / type scaffold carries its own caret offset; a plain note
+    // just needs the focus.
+    await focusNewNote(caretOffset);
     ctx.getSidebar()?.refreshTags();
     ctx.getSidebar()?.refreshObjects?.();
   }
@@ -129,6 +148,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       await notebase.refresh();
     }
     await openNoteRecordingHistory(relativePath, getOffset);
+    await focusNewNote(null);
     ctx.getSidebar()?.refreshTags();
     ctx.getSidebar()?.refreshObjects?.();
   }

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -814,6 +814,14 @@
     view.focus();
   }
 
+  /** Put the keyboard caret in the editor without moving it — the new-note
+   *  flow uses this so a freshly created note is typeable straight away
+   *  (#1561). `restorePosition(0, 0)` would focus too, but only as a side
+   *  effect of a caret restore that has nothing to restore. */
+  export function focus() {
+    view?.focus();
+  }
+
   export function restorePosition(offset: number, scrollTop?: number) {
     if (!view) return;
     const clamped = Math.max(0, Math.min(offset, view.state.doc.length));

--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -24,6 +24,7 @@ const h = vi.hoisted(() => {
     activeFilePath: 'Note.md' as string | null, activeTab: { type: 'note' } as { type: string } | null,
     content: '', setContent: vi.fn(),
     applyRenameTransitions: vi.fn(),
+    viewMode: 'source' as string, setViewMode: vi.fn(),
   };
   const dialog = {
     showPrompt: vi.fn(), showConfirm: vi.fn(), showNewNoteDialog: vi.fn(), showSnippetPicker: vi.fn(),
@@ -50,7 +51,7 @@ function file(relativePath: string): NoteFile {
 }
 
 const sidebar = { getSelectionPaths: vi.fn(() => [] as string[]), refreshTags: vi.fn(), clearSelection: vi.fn() };
-const editorComp = { restorePosition: vi.fn(), gotoLineColumn: vi.fn(), getOffset: vi.fn(() => 0) };
+const editorComp = { restorePosition: vi.fn(), gotoLineColumn: vi.fn(), getOffset: vi.fn(() => 0), focus: vi.fn() };
 let editorCompRef: typeof editorComp | undefined;
 let ctx: NoteOpsCtx;
 let ops: ReturnType<typeof createNoteOps>;
@@ -69,6 +70,7 @@ beforeEach(() => {
   h.editor.tabs = [];
   h.editor.activeFilePath = 'Note.md';
   h.editor.activeTab = { type: 'note' };
+  h.editor.viewMode = 'source';
   sidebar.getSelectionPaths.mockReturnValue([]);
   editorCompRef = undefined;
   getClipboardStore().clear();
@@ -128,6 +130,55 @@ describe('handleNewNote', () => {
     h.dialog.showNewNoteDialog.mockResolvedValue(null);
     await ops.handleNewNote();
     expect(h.api.notebase.createFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleNewNote — the caret lands in the editor (#1561)', () => {
+  beforeEach(() => {
+    editorCompRef = editorComp;
+    h.dialog.showNewNoteDialog.mockResolvedValue({ name: 'fresh', ext: '.md' });
+  });
+
+  it('focuses the editor so a plain new note is typeable without clicking', async () => {
+    await ops.handleNewNote('folder');
+    expect(editorComp.focus).toHaveBeenCalled();
+    // Nothing to restore on an empty note — no caret dispatch.
+    expect(editorComp.restorePosition).not.toHaveBeenCalled();
+  });
+
+  it('gives a preview-only pane an editor to focus, keeping the reading pane', async () => {
+    h.editor.viewMode = 'preview';
+    await ops.handleNewNote('folder');
+    expect(h.editor.setViewMode).toHaveBeenCalledWith('editor-preview');
+    expect(editorComp.focus).toHaveBeenCalled();
+  });
+
+  it('leaves the view mode alone when the pane already has an editor', async () => {
+    for (const mode of ['source', 'editor-preview']) {
+      h.editor.viewMode = mode;
+      await ops.handleNewNote('folder');
+      expect(h.editor.setViewMode).not.toHaveBeenCalled();
+    }
+  });
+
+  it('lets a template caret win over a bare focus', async () => {
+    h.dialog.showNewNoteDialog.mockResolvedValue({ name: 'fresh', ext: '.md', templateFilename: 'daily.md' });
+    h.api.templates.get.mockResolvedValue('Hello {{title}}{{cursor}} world');
+    await ops.handleNewNote('folder');
+    // restorePosition focuses as part of placing the caret.
+    expect(editorComp.restorePosition).toHaveBeenCalledWith(11, 0);
+    expect(editorComp.focus).not.toHaveBeenCalled();
+  });
+
+  it('survives a pane with no editor mounted', async () => {
+    editorCompRef = undefined;
+    await expect(ops.handleNewNote('folder')).resolves.toBeUndefined();
+  });
+
+  it('focuses the editor for the broken-link quick-fix too (#1446 create-from-reference)', async () => {
+    await ops.createNoteFromReference('folder/Missing.md');
+    expect(h.api.notebase.createFile).toHaveBeenCalledWith('folder/Missing.md');
+    expect(editorComp.focus).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #1561.

## Already half-fixed, as suspected

A note created from a **template** or an **object type** carries a caret offset (`{{cursor}}` / the type scaffold), and `restorePosition` focuses the view as part of placing the caret. So those notes have been typeable on arrival since #1064.

A note with neither — the common case, ⌘N → name → Create — got nothing. That's the reported bug.

## The fix

`Editor.focus()` (a plain `view.focus()`, no caret dispatch) plus one `focusNewNote` helper on the note-ops side, used by both creation paths:

- the New Note dialog (`handleNewNote`), and
- the broken-link quick-fix `createNoteFromReference` (#1446), which also creates an empty note and opens it.

Where a template or type scaffold supplies a caret offset, that still wins — `restorePosition` does the focusing.

## One judgment call worth your veto

A group in pure `preview` mode has **no editor to focus at all**: the new note opens as a blank rendered page with nowhere to type, and focusing is a no-op. That case now switches the group to `editor-preview` — which keeps the reading pane you chose and adds an editor beside it, rather than replacing it with `source`.

Creating a note is unambiguously an authoring action, so I think the switch is right, but it is a visible behaviour change beyond the literal ticket and it persists as the group's view mode. Say the word and I'll drop it to a no-op in preview mode, or make it switch to `source` instead.

## Tests

Six new cases in `note-ops.test.ts`: plain note focuses (and dispatches no caret restore), preview-only pane gains an editor, `source` / `editor-preview` panes are left alone, a template caret wins over a bare focus, an unmounted editor is survived, and the quick-fix path focuses too.

Mutation-checked: dropping the focus call fails three of them, and dropping the view-mode switch fails another.

`pnpm lint` clean; `pnpm test` 5710 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)