### PR TITLE
feat(llm): report LLM failures instead of swallowing them

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -238,7 +238,14 @@ export function registerConversation(): void {
     pending.resolve(answer);
   });
 
-  handle(Channels.CONVERSATION_SEND, async (e, convId: string, userMessage: string, systemPrompt?: string, currentNotePath?: string, extraTools?: import('../../shared/conversation-tools').ConversationToolKey[]) => {
+  /**
+   * One assistant turn. `userMessage === null` means RETRY (#1804): the user's
+   * turn is already persisted — main appends it *before* calling the model, so
+   * a failed turn leaves it on disk — and re-sending the text would file it a
+   * second time. Retry therefore re-runs the completion over the existing
+   * history and appends only the assistant reply.
+   */
+  const runConversationTurn = async (e: Electron.IpcMainInvokeEvent, convId: string, userMessage: string | null, systemPrompt?: string, currentNotePath?: string, extraTools?: import('../../shared/conversation-tools').ConversationToolKey[]) => {
     const win = winFromEvent(e);
     const rootPath = rootPathFromEvent(e);
     const controller = new AbortController();
@@ -256,11 +263,14 @@ export function registerConversation(): void {
 
     // Unconditional log so we can prove the current build is loaded —
     // if the user reports "no log messages" again, this is missing too.
-    console.log(`[conv] SEND start: conv=${convId} userMsgLen=${userMessage.length}`);
+    console.log(`[conv] ${userMessage === null ? 'RETRY' : 'SEND'} start: conv=${convId} userMsgLen=${userMessage?.length ?? 0}`);
 
     graph.enterLLMContext();
     try {
-      const conv = await conversation.appendMessage(convId, 'user', userMessage);
+      const conv = userMessage === null
+        ? await conversation.load(convId)
+        : await conversation.appendMessage(convId, 'user', userMessage);
+      if (!conv) throw new Error(`Conversation not found: ${convId}`);
 
       const { completeWithTools } = await import('../llm/index');
       const messages = conv.messages
@@ -327,7 +337,14 @@ export function registerConversation(): void {
       convAbortControllers.delete(win.id);
       graph.exitLLMContext();
     }
-  });
+  };
+
+  handle(Channels.CONVERSATION_SEND, (e, convId: string, userMessage: string, systemPrompt?: string, currentNotePath?: string, extraTools?: import('../../shared/conversation-tools').ConversationToolKey[]) =>
+    runConversationTurn(e, convId, userMessage, systemPrompt, currentNotePath, extraTools));
+
+  // Re-run the last turn after a failure, without re-filing the user's message.
+  handle(Channels.CONVERSATION_RETRY, (e, convId: string, systemPrompt?: string, currentNotePath?: string, extraTools?: import('../../shared/conversation-tools').ConversationToolKey[]) =>
+    runConversationTurn(e, convId, null, systemPrompt, currentNotePath, extraTools));
 
   handle(Channels.CONVERSATION_CANCEL, (e) => {
     const win = winFromEvent(e);

--- a/src/main/llm/classify-error.ts
+++ b/src/main/llm/classify-error.ts
@@ -1,0 +1,180 @@
+/**
+ * Provider error → `LlmFailureKind`, in the one place the SDK error is still
+ * intact (#1804).
+ *
+ * Electron's IPC strips the Error class and every custom property, so an SDK
+ * error's `status` / `code` / body cannot reach the renderer. Classify here,
+ * in main, and let `shared/llm-errors.ts` carry the verdict across as text.
+ *
+ * Deliberately status-first with per-provider refinements layered on top:
+ * HTTP status is the one thing all three SDKs agree on, and it degrades
+ * sensibly for the `local` provider (Ollama / LM Studio / vLLM / OpenRouter),
+ * whose error bodies we can't enumerate. The refinements only ever make a
+ * verdict *more* specific — they never rescue an unrecognised error into a
+ * confident-sounding lie, because "we don't know" (`unknown`, which renders
+ * the provider's own text) is more useful than a wrong diagnosis.
+ *
+ * The distinction that matters most to a user is `rate_limited` vs `quota`:
+ * both commonly arrive as 429, but one clears on its own in a minute and the
+ * other needs a credit card. Telling someone to "try again shortly" when their
+ * balance is empty is exactly the unhelpfulness this file exists to remove.
+ */
+import {
+  llmFailureMessage,
+  type LlmFailureKind,
+} from '../../shared/llm-errors';
+import { PROVIDERS, type ProviderId } from '../../shared/tools/providers';
+
+interface ErrorShape {
+  status?: number;
+  /** OpenAI puts a machine code here; Anthropic nests a type in the body. */
+  code?: string;
+  type?: string;
+  message?: string;
+  name?: string;
+  error?: { type?: string; message?: string; error?: { type?: string; message?: string } };
+}
+
+function shapeOf(err: unknown): ErrorShape {
+  // Every field is optional, so a plain `object` already satisfies ErrorShape —
+  // no assertion needed, and none wanted: this must stay honest about the fact
+  // that we're probing an error whose shape we don't control.
+  if (typeof err !== 'object' || err === null) return {};
+  return err;
+}
+
+/** Every scrap of provider-supplied text, lowercased, for substring probes. */
+function haystack(e: ErrorShape): string {
+  return [
+    e.message,
+    e.code,
+    e.type,
+    e.error?.type,
+    e.error?.message,
+    e.error?.error?.type,
+    e.error?.error?.message,
+  ]
+    .filter((s): s is string => typeof s === 'string')
+    .join(' ')
+    .toLowerCase();
+}
+
+/**
+ * Billing exhaustion, across providers:
+ *   Anthropic — HTTP 400, "Your credit balance is too low to access the API"
+ *   OpenAI    — HTTP 429, code `insufficient_quota`
+ *   Google    — RESOURCE_EXHAUSTED with a billing/quota body
+ * A plain 429 with none of these is ordinary rate limiting.
+ */
+function looksLikeQuota(text: string): boolean {
+  return (
+    text.includes('insufficient_quota')
+    || text.includes('credit balance')
+    || text.includes('billing')
+    || text.includes('exceeded your current quota')
+    || text.includes('quota exceeded')
+    || text.includes('payment')
+  );
+}
+
+function looksLikeContextLength(text: string): boolean {
+  return (
+    text.includes('context_length_exceeded')
+    || text.includes('context window')
+    || text.includes('prompt is too long')
+    || text.includes('maximum context length')
+    || text.includes('too many tokens')
+  );
+}
+
+/** No HTTP status at all ⇒ we never got an answer from the provider. */
+function looksLikeNetwork(e: ErrorShape, text: string): boolean {
+  if (typeof e.status === 'number') return false;
+  return (
+    e.name === 'APIConnectionError'
+    || e.name === 'APIConnectionTimeoutError'
+    || e.name === 'FetchError'
+    || /\b(enotfound|econnrefused|econnreset|etimedout|eai_again|epipe|certificate|self[- ]signed|socket hang up|network|fetch failed|timeout)\b/.test(text)
+  );
+}
+
+/** Classify without formatting — exported for tests and for reuse. */
+export function classifyProviderError(err: unknown): LlmFailureKind {
+  const e = shapeOf(err);
+  if (e.name === 'AbortError' || e.name === 'TimeoutError') return 'cancelled';
+
+  const text = haystack(e);
+  const status = e.status;
+
+  if (looksLikeNetwork(e, text)) return 'network';
+
+  if (status === 401) return 'auth';
+  if (status === 403) return 'auth';
+  if (status === 429) return looksLikeQuota(text) ? 'quota' : 'rate_limited';
+  // Anthropic's bespoke overload status, plus the standard unavailable pair.
+  if (status === 529 || status === 503) return 'overloaded';
+  if (typeof status === 'number' && status >= 500) return 'server';
+  if (status === 400 || status === 404 || status === 413 || status === 422) {
+    if (looksLikeQuota(text)) return 'quota';
+    if (looksLikeContextLength(text)) return 'context_length';
+    return 'invalid_request';
+  }
+
+  // Status-less but clearly one of these — some SDKs surface an overload or a
+  // rate limit as a typed error before an HTTP status is attached.
+  if (text.includes('overloaded')) return 'overloaded';
+  if (looksLikeQuota(text)) return 'quota';
+  if (looksLikeContextLength(text)) return 'context_length';
+
+  return 'unknown';
+}
+
+/**
+ * The user-facing half. Names the provider the user actually chose — the
+ * lesson of #1796, where every provider borrowed Anthropic's copy.
+ */
+function describe(kind: LlmFailureKind, label: string, e: ErrorShape): string {
+  const detail = typeof e.message === 'string' && e.message.trim() ? e.message.trim() : '';
+  switch (kind) {
+    case 'auth':
+      return `${label} rejected this API key — it may be invalid, expired, or revoked. Check it in Settings → AI.`;
+    case 'rate_limited':
+      return `${label} is rate limiting this key — too many requests just now. This usually clears in a minute.`;
+    case 'quota':
+      return `Your ${label} account is out of credit or has hit its quota. Retrying won't help until billing is topped up.`;
+    case 'overloaded':
+      return `${label} is overloaded right now. This is temporary and not a problem with your setup.`;
+    case 'server':
+      return `${label} had a server error${typeof e.status === 'number' ? ` (${e.status})` : ''}. Nothing wrong on your side — try again shortly.`;
+    case 'network':
+      return `Couldn't reach ${label}. Check your internet connection${detail ? ` (${detail})` : ''}.`;
+    case 'context_length':
+      return `This conversation is too long for the model's context window. Run /compact to summarise earlier turns, or start a fresh conversation.`;
+    case 'invalid_request':
+      return `${label} rejected the request${detail ? `: ${detail}` : '.'}`;
+    case 'cancelled':
+      return 'Cancelled.';
+    default:
+      return detail || `${label} returned an unexpected error.`;
+  }
+}
+
+/**
+ * Wrap a provider error as the marker-carrying Error main throws. A failure we
+ * already classified (a nested rethrow, or the unconfigured error the factory
+ * raises) passes through untouched so the original verdict wins.
+ */
+export function toLlmFailureError(err: unknown, providerId: ProviderId | null): Error {
+  const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  if (msg.includes('MINERVA_LLM_FAILURE:') || msg.includes('is not set up yet')) {
+    return err instanceof Error ? err : new Error(msg);
+  }
+  const kind = classifyProviderError(err);
+  const label = providerId ? PROVIDERS[providerId].label : 'The model provider';
+  const wrapped = new Error(
+    llmFailureMessage(kind, describe(kind, label, shapeOf(err)), providerId),
+  );
+  // Keep the original for main-side logging; it does not cross IPC.
+  wrapped.cause = err;
+  return wrapped;
+}

--- a/src/main/llm/connection-error.ts
+++ b/src/main/llm/connection-error.ts
@@ -4,36 +4,47 @@
  * SDK request — and the validation entry point can share it without an import
  * cycle, and it stays unit-testable without the SDK.
  *
- * Anthropic SDK errors carry an HTTP `status`; a status-less error is a
- * connection failure before we reached the API.
+ * SDK errors carry an HTTP `status`; a status-less error is a connection
+ * failure before we reached the service.
+ *
+ * **Every message names the service the caller passed in (#1804).** This file
+ * used to hardcode "Anthropic" in all five strings while being called by the
+ * OpenAI provider, the Google provider, AND the S3 publish target — so a bad
+ * OpenAI key reported "Anthropic rejected this key", and a failed bucket check
+ * reported "Couldn't reach Anthropic". Same bug as #1796, one layer down: the
+ * fix is the same, make the caller say who it is.
  */
 import type { ConnectionCheckResult } from '../../shared/tools/types';
 
-export function describeConnectionFailure(err: unknown): string {
+export function describeConnectionFailure(err: unknown, service: string): string {
   const status = (err as { status?: number } | null)?.status;
   if (status === 401) {
-    return 'Anthropic rejected this key — it may be invalid, expired, or revoked.';
+    return `${service} rejected this key — it may be invalid, expired, or revoked.`;
   }
   if (status === 403) {
-    return 'This key authenticated but is not permitted to use the API.';
+    return `This key authenticated but is not permitted to use ${service}.`;
   }
   if (status === 429) {
-    return 'Rate limited — the key works, but too many requests just now. Try again shortly.';
+    return `Rate limited — the key works, but too many requests just now. Try again shortly.`;
   }
   if (typeof status === 'number' && status >= 500) {
-    return 'Anthropic had a server error. The key may be fine — try again shortly.';
+    return `${service} had a server error. The key may be fine — try again shortly.`;
   }
   const detail = err instanceof Error ? err.message : String(err);
-  return `Couldn't reach Anthropic: ${detail}`;
+  return `Couldn't reach ${service}: ${detail}`;
 }
 
 /** Convenience wrapper: run a token-free validation request, mapping any throw
- *  to a `{ ok: false, error }`. The provider passes its SDK call in. */
-export async function toConnectionResult(request: () => Promise<unknown>): Promise<ConnectionCheckResult> {
+ *  to a `{ ok: false, error }`. The provider passes its SDK call in, plus the
+ *  name to put in front of the user — its own, never a borrowed one. */
+export async function toConnectionResult(
+  request: () => Promise<unknown>,
+  service: string,
+): Promise<ConnectionCheckResult> {
   try {
     await request();
     return { ok: true };
   } catch (err) {
-    return { ok: false, error: describeConnectionFailure(err) };
+    return { ok: false, error: describeConnectionFailure(err, service) };
   }
 }

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -23,6 +23,30 @@ import type { ConversationSourcePropertyDraft } from '../../shared/conversation-
 import type { ConversationClaimsDraft } from '../../shared/conversation-claims-drafts';
 import type { ConversationToolKey } from '../../shared/conversation-tools';
 import { formatToolCall } from './format-tool-call';
+import { toLlmFailureError } from './classify-error';
+import type { ProviderId } from '../../shared/tools/providers';
+
+/**
+ * Run one provider round-trip, classifying any throw into the shared failure
+ * taxonomy before it leaves main (#1804).
+ *
+ * This is the single choke point: IPC strips an SDK error's `status`/`code`, so
+ * a failure that isn't classified here can never be told apart from any other
+ * downstream — which is how "the model is overloaded" and "your key is revoked"
+ * both used to arrive in the renderer as an anonymous `console.error`.
+ *
+ * Wrap ONLY the provider call, never the surrounding tool execution.
+ */
+async function withProviderErrors<T>(
+  providerId: ProviderId,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (err) {
+    throw toLlmFailureError(err, providerId);
+  }
+}
 
 export interface StreamCallbacks {
   onChunk: (text: string) => void;
@@ -237,12 +261,12 @@ export async function complete(
     messages = [{ role: 'user', content: prompt }];
   }
 
-  const { provider, model, effort: defaultEffort } = await getProvider(modelOverride);
+  const { provider, id: providerId, model, effort: defaultEffort } = await getProvider(modelOverride);
   const effort = resolveEffort(model, effortOverride, defaultEffort);
 
   // `const` (not the outer `let`) so TS keeps the narrowing inside the closure.
   const cb = callbacks;
-  const result = await provider.complete(
+  const result = await withProviderErrors(providerId, () => provider.complete(
     {
       model,
       system,
@@ -253,7 +277,7 @@ export async function complete(
       signal: cb?.signal,
     },
     cb ? (delta) => cb.onChunk(delta) : undefined,
-  );
+  ));
   if (onUsage) onUsage(result.usage, model);
   return result.text;
 }
@@ -270,7 +294,7 @@ export async function complete(
 export async function completeWithTools(
   options: CompleteWithToolsOptions,
 ): Promise<CompleteWithToolsResult> {
-  const { provider, model, web: providerWeb, effort: defaultEffort } = await getProvider(options.model);
+  const { provider, id: providerId, model, web: providerWeb, effort: defaultEffort } = await getProvider(options.model);
   // A per-call `web` override (a `web: false` skill in the eval harness; a
   // per-conversation web setting, #1533) merges over the global web — so a caller
   // that overrides just `enabled` keeps the user's global allow/block domain lists.
@@ -323,7 +347,10 @@ export async function completeWithTools(
       );
     }
 
-    const turn = await provider.runTurn(
+    // Only the provider round-trip is wrapped — NOT the tool execution below.
+    // A tool that throws is a tool bug, and dressing it up as "the provider
+    // returned an unexpected error" would be a confident lie (#1804).
+    const turn = await withProviderErrors(providerId, () => provider.runTurn(
       {
         model,
         system: options.system,
@@ -339,7 +366,7 @@ export async function completeWithTools(
         onTextDelta: callbacks ? (delta) => callbacks.onChunk(delta) : undefined,
         onToolCallStart,
       },
-    );
+    ));
 
     sumUsage(usage, turn.usage);
     history.push(turn.assistantMessage);

--- a/src/main/llm/provider/anthropic.ts
+++ b/src/main/llm/provider/anthropic.ts
@@ -13,6 +13,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { Citation, TurnUsage } from '../../../shared/types';
 import type { ConnectionCheckResult } from '../../../shared/tools/types';
 import { toConnectionResult } from '../connection-error';
+import { PROVIDERS } from '../../../shared/tools/providers';
 import { withHistoryCacheBreakpoints } from './anthropic-cache';
 import type { Effort } from '../../../shared/tools/effort';
 import type {
@@ -251,6 +252,6 @@ export class AnthropicProvider implements LLMProvider {
   async checkConnection(): Promise<ConnectionCheckResult> {
     // A minimal authenticated GET: no tokens spent, model-agnostic. Any success
     // means the key is accepted.
-    return toConnectionResult(() => this.client.models.list({ limit: 1 }));
+    return toConnectionResult(() => this.client.models.list({ limit: 1 }), PROVIDERS.anthropic.label);
   }
 }

--- a/src/main/llm/provider/google.ts
+++ b/src/main/llm/provider/google.ts
@@ -29,6 +29,7 @@ import type {
 import type { TurnUsage } from '../../../shared/types';
 import type { ConnectionCheckResult } from '../../../shared/tools/types';
 import { toConnectionResult } from '../connection-error';
+import { PROVIDERS } from '../../../shared/tools/providers';
 import type { Effort } from '../../../shared/tools/effort';
 import type {
   ChatMessage,
@@ -221,6 +222,6 @@ export class GoogleProvider implements LLMProvider {
 
   async checkConnection(): Promise<ConnectionCheckResult> {
     // A minimal authenticated listing: no generation, so token-free.
-    return toConnectionResult(() => this.ai.models.list());
+    return toConnectionResult(() => this.ai.models.list(), PROVIDERS.google.label);
   }
 }

--- a/src/main/llm/provider/index.ts
+++ b/src/main/llm/provider/index.ts
@@ -20,6 +20,9 @@ export type { LLMProvider } from './types';
 
 export interface ResolvedProvider {
   provider: LLMProvider;
+  /** Which provider this is — so a failure can be attributed to the provider
+   *  the user actually chose rather than a hardcoded one (#1804). */
+  id: ProviderId;
   /** The effective model this provider will run (override ?? default). */
   model: string;
   web: WebToolSettings;
@@ -90,9 +93,11 @@ function buildProvider(id: ProviderId, settings: LLMSettings): LLMProvider {
 export async function getProvider(modelOverride?: string): Promise<ResolvedProvider> {
   const settings = await getSettings();
   const model = modelOverride ?? settings.model;
-  const provider = buildProvider(resolveProviderId(model, settings), settings);
+  const id = resolveProviderId(model, settings);
+  const provider = buildProvider(id, settings);
   return {
     provider,
+    id,
     model,
     web: settings.web ?? { ...DEFAULT_WEB_SETTINGS },
     effort: settings.effort,

--- a/src/main/llm/provider/openai.ts
+++ b/src/main/llm/provider/openai.ts
@@ -21,6 +21,7 @@ import OpenAI from 'openai';
 import type { TurnUsage } from '../../../shared/types';
 import type { ConnectionCheckResult } from '../../../shared/tools/types';
 import { toConnectionResult } from '../connection-error';
+import { PROVIDERS, type ProviderId } from '../../../shared/tools/providers';
 import type { Effort } from '../../../shared/tools/effort';
 import type {
   ChatMessage,
@@ -252,6 +253,11 @@ export class OpenAIProvider implements LLMProvider {
   async checkConnection(): Promise<ConnectionCheckResult> {
     // A minimal authenticated GET: no tokens spent. Any success means the key +
     // endpoint are accepted.
-    return toConnectionResult(() => this.client.models.list());
+    // `this.id` distinguishes OpenAI proper from a `local` OpenAI-compatible
+    // endpoint, so the failure names whichever one the user configured.
+    return toConnectionResult(
+      () => this.client.models.list(),
+      PROVIDERS[this.id as ProviderId]?.label ?? this.id,
+    );
   }
 }

--- a/src/main/publish/publish-to-s3.ts
+++ b/src/main/publish/publish-to-s3.ts
@@ -193,5 +193,8 @@ export async function checkS3Connection(
 ): Promise<ConnectionCheckResult> {
   const { HeadBucketCommand } = await import('@aws-sdk/client-s3');
   const client = deps.client ?? (await buildS3Client(target, creds));
-  return toConnectionResult(() => client.send(new HeadBucketCommand({ Bucket: target.bucket })));
+  return toConnectionResult(
+    () => client.send(new HeadBucketCommand({ Bucket: target.bucket })),
+    'S3',
+  );
 }

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -268,6 +268,8 @@ contextBridge.exposeInMainWorld('api', {
     listActive: () => invoke(Channels.CONVERSATION_LIST_ACTIVE),
     send: (convId: string, userMessage: string, systemPrompt?: string, currentNotePath?: string, extraTools?: Parameters<ChannelMap['conversation:send']>[4]) =>
       invoke(Channels.CONVERSATION_SEND, convId, userMessage, systemPrompt, currentNotePath, extraTools),
+    retry: (convId: string, systemPrompt?: string, currentNotePath?: string, extraTools?: Parameters<ChannelMap['conversation:retry']>[3]) =>
+      invoke(Channels.CONVERSATION_RETRY, convId, systemPrompt, currentNotePath, extraTools),
     loadUIState: () => invoke(Channels.CONVERSATION_UI_STATE_LOAD),
     saveUIState: (state: Parameters<ChannelMap['conversation:uiStateSave']>[0]) => invoke(Channels.CONVERSATION_UI_STATE_SAVE, state),
     onAskUser: (cb: (req: AskUserRequest) => void) => subscribe(Channels.CONVERSATION_ASK_USER, cb),

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -5,7 +5,7 @@
   import Icon from './Icon.svelte';
   import ToolParamsDialog from './ToolParamsDialog.svelte';
   import type { ToolContext } from '../../../shared/tools/types';
-  import { isProviderUnconfiguredError } from '../../../shared/llm-errors';
+  import { isProviderUnconfiguredError, describeLlmFailure } from '../../../shared/llm-errors';
   import { resolveNoteParams } from '../tools/resolve-note-params';
 
   interface Props {
@@ -37,7 +37,9 @@
       });
       panel.complete(result);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      // Classified in main, so this now reads "Anthropic is overloaded right
+      // now" instead of Electron's raw "Error invoking remote method …" (#1804).
+      const message = describeLlmFailure(err);
       if (isProviderUnconfiguredError(err)) {
         // Close the tool panel and let the App-level handler surface
         // the Open-Settings dialog. The panel's inline error string

--- a/src/renderer/lib/components/conversations/MessageList.svelte
+++ b/src/renderer/lib/components/conversations/MessageList.svelte
@@ -204,6 +204,49 @@
     </div>
   {/if}
 
+  <!-- A failed turn (#1804). Sits where the assistant's reply would have been,
+       so the failure is attached to the turn it belongs to rather than floating
+       free as a toast the user can scroll away from. Any text that streamed
+       before the failure renders above it — a turn that died three paragraphs
+       in still wrote three useful paragraphs, and throwing those away was part
+       of what made a failure feel like nothing had happened at all.
+
+       No danger styling per the project's UX philosophy: a rate limit is a
+       normal event, not an alarm. -->
+  {#if tab.failure && !tab.streaming}
+    {@const failure = tab.failure}
+    <div class="msg assistant failed">
+      <div class="msg-role">{roleLabel('assistant')}</div>
+      {#if failure.partial}
+        <div class="msg-content">{@html md.render(failure.partial)}</div>
+      {/if}
+      <div class="turn-error" role="status">
+        <span class="turn-error-icon" aria-hidden="true">⚠</span>
+        <div class="turn-error-body">
+          <p class="turn-error-message">{failure.message}</p>
+          <div class="turn-error-actions">
+            {#if failure.retryable}
+              <button
+                class="turn-error-action"
+                onclick={() => void store.retryLastTurn(tab.id, currentNotePath ?? undefined)}
+              >Retry</button>
+            {/if}
+            {#if failure.kind === 'context_length'}
+              <button
+                class="turn-error-action"
+                onclick={() => void store.runBuiltinCommand('compact')}
+              >Run /compact</button>
+            {/if}
+            <button
+              class="turn-error-action subtle"
+              onclick={() => store.dismissFailure(tab.id)}
+            >Dismiss</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  {/if}
+
   {#if tab.pendingQuestion}
     <div class="ask-user-card">
       <div class="ask-user-q">{tab.pendingQuestion.question}</div>
@@ -310,6 +353,56 @@
      the rules above handle its layout. */
   .msg.user .msg-content { white-space: pre-wrap; }
   .streaming .msg-content { opacity: 0.85; }
+
+  /* Failed turn (#1804). Deliberately NOT danger-styled — per the project's UX
+     philosophy a rate limit or an overloaded provider is a normal event, not an
+     alarm. It reads as an inset note attached to the turn, using the same
+     --bg-inset / --border treatment as other set-apart blocks, with the accent
+     reserved for the leading glyph so it's findable when scrolling. */
+  .turn-error {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+    margin-top: 6px;
+    padding: 10px 12px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+  }
+  .turn-error-icon {
+    color: var(--accent);
+    font-size: 13px;
+    line-height: 1.4;
+  }
+  .turn-error-body { flex: 1; min-width: 0; }
+  .turn-error-message {
+    margin: 0;
+    color: var(--text);
+    font-size: 12.5px;
+    line-height: 1.5;
+  }
+  .turn-error-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: 8px;
+  }
+  .turn-error-action {
+    padding: 3px 10px;
+    background: var(--bg-button);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 11.5px;
+    cursor: pointer;
+  }
+  .turn-error-action:hover { background: var(--bg-button-hover); }
+  .turn-error-action.subtle {
+    background: transparent;
+    color: var(--text-muted);
+  }
+  .turn-error-action.subtle:hover { color: var(--text); }
+  /* The partial text above a failure is real output, just incomplete. */
+  .failed .msg-content { opacity: 0.85; }
 
   /* "Thinking…" interstitial — three dots that pulse out of phase so the user
      can see the agent is in flight before the first chunk or tool indicator

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -603,6 +603,14 @@ export interface ConversationsApi {
     currentNotePath?: string,
     extraTools?: import('../../../shared/conversation-tools').ConversationToolKey[],
   ): Promise<Conversation>;
+  /** Re-run the last turn after a failure. The user's message is already
+   *  persisted, so this appends only the assistant reply (#1804). */
+  retry(
+    convId: string,
+    systemPrompt?: string,
+    currentNotePath?: string,
+    extraTools?: import('../../../shared/conversation-tools').ConversationToolKey[],
+  ): Promise<Conversation>;
   loadUIState(): Promise<import('../../../shared/types').ConversationsUIState>;
   saveUIState(state: import('../../../shared/types').ConversationsUIState): Promise<void>;
   onAskUser(cb: (req: import('../../../shared/conversation-tools').AskUserRequest) => void): void;

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -36,7 +36,13 @@ import type {
   AskUserRequest,
   ConversationToolKey,
 } from '../../../shared/conversation-tools';
-import { isProviderUnconfiguredError } from '../../../shared/llm-errors';
+import {
+  isProviderUnconfiguredError,
+  classifyLlmFailure,
+  describeLlmFailure,
+  isCancellation,
+  type LlmFailureKind,
+} from '../../../shared/llm-errors';
 
 /**
  * Plain deep clone for the IPC boundary. Every draft payload sent renderer→main
@@ -129,6 +135,25 @@ interface ComputeDraftStateEntry {
   afterMessageIndex: number;
 }
 
+/**
+ * A failed turn, rendered in the transcript where the reply would have been
+ * (#1804). Before this, everything except "no API key" was `console.error`d:
+ * the spinner stopped, the streamed text was thrown away, and the user's turn
+ * sat there un-replied with no explanation anywhere in the UI.
+ */
+export interface TabFailure {
+  kind: LlmFailureKind;
+  /** Already human-readable and provider-specific; classified in main. */
+  message: string;
+  /** Whether re-running the identical request is worth offering. */
+  retryable: boolean;
+  /** Text streamed before the failure. Kept, not discarded — a turn that died
+   *  three paragraphs in still wrote three useful paragraphs. */
+  partial: string;
+  /** Anchors the error block to the turn it belongs to. */
+  afterMessageIndex: number;
+}
+
 export interface TabRuntime {
   id: string;
   /** Auto-generated tab title. Set when a tool seeds the tab via
@@ -183,6 +208,8 @@ export interface TabRuntime {
   composer: string;
   streaming: boolean;
   streamedChunks: string;
+  /** The last turn's failure, or null. Cleared when a new turn starts. */
+  failure: TabFailure | null;
   /** Template-scoped tools enabled for this conversation (e.g. `ask_user`).
    *  Resolved at tab-creation time and re-sent with each turn. In-memory
    *  only — if the user reloads the project, the tab still works but the
@@ -492,28 +519,84 @@ async function send(content: string, currentNotePath?: string): Promise<void> {
   ];
   tab.streaming = true;
   tab.streamedChunks = '';
+  tab.failure = null;
   const tools = tab.extraTools.length > 0 ? [...tab.extraTools] : undefined;
   try {
     await api.conversations.send(tab.id, text, undefined, currentNotePath, tools);
     const reloaded = await api.conversations.load(tab.id);
     if (reloaded) tab.conversation = reloaded;
   } catch (e) {
-    if (isProviderUnconfiguredError(e)) {
-      // Surface as an actionable modal at the App level rather than a
-      // silent console.error — the user's optimistic message would
-      // otherwise just sit in the transcript with no explanation. Also
-      // drop that optimistic insert so the transcript isn't littered
-      // with un-replied turns after the user wires up a key.
-      tab.conversation.messages = tab.conversation.messages.slice(0, -1);
-      tab.composer = text;
-      needsApiKey = true;
-    } else if (!String(e).includes('abort')) {
-      console.error('[conv] send failed:', e);
-    }
+    handleTurnFailure(tab, e, text);
   } finally {
     tab.streaming = false;
     tab.streamedChunks = '';
   }
+}
+
+/**
+ * Re-run the turn that just failed (#1804).
+ *
+ * Goes through CONVERSATION_RETRY, not send(): main appends the user's message
+ * *before* calling the model, so a failed turn already persisted it. Re-sending
+ * the text would file the same user turn twice.
+ */
+async function retryLastTurn(tabId: string, currentNotePath?: string): Promise<void> {
+  const tab = findTab(tabId);
+  if (!tab || tab.streaming) return;
+  tab.streaming = true;
+  tab.streamedChunks = '';
+  tab.failure = null;
+  const tools = tab.extraTools.length > 0 ? [...tab.extraTools] : undefined;
+  try {
+    await api.conversations.retry(tab.id, undefined, currentNotePath, tools);
+    const reloaded = await api.conversations.load(tab.id);
+    if (reloaded) tab.conversation = reloaded;
+  } catch (e) {
+    handleTurnFailure(tab, e, null);
+  } finally {
+    tab.streaming = false;
+    tab.streamedChunks = '';
+  }
+}
+
+/**
+ * One place that decides what a failed turn looks like, shared by send() and
+ * retry(). Three outcomes:
+ *
+ * - **Cancelled** — the user's own doing; stay quiet, leave the transcript be.
+ * - **Unconfigured provider** — keep the existing App-level modal, which is a
+ *   better affordance than an inline message because the fix is elsewhere
+ *   (Settings). Roll back the optimistic turn so the transcript isn't littered
+ *   with un-replied messages once a key is wired up.
+ * - **Everything else** — an inline failure block, keeping the partial reply.
+ *
+ * `sentText` is the user's message when we can put it back in the composer
+ * (send), and null when it's already committed to the transcript (retry).
+ */
+function handleTurnFailure(tab: TabRuntime, e: unknown, sentText: string | null): void {
+  if (isCancellation(e)) return;
+
+  if (isProviderUnconfiguredError(e)) {
+    if (sentText !== null) {
+      tab.conversation.messages = tab.conversation.messages.slice(0, -1);
+      tab.composer = sentText;
+    }
+    needsApiKey = true;
+    return;
+  }
+
+  const classified = classifyLlmFailure(e);
+  tab.failure = {
+    kind: classified?.kind ?? 'unknown',
+    message: describeLlmFailure(e),
+    retryable: classified?.retryable ?? true,
+    // Whatever streamed before the failure is real output — keep it. `finally`
+    // clears streamedChunks, so capture it here.
+    partial: tab.streamedChunks,
+    afterMessageIndex: tab.conversation.messages.length,
+  };
+  // Still log for anyone with devtools open; the UI no longer depends on it.
+  console.error('[conv] turn failed:', e);
 }
 
 /**
@@ -544,7 +627,10 @@ async function compactConversation(): Promise<void> {
     activeTabId = newTab.id;
     scheduleSave();
   } catch (e) {
-    console.error('[conv] /compact failed:', e);
+    // /compact is a model call like any other — it can hit a 429, an exhausted
+    // balance, or a dead network, and used to fail by silently dropping the
+    // "Compacting earlier turns…" indicator (#1804).
+    handleTurnFailure(tab, e, null);
   } finally {
     // If the tab was swapped out, this just touches the now-detached old tab
     // object; the new tab starts with streaming=false.
@@ -627,6 +713,7 @@ function blankTabRuntime(conv: Conversation, extraTools: ConversationToolKey[]):
     composer: '',
     streaming: false,
     streamedChunks: '',
+    failure: null,
     extraTools,
   };
 }
@@ -683,6 +770,38 @@ async function cancel(): Promise<void> {
   }
 }
 
+/**
+ * Run one draft-approval write, reporting a failure instead of dropping it
+ * (#1804).
+ *
+ * All ten `approve*Draft` functions used to `await api.conversations.file*(…)`
+ * bare. A rejection there became an unhandled promise rejection: the card
+ * stayed on screen, no result line appeared, and nothing told the user their
+ * Approve hadn't landed — the worst version of this bug, because the transcript
+ * looked like the change was still pending when it had actually failed.
+ *
+ * Not retryable: these are writes, and re-firing one blind is how you get a
+ * half-applied bundle. The user re-approves from the card, which is still there.
+ */
+async function applyDraft<T>(
+  tab: TabRuntime,
+  run: () => Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false }> {
+  try {
+    return { ok: true, value: await run() };
+  } catch (e) {
+    tab.failure = {
+      kind: classifyLlmFailure(e)?.kind ?? 'unknown',
+      message: `Couldn't apply that change. ${describeLlmFailure(e)}`,
+      retryable: false,
+      partial: '',
+      afterMessageIndex: tab.conversation.messages.length,
+    };
+    console.error('[conv] apply draft failed:', e);
+    return { ok: false };
+  }
+}
+
 async function approveDraft(tabId: string, draft: ConversationDraft): Promise<{ filedPaths: string[] }> {
   const tab = findTab(tabId);
   if (!tab) return { filedPaths: [] };
@@ -693,7 +812,9 @@ async function approveDraft(tabId: string, draft: ConversationDraft): Promise<{ 
   // Snapshot before crossing IPC — Svelte 5 `$state` Proxies fail
   // structured-clone otherwise (see project memory).
   const snapshot = plainSnapshot(draft);
-  const result = await api.conversations.fileDraft(snapshot);
+  const applied = await applyDraft(tab, () => api.conversations.fileDraft(snapshot));
+  if (!applied.ok) return { filedPaths: [] };
+  const result = applied.value;
   // Drop the in-flight card and replace it with a persistent "Filed:"
   // summary keyed by the same draftId. `filedPaths` reflects the actual
   // post-collision-dedup paths the approval engine wrote.
@@ -729,7 +850,7 @@ async function approveRefactorDraft(tabId: string, draft: ConversationRefactorDr
   if (!tab) return;
   // Snapshot before crossing IPC ($state Proxies fail structured-clone).
   const snapshot = plainSnapshot(draft);
-  await api.conversations.fileRefactorDraft(snapshot);
+  if (!(await applyDraft(tab, () => api.conversations.fileRefactorDraft(snapshot))).ok) return;
   // Drop the card. The move + link rewrites land via the approval engine, and
   // the NOTEBASE_RENAMED / NOTEBASE_REWRITTEN broadcasts update any open editors.
   tab.refactorDrafts = tab.refactorDrafts.filter((d) => d.draftId !== draft.draftId);
@@ -745,7 +866,7 @@ async function approveReorgDraft(
   const tab = findTab(tabId);
   if (!tab) return;
   const snapshot = plainSnapshot(draft);
-  await api.conversations.fileReorgDraft(snapshot, selected);
+  if (!(await applyDraft(tab, () => api.conversations.fileReorgDraft(snapshot, selected))).ok) return;
   tab.reorgDrafts = tab.reorgDrafts.filter((d) => d.draftId !== draft.draftId);
 }
 
@@ -759,7 +880,7 @@ async function approveDeleteDraft(
   const tab = findTab(tabId);
   if (!tab) return;
   const snapshot = plainSnapshot(draft);
-  await api.conversations.fileDeleteDraft(snapshot, selected);
+  if (!(await applyDraft(tab, () => api.conversations.fileDeleteDraft(snapshot, selected))).ok) return;
   // Drop the card. The deletions land via the approval engine, and the
   // NOTEBASE_FILE_DELETED broadcasts close any open editors + refresh the tree.
   tab.deleteDrafts = tab.deleteDrafts.filter((d) => d.draftId !== draft.draftId);
@@ -775,7 +896,7 @@ async function approveNoteBodyDraft(
   const tab = findTab(tabId);
   if (!tab) return;
   const snapshot = plainSnapshot(draft);
-  await api.conversations.fileNoteBodyDraft(snapshot, selected);
+  if (!(await applyDraft(tab, () => api.conversations.fileNoteBodyDraft(snapshot, selected))).ok) return;
   // Drop the card. The rewrites land via the approval engine as ONE bundled
   // proposal, and the NOTEBASE_REWRITTEN broadcast reloads any open editors.
   tab.noteBodyDrafts = tab.noteBodyDrafts.filter((d) => d.draftId !== draft.draftId);
@@ -797,7 +918,9 @@ async function approveSourceDraft(
   // Snapshot before crossing IPC — same Svelte 5 $state Proxy issue
   // that bit propose_notes.
   const snapshot = plainSnapshot(draft);
-  const result = await api.conversations.fileSourceDraft(snapshot);
+  const applied = await applyDraft(tab, () => api.conversations.fileSourceDraft(snapshot));
+  if (!applied.ok) return;
+  const result = applied.value;
   // Drop the in-flight card and stash the per-source outcomes so the
   // panel can replace the card with a brief status summary.
   tab.sourceDrafts = tab.sourceDrafts.filter((d) => d.draftId !== draft.draftId);
@@ -829,7 +952,9 @@ async function approvePropertyDraft(
   // payload that first forced the JSON round-trip now in plainSnapshot — see its
   // doc for the "set_properties approved but no frontmatter landed" history.
   const plain = plainSnapshot(draft);
-  const result = await api.conversations.filePropertyDraft(plain);
+  const applied = await applyDraft(tab, () => api.conversations.filePropertyDraft(plain));
+  if (!applied.ok) return;
+  const result = applied.value;
   tab.propertyDrafts = tab.propertyDrafts.filter((d) => d.draftId !== draft.draftId);
   tab.propertyDraftResults = {
     ...tab.propertyDraftResults,
@@ -850,7 +975,9 @@ async function approveSourcePropertyDraft(
   // JSON round-trip to shed any $state Proxy before IPC structured-clone —
   // same defensive snapshot the property-draft path uses (#103).
   const plain = plainSnapshot(draft);
-  const result = await api.conversations.fileSourcePropertyDraft(plain);
+  const applied = await applyDraft(tab, () => api.conversations.fileSourcePropertyDraft(plain));
+  if (!applied.ok) return;
+  const result = applied.value;
   tab.sourcePropertyDrafts = tab.sourcePropertyDrafts.filter((d) => d.draftId !== draft.draftId);
   tab.sourcePropertyDraftResults = {
     ...tab.sourcePropertyDraftResults,
@@ -871,7 +998,9 @@ async function approveClaimsDraft(
   // JSON round-trip to shed any $state Proxy before IPC structured-clone —
   // the claims array is nested, so this is the safe snapshot (#104).
   const plain = plainSnapshot(draft);
-  const result = await api.conversations.fileClaimsDraft(plain);
+  const applied = await applyDraft(tab, () => api.conversations.fileClaimsDraft(plain));
+  if (!applied.ok) return;
+  const result = applied.value;
   tab.claimsDrafts = tab.claimsDrafts.filter((d) => d.draftId !== draft.draftId);
   tab.claimsDraftResults = {
     ...tab.claimsDraftResults,
@@ -926,7 +1055,11 @@ async function runComputeDraft(
     tab.computeDraftState = {
       ...tab.computeDraftState,
       [draft.draftId]: {
-        result: { ok: false, error: e instanceof Error ? e.message : String(e) },
+        // describeLlmFailure over `e.message`: a compute draft can be run by a
+        // model call, so this arm sees classified provider failures too — and
+        // the raw message still carries Electron's "Error invoking remote
+        // method" prefix, which is noise on a card (#1804).
+        result: { ok: false, error: describeLlmFailure(e) },
         running: false,
         insertedAt: tab.computeDraftState[draft.draftId]?.insertedAt ?? null,
         afterMessageIndex: tab.computeDraftState[draft.draftId]?.afterMessageIndex
@@ -963,6 +1096,14 @@ async function insertComputeDraft(
     return where;
   } catch (e) {
     console.error('[conv] insert compute draft failed:', e);
+    // Returning null alone left the user with a button that did nothing (#1804).
+    tab.failure = {
+      kind: classifyLlmFailure(e)?.kind ?? 'unknown',
+      message: `Couldn't insert that cell into a note. ${describeLlmFailure(e)}`,
+      retryable: false,
+      partial: '',
+      afterMessageIndex: tab.conversation.messages.length,
+    };
     return null;
   }
 }
@@ -979,6 +1120,12 @@ function discardComputeDraft(tabId: string, draftId: string): void {
 function setComposer(value: string): void {
   const tab = activeTab();
   if (tab) tab.composer = value;
+}
+
+/** Clear the inline failure block — the user has read it. */
+function dismissFailure(tabId: string): void {
+  const tab = findTab(tabId);
+  if (tab) tab.failure = null;
 }
 
 function dismissApiKeyDialog(): void {
@@ -1006,6 +1153,8 @@ export function getConversationsStore() {
     openConversationTab,
     closeTab,
     send,
+    retryLastTurn,
+    dismissFailure,
     answerQuestion,
     cancel,
     setModel,

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -516,6 +516,9 @@ export const Channels = {
   CONVERSATION_LIST: 'conversation:list',
   CONVERSATION_LIST_ACTIVE: 'conversation:listActive',
   CONVERSATION_SEND: 'conversation:send',
+  /** renderer → main: re-run the last turn after a failure. The user's message
+   *  is already persisted, so this appends only the assistant reply (#1804). */
+  CONVERSATION_RETRY: 'conversation:retry',
   CONVERSATION_STREAM: 'conversation:stream',
   CONVERSATION_CANCEL: 'conversation:cancel',
   /** main → renderer: a propose_notes tool call produced a draft for review. Payload is ConversationDraft. */

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -539,6 +539,7 @@ export interface ChannelMap {
   'conversation:list': () => Conversation[];
   'conversation:listActive': () => Conversation[];
   'conversation:send': (convId: string, userMessage: string, systemPrompt?: string, currentNotePath?: string, extraTools?: ConversationToolKey[]) => Conversation;
+  'conversation:retry': (convId: string, systemPrompt?: string, currentNotePath?: string, extraTools?: ConversationToolKey[]) => Conversation;
   'conversation:cancel': () => void;
   'conversation:uiStateLoad': () => ConversationsUIState;
   'conversation:uiStateSave': (state: ConversationsUIState) => void;

--- a/src/shared/llm-errors.ts
+++ b/src/shared/llm-errors.ts
@@ -34,6 +34,167 @@ function messageOf(err: unknown): string | null {
   return null;
 }
 
+/* ── The general failure taxonomy (#1804) ──────────────────────────────────
+ *
+ * "Provider isn't set up" was the only failure the UI could recognise, because
+ * it was the only one anybody encoded. Everything else — a revoked key, a 429,
+ * an exhausted credit balance, a 529 overload, an unplugged network cable —
+ * arrived as an opaque SDK error, got `console.error`d in the renderer, and
+ * left the user staring at an un-replied turn.
+ *
+ * IPC strips the Error class and every custom property, so an SDK error's
+ * `status` does NOT survive the boundary. Classification therefore has to
+ * happen in MAIN, where the SDK error is still intact, and travel as text. This
+ * extends the marker trick above to the whole taxonomy: main builds the message
+ * with `llmFailureMessage`, which embeds a machine token; the renderer parses
+ * it back with `classifyLlmFailure` and renders the human half.
+ *
+ * The token is stripped from anything user-visible — `describeLlmFailure` is
+ * the only thing UI should print.
+ */
+
+/** What went wrong, in terms a UI can act on. */
+export type LlmFailureKind =
+  /** No key / no base URL. Actionable: open Settings → AI. */
+  | 'unconfigured'
+  /** Key rejected, expired, revoked, or not permitted (401/403). */
+  | 'auth'
+  /** Too many requests (429). Temporary; retry works. */
+  | 'rate_limited'
+  /** Credit balance or plan quota exhausted. Retrying will NOT help. */
+  | 'quota'
+  /** Provider overloaded (429-overloaded / 503 / Anthropic 529). Temporary. */
+  | 'overloaded'
+  /** Provider-side 5xx. Temporary. */
+  | 'server'
+  /** Never reached the provider — offline, DNS, TLS, timeout. */
+  | 'network'
+  /** The request exceeded the model's context window. */
+  | 'context_length'
+  /** The provider refused the request as malformed / not permitted (4xx). */
+  | 'invalid_request'
+  /** The user cancelled. Not an error; the UI should stay quiet. */
+  | 'cancelled'
+  /** Anything unrecognised. */
+  | 'unknown';
+
+/** A parsed failure, ready to render. */
+export interface LlmFailure {
+  kind: LlmFailureKind;
+  /** Human-readable, already provider-specific. Never contains the token. */
+  message: string;
+  /** Which provider failed, when the classifier knew. */
+  provider: ProviderId | null;
+  /** Is trying the exact same request again worth offering? */
+  retryable: boolean;
+}
+
+/** Kinds where the same request may well succeed on a second attempt. */
+const RETRYABLE: ReadonlySet<LlmFailureKind> = new Set<LlmFailureKind>([
+  'rate_limited', 'overloaded', 'server', 'network',
+]);
+
+export function isRetryableKind(kind: LlmFailureKind): boolean {
+  return RETRYABLE.has(kind);
+}
+
+/**
+ * The machine half of the contract. Searched for anywhere in the message rather
+ * than anchored, because Electron wraps it ("Error invoking remote method '…':
+ * Error: <ours>") and a provider SDK may wrap it again.
+ */
+const TOKEN_RE = /MINERVA_LLM_FAILURE:([a-z_]+):([a-z]*):/;
+
+/** Build the wire message main throws. `detail` is the human half. */
+export function llmFailureMessage(
+  kind: LlmFailureKind,
+  detail: string,
+  provider: ProviderId | null = null,
+): string {
+  return `MINERVA_LLM_FAILURE:${kind}:${provider ?? ''}:${detail}`;
+}
+
+/**
+ * Parse a failure back out of whatever crossed the boundary.
+ *
+ * Returns null when this isn't one of ours — callers should NOT invent a kind
+ * for an arbitrary error, the same way `unconfiguredProvider` returns null
+ * rather than guessing a provider.
+ */
+export function classifyLlmFailure(err: unknown): LlmFailure | null {
+  const msg = messageOf(err);
+  if (msg === null) return null;
+
+  const m = TOKEN_RE.exec(msg);
+  if (m) {
+    const kind = m[1] as LlmFailureKind;
+    const provider = (m[2] || null) as ProviderId | null;
+    return {
+      kind,
+      message: msg.slice(m.index + m[0].length).trim(),
+      provider,
+      retryable: isRetryableKind(kind),
+    };
+  }
+
+  // Legacy / hand-built unconfigured messages predate the token (and the
+  // builders below still emit the human marker for them), so keep detecting
+  // those the original way rather than dropping them to 'unknown'.
+  if (isProviderUnconfiguredError(err)) {
+    return {
+      kind: 'unconfigured',
+      message: stripIpcPrefix(msg),
+      provider: unconfiguredProvider(err),
+      retryable: false,
+    };
+  }
+
+  // A user cancel comes back as a DOMException/AbortError, not as one of ours.
+  if (isAbortError(err)) {
+    return { kind: 'cancelled', message: 'Cancelled.', provider: null, retryable: false };
+  }
+
+  return null;
+}
+
+/**
+ * One-line, user-facing text for any error at all — the only thing UI should
+ * print. Unrecognised errors fall through to their own message, minus the
+ * Electron IPC prefix, so a genuinely novel failure still says *something*
+ * instead of vanishing into console.error.
+ */
+export function describeLlmFailure(err: unknown): string {
+  const failure = classifyLlmFailure(err);
+  if (failure) return failure.message;
+  const msg = messageOf(err);
+  return msg === null ? 'Something went wrong.' : stripIpcPrefix(msg);
+}
+
+/**
+ * Was this a user-initiated cancel rather than a failure?
+ *
+ * Replaces `String(e).includes('abort')` in the conversation store, which both
+ * over-matched (any provider error mentioning "abort") and under-matched (a
+ * cancel worded any other way). `AbortController` produces a DOMException named
+ * `AbortError`; the classified form covers a cancel that crossed IPC.
+ */
+export function isCancellation(err: unknown): boolean {
+  return isAbortError(err) || classifyLlmFailure(err)?.kind === 'cancelled';
+}
+
+function isAbortError(err: unknown): boolean {
+  const name = (err as { name?: unknown } | null)?.name;
+  return name === 'AbortError' || name === 'TimeoutError';
+}
+
+/** Electron prefixes a rejected handler's message; it's noise in the UI. */
+function stripIpcPrefix(msg: string): string {
+  return msg
+    .replace(/^Error invoking remote method '[^']*':\s*/, '')
+    .replace(/^(?:Error|DOMException):\s*/, '')
+    .trim();
+}
+
 function prefix(id: ProviderId): string {
   return `${PROVIDERS[id].label} ${PROVIDER_UNCONFIGURED_MARKER}`;
 }

--- a/tests/main/ipc/__snapshots__/registration.test.ts.snap
+++ b/tests/main/ipc/__snapshots__/registration.test.ts.snap
@@ -58,6 +58,7 @@ exports[`IPC registration contract (#997) > matches the known set of registered 
   "conversation:list",
   "conversation:listActive",
   "conversation:load",
+  "conversation:retry",
   "conversation:runComputeDraft",
   "conversation:send",
   "conversation:setEffort",

--- a/tests/main/ipc/register-conversation.test.ts
+++ b/tests/main/ipc/register-conversation.test.ts
@@ -33,6 +33,7 @@ const h = vi.hoisted(() => {
     exitLLMContext: vi.fn(),
     completeWithTools: vi.fn(),
     appendMessage: vi.fn(),
+    load: vi.fn(),
     setContainerId: vi.fn(),
     proposeWrite: vi.fn(),
     approveProposal: vi.fn(),
@@ -88,6 +89,7 @@ vi.mock('../../../src/main/llm/index', () => ({ completeWithTools: h.completeWit
 vi.mock('../../../src/main/llm/conversation', () => ({
   appendMessage: h.appendMessage,
   setContainerId: h.setContainerId,
+  load: h.load,
 }));
 
 // Approval engine — the trust gate.
@@ -111,10 +113,23 @@ registerConversationDrafts();
 const evt = { sender: {} };
 const send = h.handlers.get(Channels.CONVERSATION_SEND)!;
 const cancel = h.handlers.get(Channels.CONVERSATION_CANCEL)!;
+const retry = h.handlers.get(Channels.CONVERSATION_RETRY)!;
 const fileDraft = h.handlers.get(Channels.CONVERSATION_FILE_DRAFT)!;
 const fileDeleteDraft = h.handlers.get(Channels.CONVERSATION_FILE_DELETE_DRAFT)!;
 
+const CONV = {
+  id: 'conv-1',
+  messages: [{ role: 'user', content: 'hello' }],
+  systemPrompt: undefined,
+  contextBundle: {},
+  model: 'claude-x',
+  effort: 'medium',
+  webEnabled: undefined,
+  containerId: undefined,
+};
+
 function seedConversation(): void {
+  h.load.mockResolvedValue(CONV);
   h.appendMessage.mockResolvedValue({
     id: 'conv-1',
     messages: [{ role: 'user', content: 'hello' }],
@@ -299,5 +314,46 @@ describe('CONVERSATION_FILE_DELETE_DRAFT — the selection UNIT differs by kind 
     expect(h.proposeWrite.mock.calls[0]![1]).toMatchObject({
       payloads: [{ kind: 'note-delete', path: 'x.md' }],
     });
+  });
+});
+
+// ── Retry after a failed turn (#1804) ──────────────────────────────────────
+// Main appends the user's message BEFORE calling the model, so a failed turn
+// leaves it persisted. Retry therefore has to re-run the completion over the
+// existing history — going back through SEND would file the same user turn a
+// second time, which is the bug this handler exists to avoid.
+
+describe('CONVERSATION_RETRY (#1804)', () => {
+  it('registers the handler', () => {
+    expect(retry).toBeDefined();
+  });
+
+  it('re-runs the completion WITHOUT re-appending the user message', async () => {
+    h.completeWithTools.mockResolvedValue(completion('second attempt'));
+
+    await retry(evt, 'conv-1');
+
+    // Loaded, not appended-to: exactly one appendMessage call, the assistant's.
+    expect(h.load).toHaveBeenCalledWith('conv-1');
+    expect(h.completeWithTools).toHaveBeenCalledTimes(1);
+    expect(h.appendMessage).toHaveBeenCalledTimes(1);
+    expect(h.appendMessage).toHaveBeenCalledWith(
+      'conv-1', 'assistant', 'second attempt', expect.anything(),
+    );
+  });
+
+  it('runs inside the graph LLM context, and exits even when the model throws', async () => {
+    h.completeWithTools.mockRejectedValue(new Error('overloaded'));
+
+    await expect(retry(evt, 'conv-1')).rejects.toThrow('overloaded');
+
+    expect(h.enterLLMContext).toHaveBeenCalledTimes(1);
+    expect(h.exitLLMContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws rather than silently no-opping when the conversation is gone', async () => {
+    h.load.mockResolvedValue(null);
+    await expect(retry(evt, 'conv-1')).rejects.toThrow(/not found/i);
+    expect(h.completeWithTools).not.toHaveBeenCalled();
   });
 });

--- a/tests/main/llm/classify-error.test.ts
+++ b/tests/main/llm/classify-error.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Provider error → failure kind (#1804).
+ *
+ * These are the shapes the three SDKs actually throw. The distinction the
+ * tests care most about is `rate_limited` vs `quota`: both arrive as HTTP 429,
+ * but one clears by itself and the other needs a credit card, and telling
+ * someone to "try again shortly" when their balance is empty is precisely the
+ * unhelpfulness this classifier exists to remove.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyProviderError, toLlmFailureError } from '../../../src/main/llm/classify-error';
+import { classifyLlmFailure, describeLlmFailure, missingApiKeyMessage } from '../../../src/shared/llm-errors';
+
+/** An SDK-ish error: a real Error carrying the properties the SDKs attach. */
+function apiError(props: Record<string, unknown>): Error {
+  const message = typeof props.message === 'string' ? props.message : 'boom';
+  return Object.assign(new Error(message), props);
+}
+
+describe('classifyProviderError', () => {
+  it('maps auth failures from either status', () => {
+    expect(classifyProviderError(apiError({ status: 401 }))).toBe('auth');
+    expect(classifyProviderError(apiError({ status: 403 }))).toBe('auth');
+  });
+
+  it('separates a plain 429 (rate limited) from an exhausted balance (quota)', () => {
+    expect(classifyProviderError(apiError({ status: 429, message: 'Too many requests' })))
+      .toBe('rate_limited');
+    // OpenAI's shape.
+    expect(classifyProviderError(apiError({ status: 429, code: 'insufficient_quota' })))
+      .toBe('quota');
+  });
+
+  it("catches Anthropic's credit-balance 400, which is not an invalid request", () => {
+    const err = apiError({
+      status: 400,
+      message: 'Your credit balance is too low to access the Anthropic API',
+    });
+    expect(classifyProviderError(err)).toBe('quota');
+  });
+
+  it('treats 529 and 503 as a temporary overload, other 5xx as a server error', () => {
+    expect(classifyProviderError(apiError({ status: 529 }))).toBe('overloaded');
+    expect(classifyProviderError(apiError({ status: 503 }))).toBe('overloaded');
+    expect(classifyProviderError(apiError({ status: 500 }))).toBe('server');
+    expect(classifyProviderError(apiError({ status: 502 }))).toBe('server');
+  });
+
+  it('reads a status-less connection failure as network, never as a provider fault', () => {
+    expect(classifyProviderError(apiError({ name: 'APIConnectionError' }))).toBe('network');
+    expect(classifyProviderError(apiError({ message: 'getaddrinfo ENOTFOUND api.anthropic.com' })))
+      .toBe('network');
+    expect(classifyProviderError(apiError({ message: 'fetch failed' }))).toBe('network');
+  });
+
+  it('does not call a 500 a network error just because it mentions a timeout', () => {
+    // A status means we reached the provider — the presence of "timeout" in the
+    // body must not outrank that.
+    expect(classifyProviderError(apiError({ status: 500, message: 'upstream timeout' })))
+      .toBe('server');
+  });
+
+  it('recognises an over-long prompt as context_length, not a generic 400', () => {
+    expect(classifyProviderError(apiError({ status: 400, message: 'prompt is too long: 210000 tokens' })))
+      .toBe('context_length');
+    expect(classifyProviderError(apiError({ status: 400, code: 'context_length_exceeded' })))
+      .toBe('context_length');
+  });
+
+  it('reads an overload reported without a status', () => {
+    expect(classifyProviderError(apiError({ error: { type: 'overloaded_error' } })))
+      .toBe('overloaded');
+  });
+
+  it('treats an abort as a cancellation rather than a failure', () => {
+    expect(classifyProviderError(apiError({ name: 'AbortError' }))).toBe('cancelled');
+  });
+
+  it("falls back to 'unknown' rather than inventing a diagnosis", () => {
+    expect(classifyProviderError(apiError({ message: 'something weird' }))).toBe('unknown');
+    expect(classifyProviderError(null)).toBe('unknown');
+    expect(classifyProviderError(undefined)).toBe('unknown');
+    expect(classifyProviderError('a bare string')).toBe('unknown');
+  });
+});
+
+describe('toLlmFailureError → the renderer', () => {
+  it('round-trips kind, provider and human text across an IPC-style wrap', () => {
+    const wrapped = toLlmFailureError(apiError({ status: 529 }), 'anthropic');
+    // What Electron hands the renderer: our message inside its own prefix.
+    const overIpc = new Error(`Error invoking remote method 'conversation:send': Error: ${wrapped.message}`);
+
+    const failure = classifyLlmFailure(overIpc);
+    expect(failure?.kind).toBe('overloaded');
+    expect(failure?.provider).toBe('anthropic');
+    expect(failure?.retryable).toBe(true);
+    expect(failure?.message).toContain('Anthropic is overloaded');
+    // The machine token never reaches a user.
+    expect(describeLlmFailure(overIpc)).not.toContain('MINERVA_LLM_FAILURE');
+  });
+
+  it('names the provider the user actually chose (the #1796 lesson)', () => {
+    const openai = toLlmFailureError(apiError({ status: 401 }), 'openai');
+    expect(classifyLlmFailure(openai)?.message).toContain('OpenAI');
+    expect(classifyLlmFailure(openai)?.message).not.toContain('Anthropic');
+
+    const google = toLlmFailureError(apiError({ status: 429, code: 'insufficient_quota' }), 'google');
+    expect(classifyLlmFailure(google)?.message).toContain('Google Gemini');
+  });
+
+  it('marks only the self-clearing kinds retryable', () => {
+    const retryable = ['rate_limited', 'overloaded', 'server', 'network'];
+    const cases: Array<[Record<string, unknown>, string]> = [
+      [{ status: 429 }, 'rate_limited'],
+      [{ status: 529 }, 'overloaded'],
+      [{ status: 500 }, 'server'],
+      [{ name: 'APIConnectionError' }, 'network'],
+      [{ status: 401 }, 'auth'],
+      [{ status: 429, code: 'insufficient_quota' }, 'quota'],
+      [{ status: 400, message: 'prompt is too long' }, 'context_length'],
+    ];
+    for (const [props, kind] of cases) {
+      const failure = classifyLlmFailure(toLlmFailureError(apiError(props), 'anthropic'));
+      expect(failure?.kind, kind).toBe(kind);
+      expect(failure?.retryable, kind).toBe(retryable.includes(kind));
+    }
+  });
+
+  it('leaves an already-classified failure alone instead of re-wrapping it', () => {
+    const first = toLlmFailureError(apiError({ status: 401 }), 'openai');
+    const again = toLlmFailureError(first, 'anthropic');
+    // The original verdict — and the original provider — must survive.
+    expect(again.message).toBe(first.message);
+    expect(classifyLlmFailure(again)?.provider).toBe('openai');
+  });
+
+  it('passes the unconfigured-provider error through untouched', () => {
+    // The factory throws this before any provider call; re-wrapping it would
+    // destroy the marker the "Open Settings" affordance keys off.
+    const unconfigured = new Error(missingApiKeyMessage('google'));
+    const out = toLlmFailureError(unconfigured, 'google');
+    expect(out.message).toBe(unconfigured.message);
+    expect(classifyLlmFailure(out)?.kind).toBe('unconfigured');
+  });
+});

--- a/tests/main/llm/validate.test.ts
+++ b/tests/main/llm/validate.test.ts
@@ -77,20 +77,36 @@ describe('describeConnectionFailure — reason mapping', () => {
   const withStatus = (status: number) => Object.assign(new Error('x'), { status });
 
   it('401 → invalid / expired / revoked', () => {
-    expect(describeConnectionFailure(withStatus(401))).toMatch(/invalid, expired, or revoked/i);
+    expect(describeConnectionFailure(withStatus(401), 'Anthropic')).toMatch(/invalid, expired, or revoked/i);
   });
   it('403 → not permitted', () => {
-    expect(describeConnectionFailure(withStatus(403))).toMatch(/not permitted/i);
+    expect(describeConnectionFailure(withStatus(403), 'Anthropic')).toMatch(/not permitted/i);
   });
   it('429 → rate limited (key still works)', () => {
-    expect(describeConnectionFailure(withStatus(429))).toMatch(/rate limited/i);
+    expect(describeConnectionFailure(withStatus(429), 'Anthropic')).toMatch(/rate limited/i);
   });
   it('5xx → server error', () => {
-    expect(describeConnectionFailure(withStatus(503))).toMatch(/server error/i);
+    expect(describeConnectionFailure(withStatus(503), 'Anthropic')).toMatch(/server error/i);
   });
   it('status-less error → connection failure with the detail', () => {
-    const msg = describeConnectionFailure(new Error('ECONNREFUSED'));
+    const msg = describeConnectionFailure(new Error('ECONNREFUSED'), 'Anthropic');
     expect(msg).toMatch(/couldn't reach anthropic/i);
     expect(msg).toContain('ECONNREFUSED');
+  });
+
+  // The bug (#1804): every string here hardcoded "Anthropic", while the OpenAI
+  // provider, the Google provider and the S3 publish target all call through
+  // this same helper. A bad OpenAI key reported "Anthropic rejected this key";
+  // a failed bucket check reported "Couldn't reach Anthropic". Same shape as
+  // #1796, one layer down.
+  it('names the service the caller passed, never a borrowed one', () => {
+    for (const [status, service] of [[401, 'OpenAI'], [403, 'Google Gemini'], [503, 'S3']] as const) {
+      const msg = describeConnectionFailure(withStatus(status), service);
+      expect(msg, service).toContain(service);
+      expect(msg, service).not.toContain('Anthropic');
+    }
+    const s3 = describeConnectionFailure(new Error('ENOTFOUND'), 'S3');
+    expect(s3).toMatch(/couldn't reach s3/i);
+    expect(s3).not.toContain('Anthropic');
   });
 });

--- a/tests/preload/__snapshots__/preload-bridge.test.ts.snap
+++ b/tests/preload/__snapshots__/preload-bridge.test.ts.snap
@@ -87,6 +87,7 @@ exports[`preload contextBridge contract (#676) > matches the full method surface
     "onSourceDraft",
     "onSourcePropertyDraft",
     "onStream",
+    "retry",
     "runComputeDraft",
     "saveUIState",
     "send",

--- a/tests/renderer/components/MessageList-failure.test.ts
+++ b/tests/renderer/components/MessageList-failure.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The inline failed-turn block in the conversation transcript (#1804).
+ *
+ * The store tests assert that a failure is *recorded*; this asserts it is
+ * actually *shown* — the whole point of the change, since the old behaviour
+ * recorded nothing and rendered nothing. Mounts the real MessageList with a
+ * hand-built tab and checks what a user would see: the message, the preserved
+ * partial reply, and only the actions that make sense for that failure kind.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, screen } from '@testing-library/svelte';
+import type { TabRuntime, TabFailure } from '../../../src/renderer/lib/stores/conversations.svelte';
+
+const h = vi.hoisted(() => ({
+  retryLastTurn: vi.fn(),
+  dismissFailure: vi.fn(),
+  runBuiltinCommand: vi.fn(),
+  answerQuestion: vi.fn(),
+}));
+
+vi.mock('../../../src/renderer/lib/stores/conversations.svelte', () => ({
+  getConversationsStore: () => ({
+    retryLastTurn: h.retryLastTurn,
+    dismissFailure: h.dismissFailure,
+    runBuiltinCommand: h.runBuiltinCommand,
+    answerQuestion: h.answerQuestion,
+  }),
+}));
+vi.mock('../../../src/renderer/lib/stores/editor.svelte', () => ({
+  getEditorStore: () => ({ activeFilePath: null, save: vi.fn(), reloadTabFromDisk: vi.fn() }),
+}));
+vi.mock('../../../src/renderer/lib/stores/notebase.svelte', () => ({
+  getNotebaseStore: () => ({ writeFile: vi.fn() }),
+}));
+vi.mock('../../../src/renderer/lib/stores/source-data.svelte', () => ({
+  getSourceDataStore: () => ({ ingestUrl: vi.fn() }),
+}));
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { shell: { openExternal: vi.fn() }, notebase: { readFile: vi.fn() } },
+}));
+
+import MessageList from '../../../src/renderer/lib/components/conversations/MessageList.svelte';
+
+function tabWith(failure: TabFailure | null, streaming = false): TabRuntime {
+  return {
+    id: 'tab-1',
+    title: null,
+    conversation: {
+      id: 'conv-1',
+      contextBundle: {},
+      messages: [{ role: 'user', content: 'summarise this note', timestamp: 't' }],
+      status: 'active',
+      startedAt: 't',
+    },
+    drafts: [], sourceDrafts: [], sourceDraftResults: {}, noteDraftResults: {},
+    propertyDrafts: [], propertyDraftResults: {}, sourcePropertyDrafts: [],
+    sourcePropertyDraftResults: {}, claimsDrafts: [], claimsDraftResults: {},
+    computeDrafts: [], refactorDrafts: [], reorgDrafts: [], deleteDrafts: [],
+    noteBodyDrafts: [], computeDraftState: {}, pendingQuestion: null,
+    composer: '', streaming, streamedChunks: '', failure, extraTools: [],
+  } as unknown as TabRuntime;
+}
+
+const failure = (over: Partial<TabFailure> = {}): TabFailure => ({
+  kind: 'overloaded',
+  message: 'Anthropic is overloaded right now. This is temporary.',
+  retryable: true,
+  partial: '',
+  afterMessageIndex: 1,
+  ...over,
+});
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => cleanup());
+
+describe('failed turn, rendered inline (#1804)', () => {
+  it('shows nothing at all when there is no failure', () => {
+    render(MessageList, { props: { tab: tabWith(null), currentNotePath: null } });
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('shows the classified message where the reply would have been', () => {
+    render(MessageList, { props: { tab: tabWith(failure()), currentNotePath: null } });
+    expect(screen.getByText(/Anthropic is overloaded right now/)).toBeTruthy();
+  });
+
+  it('keeps the text that streamed before the failure', () => {
+    render(MessageList, {
+      props: {
+        tab: tabWith(failure({ partial: 'The note argues that large republics' })),
+        currentNotePath: null,
+      },
+    });
+    // A turn that died three paragraphs in still wrote three useful paragraphs.
+    expect(screen.getByText(/The note argues that large republics/)).toBeTruthy();
+  });
+
+  it('offers Retry for a temporary failure and wires it to the store', async () => {
+    render(MessageList, { props: { tab: tabWith(failure()), currentNotePath: 'notes/a.md' } });
+    const retry = screen.getByRole('button', { name: 'Retry' });
+
+    await fireEvent.click(retry);
+
+    expect(h.retryLastTurn).toHaveBeenCalledWith('tab-1', 'notes/a.md');
+  });
+
+  it('does NOT offer Retry when retrying cannot help', () => {
+    // An exhausted balance is the case that matters: a Retry button here is an
+    // invitation to bang on a door that will not open.
+    render(MessageList, {
+      props: {
+        tab: tabWith(failure({ kind: 'quota', retryable: false, message: 'Out of credit.' })),
+        currentNotePath: null,
+      },
+    });
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+    expect(screen.getByText('Out of credit.')).toBeTruthy();
+  });
+
+  it('offers /compact when the conversation outgrew the context window', async () => {
+    render(MessageList, {
+      props: {
+        tab: tabWith(failure({ kind: 'context_length', retryable: false, message: 'Too long.' })),
+        currentNotePath: null,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Run /compact' }));
+
+    expect(h.runBuiltinCommand).toHaveBeenCalledWith('compact');
+  });
+
+  it('can be dismissed', async () => {
+    render(MessageList, { props: { tab: tabWith(failure()), currentNotePath: null } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(h.dismissFailure).toHaveBeenCalledWith('tab-1');
+  });
+
+  it('yields to the streaming indicator while a new turn is in flight', () => {
+    // Retrying shouldn't leave the old error sitting under a live spinner.
+    render(MessageList, { props: { tab: tabWith(failure(), true), currentNotePath: null } });
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+  });
+});

--- a/tests/renderer/stores/conversations-store.test.ts
+++ b/tests/renderer/stores/conversations-store.test.ts
@@ -71,6 +71,7 @@ const h = vi.hoisted(() => {
       archive: vi.fn().mockResolvedValue(undefined),
       // turn
       send: vi.fn().mockResolvedValue(undefined),
+      retry: vi.fn().mockResolvedValue(undefined),
       cancel: vi.fn().mockResolvedValue(undefined),
       setModel: vi.fn(),
       setEffort: vi.fn(),
@@ -102,7 +103,7 @@ vi.mock('../../../src/renderer/lib/compute/run-cell-with-trust', () => ({ ensure
 const ensureComputeConsent = h.ensureComputeConsent;
 
 import { getConversationsStore } from '../../../src/renderer/lib/stores/conversations.svelte';
-import { missingApiKeyMessage } from '../../../src/shared/llm-errors';
+import { missingApiKeyMessage, llmFailureMessage } from '../../../src/shared/llm-errors';
 
 const store = getConversationsStore();
 const conv = () => h.api.conversations;
@@ -267,6 +268,141 @@ describe('send()', () => {
     expect(store.needsApiKey).toBe(false);
   });
 
+  // ── Failure reporting (#1804) ──────────────────────────────────────────
+  // Everything except the unconfigured case used to end at `console.error`: the
+  // spinner stopped, the streamed text was discarded, and the user's turn sat
+  // un-replied with nothing to explain it.
+
+  /** What Electron hands the renderer when a main handler throws. */
+  function overIpc(mainMessage: string): Error {
+    return new Error(`Error invoking remote method 'conversation:send': Error: ${mainMessage}`);
+  }
+
+  it('records a classified failure inline, keeping the user turn and the partial reply', async () => {
+    const tab = await freshTab();
+    conv().send.mockImplementationOnce(async () => {
+      // Text streamed before the provider died — this must survive.
+      tab.streamedChunks = 'The note argues that';
+      throw overIpc(llmFailureMessage('overloaded', 'Anthropic is overloaded right now.', 'anthropic'));
+    });
+
+    await store.send('summarise this');
+
+    expect(tab.failure?.kind).toBe('overloaded');
+    expect(tab.failure?.message).toBe('Anthropic is overloaded right now.');
+    expect(tab.failure?.retryable).toBe(true);
+    expect(tab.failure?.partial).toBe('The note argues that');
+    // The user's turn stays put — it's what Retry will re-run against.
+    expect(tab.conversation.messages.map((m) => m.content)).toEqual(['summarise this']);
+    expect(tab.composer).toBe('');
+    expect(tab.streaming).toBe(false);
+  });
+
+  it('never shows the machine token to the user', async () => {
+    const tab = await freshTab();
+    conv().send.mockRejectedValueOnce(
+      overIpc(llmFailureMessage('quota', 'Your OpenAI account is out of credit.', 'openai')),
+    );
+
+    await store.send('hello');
+
+    expect(tab.failure?.message).toBe('Your OpenAI account is out of credit.');
+    expect(tab.failure?.message).not.toContain('MINERVA_LLM_FAILURE');
+    expect(tab.failure?.message).not.toContain('Error invoking remote method');
+  });
+
+  it('marks a quota failure non-retryable — retrying an empty balance helps nobody', async () => {
+    const tab = await freshTab();
+    conv().send.mockRejectedValueOnce(
+      overIpc(llmFailureMessage('quota', 'Out of credit.', 'anthropic')),
+    );
+    await store.send('hello');
+    expect(tab.failure?.retryable).toBe(false);
+  });
+
+  it('stays silent on a user cancellation instead of reporting it as a failure', async () => {
+    const tab = await freshTab();
+    const abort = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    conv().send.mockRejectedValueOnce(abort);
+
+    await store.send('never mind');
+
+    expect(tab.failure).toBeNull();
+    expect(tab.streaming).toBe(false);
+  });
+
+  it('does not mistake a provider error that merely mentions "abort" for a cancel', async () => {
+    // The old check was String(e).includes('abort'), which swallowed this.
+    const tab = await freshTab();
+    conv().send.mockRejectedValueOnce(
+      overIpc(llmFailureMessage('server', 'The request was aborted upstream (502).', 'anthropic')),
+    );
+
+    await store.send('hello');
+
+    expect(tab.failure?.kind).toBe('server');
+  });
+
+  it('still routes an unconfigured provider to the modal, not the inline block', async () => {
+    const tab = await freshTab();
+    conv().send.mockRejectedValueOnce(new Error(missingApiKeyMessage('openai')));
+
+    await store.send('needs a key');
+
+    expect(store.needsApiKey).toBe(true);
+    expect(tab.failure).toBeNull();
+  });
+
+  it('retries through CONVERSATION_RETRY so the user turn is not filed twice', async () => {
+    const tab = await freshTab();
+    conv().send.mockRejectedValueOnce(
+      overIpc(llmFailureMessage('overloaded', 'Overloaded.', 'anthropic')),
+    );
+    await store.send('summarise this', 'notes/origin.md');
+    expect(tab.failure?.retryable).toBe(true);
+
+    const reloaded: Conversation = {
+      id: tab.id, contextBundle: { notePath: 'notes/origin.md' },
+      messages: [
+        { role: 'user', content: 'summarise this', timestamp: 't' },
+        { role: 'assistant', content: 'it argues X', timestamp: 't' },
+      ],
+      status: 'active', startedAt: 't',
+    };
+    conv().load.mockResolvedValueOnce(reloaded);
+
+    await store.retryLastTurn(tab.id, 'notes/origin.md');
+
+    // Main already persisted the user's message before the failed call, so a
+    // retry must NOT go back through send() — that would file it a second time.
+    expect(conv().retry).toHaveBeenCalledWith(tab.id, undefined, 'notes/origin.md', undefined);
+    expect(conv().send).toHaveBeenCalledTimes(1);
+    expect(tab.failure).toBeNull();
+    expect(tab.conversation.messages.map((m) => m.content)).toEqual(['summarise this', 'it argues X']);
+  });
+
+  it('reports a failed retry rather than clearing the error and going quiet', async () => {
+    const tab = await freshTab();
+    conv().send.mockRejectedValueOnce(overIpc(llmFailureMessage('overloaded', 'Overloaded.', 'anthropic')));
+    await store.send('hello');
+    conv().retry.mockRejectedValueOnce(overIpc(llmFailureMessage('rate_limited', 'Rate limited.', 'anthropic')));
+
+    await store.retryLastTurn(tab.id);
+
+    expect(tab.failure?.kind).toBe('rate_limited');
+    expect(tab.streaming).toBe(false);
+  });
+
+  it('dismissFailure clears the block', async () => {
+    const tab = await freshTab();
+    conv().send.mockRejectedValueOnce(overIpc(llmFailureMessage('server', 'Boom.', 'anthropic')));
+    await store.send('hello');
+    expect(tab.failure).not.toBeNull();
+
+    store.dismissFailure(tab.id);
+    expect(tab.failure).toBeNull();
+  });
+
   it('no-ops on empty content and while already streaming', async () => {
     const tab = await freshTab();
     await store.send('   ');
@@ -390,6 +526,26 @@ describe('propose_notes draft (fileDraft)', () => {
     expect(result.filedPaths).toEqual(['notes/a.md']);
     expect(tab.drafts).toHaveLength(0);
     expect(tab.noteDraftResults['d1']!.filedPaths).toEqual(['notes/a.md']);
+  });
+
+  it('reports a failed Approve instead of dropping it, and leaves the card in place', async () => {
+    // Every approve*Draft used to `await api.conversations.file*(…)` bare, so a
+    // rejection became an unhandled promise rejection: the card stayed, no
+    // result line appeared, and nothing said the write had failed (#1804).
+    const tab = await freshTab();
+    (h.cbs.onDraft as Cb)({ draftId: 'd3', conversationId: tab.id });
+    conv().fileDraft.mockRejectedValueOnce(new Error('EACCES: permission denied'));
+
+    const result = await store.approveDraft(tab.id, tab.drafts[0]!);
+
+    expect(result.filedPaths).toEqual([]);
+    expect(tab.failure?.message).toContain("Couldn't apply that change");
+    expect(tab.failure?.message).toContain('EACCES');
+    // Not retryable: re-firing a write blind is how you half-apply a bundle.
+    expect(tab.failure?.retryable).toBe(false);
+    // The card survives so the user can approve again deliberately.
+    expect(tab.drafts.map((d) => d.draftId)).toEqual(['d3']);
+    expect(tab.noteDraftResults['d3']).toBeUndefined();
   });
 
   it('Discard removes the card without writing anything', async () => {

--- a/tests/shared/llm-errors.test.ts
+++ b/tests/shared/llm-errors.test.ts
@@ -15,6 +15,11 @@ import {
   missingBaseUrlMessage,
   isProviderUnconfiguredError,
   unconfiguredProvider,
+  llmFailureMessage,
+  classifyLlmFailure,
+  describeLlmFailure,
+  isCancellation,
+  isRetryableKind,
 } from '../../src/shared/llm-errors';
 import { PROVIDERS, PROVIDER_IDS } from '../../src/shared/tools/providers';
 
@@ -79,5 +84,86 @@ describe('detection across the IPC boundary', () => {
     const vague = new Error(`Something ${PROVIDER_UNCONFIGURED_MARKER}.`);
     expect(isProviderUnconfiguredError(vague)).toBe(true);
     expect(unconfiguredProvider(vague)).toBeNull();
+  });
+});
+
+// ── The general failure taxonomy (#1804) ────────────────────────────────────
+// Same round-trip property as above, one layer up: main builds a message,
+// the renderer parses it back. IPC strips an SDK error's `status`, so text is
+// the only channel — which makes these assertions the contract.
+
+describe('llmFailureMessage → classifyLlmFailure', () => {
+  it('round-trips kind, provider and human text', () => {
+    const wire = llmFailureMessage('rate_limited', 'Anthropic is rate limiting this key.', 'anthropic');
+    const failure = classifyLlmFailure(new Error(wire));
+    expect(failure?.kind).toBe('rate_limited');
+    expect(failure?.provider).toBe('anthropic');
+    expect(failure?.message).toBe('Anthropic is rate limiting this key.');
+  });
+
+  it('survives Electron’s wrapper, the same way the unconfigured marker does', () => {
+    const wire = llmFailureMessage('overloaded', 'Overloaded.', 'google');
+    const wrapped = new Error(`Error invoking remote method 'conversation:send': Error: ${wire}`);
+    expect(classifyLlmFailure(wrapped)?.kind).toBe('overloaded');
+    expect(classifyLlmFailure(wrapped)?.message).toBe('Overloaded.');
+  });
+
+  it('never leaks the machine token into user-facing text', () => {
+    const wire = llmFailureMessage('server', 'Server error.', 'openai');
+    expect(describeLlmFailure(new Error(wire))).toBe('Server error.');
+    expect(describeLlmFailure(new Error(wire))).not.toContain('MINERVA_LLM_FAILURE');
+  });
+
+  it('carries a provider-less failure without inventing one', () => {
+    const failure = classifyLlmFailure(new Error(llmFailureMessage('network', 'Offline.')));
+    expect(failure?.provider).toBeNull();
+    expect(failure?.kind).toBe('network');
+  });
+
+  it('classifies a legacy unconfigured message that predates the token', () => {
+    const failure = classifyLlmFailure(new Error(missingApiKeyMessage('google')));
+    expect(failure?.kind).toBe('unconfigured');
+    expect(failure?.provider).toBe('google');
+    expect(failure?.retryable).toBe(false);
+  });
+
+  it('returns null for anything that is not ours, rather than guessing a kind', () => {
+    expect(classifyLlmFailure(new Error('something odd'))).toBeNull();
+    expect(classifyLlmFailure(null)).toBeNull();
+    expect(classifyLlmFailure(42)).toBeNull();
+  });
+
+  it('still says something useful for an unrecognised error', () => {
+    // The fallback path: strip Electron's prefix, show the rest. Anything is
+    // better than the console.error this replaced.
+    const raw = new Error("Error invoking remote method 'conversation:send': Error: disk on fire");
+    expect(describeLlmFailure(raw)).toBe('disk on fire');
+    expect(describeLlmFailure(null)).toBe('Something went wrong.');
+  });
+
+  it('marks exactly the self-clearing kinds retryable', () => {
+    for (const kind of ['rate_limited', 'overloaded', 'server', 'network'] as const) {
+      expect(isRetryableKind(kind), kind).toBe(true);
+    }
+    for (const kind of ['auth', 'quota', 'unconfigured', 'context_length', 'invalid_request', 'cancelled', 'unknown'] as const) {
+      expect(isRetryableKind(kind), kind).toBe(false);
+    }
+  });
+});
+
+describe('isCancellation', () => {
+  it('recognises an AbortError from AbortController', () => {
+    expect(isCancellation(Object.assign(new Error('aborted'), { name: 'AbortError' }))).toBe(true);
+  });
+
+  it('recognises a cancellation that crossed IPC', () => {
+    expect(isCancellation(new Error(llmFailureMessage('cancelled', 'Cancelled.')))).toBe(true);
+  });
+
+  it('does NOT match a provider error that merely contains the word "abort"', () => {
+    // The bug this replaces: `String(e).includes('abort')` swallowed real
+    // failures whose message happened to mention an abort.
+    const real = new Error(llmFailureMessage('server', 'The request was aborted upstream.', 'anthropic'));
+    expect(isCancellation(real)).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #1804.

Every LLM failure except "provider not configured" ended at a `console.error`. The spinner stopped, the partially streamed reply was discarded, and the user's turn sat un-replied with nothing in the UI to explain it — identical whether the provider was overloaded, the key was revoked, the account was out of credit, or the machine was offline.

## The three pieces

**1. Classify in main.** Electron's IPC strips the Error class and every custom property, so an SDK error's `status`/`code`/body cannot reach the renderer — it *couldn't* tell those cases apart. New `main/llm/classify-error.ts` maps provider errors to a shared taxonomy at the one point the SDK error is still intact; `shared/llm-errors.ts` carries the verdict across as text, extending the marker mechanism the unconfigured-provider error already used.

Wrapped around the provider round-trip only, never the surrounding tool execution — a tool that throws is a tool bug, and dressing it up as "the provider returned an error" would be a confident lie. Because it sits at the `completeWithTools` / `complete` boundary, conversation send, `/compact`, skills, drafts and auto-tag all inherit it.

Kinds: `unconfigured`, `auth`, `rate_limited`, `quota`, `overloaded`, `server`, `network`, `context_length`, `invalid_request`, `cancelled`, `unknown`. The split that matters most is **rate-limited vs quota** — both usually arrive as HTTP 429, but one clears in a minute and the other needs a credit card, so "try again shortly" is exactly the wrong thing to tell someone whose balance is empty.

Unrecognised errors stay `unknown` and render the provider's own text. "We don't know" is more useful than a wrong diagnosis.

**2. Show it in the transcript.** The failure renders where the reply would have been, keeping whatever streamed before it — a turn that died three paragraphs in still wrote three useful paragraphs. Retry appears only for kinds that can clear on their own; an over-long conversation offers `/compact` instead. No danger styling, per the project's UX philosophy: a rate limit is a normal event, not an alarm.

```
┌─ You ─────────────────────────────┐
│ Summarise this note               │
└───────────────────────────────────┘
┌─ Minerva ─────────────────────────┐
│ The note argues that large…       │  ← partial reply kept
│                                   │
│ ⚠ Anthropic is overloaded right   │
│   now. This is temporary and not  │
│   a problem with your setup.      │
│   [ Retry ]  [ Dismiss ]          │
└───────────────────────────────────┘
```

**3. Retry without duplicating the turn.** Main appends the user's message *before* calling the model, so a failed turn leaves it persisted — going back through `send()` would file it twice. Adds `CONVERSATION_RETRY`, which re-runs the completion over existing history and appends only the assistant reply.

## Also fixed

- **`connection-error.ts` hardcoded "Anthropic"** in all five messages while being called by the OpenAI provider, the Google provider **and S3 publishing**. A bad OpenAI key reported "Anthropic rejected this key"; a failed bucket check reported "Couldn't reach Anthropic". Same bug as #1796, one layer down — the caller now names itself.
- **Cancel detection was `String(e).includes('abort')`**, which swallowed real failures whose message mentioned an abort and missed cancels worded differently. Now a typed check.
- **All ten `approve*Draft` functions awaited their `file*Draft` call bare.** A rejection became an unhandled promise rejection: the card stayed on screen, no result line appeared, nothing said the write had failed. The worst variant of this bug — the transcript looked like the change was still pending when it had actually failed. They now report and leave the card in place so the user can re-approve deliberately (not auto-retried: re-firing a write blind is how you half-apply a bundle).
- **`/compact`, `insertComputeDraft`, `ToolPanel`** reported either nothing or Electron's raw `Error invoking remote method '…'` string.

## Tests

| File | Covers |
|---|---|
| `main/llm/classify-error.test.ts` | the shapes the three SDKs actually throw; 429-vs-quota; Anthropic's credit-balance 400; 529/503 vs other 5xx; status-less network; not calling a 500 "network" because it says timeout; already-classified and unconfigured pass-through |
| `shared/llm-errors.test.ts` | main→renderer round-trip through Electron's wrapper; token never leaks to the user; legacy unconfigured messages still classify; `isCancellation` does **not** match a provider error mentioning "abort" |
| `main/ipc/register-conversation.test.ts` | retry loads rather than appends (one `appendMessage`, the assistant's); stays inside the graph LLM context and exits on throw; throws on a missing conversation |
| `renderer/stores/conversations-store.test.ts` | failure recorded with partial text kept and user turn retained; quota non-retryable; cancel stays silent; retry routes to `retry` not `send`; failed retry re-reports |
| `renderer/components/MessageList-failure.test.ts` | the block actually renders — message shown, partial reply kept, Retry present only when it can help, `/compact` offered for `context_length`, hidden while streaming |

`pnpm lint` clean · `pnpm test` 582 files / 5866 tests pass · `pnpm coverage` exits 0 (new `classify-error.ts` 90% statements, `llm-errors.ts` 97.8%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
