### PR TITLE
fix(rename): show the note's name, not its filename

### DIFF
--- a/src/renderer/lib/app/note-ops.ts
+++ b/src/renderer/lib/app/note-ops.ts
@@ -17,6 +17,7 @@ import { resolveSelectionTargets, expandSelectionToNoteFiles, pathExistsInTree }
 import { describeDeleteNoun, describeDeleteMessage, offsetToLineCol, flattenNotePaths, formatCappedList, type OperationFailure } from './text-helpers';
 import { resolveWikiLinkTarget } from '../../../shared/wiki-link-resolver';
 import { removeBrokenAnchorLinks } from '../../../shared/refactor/remove-broken-anchor';
+import { NOTE_EXTENSIONS } from '../../../shared/note-extensions';
 import { setFrontmatterProperty, getFrontmatterValues } from '../../../shared/frontmatter-edit';
 import { deriveTypeProperties } from '../../../shared/objects/derive-type';
 import type { TypeInfo, PropertyDef } from '../../../shared/objects/type-def';
@@ -577,17 +578,36 @@ export function createNoteOps(ctx: NoteOpsCtx) {
   async function handleRename(relativePath: string) {
     if (!notebase.meta) return;
     const oldName = relativePath.split('/').pop()!;
-    // Seed the field with the current name so the user can tweak it instead
-    // of retyping from scratch; pre-select just the stem so typing replaces
-    // the name while the extension stays visible (#1143).
-    const rawNewName = await showPrompt('New name:', { initial: oldName, selectStem: true });
-    if (!rawNewName || rawNewName === oldName) return;
-    // Preserve the old extension when the user didn't include one. A file
-    // that drops its .md / .ttl suffix falls out of the indexed set and
-    // effectively disappears from the sidebar; almost always a mistake.
+    // The extension is Minerva's business, not the user's (#1564): the field
+    // shows the NAME, seeded with the current one so it can be tweaked rather
+    // than retyped. Editing `.md` by hand only ever ended one way — a file that
+    // loses its .md / .ttl suffix falls out of the indexed set and effectively
+    // disappears from the sidebar.
+    //
+    // Keeping it out of the field also fixes a name with a dot in it: "Notes
+    // v1.2" used to read as "already has an extension" and rename to a file
+    // with no suffix at all.
     const oldDotIdx = oldName.lastIndexOf('.');
     const oldExt = oldDotIdx > 0 ? oldName.slice(oldDotIdx) : '';
-    const newName = !rawNewName.includes('.') && oldExt ? `${rawNewName}${oldExt}` : rawNewName;
+    const oldStem = oldExt ? oldName.slice(0, -oldExt.length) : oldName;
+
+    const rawNewName = await showPrompt('New name:', { initial: oldStem });
+    const typed = rawNewName?.trim();
+    if (!typed) return;
+
+    // What the user typed is a NAME. Three cases for a trailing `.thing`:
+    // the same extension back (habit — don't double it), a different note
+    // extension (a deliberate format change, still supported), or anything
+    // else, which is simply part of the name.
+    const typedDotIdx = typed.lastIndexOf('.');
+    const typedExt = typedDotIdx > 0 ? typed.slice(typedDotIdx) : '';
+    const typedLower = typedExt.toLowerCase();
+    const keepsExt = typedLower === oldExt.toLowerCase();
+    const switchesExt = !keepsExt && NOTE_EXTENSIONS.some((e) => e === typedLower);
+    // A leading dot is taken literally — appending to it would produce
+    // `.md.md`, and it's the user's business if they want a hidden file.
+    const newName = keepsExt || switchesExt || typed.startsWith('.') ? typed : `${typed}${oldExt}`;
+    if (newName === oldName) return;
     const dir = relativePath.includes('/') ? relativePath.substring(0, relativePath.lastIndexOf('/')) : '';
     const newPath = dir ? `${dir}/${newName}` : newName;
     // Tab path + content refresh is handled by the NOTEBASE_RENAMED /

--- a/src/renderer/lib/components/DialogHost.svelte
+++ b/src/renderer/lib/components/DialogHost.svelte
@@ -23,7 +23,6 @@
     message={dialogs.prompt.message}
     suggestions={dialogs.prompt.suggestions ?? []}
     initial={dialogs.prompt.initial ?? ''}
-    selectStem={dialogs.prompt.selectStem ?? false}
     onConfirm={(v) => dialogs.confirmPrompt(v)}
     onCancel={() => dialogs.cancelPrompt()}
   />

--- a/src/renderer/lib/components/PromptDialog.svelte
+++ b/src/renderer/lib/components/PromptDialog.svelte
@@ -18,10 +18,9 @@
      *  dot) rather than the whole value, so typing replaces the name but
      *  visibly keeps the extension. Used by Rename. Falls back to a full
      *  select when `initial` has no extension. */
-    selectStem?: boolean;
   }
 
-  let { message, onConfirm, onCancel, suggestions = [], initial = '', selectStem = false }: Props = $props();
+  let { message, onConfirm, onCancel, suggestions = [], initial = '' }: Props = $props();
   // Intentional one-time seed from `initial`; dialog is short-lived and keyed.
   // svelte-ignore state_referenced_locally
   let value = $state(initial);
@@ -42,11 +41,8 @@
     inputEl?.focus();
     if (!initial || !inputEl) return;
     // Pre-select the seeded value so the user can type to replace it but
-    // Tab/Enter to accept as-is. For Rename, select only the stem (before
-    // the last dot) so the extension stays visible and untouched.
-    const dot = initial.lastIndexOf('.');
-    if (selectStem && dot > 0) inputEl.setSelectionRange(0, dot);
-    else inputEl.select();
+    // Tab/Enter to accept as-is.
+    inputEl.select();
   });
 </script>
 

--- a/src/renderer/lib/stores/dialogs.svelte.ts
+++ b/src/renderer/lib/stores/dialogs.svelte.ts
@@ -23,7 +23,6 @@ export interface PromptState {
   message: string;
   suggestions?: string[] | undefined;
   initial?: string | undefined;
-  selectStem?: boolean | undefined;
   resolve: (value: string | null) => void;
 }
 export interface NewNoteState {
@@ -96,7 +95,7 @@ export function getDialogStore() {
 
   function showPrompt(
     message: string,
-    initialOrOptions?: string | { suggestions?: string[]; initial?: string; selectStem?: boolean },
+    initialOrOptions?: string | { suggestions?: string[]; initial?: string },
   ): Promise<string | null> {
     // Two overloads to keep call sites readable. New callers pass
     // (message, "current name") for Rename-style flows; existing
@@ -109,7 +108,6 @@ export function getDialogStore() {
         message,
         suggestions: opts.suggestions,
         initial: opts.initial,
-        selectStem: opts.selectStem,
         resolve,
       };
     });

--- a/tests/renderer/app/note-ops.test.ts
+++ b/tests/renderer/app/note-ops.test.ts
@@ -85,34 +85,52 @@ beforeEach(() => {
 });
 
 describe('handleRename', () => {
-  it('preserves the original extension when the user omits one', async () => {
+  it('preserves the original extension', async () => {
     h.dialog.showPrompt.mockResolvedValue('renamed');
     await ops.handleRename('notes/foo.md');
     expect(h.api.notebase.rename).toHaveBeenCalledWith('notes/foo.md', 'notes/renamed.md');
     expect(h.notebase.refresh).toHaveBeenCalled();
   });
 
-  it('respects an explicit extension the user types', async () => {
+  it('shows the NAME, not the filename — no extension in the field (#1564)', async () => {
+    h.dialog.showPrompt.mockResolvedValue('renamed');
+    await ops.handleRename('notes/foo.md');
+    expect(h.dialog.showPrompt).toHaveBeenCalledWith('New name:', { initial: 'foo' });
+  });
+
+  it('keeps a dot that belongs to the NAME (#1564)', async () => {
+    // "Notes v1.2" used to read as "already has an extension", renaming the
+    // note to a suffixless file that drops out of the indexed set entirely.
+    h.dialog.showPrompt.mockResolvedValue('Notes v1.2');
+    await ops.handleRename('notes/foo.md');
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('notes/foo.md', 'notes/Notes v1.2.md');
+  });
+
+  it('does not double an extension typed out of habit', async () => {
+    h.dialog.showPrompt.mockResolvedValue('renamed.MD');
+    await ops.handleRename('foo.md');
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('foo.md', 'renamed.MD');
+  });
+
+  it('still lets a deliberate note-format change through', async () => {
     h.dialog.showPrompt.mockResolvedValue('renamed.ttl');
     await ops.handleRename('foo.md');
     expect(h.api.notebase.rename).toHaveBeenCalledWith('foo.md', 'renamed.ttl');
   });
 
-  it('does nothing on cancel or an unchanged name', async () => {
-    h.dialog.showPrompt.mockResolvedValue(null);
-    await ops.handleRename('foo.md');
-    h.dialog.showPrompt.mockResolvedValue('foo.md');
-    await ops.handleRename('foo.md');
-    expect(h.api.notebase.rename).not.toHaveBeenCalled();
+  it('renames a folder (no extension) with what was typed', async () => {
+    h.dialog.showPrompt.mockResolvedValue('archive');
+    await ops.handleRename('topics');
+    expect(h.dialog.showPrompt).toHaveBeenCalledWith('New name:', { initial: 'topics' });
+    expect(h.api.notebase.rename).toHaveBeenCalledWith('topics', 'archive');
   });
 
-  it('seeds the prompt with the current name and selects the stem (#1143)', async () => {
-    h.dialog.showPrompt.mockResolvedValue('renamed');
-    await ops.handleRename('notes/foo.md');
-    expect(h.dialog.showPrompt).toHaveBeenCalledWith('New name:', {
-      initial: 'foo.md',
-      selectStem: true,
-    });
+  it('does nothing on cancel, whitespace, or an unchanged name', async () => {
+    for (const answer of [null, '', '   ', 'foo']) {
+      h.dialog.showPrompt.mockResolvedValue(answer);
+      await ops.handleRename('foo.md');
+    }
+    expect(h.api.notebase.rename).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #1564.

Rename seeded the field with `note name.md` and let you edit the suffix — an implementation detail on display, and an editable one. Clearing the `.md` drops the file out of the indexed set, where it disappears from the sidebar.

The field now holds **the name alone**, and Minerva puts the extension back.

## What happens to a trailing `.thing`

The typed value is a *name*, so a dot in it needs a rule. Renaming `foo.md`:

| You type | Result | Why |
|---|---|---|
| `renamed` | `renamed.md` | the normal case |
| `renamed.md` / `renamed.MD` | `renamed.MD` | typed out of habit — not doubled into `.md.md` |
| `renamed.ttl` | `renamed.ttl` | another note extension: a deliberate format change, still supported |
| `Notes v1.2` | `Notes v1.2.md` | not an extension, just part of the name |

## The last row was a live bug

`Notes v1.2` satisfied the old `!rawNewName.includes('.')` check — read as "the user typed their own extension" — so the note was renamed to a **suffixless file**. That's precisely the disappearance the extension-preservation was written to prevent. Taking the extension out of the user's hands fixes it as a side effect.

## Dead option removed

`selectStem` existed for exactly one purpose: keeping the extension visible but unselected in this dialog. With the extension gone it has no callers, so it goes — `PromptDialog` now just selects the seeded value. Dropped from the dialog, the dialogs store, and `DialogHost`.

## Scope note

`handleCopyWithPrompt` ("Copy to (new name, or dir/name):") carries the same `includes('.')` heuristic and so the same `Notes v1.2` hazard. I left it alone — it accepts paths as well as names, so it's a different shape of fix, and it isn't what the ticket asked for. Happy to follow up.

## Tests

Seven cases in `note-ops.test.ts`: the field gets the bare stem, each row of the table above, folders (no extension) rename to what was typed, and cancel / whitespace / unchanged all stay no-ops.

`pnpm lint` clean; `pnpm test` 5720 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)