### PR TITLE
docs: inspections re-check when you save

### DIFF
--- a/tests/scripts/__snapshots__/help-docs-corpus-staleness.test.ts.snap
+++ b/tests/scripts/__snapshots__/help-docs-corpus-staleness.test.ts.snap
@@ -337,6 +337,7 @@ exports[`help-docs corpus staleness (#1288) > chunk ids freshly extracted from w
   "right-sidebar-inspections.html#fixing",
   "right-sidebar-inspections.html#reading",
   "right-sidebar-inspections.html#running",
+  "right-sidebar-inspections.html#running",
   "right-sidebar-inspections.html#scope",
   "right-sidebar-inspections.html#settings",
   "right-sidebar-inspections.html#what",

--- a/website/docs/right-sidebar-inspections.html
+++ b/website/docs/right-sidebar-inspections.html
@@ -94,8 +94,22 @@
     <p class="lede">Inspections are standing checks Minerva can run over your whole thoughtbase — links that point at nothing, notes quietly drifting out of date, sources missing the details a citation needs. The panel lists what they found, in the order worth caring about, and for many of them it can do the fixing for you. Nothing here changes a note on its own.</p>
 
     <h2 id="running">When the checks run</h2>
-    <p>Mostly, without you asking. Minerva runs them once when you open a thoughtbase and every few minutes after that, so the panel already has something to show when you open it from the right sidebar's <b>Activity</b> group.</p>
-    <p><b>Run</b> forces an immediate re-check — worth pressing after a big reorganization, or when you've just fixed a batch of things and want the list to catch up rather than waiting for the next pass.</p>
+    <p>Mostly, without you asking:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">When you save</div>
+        <div class="v">A couple of seconds after any change to a note, the checks run again — so if you've just broken a link, the panel says so while you're still looking at the note that did it. A burst of changes (a folder move, a batch of AI edits) settles into one pass rather than one per file.</div>
+      </div>
+      <div class="row">
+        <div class="k">When you open a thoughtbase</div>
+        <div class="v">Once at the start, so the panel has something to show the moment you open it from the right sidebar's <b>Activity</b> group.</div>
+      </div>
+      <div class="row">
+        <div class="k">Every few minutes</div>
+        <div class="v">A quiet backstop for the checks that go off with the calendar rather than with an edit — a note becoming stale, or a stub ageing past its threshold. Nothing changes in your notes when that happens, so there'd otherwise be nothing to trigger a re-check.</div>
+      </div>
+    </div>
+    <p>There's also a <b>Run</b> button, if you'd rather not wait the couple of seconds — or you've changed which checks are switched on and want the list to catch up straight away.</p>
 
     <div class="box">
       <span class="label">Broken links get flagged twice, on purpose</span>

--- a/website/docs/settings-inspections.html
+++ b/website/docs/settings-inspections.html
@@ -99,7 +99,7 @@
     <p>Each check has a switch and a line saying what it looks for, grouped by what it's about: <b>Notes</b>, <b>Links</b>, and <b>Sources</b>. Everything is on to begin with. Switch off anything that isn't telling you something you'd act on — a thoughtbase of daily journal entries doesn't need to hear that its notes are old, and a set of working drafts doesn't need every unfinished link flagged.</p>
     <p><b>Enable all</b> and <b>Disable all</b> are there for the two moments you want them: setting up, and starting over.</p>
     <p>A check you switch off isn't quietly filtered out of the results — it doesn't run at all. Several read your whole knowledge graph, so switching off the ones you don't want makes a run over a large thoughtbase noticeably quicker. That applies to the automatic runs too, not just the ones you ask for.</p>
-    <p>Changes take effect on the next run; press <b>Run</b> in the Inspections panel if you'd rather not wait for it.</p>
+    <p>Changes take effect on the next run — which is usually a couple of seconds after your next save. Press <b>Run</b> in the Inspections panel if you want the list to catch up immediately.</p>
 
     <h2 id="thresholds">How long is "a while"?</h2>
     <p>Two checks measure time, and neither has a right answer that suits everybody:</p>


### PR DESCRIPTION
Follows #1794. The pages said "once at open, then every few minutes" — true when written, no longer the interesting part.

## What changed

**"When the checks run"** now leads with the case that matters:

> **When you save** — A couple of seconds after any change to a note, the checks run again, so if you've just broken a link the panel says so while you're still looking at the note that did it.

then project open, then the periodic pass.

Two things I made a point of saying:

- **The periodic pass is described as what it now is** — a backstop for the checks that go off with the *calendar* rather than with an edit (a note becoming stale, a stub ageing past its threshold), and an explicit note that nothing changes in your notes when that happens, so there'd otherwise be nothing to trigger a re-check. Without that, a reader sees two overlapping mechanisms and assumes one is redundant.
- **A burst settles into one pass.** "Runs after every save" invites the reasonable worry that a folder move means one pass per file. It doesn't, and saying so costs a sentence.

**Run** is now framed as "if you'd rather not wait the couple of seconds", which is what it's actually for now.

The settings page gets the corollary: a change to which checks run takes effect on the next run, which is usually seconds away rather than up to five minutes.

Corpus snapshot regenerated (one section grew past the chunk size and split — no section renamed or lost); both pages structurally validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)