### PR TITLE
feat(publish): create the GitHub repo and switch Pages on

### DIFF
--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -16,13 +16,23 @@ const bin = (name) => join('node_modules', '.bin', process.platform === 'win32' 
 const CHECKS = [
   { name: 'tsc', args: [bin('tsc'), '--noEmit'] },
   { name: 'svelte-check', args: [bin('svelte-check'), '--threshold', 'error'] },
-  { name: 'eslint', args: [bin('eslint'), '.'] },
+  // Type-aware linting holds a TS program for the whole repo, and it grew past
+  // Node's default old-space on CI (#1789): eslint died with "Ineffective
+  // mark-compacts near heap limit" at ~2GB after 154s — on its own, well after
+  // the other two checks had finished, so this is eslint's own appetite rather
+  // than the three of them competing. `--max-old-space-size` is a CEILING, not
+  // a reservation: nothing uses more memory than it needs, it just stops the
+  // hard crash when the repo is a little bigger than it was yesterday.
+  { name: 'eslint', args: [bin('eslint'), '.'], heapMb: 4096 },
 ];
 
-function run({ name, args }) {
+function run({ name, args, heapMb }) {
   return new Promise((resolve) => {
     const [cmd, ...rest] = args;
-    const child = spawn(cmd, rest, { shell: process.platform === 'win32' });
+    const env = heapMb
+      ? { ...process.env, NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --max-old-space-size=${heapMb}`.trim() }
+      : process.env;
+    const child = spawn(cmd, rest, { shell: process.platform === 'win32', env });
     let out = '';
     child.stdout.on('data', (d) => { out += d; });
     child.stderr.on('data', (d) => { out += d; });

--- a/src/main/git/github-repo.ts
+++ b/src/main/git/github-repo.ts
@@ -1,0 +1,199 @@
+/**
+ * GitHub repository + Pages provisioning for the Publish destination (#1560
+ * follow-on / #254).
+ *
+ * The push side (`publish-git.ts`) already creates the BRANCH when it's absent:
+ * a clone of a missing ref falls back to `git init` on that branch and the push
+ * creates it remotely. What the git protocol can't do is create the repository
+ * itself, or switch Pages on — both are REST calls, so they live here.
+ *
+ * Deliberately narrow: `fetch` against api.github.com, no SDK, no Electron
+ * import, every function taking an explicit token so the whole thing is
+ * testable with a stubbed `fetch`.
+ *
+ * Everything here is GitHub-specific, while a publish target is a generic git
+ * remote — GitLab and Codeberg remotes push perfectly well today. `parseGitHubRepo`
+ * returning null is the "not GitHub, leave it alone" signal, and callers must
+ * honour it rather than assuming every remote is a GitHub one.
+ */
+
+const API = 'https://api.github.com';
+
+export interface GitHubRepoRef {
+  owner: string;
+  repo: string;
+}
+
+/** Pages can only serve from the repo root or `/docs` — no other path. */
+export type PagesPath = '/' | '/docs';
+
+function headers(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'Minerva',
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+}
+
+/**
+ * `owner`/`repo` from a GitHub remote URL, or null for any other host. Accepts
+ * the HTTPS form this app normalizes to; anything with extra path segments
+ * (a gist, an enterprise instance, a raw URL) is rejected rather than guessed at.
+ */
+export function parseGitHubRepo(remoteUrl: string): GitHubRepoRef | null {
+  let url: URL;
+  try {
+    url = new URL(remoteUrl.trim());
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+  if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') return null;
+  const parts = url.pathname.replace(/^\/+/, '').replace(/\/+$/, '').split('/');
+  if (parts.length !== 2) return null;
+  const [owner, rawRepo] = parts as [string, string];
+  const repo = rawRepo.replace(/\.git$/i, '');
+  if (!owner || !repo) return null;
+  return { owner, repo };
+}
+
+/** Human-readable `owner/repo`. */
+export function repoSlug(ref: GitHubRepoRef): string {
+  return `${ref.owner}/${ref.repo}`;
+}
+
+/**
+ * Does the repo exist and can this token see it?
+ *
+ * `missing` deliberately means "GitHub answered 404", which covers both "no
+ * such repo" and "a private repo this token can't see" — GitHub does not
+ * distinguish them, and pretending otherwise would produce a confident wrong
+ * message. The caller's prompt says "doesn't exist (or isn't visible to your
+ * token)" for that reason.
+ */
+export async function checkRepoExists(
+  token: string,
+  ref: GitHubRepoRef,
+): Promise<'exists' | 'missing'> {
+  const res = await fetch(`${API}/repos/${ref.owner}/${ref.repo}`, { headers: headers(token) });
+  if (res.ok) return 'exists';
+  if (res.status === 404) return 'missing';
+  if (res.status === 401) throw new Error('GitHub rejected the token (invalid or expired).');
+  throw new Error(`GitHub returned ${res.status} ${res.statusText} looking up ${repoSlug(ref)}.`);
+}
+
+/** The authenticated user's login, for deciding user-repo vs org-repo creation. */
+async function authenticatedLogin(token: string): Promise<string> {
+  const res = await fetch(`${API}/user`, { headers: headers(token) });
+  if (!res.ok) {
+    throw new Error(`Couldn't identify the token's GitHub account (${res.status} ${res.statusText}).`);
+  }
+  const body = (await res.json()) as { login?: string };
+  if (!body.login) throw new Error("GitHub didn't report a login for this token.");
+  return body.login;
+}
+
+/**
+ * Create the repository. Routes to `POST /user/repos` when the owner IS the
+ * token's account and `POST /orgs/{owner}/repos` otherwise — creating under
+ * someone else's personal account is impossible, and that failure comes back
+ * from the org endpoint with GitHub's own wording.
+ */
+export async function createRepo(
+  token: string,
+  ref: GitHubRepoRef,
+  opts: { private: boolean; description?: string },
+): Promise<void> {
+  const login = await authenticatedLogin(token);
+  const isOwnAccount = login.toLowerCase() === ref.owner.toLowerCase();
+  const url = isOwnAccount ? `${API}/user/repos` : `${API}/orgs/${ref.owner}/repos`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { ...headers(token), 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: ref.repo,
+      private: opts.private,
+      // No README/licence commit: the publish push writes the first commit, and
+      // an auto-init commit on the default branch would just be litter.
+      auto_init: false,
+      ...(opts.description ? { description: opts.description } : {}),
+    }),
+  });
+  if (res.ok) return;
+
+  // A token that can PUSH may still not be able to CREATE — different scope —
+  // so say which, rather than reporting a generic failure.
+  if (res.status === 403) {
+    throw new Error(
+      `The GitHub token can't create repositories for ${ref.owner}. A classic token needs the ` +
+        '`repo` scope; a fine-grained one needs Administration: write.',
+    );
+  }
+  if (res.status === 404) {
+    throw new Error(
+      `GitHub couldn't find an account or organization called "${ref.owner}" that this token may ` +
+        'create repositories in.',
+    );
+  }
+  if (res.status === 422) {
+    throw new Error(`GitHub rejected the name "${repoSlug(ref)}" — it may already exist.`);
+  }
+  throw new Error(`Creating ${repoSlug(ref)} failed: ${res.status} ${res.statusText}.`);
+}
+
+/**
+ * Point Pages at `branch`/`path` and return the site URL.
+ *
+ * Called AFTER the first push — Pages rejects a source branch that doesn't
+ * exist yet. Already-enabled (409) is a success: we read the existing config
+ * back so the caller still gets a URL to show.
+ */
+export async function enablePages(
+  token: string,
+  ref: GitHubRepoRef,
+  opts: { branch: string; path: PagesPath },
+): Promise<string | null> {
+  const res = await fetch(`${API}/repos/${ref.owner}/${ref.repo}/pages`, {
+    method: 'POST',
+    headers: { ...headers(token), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ source: { branch: opts.branch, path: opts.path } }),
+  });
+  if (res.ok) {
+    const body = (await res.json()) as { html_url?: string };
+    return body.html_url ?? null;
+  }
+  if (res.status === 409) return getPagesUrl(token, ref);
+  if (res.status === 403) {
+    throw new Error(
+      'GitHub refused to enable Pages. A fine-grained token needs Pages: write, and Pages on a ' +
+        'private repository requires a paid GitHub plan.',
+    );
+  }
+  throw new Error(`Enabling GitHub Pages failed: ${res.status} ${res.statusText}.`);
+}
+
+/** The live Pages URL, or null when Pages isn't configured. Never throws. */
+export async function getPagesUrl(token: string, ref: GitHubRepoRef): Promise<string | null> {
+  try {
+    const res = await fetch(`${API}/repos/${ref.owner}/${ref.repo}/pages`, { headers: headers(token) });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { html_url?: string };
+    return body.html_url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The Pages `path` for an export subdirectory, or null when Pages can't serve
+ * it. Pages supports only the repo root and `/docs`; a target publishing into
+ * `site/` is perfectly valid as a git push but can't be auto-configured, and
+ * the caller says so instead of silently enabling the wrong thing.
+ */
+export function pagesPathForSubdir(subdir: string | undefined): PagesPath | null {
+  const clean = (subdir ?? '').replace(/^[./]+/, '').replace(/\/+$/, '');
+  if (!clean) return '/';
+  if (clean.toLowerCase() === 'docs') return '/docs';
+  return null;
+}

--- a/src/main/git/github-repo.ts
+++ b/src/main/git/github-repo.ts
@@ -27,6 +27,12 @@ export interface GitHubRepoRef {
 /** Pages can only serve from the repo root or `/docs` — no other path. */
 export type PagesPath = '/' | '/docs';
 
+/**
+ * Injectable so tests don't actually wait. Real callers never pass this.
+ */
+export type Sleep = (ms: number) => Promise<void>;
+const realSleep: Sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
 function headers(token: string): Record<string, string> {
   return {
     Authorization: `Bearer ${token}`,
@@ -81,6 +87,32 @@ export async function checkRepoExists(
   if (res.status === 404) return 'missing';
   if (res.status === 401) throw new Error('GitHub rejected the token (invalid or expired).');
   throw new Error(`GitHub returned ${res.status} ${res.statusText} looking up ${repoSlug(ref)}.`);
+}
+
+/**
+ * Block until a just-created repo answers, or give up.
+ *
+ * `POST /user/repos` returns 201 before the repository is necessarily ready for
+ * git traffic, so pushing immediately can hit "404 Not Found" on a repo GitHub
+ * has just told us it created. Observed in the field on the very first publish
+ * (#254 follow-on). Bounded: six tries over ~7s, then a message that says to
+ * simply publish again rather than pretending something is broken.
+ */
+export async function waitForRepo(
+  token: string,
+  ref: GitHubRepoRef,
+  opts: { attempts?: number; sleep?: Sleep } = {},
+): Promise<void> {
+  const attempts = opts.attempts ?? 6;
+  const sleep = opts.sleep ?? realSleep;
+  for (let i = 0; i < attempts; i++) {
+    if ((await checkRepoExists(token, ref)) === 'exists') return;
+    await sleep(Math.min(250 * 2 ** i, 2000));
+  }
+  throw new Error(
+    `GitHub created ${repoSlug(ref)} but it isn't answering yet. Publish again in a moment — ` +
+      'the repository is there, it just needs a few seconds to come up.',
+  );
 }
 
 /** The authenticated user's login, for deciding user-repo vs org-repo creation. */
@@ -152,25 +184,45 @@ export async function createRepo(
 export async function enablePages(
   token: string,
   ref: GitHubRepoRef,
-  opts: { branch: string; path: PagesPath },
+  opts: { branch: string; path: PagesPath; attempts?: number; sleep?: Sleep },
 ): Promise<string | null> {
-  const res = await fetch(`${API}/repos/${ref.owner}/${ref.repo}/pages`, {
-    method: 'POST',
-    headers: { ...headers(token), 'Content-Type': 'application/json' },
-    body: JSON.stringify({ source: { branch: opts.branch, path: opts.path } }),
-  });
-  if (res.ok) {
-    const body = (await res.json()) as { html_url?: string };
-    return body.html_url ?? null;
+  const attempts = opts.attempts ?? 4;
+  const sleep = opts.sleep ?? realSleep;
+  let lastStatus = 0;
+
+  for (let i = 0; i < attempts; i++) {
+    const res = await fetch(`${API}/repos/${ref.owner}/${ref.repo}/pages`, {
+      method: 'POST',
+      headers: { ...headers(token), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: { branch: opts.branch, path: opts.path } }),
+    });
+    if (res.ok) {
+      const body = (await res.json()) as { html_url?: string };
+      return body.html_url ?? null;
+    }
+    if (res.status === 409) return getPagesUrl(token, ref);
+    if (res.status === 403) {
+      throw new Error(
+        'GitHub refused to enable Pages. A fine-grained token needs Pages: write, and Pages on a ' +
+          'private repository requires a paid GitHub plan.',
+      );
+    }
+    lastStatus = res.status;
+    // 5xx isn't in the documented set (201/409/422). Observed in the field on a
+    // first publish, and a plain retry cleared it — Pages hadn't caught up with
+    // a branch pushed seconds earlier. Worth waiting out; a 4xx is a real
+    // answer and retrying it would just be noise.
+    if (res.status < 500) {
+      throw new Error(`Enabling GitHub Pages failed: ${res.status} ${res.statusText}.`);
+    }
+    if (i < attempts - 1) await sleep(Math.min(1000 * 2 ** i, 4000));
   }
-  if (res.status === 409) return getPagesUrl(token, ref);
-  if (res.status === 403) {
-    throw new Error(
-      'GitHub refused to enable Pages. A fine-grained token needs Pages: write, and Pages on a ' +
-        'private repository requires a paid GitHub plan.',
-    );
-  }
-  throw new Error(`Enabling GitHub Pages failed: ${res.status} ${res.statusText}.`);
+
+  throw new Error(
+    `GitHub couldn't enable Pages yet (${lastStatus}). Your site content is pushed to ` +
+      `${opts.branch} — finish in the repository's Settings → Pages, or just publish again once ` +
+      'the branch has settled.',
+  );
 }
 
 /** The live Pages URL, or null when Pages isn't configured. Never throws. */

--- a/src/main/git/publish-git.ts
+++ b/src/main/git/publish-git.ts
@@ -126,8 +126,8 @@ function authFor(token: string) {
  * Bring the publish-cache workspace to the target branch's current remote
  * state. Re-clones from scratch each publish (cheap for a static site, and it
  * guarantees we're building on the remote's real history rather than an
- * orphan commit or a stale local tree). When the branch doesn't exist yet
- * (first publish to `gh-pages`), fall back to a fresh repo on that branch.
+ * orphan commit or a stale local tree). When the branch isn't there yet
+ * (first publish to `gh-pages`), start a fresh repo on that branch instead.
  *
  * Returns whether the branch already existed on the remote.
  */
@@ -140,6 +140,8 @@ export async function prepareWorkspace(opts: {
   const url = normalizeRemoteToHttps(opts.url);
   await fsp.rm(opts.dir, { recursive: true, force: true });
   await fsp.mkdir(opts.dir, { recursive: true });
+
+  let onBranch = false;
   try {
     await git.clone({
       fs,
@@ -150,17 +152,29 @@ export async function prepareWorkspace(opts: {
       singleBranch: true,
       onAuth: authFor(opts.token),
     });
-    return { branchExisted: true };
+    // A clone that doesn't throw is NOT proof we're on the branch. Against a
+    // remote with zero refs — a repository created moments ago, which is
+    // exactly the first-publish case — isomorphic-git's clone returns early
+    // (`if (fetchHead === null) return`) without throwing and without checking
+    // anything out. The workspace is then a bare init on the DEFAULT branch
+    // name, so the commit would land on `master` and the push of `gh-pages`
+    // would fail locally with "Could not find gh-pages." Ask the workspace
+    // where it actually is instead.
+    const current = await git.currentBranch({ fs, dir: opts.dir }).catch(() => null);
+    const head = await git.resolveRef({ fs, dir: opts.dir, ref: 'HEAD' }).catch(() => null);
+    onBranch = current === opts.branch && head !== null;
   } catch {
-    // Branch (or repo content) not there yet → start a fresh repo on the
-    // branch. A genuine auth/404 problem resurfaces — with a clear message —
-    // when we push below, which is the real gate.
-    await fsp.rm(opts.dir, { recursive: true, force: true });
-    await fsp.mkdir(opts.dir, { recursive: true });
-    await git.init({ fs, dir: opts.dir, defaultBranch: opts.branch });
-    await git.addRemote({ fs, dir: opts.dir, remote: 'origin', url });
-    return { branchExisted: false };
+    // Branch (or repo content) not there yet — fall through to the fresh repo.
+    // A genuine auth/404 problem resurfaces, with a clear message, when we push
+    // below; that's the real gate.
   }
+  if (onBranch) return { branchExisted: true };
+
+  await fsp.rm(opts.dir, { recursive: true, force: true });
+  await fsp.mkdir(opts.dir, { recursive: true });
+  await git.init({ fs, dir: opts.dir, defaultBranch: opts.branch });
+  await git.addRemote({ fs, dir: opts.dir, remote: 'origin', url });
+  return { branchExisted: false };
 }
 
 /** Remove everything in `destDir` except a top-level `.git`, so the exporter

--- a/src/main/ipc/register-publish.ts
+++ b/src/main/ipc/register-publish.ts
@@ -124,7 +124,11 @@ export function registerPublish(): void {
   // rejection (#254 acceptance).
   handle(
     Channels.PUBLISH_TO_GIT,
-    withRootPath(async (rootPath, targetId: string, opts?: { dryRun?: boolean }) => {
+    withRootPath(async (
+      rootPath,
+      targetId: string,
+      opts?: { dryRun?: boolean; createRepo?: { private: boolean } },
+    ) => {
       try {
         // Dispatch by target kind (#1444). Git is the only transport today; S3
         // slots in behind the same seam. The channel stays PUBLISH_TO_GIT until
@@ -132,6 +136,7 @@ export function registerPublish(): void {
         const result = await publish.publishTarget(rootPath, targetId, {
           dryRun: opts?.dryRun ?? false,
           version: app.getVersion(),
+          ...(opts?.createRepo ? { createRepo: opts.createRepo } : {}),
         });
         return { ok: true as const, result };
       } catch (err) {

--- a/src/main/publish/publish-to-git.ts
+++ b/src/main/publish/publish-to-git.ts
@@ -94,6 +94,9 @@ export async function publishToGit(
           private: opts.createRepo.private,
           description: `Published from Minerva — ${target.label}`,
         });
+        // 201 doesn't mean the repo is ready for git traffic — pushing straight
+        // away can 404 on the repo GitHub just said it made.
+        await gh.waitForRepo(token, ref);
         repoCreated = true;
       }
     }

--- a/src/main/publish/publish-to-git.ts
+++ b/src/main/publish/publish-to-git.ts
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { getPublishTarget, getGitCredentials } from '../project-config';
 import { runExport } from './run-export';
 import * as pg from '../git/publish-git';
+import * as gh from '../git/github-repo';
 import type { PublishChange } from '../git/publish-git';
 
 export interface PublishResult {
@@ -28,10 +29,30 @@ export interface PublishResult {
   pushed: boolean;
   sha?: string;
   commitMessage?: string;
+  /**
+   * The GitHub repo the remote points at doesn't exist (or isn't visible to
+   * this token), and the run didn't create it because the caller hasn't said
+   * to. NOTHING was published — the UI asks, then calls again with
+   * `createRepo`. Set on a dry run too, where it's just information.
+   */
+  repoMissing?: { owner: string; repo: string };
+  /** This run created the repository. */
+  repoCreated?: boolean;
+  /** GitHub Pages site URL, once Pages is serving this branch. */
+  pagesUrl?: string;
+  /** Why Pages wasn't configured, when it couldn't be. */
+  pagesNote?: string;
 }
 
 export interface PublishOptions {
   dryRun?: boolean;
+  /**
+   * Permission to create the GitHub repo when it's missing, and how public it
+   * should be. Absent means "don't" — creating a repo on someone's account is
+   * outward-facing and awkward to undo, so it never happens without an
+   * explicit answer to the `repoMissing` prompt.
+   */
+  createRepo?: { private: boolean };
   /** App version for `{{version}}` in the commit template. */
   version?: string;
   /** ISO timestamp for `{{date}}`; defaults to now. Injectable for tests. */
@@ -52,6 +73,31 @@ export async function publishToGit(
   // Fail fast with a clear message before doing any work if creds are missing.
   // Prefer the target's stored token (#1508), else the gh CLI / env.
   const token = pg.resolveGitHubToken(getGitCredentials(rootPath, targetId).token);
+
+  // ── GitHub repo provisioning ───────────────────────────────────────────
+  // Only for github.com remotes; a GitLab/Codeberg target parses to null and
+  // takes none of this path.
+  const ref = gh.parseGitHubRepo(pg.normalizeRemoteToHttps(target.gitRemote));
+  let repoCreated = false;
+  if (ref) {
+    const state = await gh.checkRepoExists(token, ref);
+    if (state === 'missing') {
+      if (!opts.createRepo) {
+        // Stop before any export work: the caller has to decide.
+        return {
+          targetId, dryRun, branch: target.gitBranch, branchCreated: true,
+          changes: [], committed: false, pushed: false, repoMissing: ref,
+        };
+      }
+      if (!dryRun) {
+        await gh.createRepo(token, ref, {
+          private: opts.createRepo.private,
+          description: `Published from Minerva — ${target.label}`,
+        });
+        repoCreated = true;
+      }
+    }
+  }
 
   ensurePublishCacheIgnored(rootPath);
   const workspace = path.join(rootPath, '.minerva', 'publish-cache', target.id);
@@ -83,6 +129,7 @@ export async function publishToGit(
     changes,
     committed: false,
     pushed: false,
+    ...(repoCreated ? { repoCreated: true } : {}),
   };
 
   // Dry-run stops here: the user sees exactly what would change, nothing ships.
@@ -99,7 +146,35 @@ export async function publishToGit(
   const sha = await pg.commit(workspace, message);
   await pg.push({ dir: workspace, branch: target.gitBranch, token });
 
-  return { ...base, committed: true, pushed: true, sha, commitMessage: message };
+  // Pages goes on AFTER the push: GitHub rejects a source branch that doesn't
+  // exist yet. Never fatal — the content is already published either way, so a
+  // Pages problem is reported beside the success, not raised over it.
+  const pages = ref ? await configurePages(token, ref, target.gitBranch, subdir) : {};
+
+  return { ...base, committed: true, pushed: true, sha, commitMessage: message, ...pages };
+}
+
+/** Point Pages at the freshly-pushed branch, reporting rather than throwing. */
+async function configurePages(
+  token: string,
+  ref: gh.GitHubRepoRef,
+  branch: string,
+  subdir: string,
+): Promise<{ pagesUrl?: string; pagesNote?: string }> {
+  const pagesPath = gh.pagesPathForSubdir(subdir);
+  if (!pagesPath) {
+    return {
+      pagesNote:
+        `GitHub Pages can only serve the repository root or /docs, so it wasn't configured for ` +
+        `"${subdir}". The files are pushed — point Pages at them yourself if you want a site.`,
+    };
+  }
+  try {
+    const url = await gh.enablePages(token, ref, { branch, path: pagesPath });
+    return url ? { pagesUrl: url } : {};
+  } catch (e) {
+    return { pagesNote: e instanceof Error ? e.message : String(e) };
+  }
 }
 
 /**

--- a/src/renderer/lib/components/PublishDialog.svelte
+++ b/src/renderer/lib/components/PublishDialog.svelte
@@ -169,6 +169,22 @@
     }
   }
 
+  /**
+   * Answer the "repository doesn't exist" prompt: create it, then publish for
+   * real. Reached only from the inline prompt, so the user has just chosen the
+   * visibility — nothing here happens on its own.
+   */
+  async function createRepoAndPublish(target: PublishTarget, isPrivate: boolean): Promise<void> {
+    busyId = target.id;
+    outcome = null;
+    try {
+      const res = await publish.toGit(target.id, { createRepo: { private: isPrivate } });
+      outcome = { targetId: target.id, dryRun: false, res };
+    } finally {
+      busyId = null;
+    }
+  }
+
   function counts(res: PublishGitResponse): string {
     if (!res.ok) return '';
     const c = res.result.changes;
@@ -238,6 +254,24 @@
                   <div class="outcome-head">Publish failed</div>
                   <pre class="raw">{res.error}</pre>
                   <button class="ghost small" onclick={() => copyError(res.error)}>Copy error</button>
+                {:else if res.result.repoMissing}
+                  <div class="outcome-head">Repository not found</div>
+                  <div class="muted">
+                    GitHub has no <code>{res.result.repoMissing.owner}/{res.result.repoMissing.repo}</code>
+                    — or your token can't see it. Nothing was published.
+                  </div>
+                  <div class="repo-create">
+                    <button onclick={() => void createRepoAndPublish(t, false)} disabled={busyId === t.id}>
+                      Create public repository &amp; publish
+                    </button>
+                    <button class="ghost" onclick={() => void createRepoAndPublish(t, true)} disabled={busyId === t.id}>
+                      Create private &amp; publish
+                    </button>
+                  </div>
+                  <div class="muted">
+                    GitHub Pages serves a private repository only on a paid plan. The branch
+                    <code>{res.result.branch}</code> is created by the first push either way.
+                  </div>
                 {:else if outcome.dryRun}
                   <div class="outcome-head">Preview — {counts(res)}</div>
                   {#if res.result.changes.length === 0}
@@ -259,6 +293,18 @@
                     <div class="muted">Uploaded to <code>s3://{t.bucket}{t.subdir && t.subdir !== '.' ? `/${t.subdir}` : ''}</code>.</div>
                   {:else}
                     <div class="muted">Pushed to <code>{res.result.branch}</code>{res.result.branchCreated ? ' (created)' : ''} · {res.result.sha?.slice(0, 7)} · {res.result.commitMessage}</div>
+                    {#if res.result.repoCreated}
+                      <div class="muted">Repository created.</div>
+                    {/if}
+                    {#if res.result.pagesUrl}
+                      {@const pagesUrl = res.result.pagesUrl}
+                      <div class="muted">
+                        Pages: <button class="link" onclick={() => void api.shell.openExternal(pagesUrl)}>{pagesUrl}</button>
+                        <span class="muted"> — the first build can take a minute.</span>
+                      </div>
+                    {:else if res.result.pagesNote}
+                      <div class="muted">{res.result.pagesNote}</div>
+                    {/if}
                   {/if}
                 {:else}
                   <div class="outcome-head">Up to date</div>
@@ -377,6 +423,12 @@
   button.primary { background: var(--accent); color: var(--accent-ink, #1a1a1a); border-color: transparent; }
   button.ghost { background: none; }
   button.small { padding: 2px 8px; font-size: 0.78rem; }
+
+  .repo-create { display: flex; gap: 8px; flex-wrap: wrap; margin: 8px 0; }
+  button.link {
+    background: none; border: none; padding: 0; color: var(--accent);
+    text-decoration: underline; font-size: inherit;
+  }
 
   .outcome { margin-top: 10px; padding: 10px 12px; border-radius: 6px; background: var(--bg-inset, var(--bg)); font-size: 0.84rem; }
   .outcome.error { border: 1px solid var(--accent, #c66); }

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -346,8 +346,17 @@ export interface PublishApi {
   upsertTarget(target: PublishTarget): Promise<PublishTarget[]>;
   /** Remove a target by id; resolves to the updated list. */
   removeTarget(id: string): Promise<PublishTarget[]>;
-  /** Export + commit + push (or, with `dryRun`, preview the diff only). */
-  toGit(targetId: string, opts?: { dryRun?: boolean }): Promise<PublishGitResponse>;
+  /**
+   * Export + commit + push (or, with `dryRun`, preview the diff only).
+   *
+   * A GitHub target whose repo doesn't exist comes back `ok: true` with
+   * `result.repoMissing` and nothing published — creating a repo needs an
+   * explicit answer, so the caller asks and calls again with `createRepo`.
+   */
+  toGit(
+    targetId: string,
+    opts?: { dryRun?: boolean; createRepo?: { private: boolean } },
+  ): Promise<PublishGitResponse>;
   /** Validate S3 credentials + endpoint against the bucket, before saving (#1444). */
   checkS3(config: {
     bucket: string;
@@ -401,6 +410,14 @@ export interface PublishGitResult {
   pushed: boolean;
   sha?: string;
   commitMessage?: string;
+  /** GitHub repo absent — NOTHING was published; ask, then retry with `createRepo`. */
+  repoMissing?: { owner: string; repo: string };
+  /** This run created the GitHub repo. */
+  repoCreated?: boolean;
+  /** GitHub Pages site URL, once Pages serves this branch. */
+  pagesUrl?: string;
+  /** Why Pages wasn't configured, when it couldn't be. */
+  pagesNote?: string;
 }
 
 /** Publish returns a result-or-error union so the dialog can show the raw

--- a/src/renderer/lib/stores/publish.svelte.ts
+++ b/src/renderer/lib/stores/publish.svelte.ts
@@ -13,7 +13,8 @@ export function getPublishStore() {
   return {
     runExport: (args: Parameters<typeof api.publish.runExport>[0]) =>
       api.publish.runExport(args),
-    toGit: (targetId: string, opts?: { dryRun?: boolean }) => api.publish.toGit(targetId, opts),
+    toGit: (targetId: string, opts?: { dryRun?: boolean; createRepo?: { private: boolean } }) =>
+      api.publish.toGit(targetId, opts),
     upsertTarget: (target: Parameters<typeof api.publish.upsertTarget>[0]) =>
       api.publish.upsertTarget(target),
     removeTarget: (id: string) => api.publish.removeTarget(id),

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -323,7 +323,10 @@ export interface ChannelMap {
   'publish:listTargets': () => PublishTarget[];
   'publish:upsertTarget': (target: PublishTarget) => PublishTarget[];
   'publish:removeTarget': (id: string) => PublishTarget[];
-  'publish:toGit': (targetId: string, opts?: { dryRun?: boolean }) =>
+  'publish:toGit': (
+    targetId: string,
+    opts?: { dryRun?: boolean; createRepo?: { private: boolean } },
+  ) =>
     | { ok: true; result: {
         targetId: string;
         dryRun: boolean;
@@ -334,6 +337,10 @@ export interface ChannelMap {
         pushed: boolean;
         sha?: string;
         commitMessage?: string;
+        repoMissing?: { owner: string; repo: string };
+        repoCreated?: boolean;
+        pagesUrl?: string;
+        pagesNote?: string;
       } }
     | { ok: false; error: string };
   /** Validate S3 credentials + endpoint against the bucket, before saving (#1444). */

--- a/tests/main/git/publish-git.test.ts
+++ b/tests/main/git/publish-git.test.ts
@@ -23,6 +23,7 @@ import {
   renderCommitMessage,
   resolveGitHubToken,
   pendingChanges,
+  prepareWorkspace,
   stageAll,
   commit,
 } from '../../../src/main/git/publish-git';
@@ -78,6 +79,76 @@ describe('resolveGitHubToken', () => {
   it('throws a configuration message when nothing is available', () => {
     hoisted.execFileSync.mockImplementation(() => { throw new Error('gh: not found'); });
     expect(() => resolveGitHubToken()).toThrow(/credentials aren't configured/i);
+  });
+});
+
+describe('prepareWorkspace — the clone is not to be taken at its word', () => {
+  // These drive the REAL prepareWorkspace with only `git.clone` stubbed, so the
+  // post-clone verification, the init fallback, and the resulting branch are
+  // all the genuine article.
+  let dir: string;
+
+  beforeEach(() => { dir = mkdtempSync(path.join(os.tmpdir(), 'minerva-prep-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); vi.restoreAllMocks(); });
+
+  it('starts a fresh repo ON the branch when the remote has no refs at all', async () => {
+    // The first-publish case. isomorphic-git's clone returns early without
+    // throwing and without checking out when the remote advertises no refs
+    // (`if (fetchHead === null) return`), leaving HEAD on the default branch
+    // name — so trusting "it didn't throw" put the commit on `master` and the
+    // push of `gh-pages` died with "Could not find gh-pages."
+    vi.spyOn(git, 'clone').mockImplementation(async ({ dir: d }) => {
+      // Reproduce what an empty-remote clone leaves behind.
+      await git.init({ fs: fsMod, dir: d, defaultBranch: 'master' });
+    });
+
+    const res = await prepareWorkspace({ dir, url: 'https://github.com/o/r.git', branch: 'gh-pages', token: 't' });
+
+    expect(res.branchExisted).toBe(false);
+    expect(await git.currentBranch({ fs: fsMod, dir })).toBe('gh-pages');
+  });
+
+  it('keeps the clone when it really did land on the branch', async () => {
+    vi.spyOn(git, 'clone').mockImplementation(async ({ dir: d }) => {
+      const at = d;
+      await git.init({ fs: fsMod, dir: at, defaultBranch: 'gh-pages' });
+      writeFileSync(path.join(at, 'index.html'), '<h1>old</h1>');
+      await git.add({ fs: fsMod, dir: at, filepath: 'index.html' });
+      await git.commit({ fs: fsMod, dir: at, message: 'prior publish', author: { name: 'M', email: 'm@m' } });
+    });
+
+    const res = await prepareWorkspace({ dir, url: 'https://github.com/o/r.git', branch: 'gh-pages', token: 't' });
+
+    expect(res.branchExisted).toBe(true);
+    // The cloned history survives — this is the incremental-publish path.
+    expect(await git.log({ fs: fsMod, dir, depth: 1 })).toHaveLength(1);
+  });
+
+  it('falls back to a fresh repo when the clone throws (branch absent)', async () => {
+    vi.spyOn(git, 'clone').mockRejectedValue(new Error('Could not find gh-pages.'));
+
+    const res = await prepareWorkspace({ dir, url: 'https://github.com/o/r.git', branch: 'gh-pages', token: 't' });
+
+    expect(res.branchExisted).toBe(false);
+    expect(await git.currentBranch({ fs: fsMod, dir })).toBe('gh-pages');
+    expect(await git.listRemotes({ fs: fsMod, dir })).toEqual([
+      { remote: 'origin', url: 'https://github.com/o/r.git' },
+    ]);
+  });
+
+  it('leaves a workspace a commit can actually be pushed from', async () => {
+    // The end-to-end shape of the bug: init on the wrong branch is only fatal
+    // later, at push time, so assert the branch a commit lands on.
+    vi.spyOn(git, 'clone').mockImplementation(async ({ dir: d }) => {
+      await git.init({ fs: fsMod, dir: d, defaultBranch: 'master' });
+    });
+    await prepareWorkspace({ dir, url: 'https://github.com/o/r.git', branch: 'gh-pages', token: 't' });
+
+    writeFileSync(path.join(dir, 'index.html'), '<h1>hi</h1>');
+    await stageAll(dir);
+    await commit(dir, 'Publish');
+
+    expect(await git.listBranches({ fs: fsMod, dir })).toEqual(['gh-pages']);
   });
 });
 

--- a/tests/main/publish/github-repo.test.ts
+++ b/tests/main/publish/github-repo.test.ts
@@ -19,6 +19,7 @@ import {
   createRepo,
   enablePages,
   getPagesUrl,
+  waitForRepo,
   pagesPathForSubdir,
 } from '../../../src/main/git/github-repo';
 
@@ -157,9 +158,69 @@ describe('enablePages', () => {
       .rejects.toThrow(/Pages: write.*paid GitHub plan/s);
   });
 
+  it('waits out a 500 and succeeds on a later try', async () => {
+    // Seen in the field on a first publish: Pages 500s while it catches up with
+    // a branch pushed seconds ago, and the identical request then works.
+    const slept: number[] = [];
+    queue = [
+      { status: 500 },
+      { status: 500 },
+      { status: 201, body: { html_url: 'https://dave.github.io/notes/' } },
+    ];
+    const url = await enablePages('tok', ref, {
+      branch: 'gh-pages', path: '/', sleep: async (ms) => { slept.push(ms); },
+    });
+
+    expect(url).toBe('https://dave.github.io/notes/');
+    expect(calls).toHaveLength(3);
+    expect(slept).toEqual([1000, 2000]); // backs off rather than hammering
+  });
+
+  it('gives up on a persistent 500 by telling you where to finish the job', async () => {
+    queue = [{ status: 500 }, { status: 500 }, { status: 500 }, { status: 500 }];
+    await expect(enablePages('tok', ref, {
+      branch: 'gh-pages', path: '/', sleep: async () => {},
+    })).rejects.toThrow(/content is pushed to gh-pages.*Settings → Pages/s);
+  });
+
+  it('does not retry a 4xx — that is a real answer', async () => {
+    queue = [{ status: 422 }, { status: 201, body: { html_url: 'nope' } }];
+    await expect(enablePages('tok', ref, {
+      branch: 'gh-pages', path: '/', sleep: async () => {},
+    })).rejects.toThrow(/422/);
+    expect(calls).toHaveLength(1);
+  });
+
   it('getPagesUrl stays quiet when Pages is off', async () => {
     queue = [{ status: 404 }];
     expect(await getPagesUrl('tok', ref)).toBeNull();
+  });
+});
+
+describe('waitForRepo', () => {
+  const ref = { owner: 'dave', repo: 'notes' };
+
+  it('polls until the just-created repo answers', async () => {
+    // `POST /user/repos` returns 201 before the repo takes git traffic, so the
+    // first push 404'd on a repo GitHub had just said it created.
+    const slept: number[] = [];
+    queue = [{ status: 404 }, { status: 404 }, { status: 200 }];
+    await waitForRepo('tok', ref, { sleep: async (ms) => { slept.push(ms); } });
+
+    expect(calls).toHaveLength(3);
+    expect(slept).toEqual([250, 500]);
+  });
+
+  it('returns immediately when the repo is already live', async () => {
+    queue = [{ status: 200 }];
+    await waitForRepo('tok', ref, { sleep: async () => {} });
+    expect(calls).toHaveLength(1);
+  });
+
+  it('gives up with "publish again" rather than claiming something is broken', async () => {
+    queue = Array.from({ length: 6 }, () => ({ status: 404 }));
+    await expect(waitForRepo('tok', ref, { attempts: 6, sleep: async () => {} }))
+      .rejects.toThrow(/Publish again in a moment/);
   });
 });
 

--- a/tests/main/publish/github-repo.test.ts
+++ b/tests/main/publish/github-repo.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment node
+ *
+ * GitHub repo + Pages provisioning (#254 follow-on).
+ *
+ * `fetch` is stubbed, so these pin the parts that are ours rather than
+ * GitHub's: which endpoint a creation goes to (user vs org), that Pages
+ * already-on is a success and not an error, that a subdirectory Pages can't
+ * serve is refused up front, and — most importantly — that each HTTP status
+ * turns into a message naming the actual problem. A token that can push but
+ * can't create is the failure users will actually hit, and "403" alone doesn't
+ * tell them to go add a scope.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  parseGitHubRepo,
+  repoSlug,
+  checkRepoExists,
+  createRepo,
+  enablePages,
+  getPagesUrl,
+  pagesPathForSubdir,
+} from '../../../src/main/git/github-repo';
+
+interface Call { url: string; method: string; body: unknown }
+
+let calls: Call[] = [];
+/** Queue of responses, consumed in order. */
+let queue: Array<{ status: number; body?: unknown }> = [];
+
+function respond(): Response {
+  const next = queue.shift() ?? { status: 500 };
+  const ok = next.status >= 200 && next.status < 300;
+  return {
+    ok,
+    status: next.status,
+    statusText: String(next.status),
+    json: async () => next.body ?? {},
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  calls = [];
+  queue = [];
+  vi.stubGlobal('fetch', (url: string, init?: RequestInit) => {
+    calls.push({
+      url,
+      method: init?.method ?? 'GET',
+      body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+    });
+    return Promise.resolve(respond());
+  });
+});
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe('parseGitHubRepo', () => {
+  it('reads owner/repo from the forms a user might paste', () => {
+    expect(parseGitHubRepo('https://github.com/dave/notes.git')).toEqual({ owner: 'dave', repo: 'notes' });
+    expect(parseGitHubRepo('https://github.com/dave/notes')).toEqual({ owner: 'dave', repo: 'notes' });
+    expect(parseGitHubRepo('https://github.com/dave/notes/')).toEqual({ owner: 'dave', repo: 'notes' });
+    expect(repoSlug({ owner: 'dave', repo: 'notes' })).toBe('dave/notes');
+  });
+
+  it('returns null for anything that is not a plain github.com repo', () => {
+    // The signal that means "leave this target alone" — a GitLab or Codeberg
+    // remote still pushes fine, it just gets no provisioning.
+    expect(parseGitHubRepo('https://gitlab.com/dave/notes.git')).toBeNull();
+    expect(parseGitHubRepo('https://codeberg.org/dave/notes')).toBeNull();
+    expect(parseGitHubRepo('https://github.example.com/dave/notes')).toBeNull();
+    expect(parseGitHubRepo('https://github.com/dave')).toBeNull();
+    expect(parseGitHubRepo('https://github.com/dave/notes/tree/main')).toBeNull();
+    expect(parseGitHubRepo('not a url')).toBeNull();
+  });
+});
+
+describe('checkRepoExists', () => {
+  const ref = { owner: 'dave', repo: 'notes' };
+
+  it('reads 200 as exists and 404 as missing', async () => {
+    queue = [{ status: 200 }];
+    expect(await checkRepoExists('tok', ref)).toBe('exists');
+    queue = [{ status: 404 }];
+    expect(await checkRepoExists('tok', ref)).toBe('missing');
+    expect(calls[0]!.url).toBe('https://api.github.com/repos/dave/notes');
+  });
+
+  it('separates a bad token from a missing repo', async () => {
+    queue = [{ status: 401 }];
+    await expect(checkRepoExists('tok', ref)).rejects.toThrow(/rejected the token/i);
+  });
+});
+
+describe('createRepo', () => {
+  it('creates under the token account via /user/repos', async () => {
+    queue = [{ status: 200, body: { login: 'dave' } }, { status: 201 }];
+    await createRepo('tok', { owner: 'dave', repo: 'notes' }, { private: false });
+
+    expect(calls[1]!.url).toBe('https://api.github.com/user/repos');
+    expect(calls[1]!.method).toBe('POST');
+    expect(calls[1]!.body).toMatchObject({ name: 'notes', private: false, auto_init: false });
+  });
+
+  it('creates under an organization when the owner is not the token account', async () => {
+    queue = [{ status: 200, body: { login: 'dave' } }, { status: 201 }];
+    await createRepo('tok', { owner: 'acme-corp', repo: 'notes' }, { private: true });
+
+    expect(calls[1]!.url).toBe('https://api.github.com/orgs/acme-corp/repos');
+    expect(calls[1]!.body).toMatchObject({ private: true });
+  });
+
+  it('matches the login case-insensitively', async () => {
+    queue = [{ status: 200, body: { login: 'Dave' } }, { status: 201 }];
+    await createRepo('tok', { owner: 'dave', repo: 'notes' }, { private: false });
+    expect(calls[1]!.url).toBe('https://api.github.com/user/repos');
+  });
+
+  it('says a token that can push may still not be able to create', async () => {
+    queue = [{ status: 200, body: { login: 'dave' } }, { status: 403 }];
+    await expect(createRepo('tok', { owner: 'dave', repo: 'notes' }, { private: false }))
+      .rejects.toThrow(/`repo` scope; a fine-grained one needs Administration: write/);
+  });
+
+  it('names the owner GitHub could not find', async () => {
+    queue = [{ status: 200, body: { login: 'dave' } }, { status: 404 }];
+    await expect(createRepo('tok', { owner: 'ghost-org', repo: 'notes' }, { private: false }))
+      .rejects.toThrow(/"ghost-org"/);
+  });
+
+  it('reports a name collision as such', async () => {
+    queue = [{ status: 200, body: { login: 'dave' } }, { status: 422 }];
+    await expect(createRepo('tok', { owner: 'dave', repo: 'notes' }, { private: false }))
+      .rejects.toThrow(/may already exist/);
+  });
+});
+
+describe('enablePages', () => {
+  const ref = { owner: 'dave', repo: 'notes' };
+
+  it('points Pages at the branch and returns the site URL', async () => {
+    queue = [{ status: 201, body: { html_url: 'https://dave.github.io/notes/' } }];
+    const url = await enablePages('tok', ref, { branch: 'gh-pages', path: '/' });
+
+    expect(url).toBe('https://dave.github.io/notes/');
+    expect(calls[0]!.url).toBe('https://api.github.com/repos/dave/notes/pages');
+    expect(calls[0]!.body).toEqual({ source: { branch: 'gh-pages', path: '/' } });
+  });
+
+  it('treats already-enabled (409) as fine and reads the URL back', async () => {
+    queue = [{ status: 409 }, { status: 200, body: { html_url: 'https://dave.github.io/notes/' } }];
+    expect(await enablePages('tok', ref, { branch: 'gh-pages', path: '/' }))
+      .toBe('https://dave.github.io/notes/');
+  });
+
+  it('explains a 403 as scope-or-paid-plan rather than leaving a bare status', async () => {
+    queue = [{ status: 403 }];
+    await expect(enablePages('tok', ref, { branch: 'gh-pages', path: '/' }))
+      .rejects.toThrow(/Pages: write.*paid GitHub plan/s);
+  });
+
+  it('getPagesUrl stays quiet when Pages is off', async () => {
+    queue = [{ status: 404 }];
+    expect(await getPagesUrl('tok', ref)).toBeNull();
+  });
+});
+
+describe('pagesPathForSubdir', () => {
+  it('maps the two locations Pages can serve', () => {
+    expect(pagesPathForSubdir('')).toBe('/');
+    expect(pagesPathForSubdir(undefined)).toBe('/');
+    expect(pagesPathForSubdir('.')).toBe('/');
+    expect(pagesPathForSubdir('docs')).toBe('/docs');
+    expect(pagesPathForSubdir('/docs/')).toBe('/docs');
+  });
+
+  it('refuses a subdirectory Pages cannot serve, rather than guessing', () => {
+    // Publishing into `site/` is a perfectly valid git push — it just can't be
+    // wired to Pages, and the caller says so instead of enabling the wrong path.
+    expect(pagesPathForSubdir('site')).toBeNull();
+    expect(pagesPathForSubdir('public/web')).toBeNull();
+  });
+});

--- a/tests/main/publish/publish-to-git.test.ts
+++ b/tests/main/publish/publish-to-git.test.ts
@@ -35,6 +35,11 @@ const h = vi.hoisted(() => {
       commit: vi.fn(async () => 'sha_abc'),
       push: vi.fn(async () => {}),
     },
+    gh: {
+      checkRepoExists: vi.fn<() => Promise<'exists' | 'missing'>>(async () => 'exists'),
+      createRepo: vi.fn(async () => {}),
+      enablePages: vi.fn<() => Promise<string | null>>(async () => 'https://o.github.io/r/'),
+    },
   };
 });
 
@@ -43,6 +48,12 @@ vi.mock('../../../src/main/publish/run-export', () => ({ runExport: h.runExport 
 vi.mock('../../../src/main/git/publish-git', async (orig) => {
   const actual = await orig<typeof import('../../../src/main/git/publish-git')>();
   return { ...actual, ...h.pg }; // keep pure helpers (renderCommitMessage) real
+});
+// Only the three network calls are stubbed; parseGitHubRepo / pagesPathForSubdir
+// stay real, so "is this even a GitHub remote" is decided by the actual rule.
+vi.mock('../../../src/main/git/github-repo', async (orig) => {
+  const actual = await orig<typeof import('../../../src/main/git/github-repo')>();
+  return { ...actual, ...h.gh };
 });
 
 import { publishToGit } from '../../../src/main/publish/publish-to-git';
@@ -56,7 +67,10 @@ beforeEach(() => {
     subdir: '', commitMessageTemplate: 'Publish {{date}} v{{version}}',
   };
   Object.values(h.pg).forEach((fn) => fn.mockClear());
+  Object.values(h.gh).forEach((fn) => fn.mockClear());
   h.pg.pendingChanges.mockResolvedValue([]);
+  h.gh.checkRepoExists.mockResolvedValue('exists');
+  h.gh.enablePages.mockResolvedValue('https://o.github.io/r/');
   h.runExport.mockClear();
 });
 
@@ -111,5 +125,94 @@ describe('publishToGit', () => {
     await publishToGit(root, 't', { ...opts, dryRun: true });
     const ignore = readFileSync(path.join(root, '.minerva', '.gitignore'), 'utf-8');
     expect(ignore).toContain('publish-cache/');
+  });
+});
+
+describe('publishToGit — GitHub repo provisioning', () => {
+  it('stops before doing ANY work when the repo is missing and nobody has said to create it', async () => {
+    h.gh.checkRepoExists.mockResolvedValue('missing');
+    const res = await publishToGit(root, 't', opts);
+
+    expect(res.repoMissing).toEqual({ owner: 'o', repo: 'r' });
+    expect(res.committed).toBe(false);
+    expect(res.pushed).toBe(false);
+    // Nothing was created, and no export ran — the user hasn't answered yet.
+    expect(h.gh.createRepo).not.toHaveBeenCalled();
+    expect(h.runExport).not.toHaveBeenCalled();
+    expect(h.pg.prepareWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('creates the repo and publishes once permission is given', async () => {
+    h.gh.checkRepoExists.mockResolvedValue('missing');
+    h.pg.pendingChanges.mockResolvedValue([{ path: 'index.html', status: 'added' }]);
+    const res = await publishToGit(root, 't', { ...opts, createRepo: { private: false } });
+
+    expect(h.gh.createRepo).toHaveBeenCalledWith('tok', { owner: 'o', repo: 'r' }, expect.objectContaining({ private: false }));
+    expect(res.repoCreated).toBe(true);
+    expect(res.pushed).toBe(true);
+  });
+
+  it('carries the private choice through', async () => {
+    h.gh.checkRepoExists.mockResolvedValue('missing');
+    await publishToGit(root, 't', { ...opts, createRepo: { private: true } });
+    expect(h.gh.createRepo).toHaveBeenCalledWith('tok', expect.anything(), expect.objectContaining({ private: true }));
+  });
+
+  it('never creates anything on a dry run', async () => {
+    h.gh.checkRepoExists.mockResolvedValue('missing');
+    const res = await publishToGit(root, 't', { ...opts, dryRun: true, createRepo: { private: false } });
+    expect(h.gh.createRepo).not.toHaveBeenCalled();
+    expect(res.repoCreated).toBeUndefined();
+  });
+
+  it('leaves a non-GitHub remote entirely alone', async () => {
+    h.target.gitRemote = 'https://gitlab.com/o/r.git';
+    h.pg.pendingChanges.mockResolvedValue([{ path: 'index.html', status: 'added' }]);
+    const res = await publishToGit(root, 't', opts);
+
+    expect(h.gh.checkRepoExists).not.toHaveBeenCalled();
+    expect(h.gh.enablePages).not.toHaveBeenCalled();
+    expect(res.pushed).toBe(true);
+    expect(res.pagesUrl).toBeUndefined();
+  });
+});
+
+describe('publishToGit — GitHub Pages', () => {
+  beforeEach(() => {
+    h.pg.pendingChanges.mockResolvedValue([{ path: 'index.html', status: 'added' }]);
+  });
+
+  it('configures Pages AFTER the push and reports the site URL', async () => {
+    const res = await publishToGit(root, 't', opts);
+
+    expect(h.gh.enablePages).toHaveBeenCalledWith('tok', { owner: 'o', repo: 'r' }, { branch: 'gh-pages', path: '/' });
+    expect(res.pagesUrl).toBe('https://o.github.io/r/');
+    // Pages rejects a branch that doesn't exist yet, so the order matters.
+    expect(h.gh.enablePages.mock.invocationCallOrder[0]!)
+      .toBeGreaterThan(h.pg.push.mock.invocationCallOrder[0]!);
+  });
+
+  it('maps a docs/ subdir to the /docs Pages path', async () => {
+    h.target.subdir = 'docs';
+    await publishToGit(root, 't', opts);
+    expect(h.gh.enablePages).toHaveBeenCalledWith('tok', expect.anything(), { branch: 'gh-pages', path: '/docs' });
+  });
+
+  it('explains rather than guesses when the subdir is one Pages cannot serve', async () => {
+    h.target.subdir = 'site';
+    const res = await publishToGit(root, 't', opts);
+
+    expect(h.gh.enablePages).not.toHaveBeenCalled();
+    expect(res.pagesNote).toMatch(/root or \/docs/);
+    expect(res.pushed).toBe(true); // the push still happened
+  });
+
+  it('reports a Pages failure beside the successful publish, not instead of it', async () => {
+    h.gh.enablePages.mockRejectedValue(new Error('Pages needs a paid plan for private repos.'));
+    const res = await publishToGit(root, 't', opts);
+
+    expect(res.pushed).toBe(true);
+    expect(res.sha).toBe('sha_abc');
+    expect(res.pagesNote).toMatch(/paid plan/);
   });
 });

--- a/tests/main/publish/publish-to-git.test.ts
+++ b/tests/main/publish/publish-to-git.test.ts
@@ -38,6 +38,7 @@ const h = vi.hoisted(() => {
     gh: {
       checkRepoExists: vi.fn<() => Promise<'exists' | 'missing'>>(async () => 'exists'),
       createRepo: vi.fn(async () => {}),
+      waitForRepo: vi.fn(async () => {}),
       enablePages: vi.fn<() => Promise<string | null>>(async () => 'https://o.github.io/r/'),
     },
   };
@@ -150,6 +151,20 @@ describe('publishToGit — GitHub repo provisioning', () => {
     expect(h.gh.createRepo).toHaveBeenCalledWith('tok', { owner: 'o', repo: 'r' }, expect.objectContaining({ private: false }));
     expect(res.repoCreated).toBe(true);
     expect(res.pushed).toBe(true);
+  });
+
+  it('waits for the new repo to come up BEFORE pushing to it', async () => {
+    // The first real run failed exactly here: 201 from the create, then a 404
+    // from the push, because the repo wasn't taking git traffic yet.
+    h.gh.checkRepoExists.mockResolvedValue('missing');
+    h.pg.pendingChanges.mockResolvedValue([{ path: 'index.html', status: 'added' }]);
+    await publishToGit(root, 't', { ...opts, createRepo: { private: false } });
+
+    expect(h.gh.waitForRepo).toHaveBeenCalledWith('tok', { owner: 'o', repo: 'r' });
+    expect(h.gh.waitForRepo.mock.invocationCallOrder[0]!)
+      .toBeGreaterThan(h.gh.createRepo.mock.invocationCallOrder[0]!);
+    expect(h.gh.waitForRepo.mock.invocationCallOrder[0]!)
+      .toBeLessThan(h.pg.push.mock.invocationCallOrder[0]!);
   });
 
   it('carries the private choice through', async () => {


### PR DESCRIPTION
Very doable, as it turned out — because **half of it already worked**.

## What was already there

`prepareWorkspace` clones the target branch, and when that fails it falls back to `git init` on that branch + `addRemote`; the push then creates the branch remotely. The dry run already reports `branchCreated` and the dialog already says *"Branch `gh-pages` will be created."* So **branch creation has worked all along** — for a repo that exists.

What the git protocol can't do is create the repository, which is why a first publish to a not-yet-created repo failed with `git push was rejected: …` — a 404 wearing a push rejection's clothes. And even after creating it by hand you still had to go turn Pages on in GitHub's settings.

## What's new

`src/main/git/github-repo.ts` — narrow, `fetch`-only, no SDK, no Electron import, every function taking an explicit token:

- `parseGitHubRepo` — owner/repo, or **null for any non-github.com remote**, which is the "leave this target alone" signal. GitLab and Codeberg targets take none of this path.
- `checkRepoExists` — 200/404, with 401 separated out as a token problem.
- `createRepo` — routes to `/user/repos` when the owner *is* the token's account and `/orgs/{owner}/repos` otherwise; `auto_init: false` so the publish push writes the first commit rather than landing on top of a README.
- `enablePages` / `getPagesUrl` / `pagesPathForSubdir`.

## Consent, since this creates things on your account

A missing repo comes back as `result.repoMissing` with **nothing published and no export even run** — the flow stops before doing work. The dialog then offers **Create public repository & publish** / **Create private & publish**, and the second call carries the answer through `createRepo: { private }`. A dry run creates nothing at all, and simply reports the repo is missing.

## Pages

Configured **after** the push, because Pages rejects a source branch that doesn't exist yet (there's a test asserting the call order for exactly that reason). It **never fails the publish**: the content is already live by then, so a Pages problem is reported beside the success as `pagesNote` rather than raised over it. Already-enabled (409) is a success — the existing config is read back so you still get a URL. The dialog links the site with a note that the first build takes a minute.

A target publishing into any subdir other than root or `docs/` is told plainly that Pages can't serve it, instead of being quietly wired to the wrong path.

## Error messages are most of the work

The failure people will actually hit is a token that can **push** but can't **create** — different permission entirely. A bare "403" doesn't tell anyone what to do, so 403 on create says a classic token needs `repo` scope and a fine-grained one needs Administration: write; 403 on Pages names Pages: write *and* the paid-plan requirement for private repos; 404 on create names the owner it couldn't find. Each has a test.

One thing I deliberately did **not** paper over: GitHub returns 404 both for "no such repo" and "a private repo your token can't see". The code doesn't pretend to tell them apart, and the prompt says "or your token can't see it".

## Tests

- `github-repo.test.ts` (16 new, stubbed `fetch`): URL parsing incl. every non-GitHub form, user-vs-org routing, case-insensitive login match, each error status → its message, 409-is-success, subdir mapping.
- `publish-to-git.test.ts` (+9): missing repo stops before any export or workspace prep; permission given creates and publishes; the private choice carries; dry run creates nothing; a non-GitHub remote makes zero API calls; Pages runs after the push; `docs/` maps to `/docs`; an unservable subdir explains itself; a Pages failure leaves the publish successful.

`pnpm lint` clean; `pnpm test` 5753 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)