### PR TITLE
feat(preview): remember where each note was left in the preview pane

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -945,6 +945,7 @@
     registerAppIpc({
       getEditorComponent: () => editorComponent,
       getEditorComponents: () => editorComponents,
+      getPreviewComponent: () => previewComponent,
       getSidebar: () => sidebar,
       getRightSidebar: () => rightSidebar,
       bumpGraphRevision: () => { graphRevision++; },
@@ -1280,6 +1281,8 @@
                         bind:this={previewComponents[groupId]}
                         content={note.content}
                         notePath={note.relativePath}
+                        previewScrollTop={note.previewScrollTop}
+                        onScrollPositionSave={editor.savePreviewScroll}
                         {numberedHeadings}
                         getNotePaths={() => flattenNotePaths(notebase.files)}
                         getAliases={() => aliasEntries}

--- a/src/renderer/lib/app/ipc-wiring.ts
+++ b/src/renderer/lib/app/ipc-wiring.ts
@@ -64,6 +64,9 @@ export interface IpcWiringCtx {
   // Component refs (App-owned; resolve at callback time).
   getEditorComponent: () => EditorRef | undefined;
   getEditorComponents: () => Record<string, { restorePosition(offset: number, scrollTop?: number): void } | undefined>;
+  /** Focused pane's preview, for the beforeunload scroll capture. Undefined
+   *  when that pane isn't showing a preview. */
+  getPreviewComponent: () => { currentScrollTop(): number } | undefined;
   getSidebar: () => SidebarRef | undefined;
   getRightSidebar: () => { refresh(): void } | undefined;
 
@@ -174,6 +177,11 @@ export function registerAppIpc(ctx: IpcWiringCtx): void {
         editorComponent.getOffset(),
         editorComponent.getView()?.scrollDOM.scrollTop ?? 0,
       );
+    }
+    // Same for the preview pane, which saves on teardown that never comes here.
+    const previewComponent = ctx.getPreviewComponent();
+    if (editor.activeFilePath && previewComponent) {
+      editor.savePreviewScroll(editor.activeFilePath, previewComponent.currentScrollTop());
     }
     editor.flushAutoSave();
     editor.persistTabs();

--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -24,9 +24,10 @@ import { substituteTemplate } from '../../../shared/templates';
 import { buildTypedNoteScaffold } from '../../../shared/objects/scaffold';
 import { CONFIRM_KEYS } from '../confirm-keys';
 import type { SafeDeleteBlocker } from '../../../shared/types';
+import { tick } from 'svelte';
 
 /** Minimal structural views of the bind:this component refs the note-ops touch. */
-interface EditorRef { restorePosition(offset: number, scrollTop: number): void; gotoLineColumn(line: number, col: number): void; getOffset(): number; }
+interface EditorRef { restorePosition(offset: number, scrollTop: number): void; gotoLineColumn(line: number, col: number): void; getOffset(): number; focus(): void; }
 interface SidebarRef { getSelectionPaths(): string[]; refreshTags(): void; refreshObjects?(): void; clearSelection(): void; }
 interface SafeDeleteState { selectionCount: number; targets: string[]; blockers: SafeDeleteBlocker[]; proceed: () => void | Promise<void>; }
 
@@ -52,6 +53,29 @@ export function createNoteOps(ctx: NoteOpsCtx) {
 
   /** The active editor caret, for recording a note from-position in nav history. */
   const getOffset = () => ctx.getEditorComponent()?.getOffset();
+
+  /**
+   * Land the caret in the editor after creating a note (#1561). Creating a note
+   * is an authoring action — the user's next move is to type, and having to
+   * click into the pane first is pure friction.
+   *
+   * A group in pure `preview` mode has no editor to focus at all, so a new note
+   * opens as a blank rendered page with nowhere to type. Give it one, keeping
+   * the reading pane the user chose (`editor-preview` rather than `source`).
+   *
+   * `tick()` lets the note (and, if we just switched, the editor) mount; the
+   * extra frame lets CodeMirror finish its own setup before we take focus.
+   */
+  async function focusNewNote(caretOffset: number | null): Promise<void> {
+    if (editor.viewMode === 'preview') editor.setViewMode('editor-preview');
+    await tick();
+    requestAnimationFrame(() => {
+      const component = ctx.getEditorComponent();
+      if (!component) return;
+      if (caretOffset !== null) component.restorePosition(caretOffset, 0);
+      else component.focus();
+    });
+  }
 
   async function handleNewNote(directory: string = '') {
     if (!notebase.meta) return;
@@ -103,14 +127,9 @@ export function createNoteOps(ctx: NoteOpsCtx) {
     // Record nav history so Back returns to the note you were on before
     // creating this one (#1446 — creation paths were dead for Back).
     await openNoteRecordingHistory(relativePath, getOffset);
-    if (caretOffset !== null) {
-      // Wait one frame so the editor has mounted the file before we
-      // restore the position — restorePosition is a no-op against an
-      // empty doc otherwise. Capture in a const so TS keeps the
-      // narrowing past the closure boundary.
-      const offset = caretOffset;
-      requestAnimationFrame(() => ctx.getEditorComponent()?.restorePosition(offset, 0));
-    }
+    // A template / type scaffold carries its own caret offset; a plain note
+    // just needs the focus.
+    await focusNewNote(caretOffset);
     ctx.getSidebar()?.refreshTags();
     ctx.getSidebar()?.refreshObjects?.();
   }
@@ -129,6 +148,7 @@ export function createNoteOps(ctx: NoteOpsCtx) {
       await notebase.refresh();
     }
     await openNoteRecordingHistory(relativePath, getOffset);
+    await focusNewNote(null);
     ctx.getSidebar()?.refreshTags();
     ctx.getSidebar()?.refreshObjects?.();
   }

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -814,6 +814,14 @@
     view.focus();
   }
 
+  /** Put the keyboard caret in the editor without moving it — the new-note
+   *  flow uses this so a freshly created note is typeable straight away
+   *  (#1561). `restorePosition(0, 0)` would focus too, but only as a side
+   *  effect of a caret restore that has nothing to restore. */
+  export function focus() {
+    view?.focus();
+  }
+
   export function restorePosition(offset: number, scrollTop?: number) {
     if (!view) return;
     const clamped = Math.max(0, Math.min(offset, view.state.doc.length));

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import {onDestroy} from 'svelte';
+    import {onDestroy, untrack} from 'svelte';
     import Icon from './Icon.svelte';
     import {installDismissOnClickOutside} from '../dismiss-menu';
     import '../../styles/hljs-minerva.css';
@@ -60,6 +60,13 @@
          * the editor's path isn't surfaced (preview-only contexts).
          */
         notePath?: string | null;
+        /** Where this note's preview was last left, restored once the new
+         *  content has rendered (#1718 follow-up). Omit / 0 for the top. */
+        previewScrollTop?: number | undefined;
+        /** Hand the outgoing note's preview offset back to the host so it can
+         *  be remembered on the tab. Fired when the note changes and on
+         *  teardown (view-mode switch, tab close, window close). */
+        onScrollPositionSave?: (notePath: string, scrollTop: number) => void;
         onNavigate: (target: string) => void;
         /** Broken-link hover quick-fix (#1446): create the missing note the
          *  hovered `[[link]]` points at. Mirrors the editor's hover lightbulb. */
@@ -142,6 +149,8 @@
     let {
         content,
         notePath = null,
+        previewScrollTop,
+        onScrollPositionSave,
         onNavigate,
         onCreateNoteFromReference,
         onTagSelect,
@@ -336,6 +345,16 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         if (c === lastRendered && np === lastRenderedNotePath) return;
 
         if (renderTimer) clearTimeout(renderTimer);
+        // Switching notes renders straight away: the debounce exists to absorb
+        // keystrokes within one note, and waiting on a note change just shows
+        // the previous note's body for a beat — and delays the scroll restore
+        // below, which can't run until the new HTML is in the DOM.
+        if (np !== lastRenderedNotePath) {
+            rendered = renderContent(c);
+            lastRendered = c;
+            lastRenderedNotePath = np;
+            return;
+        }
         renderTimer = setTimeout(() => {
             rendered = renderContent(c);
             lastRendered = c;
@@ -491,21 +510,62 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         }
     }
 
-    // Open every note at its top (#1718). Unlike the editor — which App.svelte
-    // keys on the note path, so it remounts scrolled to zero — one Preview
-    // element serves every note in the group, and a scroll container keeps its
-    // offset when its contents are replaced. The reader would land partway down
-    // a note they'd never opened, at whatever offset the PREVIOUS note was left
-    // at. Keyed on the path alone, so editing the note you're reading (the
-    // split editor-preview view re-renders on every keystroke) doesn't yank you
-    // back to the top. Runs before the pending-anchor jump below, which scrolls
-    // in a rAF and so still wins for a `[[note#section]]` navigation.
+    // Preview scroll memory (#1718 + follow-up). One Preview element serves
+    // every note in the group — unlike the editor, which App.svelte keys on the
+    // note path — and a scroll container keeps its offset when its contents are
+    // replaced. Left alone, a note opened at random landed at whatever offset
+    // the PREVIOUS note was left at.
+    //
+    // So on a note change: hand the outgoing note's offset to the host (which
+    // remembers it on the tab, alongside the editor's own cursor + scroll), and
+    // queue this note's remembered offset. A note never read before has none
+    // and opens at the top, which is what #1718 asked for.
+    //
+    // The restore can't happen here: the new note's HTML isn't in the DOM yet,
+    // so the container has the wrong height and the browser would clamp the
+    // offset to 0. It runs off `rendered` below instead.
     let lastScrolledNotePath: string | null | undefined = undefined;
+    let pendingScrollRestore: number | null = null;
+
     $effect(() => {
         const path = notePath;
         if (!previewEl || path === lastScrolledNotePath) return;
+        if (lastScrolledNotePath) onScrollPositionSave?.(lastScrolledNotePath, previewEl.scrollTop);
         lastScrolledNotePath = path;
+        // Untracked: this effect fires on a note CHANGE. Remembering the
+        // outgoing offset writes back through the host and would otherwise
+        // re-enter here on our own save.
+        const saved = untrack(() => previewScrollTop) ?? 0;
         previewEl.scrollTop = 0;
+        pendingScrollRestore = saved > 0 ? saved : null;
+    });
+
+    // The other half: once the new note's HTML has rendered, put the reader
+    // back where they were. A frame later, so layout has settled. Images and
+    // diagrams hydrate after this and can still shift things — the same
+    // approximation the editor's own scroll restore lives with.
+    $effect(() => {
+        rendered;
+        if (pendingScrollRestore === null || !previewEl) return;
+        const top = pendingScrollRestore;
+        pendingScrollRestore = null;
+        requestAnimationFrame(() => {
+            if (previewEl) previewEl.scrollTop = top;
+        });
+    });
+
+    /** Where the pane is scrolled right now. The window closing doesn't run
+     *  Svelte teardown, so the app-level beforeunload hook reads this. */
+    export function currentScrollTop(): number {
+        return previewEl?.scrollTop ?? 0;
+    }
+
+    // Teardown — a view-mode switch, a closed tab, or the window going away.
+    // The note-change path above never sees these, so save here too.
+    $effect(() => () => {
+        if (previewEl && lastScrolledNotePath) {
+            onScrollPositionSave?.(lastScrolledNotePath, previewEl.scrollTop);
+        }
     });
 
     // After render, if the caller asked us to jump to a heading or block, do it.

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -26,6 +26,10 @@ export interface NoteTab {
   plainText?: boolean | undefined;
   cursorOffset?: number | undefined;
   scrollTop?: number | undefined;
+  /** Preview-pane scroll offset. Separate from `scrollTop`: the editor and the
+   *  preview lay the same note out at different heights, so sharing one number
+   *  would land the reader in the wrong place. */
+  previewScrollTop?: number | undefined;
   /**
    * Serialised CodeMirror `EditorState` (doc + selection + history
    * stacks) captured on Editor unmount. Used to restore undo/redo across
@@ -630,6 +634,18 @@ export function getEditorStore() {
     }
   }
 
+  /**
+   * Remember where the preview pane was left for a note (#1718 follow-up).
+   * Keyed by path like `saveEditorState`, so a note open in two panes shares
+   * one remembered offset — the same tradeoff the editor already makes.
+   */
+  function savePreviewScroll(relativePath: string, scrollTop: number) {
+    const tab = allTabs().find((t) => isNote(t) && t.relativePath === relativePath) as NoteTab | undefined;
+    if (!tab || tab.previewScrollTop === scrollTop) return;
+    tab.previewScrollTop = scrollTop;
+    schedulePersistTabs();
+  }
+
   // ── View mode (per group) ─────────────────────────────────────────────────
 
   function setViewMode(mode: ViewMode, groupId?: string) {
@@ -661,6 +677,7 @@ export function getEditorStore() {
         ...(t.plainText ? { plainText: true } : {}),
         ...(t.cursorOffset !== undefined ? { cursorOffset: t.cursorOffset } : {}),
         ...(t.scrollTop !== undefined ? { scrollTop: t.scrollTop } : {}),
+        ...(t.previewScrollTop !== undefined ? { previewScrollTop: t.previewScrollTop } : {}),
       };
     } else if (isUnsupported(t)) {
       return { type: 'unsupported', relativePath: t.relativePath };
@@ -726,6 +743,7 @@ export function getEditorStore() {
           ...(saved.plainText ? { plainText: true } : {}),
           cursorOffset: saved.cursorOffset,
           scrollTop: saved.scrollTop,
+          previewScrollTop: saved.previewScrollTop,
         };
       } catch {
         return null; // file deleted since last session
@@ -1151,6 +1169,7 @@ export function getEditorStore() {
     switchTab,
     clear,
     saveEditorState,
+    savePreviewScroll,
     setViewMode,
     cycleViewMode,
     openQuery,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -260,6 +260,10 @@ export interface SavedNoteTab {
   relativePath: string;
   cursorOffset?: number;
   scrollTop?: number;
+  /** Where the PREVIEW pane was scrolled to, kept separately from the editor's
+   *  `scrollTop` — the two panes render the same note at different heights, so
+   *  one offset can't serve both (#1718 follow-up). */
+  previewScrollTop?: number;
   /** True for a file opened in plain-text mode (#1130); omitted for markdown. */
   plainText?: boolean;
 }

--- a/tests/renderer/app/ipc-wiring.test.ts
+++ b/tests/renderer/app/ipc-wiring.test.ts
@@ -78,7 +78,7 @@ const h = vi.hoisted(() => {
     closeTabsForDeletedPath: vi.fn(), applyRenameTransitions: vi.fn(),
     isPathDirty: vi.fn(() => false), reloadTabFromDisk: vi.fn().mockResolvedValue(undefined),
     restoreTabs: vi.fn().mockResolvedValue(undefined), noteTabForGroup: vi.fn(() => undefined),
-    saveEditorState: vi.fn(), flushAutoSave: vi.fn(), persistTabs: vi.fn(),
+    saveEditorState: vi.fn(), savePreviewScroll: vi.fn(), flushAutoSave: vi.fn(), persistTabs: vi.fn(),
   };
   const busy = { label: '', setLabel: vi.fn() };
   const toolPanel = { appendChunk: vi.fn() };
@@ -111,6 +111,7 @@ const editorComponent = {
   changeFontSize: vi.fn(), currentFontSize: vi.fn(() => 18), resetFontSize: vi.fn(),
   runSortLines: vi.fn(), openFind: vi.fn(), openFindReplace: vi.fn(),
 };
+let previewComponent: { currentScrollTop(): number } | undefined;
 const sidebar = { refreshTags: vi.fn(), refreshSources: vi.fn(), refreshTables: vi.fn() };
 const rightSidebar = { refresh: vi.fn() };
 
@@ -132,6 +133,7 @@ function makeCtx(): { ctx: IpcWiringCtx; spies: Record<string, ReturnType<typeof
   const ctx = {
     getEditorComponent: () => editorComponent,
     getEditorComponents: () => ({ g1: { restorePosition: vi.fn() } }),
+    getPreviewComponent: () => previewComponent,
     getSidebar: () => sidebar,
     getRightSidebar: () => rightSidebar,
     getEditorFontSize: () => 14,
@@ -156,6 +158,7 @@ beforeEach(() => {
   h.editor.groups = [];
   h.busy.label = '';
   window.print = vi.fn();
+  previewComponent = undefined;
   ({ ctx, spies } = makeCtx());
   registerAppIpc(ctx);
 });
@@ -399,5 +402,27 @@ describe('lifecycle hooks', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('beforeunload — capture pane state the window close would lose', () => {
+  it('saves the preview scroll alongside the editor caret + scroll', () => {
+    h.editor.activeFilePath = 'a.md';
+    previewComponent = { currentScrollTop: () => 640 };
+
+    window.dispatchEvent(new Event('beforeunload'));
+
+    expect(h.editor.saveEditorState).toHaveBeenCalledWith('a.md', 0, 0);
+    expect(h.editor.savePreviewScroll).toHaveBeenCalledWith('a.md', 640);
+    expect(h.editor.persistTabs).toHaveBeenCalled();
+  });
+
+  it('saves no preview scroll when the pane is showing no preview', () => {
+    h.editor.activeFilePath = 'a.md';
+    previewComponent = undefined; // source-only view mode
+
+    window.dispatchEvent(new Event('beforeunload'));
+
+    expect(h.editor.savePreviewScroll).not.toHaveBeenCalled();
   });
 });

--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -24,6 +24,7 @@ const h = vi.hoisted(() => {
     activeFilePath: 'Note.md' as string | null, activeTab: { type: 'note' } as { type: string } | null,
     content: '', setContent: vi.fn(),
     applyRenameTransitions: vi.fn(),
+    viewMode: 'source' as string, setViewMode: vi.fn(),
   };
   const dialog = {
     showPrompt: vi.fn(), showConfirm: vi.fn(), showNewNoteDialog: vi.fn(), showSnippetPicker: vi.fn(),
@@ -50,7 +51,7 @@ function file(relativePath: string): NoteFile {
 }
 
 const sidebar = { getSelectionPaths: vi.fn(() => [] as string[]), refreshTags: vi.fn(), clearSelection: vi.fn() };
-const editorComp = { restorePosition: vi.fn(), gotoLineColumn: vi.fn(), getOffset: vi.fn(() => 0) };
+const editorComp = { restorePosition: vi.fn(), gotoLineColumn: vi.fn(), getOffset: vi.fn(() => 0), focus: vi.fn() };
 let editorCompRef: typeof editorComp | undefined;
 let ctx: NoteOpsCtx;
 let ops: ReturnType<typeof createNoteOps>;
@@ -69,6 +70,7 @@ beforeEach(() => {
   h.editor.tabs = [];
   h.editor.activeFilePath = 'Note.md';
   h.editor.activeTab = { type: 'note' };
+  h.editor.viewMode = 'source';
   sidebar.getSelectionPaths.mockReturnValue([]);
   editorCompRef = undefined;
   getClipboardStore().clear();
@@ -128,6 +130,55 @@ describe('handleNewNote', () => {
     h.dialog.showNewNoteDialog.mockResolvedValue(null);
     await ops.handleNewNote();
     expect(h.api.notebase.createFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleNewNote — the caret lands in the editor (#1561)', () => {
+  beforeEach(() => {
+    editorCompRef = editorComp;
+    h.dialog.showNewNoteDialog.mockResolvedValue({ name: 'fresh', ext: '.md' });
+  });
+
+  it('focuses the editor so a plain new note is typeable without clicking', async () => {
+    await ops.handleNewNote('folder');
+    expect(editorComp.focus).toHaveBeenCalled();
+    // Nothing to restore on an empty note — no caret dispatch.
+    expect(editorComp.restorePosition).not.toHaveBeenCalled();
+  });
+
+  it('gives a preview-only pane an editor to focus, keeping the reading pane', async () => {
+    h.editor.viewMode = 'preview';
+    await ops.handleNewNote('folder');
+    expect(h.editor.setViewMode).toHaveBeenCalledWith('editor-preview');
+    expect(editorComp.focus).toHaveBeenCalled();
+  });
+
+  it('leaves the view mode alone when the pane already has an editor', async () => {
+    for (const mode of ['source', 'editor-preview']) {
+      h.editor.viewMode = mode;
+      await ops.handleNewNote('folder');
+      expect(h.editor.setViewMode).not.toHaveBeenCalled();
+    }
+  });
+
+  it('lets a template caret win over a bare focus', async () => {
+    h.dialog.showNewNoteDialog.mockResolvedValue({ name: 'fresh', ext: '.md', templateFilename: 'daily.md' });
+    h.api.templates.get.mockResolvedValue('Hello {{title}}{{cursor}} world');
+    await ops.handleNewNote('folder');
+    // restorePosition focuses as part of placing the caret.
+    expect(editorComp.restorePosition).toHaveBeenCalledWith(11, 0);
+    expect(editorComp.focus).not.toHaveBeenCalled();
+  });
+
+  it('survives a pane with no editor mounted', async () => {
+    editorCompRef = undefined;
+    await expect(ops.handleNewNote('folder')).resolves.toBeUndefined();
+  });
+
+  it('focuses the editor for the broken-link quick-fix too (#1446 create-from-reference)', async () => {
+    await ops.createNoteFromReference('folder/Missing.md');
+    expect(h.api.notebase.createFile).toHaveBeenCalledWith('folder/Missing.md');
+    expect(editorComp.focus).toHaveBeenCalled();
   });
 });
 

--- a/tests/renderer/components/Preview.test.ts
+++ b/tests/renderer/components/Preview.test.ts
@@ -135,7 +135,7 @@ describe('Preview (render/smoke)', () => {
     expect(container.textContent).not.toContain('Hello World');
   });
 
-  it('scrolls back to the top when the note changes (#1718)', async () => {
+  it('opens a never-read note at the top (#1718)', async () => {
     // The preview pane is NOT keyed on the note path the way the editor is —
     // one element serves every note — so without an explicit reset the next
     // note opens at the previous note's scroll offset.
@@ -148,6 +148,42 @@ describe('Preview (render/smoke)', () => {
 
     await rerender(props({ notePath: 'notes/other.md', content: '# Other\n\nA different note.\n' }));
     expect(preview.scrollTop).toBe(0);
+  });
+
+  it('restores the remembered offset for a note that was read before', async () => {
+    const onScrollPositionSave = vi.fn();
+    const long = `# Long\n\n${'Filler paragraph.\n\n'.repeat(80)}`;
+    const { container, rerender } = render(Preview, props({ content: long, onScrollPositionSave }));
+    const preview = container.querySelector<HTMLElement>('.preview')!;
+    preview.scrollTop = 640;
+
+    // Away to another note: the outgoing offset goes back to the host…
+    await rerender(props({
+      notePath: 'notes/other.md', content: '# Other\n\nA different note.\n', onScrollPositionSave,
+    }));
+    expect(onScrollPositionSave).toHaveBeenCalledWith('notes/hello.md', 640);
+    expect(preview.scrollTop).toBe(0);
+
+    // …and back again, with the host handing that offset in as a prop.
+    await rerender(props({ content: long, previewScrollTop: 640, onScrollPositionSave }));
+    await waitFor(() => expect(preview.scrollTop).toBe(640));
+  });
+
+  it('saves the offset on teardown too — a view switch or a closed tab', async () => {
+    const onScrollPositionSave = vi.fn();
+    const { container, unmount } = render(Preview, props({
+      content: `# Long\n\n${'Filler.\n\n'.repeat(60)}`,
+      onScrollPositionSave,
+    }));
+    container.querySelector<HTMLElement>('.preview')!.scrollTop = 275;
+    unmount();
+    expect(onScrollPositionSave).toHaveBeenCalledWith('notes/hello.md', 275);
+  });
+
+  it('reports its live offset for the window-close capture', async () => {
+    const { container, component } = render(Preview, props());
+    container.querySelector<HTMLElement>('.preview')!.scrollTop = 128;
+    expect((component as unknown as { currentScrollTop(): number }).currentScrollTop()).toBe(128);
   });
 
   it('leaves the scroll alone while the SAME note is edited', async () => {

--- a/tests/renderer/stores/editor-store.test.ts
+++ b/tests/renderer/stores/editor-store.test.ts
@@ -627,6 +627,37 @@ describe('persist + restore across every tab kind', () => {
     expect(tabs[4].type === 'unsupported' && tabs[4].ext).toBe('.bin');
   });
 
+  it('round-trips the preview scroll offset, kept separate from the editor scroll', async () => {
+    await editor.openFile('a.md');
+    editor.saveEditorState('a.md', 12, 120);   // editor caret + scroll
+    editor.savePreviewScroll('a.md', 640);     // preview scroll — a different pane, a different height
+
+    editor.persistTabs();
+    const saved = h.tabsSave.mock.calls.at(-1)?.[0] as LayoutSession;
+    expect(saved.groups[0].tabs[0]).toMatchObject({
+      type: 'note', relativePath: 'a.md', scrollTop: 120, previewScrollTop: 640,
+    });
+
+    h.tabsLoad.mockResolvedValueOnce(saved);
+    await editor.restoreTabs();
+    const tab = editor.groups[0].tabs[0];
+    expect(tab.type === 'note' && tab.scrollTop).toBe(120);
+    expect(tab.type === 'note' && tab.previewScrollTop).toBe(640);
+  });
+
+  it('savePreviewScroll ignores an unknown path and skips a no-op write', async () => {
+    await editor.openFile('a.md');
+    editor.savePreviewScroll('ghost.md', 90);  // no such tab
+    editor.persistTabs();
+    const first = h.tabsSave.mock.calls.at(-1)?.[0] as LayoutSession;
+    expect(first.groups[0].tabs[0]).not.toHaveProperty('previewScrollTop');
+
+    editor.savePreviewScroll('a.md', 0);       // top of the note is a real position
+    editor.persistTabs();
+    const second = h.tabsSave.mock.calls.at(-1)?.[0] as LayoutSession;
+    expect(second.groups[0].tabs[0]).toMatchObject({ previewScrollTop: 0 });
+  });
+
   it('reconstructTab defaults a legacy query language to sparql, pdf page to 1, graph depth to 1', async () => {
     h.tabsLoad.mockResolvedValueOnce({
       version: 2,


### PR DESCRIPTION
Follow-up to #1780, per your note on that PR: keep existing scroll positions in preview mode as far as possible.

## What #1780 traded away

It fixed the preview opening a note at the *previous* note's offset by resetting to the top. That cured the wrong-note landing but threw away the right-note one — returning to a note you'd read halfway through started you over.

## Now

The preview remembers its offset per note, the way the editor already remembers cursor + scroll:

- On a note change, the outgoing offset goes back to the host through a callback prop; the editor store puts it on the tab as **`previewScrollTop`**.
- Kept **separate from the editor's `scrollTop`** — the two panes lay the same note out at different heights (48px padding, 800px measure, rendered images and diagrams vs. source lines), so one number in the other pane lands you somewhere unrelated.
- It's part of the persisted session, so positions survive a restart.
- A note never read before has no offset and opens at the top, which is what #1718 asked for.

## Two supporting changes

**The restore waits for render.** Set the offset any earlier and the container still holds the *old* note's HTML at the wrong height, so the browser clamps it — usually to 0. The restore runs off `rendered`, one frame later, the same trick the pending-anchor jump uses.

**Switching notes now renders immediately** instead of after the ~120ms debounce. That debounce exists to absorb keystrokes within one note; on a note *change* it only showed the previous note's body for a beat — and it delayed the restore, since there was nothing to restore into.

## Where it saves

Note change, teardown (view-mode switch, closed tab), and the app's `beforeunload` hook — the window closing doesn't run Svelte teardown, so `Preview.currentScrollTop()` is read there. Those are the same three points the editor saves at.

## Known limitation, inherited

`savePreviewScroll` resolves the tab by path across all panes, exactly like `saveEditorState`. With the *same note* open in two split panes, both write to the first matching tab, so the second pane won't restore. Pre-existing behaviour for the editor's own scroll; fixing it properly means making both methods group-aware, which is its own change.

## Tests

- `Preview.test.ts` — save-on-change hands the outgoing path + offset back, restore lands the remembered offset after render, teardown saves, `currentScrollTop()` reports live, an unread note still opens at top, and editing the note you're reading still doesn't move you. Mutation-checked: dropping the restore, the change-save, or the teardown-save each fails a test.
- `editor-store.test.ts` — `previewScrollTop` survives persist → restore beside a different `scrollTop`; unknown paths are ignored and 0 is a real position, not a no-op.
- `ipc-wiring.test.ts` — beforeunload captures the preview scroll alongside the editor state, and skips it when the pane shows no preview.

`pnpm lint` clean; `pnpm test` 5717 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)