### PR TITLE
docs: retire CONTRIBUTING.md so the new-issue banner goes away

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,11 @@ src/
 
 ## Contributing
 
-Bug reports, feature ideas, skills, and pull requests are all welcome. See
-[CONTRIBUTING.md](CONTRIBUTING.md) for setup, conventions, and how to open a
-good PR.
+Bug reports and feature ideas are welcome as
+[issues](https://github.com/dgriffith/ide-for-thought/issues) — just describe
+what happened, there's no form to fill in. For working on the code, see
+[docs/development.md](docs/development.md) for setup, conventions, and how to
+open a good PR.
 
 ## License
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,12 +1,18 @@
-# Contributing to Minerva
+# Developing Minerva
 
-Thanks for your interest in Minerva! Bug reports, feature ideas, and pull
-requests are all welcome. This guide covers how to get set up, the conventions
-the codebase follows, and what a good pull request looks like.
+**Filing a bug or a feature idea? None of this applies to you** — open an
+[issue](https://github.com/dgriffith/ide-for-thought/issues) and describe what
+happened in your own words. That's the whole process.
+
+This guide is for people who want to work on the code: how to get set up, the
+conventions the codebase follows, and what a good pull request looks like. It
+lived at `CONTRIBUTING.md` until #1558 — GitHub turns a file by that name into a
+"please read the contributing guidelines" banner on the new-issue page, which is
+the wrong thing to put in front of someone reporting a bug.
 
 > Minerva is an Electron · Svelte 5 · TypeScript desktop app. The repository is
 > named `ide-for-thought`; the product is **Minerva**. If you only want to
-> understand the architecture, [`CLAUDE.md`](CLAUDE.md) is the fullest map of how
+> understand the architecture, [`CLAUDE.md`](../CLAUDE.md) is the fullest map of how
 > the pieces fit together.
 
 ## Ways to contribute
@@ -24,14 +30,14 @@ the codebase follows, and what a good pull request looks like.
   regardless of implementation quality.
 - **Author a skill** — the Learning / Research / Analysis menus are populated by
   markdown *skill* files, not code. You can add one without touching TypeScript;
-  see [`docs/authoring-skills.md`](docs/authoring-skills.md).
+  see [`authoring-skills.md`](authoring-skills.md).
 - **Send a pull request** — fixes, tests, docs, and features are all fair game.
   For anything large, please open an issue first so we can agree on the approach
   before you invest the time.
 
 ## Getting set up
 
-You need **Node 24+** (see [`.nvmrc`](.nvmrc)) and **pnpm 10**. Minerva uses
+You need **Node 24+** (see [`.nvmrc`](../.nvmrc)) and **pnpm 10**. Minerva uses
 `corepack`/pnpm — do not use `npm` or `yarn`.
 
 ```bash
@@ -85,11 +91,11 @@ IPC channels are declared in `src/shared/channels.ts` and typed in
 files in a fixed order — channel constant → main handler → `register-*.ts`
 handler registration → `preload.ts` → the `api` interface in
 `src/renderer/lib/ipc/client.ts`. The recipe is spelled out in
-[`CLAUDE.md`](CLAUDE.md) under *IPC Pattern*.
+[`CLAUDE.md`](../CLAUDE.md) under *IPC Pattern*.
 
 ## Conventions
 
-These are the ones most likely to trip up a first PR. [`CLAUDE.md`](CLAUDE.md)
+These are the ones most likely to trip up a first PR. [`CLAUDE.md`](../CLAUDE.md)
 has the complete list.
 
 - **Svelte 5 runes, not Svelte 4.** Use `$state`, `$derived`, `$effect`, and
@@ -123,7 +129,7 @@ approves it. If your change adds an AI write path, it **must** route through the
 approval engine, and you should wrap the apply path in `withLLMContext` so the
 write guard can catch a regression. Under the test runner the guard *throws*, so
 an accidental bypass fails CI. See the *LLM Integration Principles* and *Code
-Review Checklist for LLM/Graph PRs* sections of [`CLAUDE.md`](CLAUDE.md) before
+Review Checklist for LLM/Graph PRs* sections of [`CLAUDE.md`](../CLAUDE.md) before
 touching this area.
 
 ## Scope and non-negotiables
@@ -215,4 +221,4 @@ A maintainer will review and, once it's ready, squash-merge it.
 ## License
 
 By contributing, you agree that your contributions are licensed under the
-project's [MIT License](LICENSE).
+project's [MIT License](../LICENSE).


### PR DESCRIPTION
Closes #1558.

## Why it can only be removal, not simplification

The banner is generated by GitHub, not by us. Per [their docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors): *"When someone opens a pull request or creates an issue, they will see a link to that file"* — triggered by a `CONTRIBUTING.md` in the repo **root**, **`docs/`**, or **`.github/`**. The wording is fixed; there's no setting, template, or front-matter that changes it.

So "simplify the banner" isn't on the table. What's left is: stop having a file by that name, or leave a contributor-onboarding doc in front of every bug reporter.

## What this does

`CONTRIBUTING.md` → **`docs/development.md`**, retitled *Developing Minerva*, with:

- a new opening line for anyone who does land there: *"Filing a bug or a feature idea? None of this applies to you — open an issue and describe what happened in your own words. That's the whole process."*
- relative links repointed for the new depth (`../CLAUDE.md`, `../.nvmrc`, `../LICENSE`, `authoring-skills.md`)
- a note recording why it isn't called CONTRIBUTING.md, so nobody helpfully renames it back

README's Contributing section now says bug reports need no form, and points developers at `docs/development.md` — where someone looking to contribute actually looks.

Verified via the API that `CONTRIBUTING.md` is the only community file in play (`repos/.../community/profile` lists it; there are no issue templates and no code of conduct).

## Trade-off

The repo loses GitHub's auto-generated "Contributing" sidebar link and that checkbox on its community profile. For a project whose issue reporters are mostly non-technical users of the app, that looks like the right side of the trade — but it's a real loss, and the alternative (keep the file, rewrite its first paragraph to be friendly) leaves the banner itself on screen, which is what the ticket objects to.

Nothing in `src/` or the test suite references the file; `pnpm test` 5720 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)