### PR TITLE
feat: bug report and feature request issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Something in Minerva doesn't work the way it should.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time. Fill in what you know — only the first box
+        is required, and "it did the wrong thing when I clicked X" is a
+        perfectly good bug report.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the problem in your own words.
+      placeholder: When I open a note from the sidebar, the preview starts halfway down the page.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect instead?
+      placeholder: It should start at the top of the note.
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: |
+        If you can make it happen again, the steps help enormously. Skip this
+        if it only happened once — an unreproducible report is still worth
+        filing.
+      placeholder: |
+        1. Open a long note and scroll to the bottom
+        2. Click a different note in the sidebar
+        3. The new note opens scrolled down
+
+  - type: input
+    id: version
+    attributes:
+      label: Minerva version
+      description: Help → About Minerva (on macOS, Minerva → About Minerva).
+      placeholder: "1.0.0"
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other / not sure
+
+  - type: markdown
+    attributes:
+      value: |
+        Screenshots and short screen recordings are welcome — drag them into
+        any box above.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+# A blank issue stays one click away: the forms are there to help someone who
+# wants the help, not to make a one-line report cost more than one line (#1558).
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/dgriffith/ide-for-thought/tree/main/docs
+    about: How a feature is meant to work — worth a look before filing.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest something Minerva should do.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Only the first box is required. If you already know exactly what you
+        want built, say so there and skip the rest.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: |
+        The problem you're running into, or the thing you want to be able to
+        do. Describing the need rather than the solution often surfaces a
+        better fix than either of us had in mind.
+      placeholder: I keep losing my place when I switch between notes while reading.
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What would you like Minerva to do?
+      description: Your idea for the fix, if you have one.
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: How do you work around it today?
+      description: Useful for judging how much the gap costs you.

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -925,7 +925,10 @@ function buildHelpMenu(isMac: boolean): Electron.MenuItemConstructorOptions {
 }
 
 const DOCS_URL = 'https://github.com/dgriffith/ide-for-thought/tree/main/docs';
-const ISSUES_URL = 'https://github.com/dgriffith/ide-for-thought/issues';
+// The template chooser, not the issue list: Help → Report an Issue is someone
+// wanting to report, and the chooser is where the bug / feature forms live
+// (.github/ISSUE_TEMPLATE). A blank issue is still one click from there.
+const ISSUES_URL = 'https://github.com/dgriffith/ide-for-thought/issues/new/choose';
 
 /** The most recently built menu template — the source for the shortcuts
  *  reference, so it reflects whatever menu state the user is actually in. */

--- a/src/renderer/lib/components/AboutDialog.svelte
+++ b/src/renderer/lib/components/AboutDialog.svelte
@@ -17,7 +17,8 @@
   let { onClose }: Props = $props();
 
   const REPO_URL = 'https://github.com/dgriffith/ide-for-thought';
-  const ISSUES_URL = 'https://github.com/dgriffith/ide-for-thought/issues';
+  // The template chooser, matching Help → Report an Issue (see main/menu.ts).
+  const ISSUES_URL = 'https://github.com/dgriffith/ide-for-thought/issues/new/choose';
   const FUTURE_TOKENS_URL = 'https://github.com/jordanrubin/FUTURE_TOKENS';
 
   let info = $state<AppInfo | null>(null);


### PR DESCRIPTION
Follow-on from #1558/#1785 — same audience, opposite direction: having removed the wall of contributor guidelines, give reporters something that actively helps them.

## Issue forms, one required field each

**Bug report** (`bug_report.yml`, labels `bug`)
- What happened? — *the only required field*
- What did you expect instead?
- Steps to reproduce — explicitly says to skip it if it happened once and won't repeat
- Minerva version (free text, with a pointer to Help → About rather than a dropdown that goes stale every release)
- Operating system (dropdown)

**Feature request** (`feature_request.yml`, labels `enhancement`)
- What are you trying to do? — *the only required field*, and it asks for the need rather than the solution
- What would you like Minerva to do?
- How do you work around it today?

Both open with a line saying only the first box is required, so nobody feels obliged to fill in a form they don't have answers for. `bug` and `enhancement` already exist as repo labels.

## Blank issues stay

`config.yml` sets `blank_issues_enabled: true` — "Open a blank issue" remains on the chooser. The forms are there for someone who wants the help, not to make a one-line report cost more than one line. That includes you; most of the tickets I've worked from this session are one sentence and would be worse as filled-in forms.

The one contact link points at the in-repo docs — the same destination as Help → Documentation. (I nearly wrote a docs-site URL from memory; there's no CNAME or deployed site in the repo, so that link would have 404'd.)

## Menu change worth noticing

`Help → Report an Issue…` and the matching link in the About dialog pointed at the **issue list**. They now open `/issues/new/choose`, the template chooser. A user picking "Report an Issue" means to report, and the list is precisely where the forms aren't — most people would land there and never see them.

The trade-off is losing the incidental "scroll the list and notice your bug is already filed" step. Say the word and I'll put it back; the forms work either way, since New Issue from the list also routes through the chooser.

## Verification

All three files parsed with the `yaml` package to confirm they're valid (GitHub silently ignores a malformed form and falls back to a blank issue, which would have looked like the feature simply not working). Field inventory checked programmatically: one `required` per form.

`pnpm lint` clean; `pnpm test` 5720 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)