### PR TITLE
feat: open thoughtbase pickers where your thoughtbases live

### DIFF
--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -1,4 +1,4 @@
-import { app, dialog } from 'electron';
+import { dialog } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
@@ -16,7 +16,7 @@ import { projectContext } from '../project-context-types';
 import { writeAndReindex } from '../notebase/write-pipeline';
 import * as search from '../search/index';
 import * as vectors from '../embeddings/vector-store';
-import { clearRecentProjects } from '../recent-projects';
+import { clearRecentProjects, defaultThoughtbaseDir } from '../recent-projects';
 import { rebuildMenu } from '../menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, markPathHandled, windowsForProject } from '../window-manager';
 import { getOnboardingDismissed, setOnboardingDismissed } from '../project-config';
@@ -46,7 +46,8 @@ import {
 async function promptTutorialDestination(win: Electron.BrowserWindow): Promise<string | null> {
   const result = await dialog.showSaveDialog(win, {
     title: 'Install Tutorial Thoughtbase',
-    defaultPath: path.join(app.getPath('home'), TUTORIAL_DEFAULT_NAME),
+    // Beside the user's other thoughtbases, not dumped in home (#1560).
+    defaultPath: path.join(defaultThoughtbaseDir(), TUTORIAL_DEFAULT_NAME),
     buttonLabel: 'Install Tutorial',
     properties: ['createDirectory'],
   });
@@ -74,6 +75,7 @@ export function registerNotebase(): void {
       properties: ['openDirectory', 'createDirectory'],
       title: 'Choose location for new thoughtbase',
       buttonLabel: 'Create Thoughtbase',
+      defaultPath: defaultThoughtbaseDir(),
     });
     if (result.canceled || result.filePaths.length === 0) return null;
 
@@ -129,6 +131,7 @@ export function registerNotebase(): void {
     const result = await dialog.showOpenDialog(parentWin, {
       properties: ['openDirectory'],
       title: 'Open thoughtbase',
+      defaultPath: defaultThoughtbaseDir(),
     });
     if (result.canceled || result.filePaths.length === 0) return null;
     const rootPath = result.filePaths[0]!;
@@ -146,6 +149,7 @@ export function registerNotebase(): void {
       properties: ['openDirectory', 'createDirectory'],
       title: 'Choose location for new thoughtbase',
       buttonLabel: 'Create Thoughtbase',
+      defaultPath: defaultThoughtbaseDir(),
     });
     if (result.canceled || result.filePaths.length === 0) return null;
     const rootPath = result.filePaths[0]!;

--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -4,6 +4,7 @@ import fsSync from 'node:fs';
 import path from 'node:path';
 import type { NoteFile, NotebaseMeta } from '../../shared/types';
 import { resolveDisplayName } from '../project-config';
+import { defaultThoughtbaseDir } from '../recent-projects';
 import { onNoteWritten, moveHistory } from '../history';
 
 const IGNORED_DIRS = new Set(['.git', 'node_modules', '.minerva', '.obsidian']);
@@ -14,6 +15,7 @@ export async function openNotebase(): Promise<NotebaseMeta | null> {
     // fresh directory to open as a thoughtbase without leaving the app (#1036).
     properties: ['openDirectory', 'createDirectory'],
     title: 'Open Thoughtbase',
+    defaultPath: defaultThoughtbaseDir(),
   });
 
   if (result.canceled || result.filePaths.length === 0) {

--- a/src/main/recent-projects.ts
+++ b/src/main/recent-projects.ts
@@ -3,11 +3,20 @@ import path from 'node:path';
 import { app } from 'electron';
 
 const MAX_RECENT = 10;
-const filePath = path.join(app.getPath('userData'), 'recent-projects.json');
+
+/**
+ * Resolved per call, not at module load. `app.getPath` is unavailable until
+ * Electron is ready, so a module-level constant made merely IMPORTING this file
+ * a side effect — which broke every test suite that reaches it transitively
+ * (notebase/fs.ts → read-note.ts → …) with a bare `electron` mock.
+ */
+function recentsFilePath(): string {
+  return path.join(app.getPath('userData'), 'recent-projects.json');
+}
 
 export function getRecentProjects(): string[] {
   try {
-    const data = fs.readFileSync(filePath, 'utf-8');
+    const data = fs.readFileSync(recentsFilePath(), 'utf-8');
     return JSON.parse(data) as string[];
   } catch {
     return [];
@@ -18,9 +27,39 @@ export function addRecentProject(projectPath: string): void {
   const recent = getRecentProjects().filter((p) => p !== projectPath);
   recent.unshift(projectPath);
   if (recent.length > MAX_RECENT) recent.length = MAX_RECENT;
-  fs.writeFileSync(filePath, JSON.stringify(recent), 'utf-8');
+  fs.writeFileSync(recentsFilePath(), JSON.stringify(recent), 'utf-8');
+}
+
+/**
+ * Where a thoughtbase folder picker should start (#1560).
+ *
+ * People keep their thoughtbases together — a `~/Minerva`, `~/thoughtbases`, or
+ * `~/notes` folder — so the PARENT of the last one they opened is a far better
+ * guess than the OS default, which lands on Downloads or wherever some
+ * unrelated save panel was last. No new setting: the recents list already
+ * records every thoughtbase opened or created, so the answer is derivable, and
+ * it retrains itself the moment the user starts keeping them somewhere else.
+ *
+ * Walks the list rather than taking the head blindly: a thoughtbase that's been
+ * deleted or moved shouldn't cost the hint. Falls back to Documents — a
+ * conventional home for a new folder, and specifically not Downloads.
+ */
+export function defaultThoughtbaseDir(): string {
+  for (const projectPath of getRecentProjects()) {
+    const parent = path.dirname(projectPath);
+    // `path.dirname('/')` is '/' — a root with no parent tells us nothing.
+    if (parent === projectPath) continue;
+    try {
+      if (fs.statSync(parent).isDirectory()) return parent;
+    } catch { /* gone since it was last opened — try the next one */ }
+  }
+  try {
+    return app.getPath('documents');
+  } catch {
+    return app.getPath('home');
+  }
 }
 
 export function clearRecentProjects(): void {
-  fs.writeFileSync(filePath, '[]', 'utf-8');
+  fs.writeFileSync(recentsFilePath(), '[]', 'utf-8');
 }

--- a/tests/main/recent-projects.test.ts
+++ b/tests/main/recent-projects.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment node
+ *
+ * `defaultThoughtbaseDir` (#1560) — where the thoughtbase folder pickers start.
+ *
+ * The rule is "the parent of the last thoughtbase you opened", derived from the
+ * recents list rather than a new setting. What's worth pinning is the behaviour
+ * around the edges: a deleted project must not cost the hint, and the fallback
+ * must not be Downloads (the whole complaint in the issue).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// `recent-projects.ts` resolves its JSON path at MODULE load, so the mocked
+// `getPath` has to answer before the import below — hence a fixed root rather
+// than a per-test mkdtemp. Each test rebuilds it from scratch.
+const h = vi.hoisted(() => {
+  const root = `${process.env.TMPDIR ?? '/tmp'}/minerva-recent-projects-test`;
+  const paths: Record<string, string> = {
+    userData: `${root}/userData`,
+    documents: `${root}/Documents`,
+    home: `${root}/home`,
+  };
+  return { root, paths, getPath: vi.fn((name: string) => paths[name] ?? paths.userData!) };
+});
+
+vi.mock('electron', () => ({
+  app: { getPath: (name: string) => h.getPath(name) },
+}));
+
+import {
+  addRecentProject,
+  clearRecentProjects,
+  defaultThoughtbaseDir,
+} from '../../src/main/recent-projects';
+
+const tmp = h.root;
+
+beforeEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  for (const d of Object.values(h.paths)) fs.mkdirSync(d, { recursive: true });
+  h.getPath.mockImplementation((name: string) => h.paths[name] ?? h.paths.userData!);
+  clearRecentProjects();
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+/** Create a thoughtbase directory and record it as recently opened. */
+function opened(relative: string): string {
+  const abs = path.join(tmp, relative);
+  fs.mkdirSync(abs, { recursive: true });
+  addRecentProject(abs);
+  return abs;
+}
+
+describe('defaultThoughtbaseDir', () => {
+  it('offers the folder the last thoughtbase was opened from', () => {
+    opened('Minerva/Research');
+    expect(defaultThoughtbaseDir()).toBe(path.join(tmp, 'Minerva'));
+  });
+
+  it('follows the user when they start keeping thoughtbases somewhere else', () => {
+    opened('Minerva/Research');
+    opened('work/notes/Client');
+    expect(defaultThoughtbaseDir()).toBe(path.join(tmp, 'work/notes'));
+  });
+
+  it('falls through to an older project when the newest one is gone', () => {
+    opened('Minerva/Research');
+    const moved = opened('Downloads/demo-thoughtbase');
+    fs.rmSync(moved, { recursive: true, force: true });
+    fs.rmSync(path.join(tmp, 'Downloads'), { recursive: true, force: true });
+    // Not Downloads (which no longer exists), and not the Documents fallback —
+    // the still-present Minerva folder is the right answer.
+    expect(defaultThoughtbaseDir()).toBe(path.join(tmp, 'Minerva'));
+  });
+
+  it('falls back to Documents — never Downloads — with no usable history', () => {
+    expect(defaultThoughtbaseDir()).toBe(h.paths.documents);
+  });
+
+  it('falls back to home when the platform has no Documents folder', () => {
+    h.getPath.mockImplementation((name: string) => {
+      if (name === 'documents') throw new Error('no XDG documents dir');
+      return h.paths[name] ?? h.paths.userData!;
+    });
+    expect(defaultThoughtbaseDir()).toBe(h.paths.home);
+  });
+
+  it('ignores a recorded path with no parent to speak of', () => {
+    addRecentProject(path.parse(tmp).root);
+    expect(defaultThoughtbaseDir()).toBe(h.paths.documents);
+  });
+
+  it('ignores a recorded path whose parent is a file, not a folder', () => {
+    const file = path.join(tmp, 'not-a-folder');
+    fs.writeFileSync(file, 'x');
+    addRecentProject(path.join(file, 'Thoughtbase'));
+    expect(defaultThoughtbaseDir()).toBe(h.paths.documents);
+  });
+});


### PR DESCRIPTION
Closes #1560, implementing your reading of it: remember the parent directory of wherever thoughtbases get opened, and offer that next time.

## No new setting

The recents list already records every thoughtbase opened or created, so the answer is derivable — `defaultThoughtbaseDir()` takes the parent of the most recent one. That means it needs no first-run configuration, no "default folder" preference to find and set, and it **retrains itself** the moment someone starts keeping thoughtbases somewhere else.

Two details that matter more than they look:

- **Walks the list, doesn't take the head.** A thoughtbase that's been deleted or moved since would otherwise throw you back to the OS default; the next-most-recent still-present folder is a better answer.
- **Falls back to Documents, pointedly not Downloads** — the whole complaint in the issue. Falls back again to home on a platform with no Documents folder.

## Where it applies

All four thoughtbase pickers: Open, Create, and their "…in new window" variants. Plus the tutorial install panel, which defaulted to dropping `Minerva Tutorial` in the home directory — same question, same answer.

## One fix this shook out

`recent-projects.ts` resolved its JSON path at **module load**:

```ts
const filePath = path.join(app.getPath('userData'), 'recent-projects.json');
```

Importing the module was therefore a side effect requiring a ready Electron `app`. Fine while only `window-manager` and `menu` imported it — but this change adds `notebase/fs.ts` as an importer, and fs.ts is reached transitively by a large slice of the suite (`fs.ts` → `read-note.ts` → the tool tests, the skills tests, the CLI eval tests…). **76 test suites failed to collect** the first time I ran the full suite. Resolving the path per call fixes it and removes a genuine fragility rather than papering over it with more mocks.

Worth flagging because the failure mode was "76 suites red, 0 tests failed" — the shape of the resource-contention flake I've seen in this repo before, and I nearly dismissed it as one.

## Tests

`tests/main/recent-projects.test.ts` (7 new, first coverage of this module): the parent of the last thoughtbase wins; a new location retrains it; a deleted newest project falls through to an older one rather than to the fallback; the fallback is Documents; home when Documents is unavailable; a filesystem root and a parent-that's-a-file are both ignored.

Mutation-checked: emptying the recents scan fails three of them.

`pnpm lint` clean; `pnpm test` 5727 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)