### PR TITLE
fix(mermaid): measure labels in the font they're drawn in

### DIFF
--- a/src/renderer/lib/components/AppearanceSettings.svelte
+++ b/src/renderer/lib/components/AppearanceSettings.svelte
@@ -57,6 +57,11 @@
   });
   $effect(() => {
     setFontFamily(fontFamily);
+    // Same fan-out as a theme change: the canvas surfaces can't pick a CSS
+    // custom-property change up on their own, and mermaid in particular *sizes*
+    // its labels against this font — leave it stale and every diagram keeps
+    // boxes measured for the previous font (#1802).
+    onThemeChanged();
   });
 </script>
 

--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -499,7 +499,9 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
      * Re-render mermaid diagrams against the new theme tokens. Called
      * from App.svelte when the user cycles the theme — the existing
      * SVG was generated with the old palette and would otherwise look
-     * out of place.
+     * out of place — and on a content-font change, where the stale SVG
+     * is worse than out of place: mermaid *sizes* each label against
+     * that font, so the old boxes clip the new text (#1802).
      */
     export function updateTheme(): void {
         invalidateMermaidTheme();

--- a/src/renderer/lib/markdown/mermaid-renderer.ts
+++ b/src/renderer/lib/markdown/mermaid-renderer.ts
@@ -24,7 +24,8 @@ type MermaidApi = {
 };
 
 let mermaidPromise: Promise<MermaidApi> | null = null;
-let initializedFor: 'dark' | 'light' | 'contrast' | null = null;
+/** `<theme>|<label font>` — both feed themeVariables, so both must key the cache. */
+let initializedFor: string | null = null;
 let counter = 0;
 
 async function loadMermaid(): Promise<MermaidApi> {
@@ -36,9 +37,9 @@ async function loadMermaid(): Promise<MermaidApi> {
   return mermaidPromise;
 }
 
-function ensureInitialized(api: MermaidApi): void {
-  const effective = getEffectiveTheme(getThemeMode());
-  if (initializedFor === effective) return;
+function ensureInitialized(api: MermaidApi, fontFamily: string): void {
+  const key = `${getEffectiveTheme(getThemeMode())}|${fontFamily}`;
+  if (initializedFor === key) return;
   // Mermaid's `base` theme accepts variable overrides; using it instead
   // of `dark` / `default` lets us pin every color to a catppuccin token.
   const tokens = readThemeTokens();
@@ -61,10 +62,30 @@ function ensureInitialized(api: MermaidApi): void {
       clusterBorder: tokens.border,
       titleColor: tokens.text,
       edgeLabelBackground: tokens.bg,
-      fontFamily: 'inherit',
+      fontFamily,
     },
   });
-  initializedFor = effective;
+  initializedFor = key;
+}
+
+/**
+ * The font mermaid's labels will actually be drawn in (#1802).
+ *
+ * Mermaid sizes each label by rendering it into a temp div it appends to
+ * `document.body`, then bakes that measurement into a fixed-width
+ * `<foreignObject>`. The finished SVG is injected into `.preview`, which uses
+ * the *content* font (`--content-font-family`) while `body` uses the *UI* font
+ * (`--font-sans`). Passing `fontFamily: 'inherit'` let those two disagree:
+ * every label was measured in one font and drawn in another, so under any
+ * non-default Appearance → Content font preset the text overran the box it was
+ * sized for and the foreignObject clipped it ("Write a n", "Knowledge grap").
+ *
+ * Resolving the preview's own computed family and handing mermaid that concrete
+ * stack makes measurement and render agree, so a long label wraps at mermaid's
+ * `wrappingWidth` instead of being cut.
+ */
+function labelFontFamily(root: HTMLElement): string {
+  return getComputedStyle(root).fontFamily || 'inherit';
 }
 
 function readThemeTokens(): {
@@ -104,7 +125,7 @@ export async function hydrateMermaidBlocks(root: HTMLElement): Promise<void> {
   let api: MermaidApi;
   try {
     api = await loadMermaid();
-    ensureInitialized(api);
+    ensureInitialized(api, labelFontFamily(root));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     for (const el of blocks) {
@@ -143,7 +164,8 @@ export async function hydrateMermaidBlocks(root: HTMLElement): Promise<void> {
 
 /**
  * Reset cached theme so the next render re-initializes mermaid with
- * the current theme variables. Call after a theme change.
+ * the current theme variables. Call after a theme *or* content-font change —
+ * both feed themeVariables, and a font change also resizes every label (#1802).
  */
 export function invalidateMermaidTheme(): void {
   initializedFor = null;

--- a/tests/renderer/markdown/mermaid-renderer.test.ts
+++ b/tests/renderer/markdown/mermaid-renderer.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Mermaid label font resolution (#1802).
+ *
+ * Mermaid measures each label off-DOM in `document.body` (the UI font) but the
+ * finished SVG is injected into `.preview` (the content font). Passing
+ * `fontFamily: 'inherit'` let those disagree, so labels were sized for one font
+ * and drawn in another — visibly clipped node text under any non-default
+ * Appearance → Content font preset.
+ *
+ * jsdom can't measure glyphs, so these assert the contract that makes the two
+ * agree: mermaid is initialized with the *preview's own resolved family*, and
+ * re-initialized when that family changes (the cache is keyed on it, not just
+ * on the theme).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const initialize = vi.fn();
+const render = vi.fn(async () => ({ svg: '<svg xmlns="http://www.w3.org/2000/svg"><g class="node"></g></svg>' }));
+
+vi.mock('mermaid', () => ({ default: { initialize, render } }));
+// The theme module reaches for app state we don't need here; pin it so the
+// cache key varies only by font.
+vi.mock('../../../src/renderer/lib/theme', () => ({
+  getThemeMode: () => 'dark',
+  getEffectiveTheme: () => 'dark',
+}));
+
+import { hydrateMermaidBlocks, invalidateMermaidTheme } from '../../../src/renderer/lib/markdown/mermaid-renderer';
+
+/** A `.preview`-alike root holding one unrendered mermaid placeholder. */
+function previewWith(fontFamily: string): HTMLElement {
+  const root = document.createElement('div');
+  root.style.fontFamily = fontFamily;
+  const block = document.createElement('div');
+  block.className = 'mermaid-block';
+  block.textContent = 'flowchart LR\n  A[Write a note] --> B[Minerva indexes it]';
+  root.appendChild(block);
+  document.body.appendChild(root);
+  return root;
+}
+
+function lastFontFamily(): unknown {
+  const call = initialize.mock.calls.at(-1)?.[0] as { themeVariables?: Record<string, unknown> };
+  return call?.themeVariables?.fontFamily;
+}
+
+describe('hydrateMermaidBlocks font resolution (#1802)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    initialize.mockClear();
+    render.mockClear();
+    invalidateMermaidTheme();
+  });
+
+  it('initializes mermaid with the preview\'s resolved font, not "inherit"', async () => {
+    await hydrateMermaidBlocks(previewWith('"Berkeley Mono", monospace'));
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(lastFontFamily()).toBe('"Berkeley Mono", monospace');
+    expect(lastFontFamily()).not.toBe('inherit');
+  });
+
+  it('re-initializes when the content font changes under an unchanged theme', async () => {
+    await hydrateMermaidBlocks(previewWith('"IBM Plex Sans", sans-serif'));
+    expect(lastFontFamily()).toBe('"IBM Plex Sans", sans-serif');
+
+    // Same theme, different font — the old cache key ('dark') would have
+    // short-circuited here and left every label measured for the previous font.
+    await hydrateMermaidBlocks(previewWith('Georgia, serif'));
+
+    expect(initialize).toHaveBeenCalledTimes(2);
+    expect(lastFontFamily()).toBe('Georgia, serif');
+  });
+
+  it('does not re-initialize when neither theme nor font changed', async () => {
+    await hydrateMermaidBlocks(previewWith('Georgia, serif'));
+    await hydrateMermaidBlocks(previewWith('Georgia, serif'));
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders the diagram into the placeholder and marks it done', async () => {
+    const root = previewWith('Georgia, serif');
+    await hydrateMermaidBlocks(root);
+
+    const block = root.querySelector('.mermaid-block');
+    expect(block?.getAttribute('data-mermaid-rendered')).toBe('ok');
+    expect(block?.querySelector('svg')).not.toBeNull();
+    // Idempotent: an already-rendered block isn't re-rendered.
+    await hydrateMermaidBlocks(root);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #1802 — the clipped Mermaid node labels in the tutorial thoughtbase.

## The bug

Mermaid sizes each label by rendering it into a temp div it appends to `document.body`, then bakes that measurement into a fixed-width `<foreignObject>`. The finished SVG is injected into `.preview`. The two contexts resolve fonts differently:

- `body` → `--font-sans` (UI font)
- `.preview` (`Preview.svelte:1238`) → `var(--content-font-family, inherit)` — the Appearance → Content font preset

`mermaid-renderer.ts` passed `fontFamily: 'inherit'`, so labels were measured in the UI font and drawn in the content font. Whenever those differ the text overruns the box it was sized for and the `foreignObject` clips it.

Invisible on the stock `Minerva default (Plex)` preset — which is why it went unnoticed — and badly broken on the four mono presets.

## The fix

Resolve the preview's own computed family (`getComputedStyle(root).fontFamily`) and hand mermaid that concrete stack. Measurement and render then agree, so a long label wraps at mermaid's `wrappingWidth` instead of being cut.

Two things came with it:

1. `initializedFor` was keyed only on the theme, so the first render's font would have stuck for the session. It now keys on theme + font.
2. A font-preset change didn't invalidate mermaid at all — only a theme change did — so diagrams stayed measured for the old font until reload. The Appearance font `$effect` now runs the same surface re-tint fan-out a theme change does.

## Verification

Rendered the two tutorial diagrams (**Diagrams and Embeds**, **The AI Proposes You Confirm**) through the real patched module in headless Chromium, under each font preset, measuring every label's rendered text width against its baked `foreignObject` width:

| Content font | max label overflow before | after |
|---|---|---|
| default (Plex) | 0.0px | 0.0px |
| Serif | +1.5px | 0.0px |
| System Sans | — | 0.0px |
| Monospace | **+47.2px** | 0.0px |

Before, under Monospace: `Write a n`, `Minerva indexe`, `Knowledge grap`, `Insig`, `Run a sk`, `Proposal (pend`, `You review the`, `Applied to your`, `Discarde`. After: every label intact, `Query with SPARQL or SQL` and `Applied to your notes` wrapping to two lines rather than clipping.

Also adds `tests/renderer/markdown/mermaid-renderer.test.ts` (4 tests). jsdom can't measure glyphs, so it asserts the contract that makes the two agree: mermaid is initialized with the preview's resolved family (never `'inherit'`), re-initializes when that family changes under an unchanged theme, and doesn't re-initialize when neither changed.

`pnpm lint` clean; `pnpm test tests/renderer` 172 files / 1967 tests pass.

No tutorial content changes — the source markdown was never the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
