### PR TITLE
fix(copy): name conversation affordances that exist

### DIFF
--- a/src/shared/welcome-note.ts
+++ b/src/shared/welcome-note.ts
@@ -40,8 +40,9 @@ A few ways in:
   note — Minerva weaves the links into a knowledge graph you can query.
 - **Label with tags and frontmatter.** Titles, tags, and links are all indexed;
   the \`entrypoint\` tag above is what marks this as your starting note.
-- **Ask questions of your notes.** Open a conversation to explore or challenge what
-  you've written — nothing lands in your graph without your approval.
+- **Ask questions of your notes.** The **New Conversation** button above the editor
+  starts one; right-click a note's tab and choose *Ask About This…* to start from
+  that note — nothing lands in your graph without your approval.
 
 When you're ready, press ${newNote} and start writing.
 `;

--- a/tests/shared/welcome-note.test.ts
+++ b/tests/shared/welcome-note.test.ts
@@ -22,6 +22,17 @@ describe('welcomeNoteContent', () => {
     expect(welcomeNoteContent(false)).not.toContain('⌘N');
   });
 
+  it('names conversation affordances that actually exist (#1569)', () => {
+    const body = welcomeNoteContent(true);
+    // It used to say "Open a conversation", which matches no button, menu item,
+    // or shortcut — a reader went looking for it and filed a bug. Both labels
+    // below are real: the button above the editor (App.svelte) and the
+    // tab / editor / preview context-menu item.
+    expect(body).toContain('New Conversation');
+    expect(body).toContain('Ask About This');
+    expect(body).not.toMatch(/open a conversation/i);
+  });
+
   it('greets the reader', () => {
     expect(welcomeNoteContent(true)).toContain('Welcome to your thoughtbase');
   });

--- a/website/docs/conversations-chatting.html
+++ b/website/docs/conversations-chatting.html
@@ -95,7 +95,7 @@
       </div>
       <div class="row">
         <div class="k">Start fresh</div>
-        <div class="v">The <b>+</b> button in the conversation list, <b>View → New Conversation</b>, or the <b>New Conversation</b> button above the editor. This opens a blank conversation with no particular note attached.</div>
+        <div class="v">The <b>New Conversation</b> button above the editor, the <b>+</b> button in the conversation list, or <b>Learning → Ask a Question</b>. This opens a blank conversation with no particular note attached.</div>
       </div>
       <div class="row">
         <div class="k">Ask about a note</div>


### PR DESCRIPTION
Closes #1569. Verbiage, as you guessed — but the reporter was right twice.

## The welcome note

> **Ask questions of your notes.** Open a conversation to explore or challenge what you've written…

"Open a conversation" matches **no button, no menu item, no shortcut**. Every other bullet in that note names a concrete gesture — press ⌘N, type `[[` — and this one was the outlier, so someone acting on it goes hunting and finds "Ask a Question" under Learning, which doesn't obviously match. Hence the issue.

It now names the two real ways in:

> **Ask questions of your notes.** The **New Conversation** button above the editor starts one; right-click a note's tab and choose *Ask About This…* to start from that note — nothing lands in your graph without your approval.

I inventoried the affordances before writing that, rather than picking the one I remembered: the labelled **New Conversation** button above the editor (`App.svelte`), the **+** in the conversation list, **Learning → Ask a Question**, **View → Toggle Conversations** (⌘⇧K, which shows the panel rather than starting anything), and **Ask About This…** on the tab / editor / preview context menus. The button leads because it's the one that's visible without opening a menu.

## The same drift in the docs

`conversations-chatting.html` listed **"View → New Conversation"**. That item moved to Learning ▸ Ask a Question a while back — `menu.ts` even carries a comment recording the move — so the docs have been pointing at a menu entry that isn't there. Now: the button, the **+**, and **Learning → Ask a Question**, most-discoverable first.

The help-corpus staleness snapshot is unaffected (it keys on section ids, and this edit is body text inside an existing row) — checked, not assumed.

## Test

One case in `welcome-note.test.ts`: the note names labels that exist and no longer contains "open a conversation". A string assertion, but a load-bearing one — that string *is* the bug.

`pnpm lint` clean; `pnpm test` 5728 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)