### PR TITLE
docs: rewrite the welcome note around why, not how

### DIFF
--- a/src/shared/welcome-note.ts
+++ b/src/shared/welcome-note.ts
@@ -18,6 +18,12 @@ export const WELCOME_NOTE_PATH = 'Welcome.md';
  * what the app itself writes (via YAML.stringify), so the indexer parses it
  * reliably; the `entrypoint` tag makes this the thoughtbase's designated
  * starting surface, which the renderer re-opens on later empty-editor loads.
+ *
+ * The prose leads with WHY a thoughtbase, in the website's framing, rather than
+ * with Minerva's mechanics — someone who has just declined the onboarding modal
+ * has no reason yet to care how the knowledge graph works. It also never points
+ * at the properties block "above": the editor collapses it by default, so on
+ * most screens there is nothing there to see.
  */
 export function welcomeNoteContent(isMac: boolean): string {
   const newNote = isMac ? '⌘N' : 'Ctrl+N';
@@ -28,22 +34,48 @@ tags:
 
 # Welcome to your thoughtbase
 
-This is Minerva — a workshop for thinking in writing. You're reading your first
-note. Edit it, or delete it once you've found your footing; every note is a plain
-Markdown file on disk that you fully own.
+Somewhere in your chat history is a genuinely good idea you worked out with an
+AI a few weeks ago. You can't find it. It wasn't written down anywhere you own,
+it didn't connect to anything else you know, and the next conversation started
+from nothing.
 
-A few ways in:
+This is where that work goes instead. A **thoughtbase** is a place your thinking
+lands and stays — notes you keep, link, question, and build on for years rather
+than until you close a tab. Every note you add gives the next conversation more
+to work with, so what you write compounds instead of scrolling away.
 
-- **Press ${newNote} to create a new note.** That's the same shortcut whenever you
-  want a fresh page.
-- **Connect ideas with \`[[wiki-links]]\`.** Type \`[[\` and start naming another
-  note — Minerva weaves the links into a knowledge graph you can query.
-- **Label with tags and frontmatter.** Titles, tags, and links are all indexed;
-  the \`entrypoint\` tag above is what marks this as your starting note.
-- **Ask questions of your notes.** The **New Conversation** button above the editor
-  starts one; right-click a note's tab and choose *Ask About This…* to start from
-  that note — nothing lands in your graph without your approval.
+Three things worth knowing before you start:
 
-When you're ready, press ${newNote} and start writing.
+- **You stay in control.** The assistant proposes; you decide. Nothing it writes
+  reaches your notes until you've read it and approved it.
+- **It's yours, permanently.** Every note is a plain Markdown file in a folder
+  on your own disk. No account, no server. If Minerva disappeared tomorrow, your
+  thinking would still open in any text editor.
+- **It gets better as it grows.** Notes that link to each other are worth more
+  than notes in a pile — and the assistant can answer from what you actually
+  wrote, telling you which note each answer came from.
+
+## Try three things
+
+**Write something.** Press ${newNote} and start a note about whatever you're
+actually working on today. A paragraph is plenty. This note is yours to edit or
+delete once you've found your footing.
+
+**Connect it to something.** Type \`[[\` anywhere and start naming another note.
+Links are what turn a folder of files into a map of what you know — and you can
+link to a note before you've written it.
+
+**Ask about your notes.** The **New Conversation** button above the editor
+starts a conversation that can read what you've written. Right-click a note's
+tab and choose *Ask About This…* to start from one note in particular. Whatever
+it suggests, you see before it lands.
+
+## When you want more
+
+A note can carry **properties** — labelled fields like an author or a date — and
+tags for grouping. Settings has the rest: how the editor behaves, which AI
+models you use, and what gets checked as you write.
+
+Press ${newNote} when you're ready.
 `;
 }

--- a/tests/shared/welcome-note.test.ts
+++ b/tests/shared/welcome-note.test.ts
@@ -33,6 +33,30 @@ describe('welcomeNoteContent', () => {
     expect(body).not.toMatch(/open a conversation/i);
   });
 
+  it('says "properties", never "frontmatter" (#welcome-copy)', () => {
+    const body = welcomeNoteContent(true);
+    expect(body).toContain('properties');
+    expect(body.toLowerCase()).not.toContain('frontmatter');
+  });
+
+  it('never points at the properties block "above"', () => {
+    // The editor collapses it by default, so on most screens there is nothing
+    // there to look at — the old copy sent readers to a blank line.
+    const body = welcomeNoteContent(true);
+    expect(body).not.toMatch(/tag above|block above|above marks/i);
+  });
+
+  it('leads with why a thoughtbase, not with the machinery', () => {
+    const body = welcomeNoteContent(true);
+    const intro = body.slice(0, body.indexOf('## '));
+    // The pitch, in the website's framing.
+    expect(intro).toMatch(/thoughtbase/i);
+    expect(intro).toMatch(/chat history|conversation started from nothing|compounds/i);
+    // Not the internals. "Knowledge graph" is a thing you come to want, not a
+    // reason to start.
+    expect(body).not.toMatch(/knowledge graph|wiki-link|indexed|SPARQL/i);
+  });
+
   it('greets the reader', () => {
     expect(welcomeNoteContent(true)).toContain('Welcome to your thoughtbase');
   });


### PR DESCRIPTION
Your points 1–3, plus the reframing they imply. Point 4 (screenshots) I attempted and then backed out of — reasoning at the bottom, because I think it's worth your call rather than mine.

## 1. "Frontmatter" → "properties"

Our word, not the user's. The app calls it properties everywhere else.

## 2. No more pointing at the collapsed block

It said *"the `entrypoint` tag above is what marks this as your starting note"*. The editor collapses the properties block by default, so for most readers that sentence pointed at a blank line. Nothing in the note now refers to anything above it.

## 3. Why, not how

The old note led with the machinery — indexing, wiki-links, a graph you can query. Someone who just declined the onboarding modal has no reason yet to care. It now opens the way the website does:

> Somewhere in your chat history is a genuinely good idea you worked out with an AI a few weeks ago. You can't find it. It wasn't written down anywhere you own, it didn't connect to anything else you know, and the next conversation started from nothing.
>
> This is where that work goes instead.

Then the three reasons — you stay in control, it's yours permanently, it gets better as it grows — stated as reasons to start rather than as a feature list. The actions follow as *"try three things"*: write, connect, ask, each with the concrete gesture attached. "Knowledge graph" doesn't appear; "a map of what you know" does the same work without the jargon.

## 4. Screenshots — attempted, then pulled

The mechanism works and I built it: ship PNGs in `resources/` (already packaged wholesale via `extraResource`), copy them into `.minerva/welcome/` beside the note on seed, reference them relatively. `.minerva` is filtered from the sidebar, so the assets stay invisible, and image paths resolve into it fine.

What stopped me was the pictures themselves:

- **The conversation shot** came out mid-transcript, cut off at the top, showing a *broken-link debugging session* from the demo vault — with a token cost on screen. That's a bad first impression to bake into every new user's first note.
- **The `[[` autocomplete shot** resisted automation: the keystrokes didn't reach the pane I expected and the popup never opened. I added an assertion so the capture fails rather than silently shipping a picture of an untouched note — which is exactly what the first attempt produced.

Doing this properly needs a purpose-built fixture — a short, friendly conversation seeded for the shot rather than whatever the demo vault happens to contain — and a reliable way to drive the completion popup. That's a real piece of work, not a trim, so I'd rather do it deliberately than ship two mediocre images. Say the word and it's the next thing I pick up.

There's also a question worth deciding first: assets copied into `.minerva/welcome/` outlive the note if the user deletes it. Tolerable (they're invisible and small), but it is litter in someone's folder, and it's your call whether that's a fair trade for two pictures.

## Tests

Three new: the properties/frontmatter swap, the absence of any "above" reference, and that the opening paragraphs give a reason rather than describe a mechanism (asserting the machinery words stay out).

`pnpm lint` clean; `pnpm test` 5821 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)