### PR TITLE
fix(llm): name the provider that actually needs setting up

### DIFF
--- a/src/main/llm/provider/index.ts
+++ b/src/main/llm/provider/index.ts
@@ -6,11 +6,11 @@
  * (BYOM #1495) — so the caller passes its resolved model in.
  */
 import { getSettings } from '../settings';
-import { MISSING_API_KEY_MARKER } from '../../../shared/llm-errors';
+import { missingApiKeyMessage, missingBaseUrlMessage } from '../../../shared/llm-errors';
 import { DEFAULT_WEB_SETTINGS, type LLMSettings } from '../../../shared/tools/types';
 import type { Effort } from '../../../shared/tools/effort';
 import { providerForModel } from '../../../shared/tools/models';
-import { PROVIDERS, type ProviderId } from '../../../shared/tools/providers';
+import { type ProviderId } from '../../../shared/tools/providers';
 import { AnthropicProvider } from './anthropic';
 import { OpenAIProvider } from './openai';
 import { GoogleProvider } from './google';
@@ -28,11 +28,10 @@ export interface ResolvedProvider {
 }
 
 /** The marker error the renderer detects to show the "Open Settings"
- *  affordance, named per provider so the message is honest. */
+ *  affordance. Built in `shared/llm-errors.ts` beside the parser that reads
+ *  the provider back out, so the two can't drift. */
 function missingKeyError(id: ProviderId): Error {
-  const meta = PROVIDERS[id];
-  const env = meta.envVar ? ` or the ${meta.envVar} environment variable` : '';
-  return new Error(`${MISSING_API_KEY_MARKER}. Set the ${meta.label} API key in the LLM settings${env}.`);
+  return new Error(missingApiKeyMessage(id));
 }
 
 /**
@@ -72,9 +71,10 @@ function buildProvider(id: ProviderId, settings: LLMSettings): LLMProvider {
       // local servers). Reports id 'local' for provenance.
       const c = settings.providers.local;
       if (!c?.baseURL) {
-        throw new Error(
-          `${MISSING_API_KEY_MARKER}. Set a base URL for the ${PROVIDERS.local.label} endpoint in the LLM settings.`,
-        );
+        // Same channel as a missing key — the renderer's "open Settings"
+        // affordance fires for either — but the local provider needs an
+        // ADDRESS, not a key, so it says so.
+        throw new Error(missingBaseUrlMessage('local'));
       }
       return new OpenAIProvider(c.apiKey ?? '', c.baseURL, undefined, 'local');
     }

--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -98,7 +98,8 @@
   import { describeProposer } from '../shared/provenance';
   import { CONFIRM_KEYS } from './lib/confirm-keys';
   import { sectionAnchorAt } from './lib/markdown/headings';
-  import { isMissingApiKeyError } from '../shared/llm-errors';
+  import { isProviderUnconfiguredError, unconfiguredProvider } from '../shared/llm-errors';
+  import { PROVIDERS } from '../shared/tools/providers';
   import { runCellWithTrust } from './lib/compute/run-cell-with-trust';
   import { findRunnableFences, RUNNABLE_LANGUAGE_SET } from '../shared/compute/fences';
   import { toggleTaskOnLine } from './lib/editor/task-toggle';
@@ -233,7 +234,7 @@
 
   // Surface the missing-API-key dialog whenever the conversations
   // store flags it. The store flips the flag from its send() catch
-  // block on `isMissingApiKeyError`; we read the flag here (which makes
+  // block on `isProviderUnconfiguredError`; we read the flag here (which makes
   // it a reactive dep), show the modal, then call dismiss so a follow-up
   // failure can re-fire the dialog.
   $effect(() => {
@@ -525,18 +526,31 @@
    *  confirm. Returns false for any other error so the caller's
    *  existing error path runs untouched. */
   async function maybeHandleMissingApiKey(err: unknown): Promise<boolean> {
-    if (!isMissingApiKeyError(err)) return false;
-    await handleMissingApiKey();
+    if (!isProviderUnconfiguredError(err)) return false;
+    await handleMissingApiKey(err);
     return true;
   }
-  async function handleMissingApiKey(): Promise<void> {
+  /**
+   * `err` is optional because one caller (the conversations store) signals
+   * through a flag rather than handing the error over. Without it we say
+   * something true-but-general — better than naming a provider we'd only be
+   * guessing at, which is the bug this replaced (#1796 follow-up).
+   */
+  async function handleMissingApiKey(err?: unknown): Promise<void> {
     if (missingApiKeyPromptShown) return;
     missingApiKeyPromptShown = true;
     try {
+      const provider = err === undefined ? null : unconfiguredProvider(err);
+      const meta = provider ? PROVIDERS[provider] : null;
+      const what = meta && !meta.requiresKey ? 'a base URL' : 'an API key';
+      const envHint = meta?.envVar ? ` You can also set the ${meta.envVar} environment variable.` : '';
+      const message = meta
+        ? `This conversation is set to use ${meta.label}, which isn’t set up yet. ` +
+          `Open Settings → AI to add ${what}.${envHint}`
+        : 'The model this action uses isn’t set up yet. Open Settings → AI to add an API key ' +
+          'for the service you want to use.';
       const ok = await showConfirm(
-        'This action needs an Anthropic API key, which isn’t configured yet. ' +
-          'Open Settings → AI to paste your key, or set the ANTHROPIC_API_KEY ' +
-          'environment variable before launching the app.',
+        message,
         CONFIRM_KEYS.missingApiKey,
         'Open Settings',
         { hideDontAskAgain: true },

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -98,7 +98,7 @@
     {
       label: 'AI',
       items: [
-        { id: 'ai', label: 'AI', sub: 'Model · API key · tool prefs' },
+        { id: 'ai', label: 'AI', sub: 'Models · provider keys · voice' },
         { id: 'skills', label: 'Skills', sub: 'Conversation skills · import' },
       ],
     },

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -5,7 +5,7 @@
   import Icon from './Icon.svelte';
   import ToolParamsDialog from './ToolParamsDialog.svelte';
   import type { ToolContext } from '../../../shared/tools/types';
-  import { isMissingApiKeyError } from '../../../shared/llm-errors';
+  import { isProviderUnconfiguredError } from '../../../shared/llm-errors';
   import { resolveNoteParams } from '../tools/resolve-note-params';
 
   interface Props {
@@ -38,7 +38,7 @@
       panel.complete(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (isMissingApiKeyError(err)) {
+      if (isProviderUnconfiguredError(err)) {
         // Close the tool panel and let the App-level handler surface
         // the Open-Settings dialog. The panel's inline error string
         // still mentioned the missing key, but with no actionable

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -36,7 +36,7 @@ import type {
   AskUserRequest,
   ConversationToolKey,
 } from '../../../shared/conversation-tools';
-import { isMissingApiKeyError } from '../../../shared/llm-errors';
+import { isProviderUnconfiguredError } from '../../../shared/llm-errors';
 
 /**
  * Plain deep clone for the IPC boundary. Every draft payload sent renderer→main
@@ -498,7 +498,7 @@ async function send(content: string, currentNotePath?: string): Promise<void> {
     const reloaded = await api.conversations.load(tab.id);
     if (reloaded) tab.conversation = reloaded;
   } catch (e) {
-    if (isMissingApiKeyError(e)) {
+    if (isProviderUnconfiguredError(e)) {
       // Surface as an actionable modal at the App level rather than a
       // silent console.error — the user's optimistic message would
       // otherwise just sit in the transcript with no explanation. Also

--- a/src/shared/llm-errors.ts
+++ b/src/shared/llm-errors.ts
@@ -1,20 +1,67 @@
 /**
- * Stable marker substring carried by the Error thrown when the
- * Anthropic API key is not configured. Lives in `shared/` so both the
- * main process (which throws it) and the renderer (which detects it
- * across the IPC boundary) reference the same constant — IPC strips
- * the Error class, so message-matching is what we have.
+ * The "this provider isn't set up" error contract, shared by the process that
+ * throws it and the one that reacts to it.
  *
- * Detection across IPC: Electron's `invoke` rejects with a plain Error
- * whose `.message` carries the main-process error's message (prefixed
- * with "Error invoking remote method '…': "), so the marker still
- * appears as a substring in the rejection's message.
+ * IPC strips the Error class, so message-matching is what we have: main throws
+ * a message containing `PROVIDER_UNCONFIGURED_MARKER`, and the renderer detects
+ * it across the boundary (Electron's `invoke` rejects with a plain Error whose
+ * `.message` carries the main-process text, prefixed with "Error invoking
+ * remote method '…': ", so the marker survives as a substring).
+ *
+ * The message BUILDERS live here beside the parser on purpose (#1796
+ * follow-up). The marker used to be hardcoded to "Anthropic API key not
+ * configured" and every provider borrowed it, so choosing a Gemini model with
+ * no Gemini key produced "Anthropic API key not configured. Set the Google
+ * Gemini API key…" — and the renderer's dialog, having no way to know better,
+ * told you to set ANTHROPIC_API_KEY. Keeping both halves in one file is what
+ * makes the round-trip testable.
+ *
+ * "Unconfigured" rather than "missing key" because the local /
+ * OpenAI-compatible provider needs a base URL, not a key, and reports through
+ * the same channel — a message about an API key would be wrong for it.
  */
-export const MISSING_API_KEY_MARKER = 'Anthropic API key not configured';
 
-export function isMissingApiKeyError(err: unknown): boolean {
-  if (err == null) return false;
-  if (err instanceof Error) return err.message.includes(MISSING_API_KEY_MARKER);
-  if (typeof err === 'string') return err.includes(MISSING_API_KEY_MARKER);
-  return false;
+import { PROVIDERS, PROVIDER_IDS, type ProviderId } from './tools/providers';
+
+/** Stable substring identifying an unconfigured-provider failure. Neutral: the
+ *  provider is named around it, never inside it. */
+export const PROVIDER_UNCONFIGURED_MARKER = 'is not set up yet';
+
+function messageOf(err: unknown): string | null {
+  if (err == null) return null;
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return null;
+}
+
+function prefix(id: ProviderId): string {
+  return `${PROVIDERS[id].label} ${PROVIDER_UNCONFIGURED_MARKER}`;
+}
+
+/** "This provider has no API key." Names the provider and its env var. */
+export function missingApiKeyMessage(id: ProviderId): string {
+  const env = PROVIDERS[id].envVar ? ` or set ${PROVIDERS[id].envVar}` : '';
+  return `${prefix(id)}. Add an API key in Settings → AI${env}.`;
+}
+
+/** "This provider has no endpoint." The local provider's equivalent. */
+export function missingBaseUrlMessage(id: ProviderId): string {
+  return `${prefix(id)}. Add a base URL in Settings → AI.`;
+}
+
+/** Did this failure come from a provider that isn't set up? */
+export function isProviderUnconfiguredError(err: unknown): boolean {
+  const msg = messageOf(err);
+  return msg !== null && msg.includes(PROVIDER_UNCONFIGURED_MARKER);
+}
+
+/**
+ * Which provider isn't set up, or null when the error isn't one of ours.
+ * Callers should treat null as "say something generic" rather than guessing a
+ * provider — guessing is the bug this replaced.
+ */
+export function unconfiguredProvider(err: unknown): ProviderId | null {
+  const msg = messageOf(err);
+  if (msg === null) return null;
+  return PROVIDER_IDS.find((id) => msg.includes(prefix(id))) ?? null;
 }

--- a/tests/main/llm/provider-factory.test.ts
+++ b/tests/main/llm/provider-factory.test.ts
@@ -13,7 +13,7 @@ const h = vi.hoisted(() => ({ getSettings: vi.fn() }));
 vi.mock('../../../src/main/llm/settings', () => ({ getSettings: h.getSettings }));
 
 import { getProvider } from '../../../src/main/llm/provider';
-import { MISSING_API_KEY_MARKER } from '../../../src/shared/llm-errors';
+import { PROVIDER_UNCONFIGURED_MARKER } from '../../../src/shared/llm-errors';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -67,7 +67,7 @@ describe('getProvider — local / custom models (#1497)', () => {
 
   it('throws asking for a base URL when a custom model is selected but local has none', async () => {
     h.getSettings.mockResolvedValue({ providers: {}, customModels: [{ id: 'llama3.1' }], model: 'claude-opus-5' });
-    await expect(getProvider('llama3.1')).rejects.toThrow(MISSING_API_KEY_MARKER);
+    await expect(getProvider('llama3.1')).rejects.toThrow(PROVIDER_UNCONFIGURED_MARKER);
     await expect(getProvider('llama3.1')).rejects.toThrow(/base URL/i);
   });
 
@@ -81,19 +81,19 @@ describe('getProvider — local / custom models (#1497)', () => {
 describe('getProvider — missing credentials', () => {
   it('throws the marker error naming OpenAI when its key is absent', async () => {
     h.getSettings.mockResolvedValue({ providers: { anthropic: { apiKey: 'sk-ant' } }, model: 'claude-opus-5' });
-    await expect(getProvider('gpt-5')).rejects.toThrow(MISSING_API_KEY_MARKER);
+    await expect(getProvider('gpt-5')).rejects.toThrow(PROVIDER_UNCONFIGURED_MARKER);
     await expect(getProvider('gpt-5')).rejects.toThrow(/OpenAI/);
   });
 
   it('throws the marker error naming Gemini when its key is absent', async () => {
     h.getSettings.mockResolvedValue({ providers: { anthropic: { apiKey: 'sk-ant' } }, model: 'claude-opus-5' });
-    await expect(getProvider('gemini-2.5-pro')).rejects.toThrow(MISSING_API_KEY_MARKER);
+    await expect(getProvider('gemini-2.5-pro')).rejects.toThrow(PROVIDER_UNCONFIGURED_MARKER);
     await expect(getProvider('gemini-2.5-pro')).rejects.toThrow(/Gemini/);
   });
 
   it('throws the marker error naming Anthropic when its key is absent', async () => {
     h.getSettings.mockResolvedValue({ providers: {}, model: 'claude-opus-5' });
-    await expect(getProvider()).rejects.toThrow(MISSING_API_KEY_MARKER);
+    await expect(getProvider()).rejects.toThrow(PROVIDER_UNCONFIGURED_MARKER);
     await expect(getProvider()).rejects.toThrow(/Anthropic/);
   });
 });

--- a/tests/renderer/stores/conversations-store.test.ts
+++ b/tests/renderer/stores/conversations-store.test.ts
@@ -102,6 +102,7 @@ vi.mock('../../../src/renderer/lib/compute/run-cell-with-trust', () => ({ ensure
 const ensureComputeConsent = h.ensureComputeConsent;
 
 import { getConversationsStore } from '../../../src/renderer/lib/stores/conversations.svelte';
+import { missingApiKeyMessage } from '../../../src/shared/llm-errors';
 
 const store = getConversationsStore();
 const conv = () => h.api.conversations;
@@ -249,9 +250,11 @@ describe('send()', () => {
     expect(tab.composer).toBe('');
   });
 
-  it('surfaces a missing-API-key error: restores the composer, drops the optimistic turn, flips needsApiKey', async () => {
+  it('surfaces an unconfigured-provider error: restores the composer, drops the optimistic turn, flips needsApiKey', async () => {
     const tab = await freshTab();
-    conv().send.mockRejectedValueOnce(new Error('Anthropic API key not configured'));
+    // Built through the shared helper rather than a hardcoded string, so this
+    // can't drift from the message main actually throws (#1796 follow-up).
+    conv().send.mockRejectedValueOnce(new Error(missingApiKeyMessage('openai')));
 
     await store.send('needs a key');
 

--- a/tests/shared/llm-errors.test.ts
+++ b/tests/shared/llm-errors.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The unconfigured-provider error contract (#1796 follow-up).
+ *
+ * The bug: the marker was hardcoded to "Anthropic API key not configured" and
+ * every provider borrowed it, so picking Gemini with no Gemini key produced an
+ * Anthropic-flavoured message and a dialog telling you to set
+ * ANTHROPIC_API_KEY. The producer and the parser now sit in one file, and these
+ * assert the round-trip for EVERY provider — which is the property that keeps
+ * the two halves honest as providers are added.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  PROVIDER_UNCONFIGURED_MARKER,
+  missingApiKeyMessage,
+  missingBaseUrlMessage,
+  isProviderUnconfiguredError,
+  unconfiguredProvider,
+} from '../../src/shared/llm-errors';
+import { PROVIDERS, PROVIDER_IDS } from '../../src/shared/tools/providers';
+
+describe('missing-key messages', () => {
+  it('round-trips every provider: message → detected → same provider back', () => {
+    for (const id of PROVIDER_IDS) {
+      const msg = missingApiKeyMessage(id);
+      expect(isProviderUnconfiguredError(new Error(msg)), id).toBe(true);
+      expect(unconfiguredProvider(new Error(msg)), id).toBe(id);
+    }
+  });
+
+  it('names the provider the user actually chose, not Anthropic', () => {
+    expect(missingApiKeyMessage('google')).toContain('Google Gemini');
+    expect(missingApiKeyMessage('google')).not.toContain('Anthropic');
+    expect(missingApiKeyMessage('openai')).not.toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('names each provider’s own environment variable, and omits it when there is none', () => {
+    for (const id of PROVIDER_IDS) {
+      const msg = missingApiKeyMessage(id);
+      const env = PROVIDERS[id].envVar;
+      if (env) expect(msg, id).toContain(env);
+      else expect(msg, id).not.toMatch(/set [A-Z_]+\./);
+    }
+  });
+
+  it('says base URL, not API key, for the provider that needs an address', () => {
+    // The local / OpenAI-compatible endpoint reports through the same channel,
+    // so the same "open Settings" affordance fires — but telling someone to add
+    // an API key when the problem is a missing address sends them nowhere.
+    const msg = missingBaseUrlMessage('local');
+    expect(msg).toContain('base URL');
+    expect(msg).not.toContain('API key');
+    expect(unconfiguredProvider(new Error(msg))).toBe('local');
+  });
+});
+
+describe('detection across the IPC boundary', () => {
+  it('survives Electron’s "Error invoking remote method" prefix', () => {
+    const wrapped = new Error(
+      `Error invoking remote method 'conversation:send': Error: ${missingApiKeyMessage('openai')}`,
+    );
+    expect(isProviderUnconfiguredError(wrapped)).toBe(true);
+    expect(unconfiguredProvider(wrapped)).toBe('openai');
+  });
+
+  it('accepts a bare string, since IPC sometimes hands one over', () => {
+    expect(isProviderUnconfiguredError(missingApiKeyMessage('anthropic'))).toBe(true);
+  });
+
+  it('ignores anything else', () => {
+    for (const other of [null, undefined, 42, new Error('rate limited'), 'network down']) {
+      expect(isProviderUnconfiguredError(other), String(other)).toBe(false);
+      expect(unconfiguredProvider(other), String(other)).toBeNull();
+    }
+  });
+
+  it('returns null rather than guessing when the provider is not named', () => {
+    // Only reachable if something builds a message by hand. The caller's
+    // fallback is generic copy — guessing a provider is the original bug.
+    const vague = new Error(`Something ${PROVIDER_UNCONFIGURED_MARKER}.`);
+    expect(isProviderUnconfiguredError(vague)).toBe(true);
+    expect(unconfiguredProvider(vague)).toBeNull();
+  });
+});


### PR DESCRIPTION
The two bits of stale copy from #1796.

## The missing-key dialog always said "Anthropic"

Pick a Gemini or GPT model with no key for it and you got:

> This action needs an **Anthropic** API key, which isn't configured yet. Open Settings → AI to paste your key, or set the **ANTHROPIC_API_KEY** environment variable.

Always Anthropic, whichever provider you'd chosen — pointing you at the wrong key, the wrong service, and the wrong environment variable.

**Two causes, both fixed:**

- The marker substring the renderer detects **was itself the sentence** `'Anthropic API key not configured'`, which every provider borrowed. So the thrown message read "Anthropic API key not configured. Set the Google Gemini API key…" — contradicting itself inside one sentence.
- `App.svelte` wrote its own Anthropic-flavoured copy because the error gave it no way to know better.

The marker is now provider-neutral, and the message **builders live beside the parser** in `shared/llm-errors.ts` so producer and consumer can't drift. The dialog names the provider, what it needs, and that provider's own env var.

When the provider can't be determined it says something true and general rather than picking one. Guessing is precisely what this replaces.

## Generalized from "missing key" to "not set up"

The **local / OpenAI-compatible** endpoint reports through the same channel but needs a **base URL**, not a key — and it was also saying "API key", pointing users at a field that wouldn't have helped. So `isMissingApiKeyError` → `isProviderUnconfiguredError`, with `missingBaseUrlMessage` for that case. Same detection, same "open Settings" affordance, honest words.

## The AI tab subtitle

`Model · API key · tool prefs` → `Models · provider keys · voice`. Singular key was wrong, and tool prefs aren't on that tab.

## Tests

8 new in `tests/shared/llm-errors.test.ts`. The load-bearing one is a **round-trip over every provider** — message → detected → same provider back — because that's the property that stays honest as providers are added, rather than four hand-written assertions that rot.

Also: each provider's own env var appears (and none appears for the keyless one), the local case says base URL and not API key, detection survives Electron's `Error invoking remote method '…'` prefix, and an un-named provider yields `null` instead of a guess.

Mutation-checked: hardcoding `unconfiguredProvider` back to `'anthropic'` fails five of them.

The existing store test built its fixture from the literal old string; it now builds it through the shared helper, so it can't drift from what main actually throws.

`pnpm lint` clean; `pnpm test` 5818 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)