### PR TITLE
fix(llm): stop discarding streamed text when a turn fails or is stopped

### DIFF
--- a/src/main/llm/classify-error.ts
+++ b/src/main/llm/classify-error.ts
@@ -32,7 +32,33 @@ interface ErrorShape {
   type?: string;
   message?: string;
   name?: string;
+  /** Where `fetch`/undici keeps the real failure (`ECONNRESET`, `fetch
+   *  failed`) under an SDK error whose own message says only "Connection
+   *  error." */
+  cause?: unknown;
   error?: { type?: string; message?: string; error?: { type?: string; message?: string } };
+}
+
+/**
+ * Stainless-generated SDK errors — Anthropic's and OpenAI's whole error
+ * hierarchy — never assign `.name`, so every one of them reports the inherited
+ * `'Error'`. Matching `err.name === 'APIConnectionError'` therefore silently
+ * never fires, which is how a user's Cancel came back as an anonymous failure
+ * block and a dropped connection came back with no Retry button (#1809).
+ *
+ * Their constructor messages ARE stable, and these classes only exist for
+ * failures that never got an HTTP response, so we match the message when there
+ * is no status. The `.name` checks stay for SDKs that do set one (Google raises
+ * a genuine `DOMException` named `AbortError`).
+ */
+const SDK_ABORT_MESSAGE = 'request was aborted.';
+const SDK_CONNECTION_MESSAGES = ['connection error.', 'request timed out.'];
+
+/** A status-less SDK error whose message is one of `messages`. */
+function isBareSdkError(e: ErrorShape, messages: readonly string[]): boolean {
+  if (typeof e.status === 'number') return false;
+  if (typeof e.message !== 'string') return false;
+  return messages.includes(e.message.trim().toLowerCase());
 }
 
 function shapeOf(err: unknown): ErrorShape {
@@ -53,10 +79,30 @@ function haystack(e: ErrorShape): string {
     e.error?.message,
     e.error?.error?.type,
     e.error?.error?.message,
+    causeChainText(e),
   ]
     .filter((s): s is string => typeof s === 'string')
     .join(' ')
     .toLowerCase();
+}
+
+/**
+ * The `cause` chain, which is where the actual diagnosis lives when an SDK
+ * wraps a transport failure: `APIConnectionError: Connection error.` says
+ * nothing, while its cause says `ECONNRESET` or `fetch failed`. Undici nests
+ * one level deeper again, hence the walk rather than a single lookup.
+ */
+function causeChainText(e: ErrorShape, depth = 3): string {
+  const parts: string[] = [];
+  let cur: unknown = e.cause;
+  for (let i = 0; i < depth && cur; i++) {
+    const c = cur as { message?: unknown; code?: unknown; name?: unknown; cause?: unknown };
+    for (const v of [c.message, c.code, c.name]) {
+      if (typeof v === 'string') parts.push(v);
+    }
+    cur = c.cause;
+  }
+  return parts.join(' ');
 }
 
 /**
@@ -91,17 +137,27 @@ function looksLikeContextLength(text: string): boolean {
 function looksLikeNetwork(e: ErrorShape, text: string): boolean {
   if (typeof e.status === 'number') return false;
   return (
-    e.name === 'APIConnectionError'
+    isBareSdkError(e, SDK_CONNECTION_MESSAGES)
+    || e.name === 'APIConnectionError'
     || e.name === 'APIConnectionTimeoutError'
     || e.name === 'FetchError'
-    || /\b(enotfound|econnrefused|econnreset|etimedout|eai_again|epipe|certificate|self[- ]signed|socket hang up|network|fetch failed|timeout)\b/.test(text)
+    || /\b(enotfound|econnrefused|econnreset|etimedout|eai_again|epipe|certificate|self[- ]signed|socket hang up|network|fetch failed|timed out|timeout)\b/.test(text)
+  );
+}
+
+/** Did the user stop this themselves? */
+function looksLikeAbort(e: ErrorShape): boolean {
+  return (
+    e.name === 'AbortError'
+    || e.name === 'TimeoutError'
+    || isBareSdkError(e, [SDK_ABORT_MESSAGE])
   );
 }
 
 /** Classify without formatting — exported for tests and for reuse. */
 export function classifyProviderError(err: unknown): LlmFailureKind {
   const e = shapeOf(err);
-  if (e.name === 'AbortError' || e.name === 'TimeoutError') return 'cancelled';
+  if (looksLikeAbort(e)) return 'cancelled';
 
   const text = haystack(e);
   const status = e.status;
@@ -163,13 +219,22 @@ function describe(kind: LlmFailureKind, label: string, e: ErrorShape): string {
  * Wrap a provider error as the marker-carrying Error main throws. A failure we
  * already classified (a nested rethrow, or the unconfigured error the factory
  * raises) passes through untouched so the original verdict wins.
+ *
+ * `aborted` is our own signal's state, and it outranks the SDK's account of
+ * what happened: an abort that tore the socket down can surface as a connection
+ * error, and telling the user their network failed when they pressed Stop is
+ * the same class of confident lie this module exists to avoid.
  */
-export function toLlmFailureError(err: unknown, providerId: ProviderId | null): Error {
+export function toLlmFailureError(
+  err: unknown,
+  providerId: ProviderId | null,
+  opts?: { aborted?: boolean },
+): Error {
   const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
   if (msg.includes('MINERVA_LLM_FAILURE:') || msg.includes('is not set up yet')) {
     return err instanceof Error ? err : new Error(msg);
   }
-  const kind = classifyProviderError(err);
+  const kind = opts?.aborted ? 'cancelled' : classifyProviderError(err);
   const label = providerId ? PROVIDERS[providerId].label : 'The model provider';
   const wrapped = new Error(
     llmFailureMessage(kind, describe(kind, label, shapeOf(err)), providerId),

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -36,15 +36,19 @@ import type { ProviderId } from '../../shared/tools/providers';
  * both used to arrive in the renderer as an anonymous `console.error`.
  *
  * Wrap ONLY the provider call, never the surrounding tool execution.
+ *
+ * `signal` is the caller's abort signal, passed so a cancelled turn is reported
+ * as cancelled whatever shape the SDK's error took (#1809).
  */
 async function withProviderErrors<T>(
   providerId: ProviderId,
   run: () => Promise<T>,
+  signal?: AbortSignal,
 ): Promise<T> {
   try {
     return await run();
   } catch (err) {
-    throw toLlmFailureError(err, providerId);
+    throw toLlmFailureError(err, providerId, { aborted: signal?.aborted ?? false });
   }
 }
 
@@ -277,7 +281,7 @@ export async function complete(
       signal: cb?.signal,
     },
     cb ? (delta) => cb.onChunk(delta) : undefined,
-  ));
+  ), cb?.signal);
   if (onUsage) onUsage(result.usage, model);
   return result.text;
 }
@@ -366,7 +370,7 @@ export async function completeWithTools(
         onTextDelta: callbacks ? (delta) => callbacks.onChunk(delta) : undefined,
         onToolCallStart,
       },
-    ));
+    ), callbacks?.signal);
 
     sumUsage(usage, turn.usage);
     history.push(turn.assistantMessage);

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -4,7 +4,7 @@
   import { api } from '../ipc/client';
   import Icon from './Icon.svelte';
   import ToolParamsDialog from './ToolParamsDialog.svelte';
-  import type { ToolContext } from '../../../shared/tools/types';
+  import type { ToolContext, ToolExecutionResult } from '../../../shared/tools/types';
   import { isProviderUnconfiguredError, describeLlmFailure } from '../../../shared/llm-errors';
   import { resolveNoteParams } from '../tools/resolve-note-params';
 
@@ -92,20 +92,34 @@
 
   async function handleCancel() {
     await panel.cancelTool();
-    panel.fail('Cancelled');
+    panel.fail('Stopped. This output is partial.');
     running = false;
   }
 
+  /**
+   * What the review actions operate on: the finished result, or — when the run
+   * failed or the user stopped it — the text that made it out before it died.
+   * Keeping a partial on screen but refusing to let the user file it would be
+   * half a fix (#1809); an incomplete answer is still theirs to keep.
+   */
+  function reviewResult(): ToolExecutionResult | null {
+    if (panel.result) return panel.result;
+    if (!panel.activeTool || !panel.streamedOutput) return null;
+    return { toolId: panel.activeTool.id, output: panel.streamedOutput };
+  }
+
   async function handleSaveAsNote() {
-    if (!panel.result) return;
-    await handleToolOutput(panel.result, 'newNote', $state.snapshot(panel.context));
+    const result = reviewResult();
+    if (!result) return;
+    await handleToolOutput(result, 'newNote', $state.snapshot(panel.context));
     onNoteCreated?.();
     panel.close();
   }
 
   async function handleAppend() {
-    if (!panel.result) return;
-    await handleToolOutput(panel.result, 'appendToNote', $state.snapshot(panel.context));
+    const result = reviewResult();
+    if (!result) return;
+    await handleToolOutput(result, 'appendToNote', $state.snapshot(panel.context));
     panel.close();
   }
 
@@ -183,11 +197,15 @@
           <div class="error-msg">{panel.error}</div>
         {/if}
         <div class="actions">
-          {#if !panel.error}
-            <button class="btn primary" onclick={handleSaveAsNote}>Save as Note</button>
-            <button class="btn" onclick={handleAppend}>Append to Current</button>
-          {/if}
+          <!-- Same actions whether the run finished or died partway; the labels
+               say which one the user is filing, and then get out of the way. -->
           {#if output}
+            <button class="btn primary" onclick={handleSaveAsNote}>
+              {panel.error ? 'Save Partial as Note' : 'Save as Note'}
+            </button>
+            <button class="btn" onclick={handleAppend}>
+              {panel.error ? 'Append Partial' : 'Append to Current'}
+            </button>
             <button class="btn" onclick={handleCopyToClipboard}>Copy</button>
           {/if}
           <button class="btn" onclick={() => panel.close()}>

--- a/src/renderer/lib/components/ToolPanel.svelte
+++ b/src/renderer/lib/components/ToolPanel.svelte
@@ -167,18 +167,27 @@
       </div>
 
     {:else if panel.panelState === 'review'}
+      {@const output = panel.result?.output ?? panel.streamedOutput}
       <div class="tool-body output-body">
+        <!-- A failure used to replace the output with the error line, so text
+             the user had just watched stream in vanished as it landed (#1809).
+             Whatever streamed before a run died is real output — the same call
+             the transcript makes for a failed conversation turn — so it stays
+             on screen, with the error underneath it. -->
+        {#if output}
+          <div class="output-scroll">
+            <pre class="output">{output}</pre>
+          </div>
+        {/if}
         {#if panel.error}
           <div class="error-msg">{panel.error}</div>
-        {:else}
-          <div class="output-scroll">
-            <pre class="output">{panel.result?.output ?? panel.streamedOutput}</pre>
-          </div>
         {/if}
         <div class="actions">
           {#if !panel.error}
             <button class="btn primary" onclick={handleSaveAsNote}>Save as Note</button>
             <button class="btn" onclick={handleAppend}>Append to Current</button>
+          {/if}
+          {#if output}
             <button class="btn" onclick={handleCopyToClipboard}>Copy</button>
           {/if}
           <button class="btn" onclick={() => panel.close()}>

--- a/src/renderer/lib/components/conversations/MessageList.svelte
+++ b/src/renderer/lib/components/conversations/MessageList.svelte
@@ -221,7 +221,12 @@
         <div class="msg-content">{@html md.render(failure.partial)}</div>
       {/if}
       <div class="turn-error" role="status">
-        <span class="turn-error-icon" aria-hidden="true">⚠</span>
+        <!-- No warning glyph on a turn the user stopped themselves — pressing
+             Stop worked, and flagging it as a problem would be exactly the
+             alarm this project's UX philosophy rules out. -->
+        {#if failure.kind !== 'cancelled'}
+          <span class="turn-error-icon" aria-hidden="true">⚠</span>
+        {/if}
         <div class="turn-error-body">
           <p class="turn-error-message">{failure.message}</p>
           <div class="turn-error-actions">

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -574,7 +574,22 @@ async function retryLastTurn(tabId: string, currentNotePath?: string): Promise<v
  * (send), and null when it's already committed to the transcript (retry).
  */
 function handleTurnFailure(tab: TabRuntime, e: unknown, sentText: string | null): void {
-  if (isCancellation(e)) return;
+  if (isCancellation(e)) {
+    // Quiet, but not destructive: a stopped turn keeps whatever it had already
+    // written, in the slot the reply would have occupied. Main only appends the
+    // assistant message on success, so this block is the *only* copy — hence
+    // saying so rather than letting the user assume it was filed.
+    if (tab.streamedChunks) {
+      tab.failure = {
+        kind: 'cancelled',
+        message: 'Stopped. This partial reply wasn\'t saved to the conversation.',
+        retryable: false,
+        partial: tab.streamedChunks,
+        afterMessageIndex: tab.conversation.messages.length,
+      };
+    }
+    return;
+  }
 
   if (isProviderUnconfiguredError(e)) {
     if (sentText !== null) {
@@ -761,13 +776,16 @@ async function clearConversation(): Promise<void> {
   scheduleSave();
 }
 
+/**
+ * Stop the in-flight turn. Deliberately does NOT touch the tab's streaming
+ * state: aborting makes the in-flight `send()` / `retryLastTurn()` reject, and
+ * that rejection is what turns the streamed text into a stopped-turn block
+ * (`handleTurnFailure`) before `finally` clears the buffer. Clearing
+ * `streamedChunks` here — which is what this used to do — erased the partial
+ * reply a few milliseconds before the code that wanted to keep it ran (#1809).
+ */
 async function cancel(): Promise<void> {
   await api.conversations.cancel();
-  const tab = activeTab();
-  if (tab) {
-    tab.streaming = false;
-    tab.streamedChunks = '';
-  }
 }
 
 /**

--- a/tests/main/llm/classify-error.test.ts
+++ b/tests/main/llm/classify-error.test.ts
@@ -8,8 +8,13 @@
  * unhelpfulness this classifier exists to remove.
  */
 import { describe, it, expect } from 'vitest';
+import {
+  APIUserAbortError,
+  APIConnectionError,
+  APIConnectionTimeoutError,
+} from '@anthropic-ai/sdk';
 import { classifyProviderError, toLlmFailureError } from '../../../src/main/llm/classify-error';
-import { classifyLlmFailure, describeLlmFailure, missingApiKeyMessage } from '../../../src/shared/llm-errors';
+import { classifyLlmFailure, describeLlmFailure, missingApiKeyMessage, isCancellation } from '../../../src/shared/llm-errors';
 
 /** An SDK-ish error: a real Error carrying the properties the SDKs attach. */
 function apiError(props: Record<string, unknown>): Error {
@@ -74,6 +79,62 @@ describe('classifyProviderError', () => {
 
   it('treats an abort as a cancellation rather than a failure', () => {
     expect(classifyProviderError(apiError({ name: 'AbortError' }))).toBe('cancelled');
+  });
+
+  /**
+   * Real instances, not hand-built lookalikes (#1809). The lookalikes above set
+   * `name`, which is exactly what these classes DON'T do: Stainless generates
+   * them without assigning `.name`, so every one reports the inherited
+   * `'Error'` and every `name`-based check silently never fired. A user's
+   * Cancel came back as an anonymous failure block, and a dropped connection
+   * came back as `unknown` — which is not retryable, so the one failure most
+   * worth retrying was the one with no Retry button.
+   */
+  describe('the errors the Anthropic SDK actually throws', () => {
+    it('has no usable .name — the premise of these cases', () => {
+      expect(new APIUserAbortError().name).toBe('Error');
+      expect(new APIConnectionError({ message: undefined }).name).toBe('Error');
+    });
+
+    it('reads a user abort as cancelled', () => {
+      expect(classifyProviderError(new APIUserAbortError())).toBe('cancelled');
+      // …and the renderer, which only sees text, agrees.
+      expect(isCancellation(toLlmFailureError(new APIUserAbortError(), 'anthropic'))).toBe(true);
+    });
+
+    it('reads a torn connection as network, and offers a retry', () => {
+      const err = new APIConnectionError({ message: undefined, cause: new Error('ECONNRESET') });
+      expect(classifyProviderError(err)).toBe('network');
+      const failure = classifyLlmFailure(toLlmFailureError(err, 'anthropic'));
+      expect(failure?.kind).toBe('network');
+      expect(failure?.retryable).toBe(true);
+    });
+
+    it('reads a timeout as network', () => {
+      expect(classifyProviderError(new APIConnectionTimeoutError({}))).toBe('network');
+    });
+  });
+
+  it('mines the cause chain, where the real diagnosis hides', () => {
+    // undici: `TypeError: fetch failed` with the actual code one level down.
+    const err = Object.assign(new TypeError('fetch failed'), {
+      cause: Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:11434'), { code: 'ECONNREFUSED' }),
+    });
+    expect(classifyProviderError(err)).toBe('network');
+    // A wrapper whose own message says nothing at all still classifies.
+    const opaque = Object.assign(new Error('Something went wrong'), {
+      cause: { code: 'ENOTFOUND' },
+    });
+    expect(classifyProviderError(opaque)).toBe('network');
+  });
+
+  it('lets our own abort signal outrank whatever the SDK called it', () => {
+    // An abort can tear the socket down and surface as a connection error;
+    // "check your internet connection" would be a lie when the user hit Stop.
+    const err = new APIConnectionError({ message: undefined, cause: new Error('aborted') });
+    const wrapped = toLlmFailureError(err, 'anthropic', { aborted: true });
+    expect(classifyLlmFailure(wrapped)?.kind).toBe('cancelled');
+    expect(isCancellation(wrapped)).toBe(true);
   });
 
   it("falls back to 'unknown' rather than inventing a diagnosis", () => {

--- a/tests/renderer/components/MessageList-failure.test.ts
+++ b/tests/renderer/components/MessageList-failure.test.ts
@@ -138,6 +138,25 @@ describe('failed turn, rendered inline (#1804)', () => {
     expect(h.dismissFailure).toHaveBeenCalledWith('tab-1');
   });
 
+  it('renders a stopped turn without the warning glyph (#1809)', () => {
+    // A cancelled turn reuses this block to keep its partial text, but the user
+    // pressing Stop is not a problem being reported back at them — no alarm.
+    const stopped = failure({
+      kind: 'cancelled',
+      retryable: false,
+      message: 'Stopped. This partial reply wasn\'t saved to the conversation.',
+      partial: 'The note argues that large republics',
+    });
+    const { container } = render(MessageList, {
+      props: { tab: tabWith(stopped), currentNotePath: null },
+    });
+
+    expect(screen.getByText(/The note argues that large republics/)).toBeTruthy();
+    expect(screen.getByText(/Stopped\./)).toBeTruthy();
+    expect(container.querySelector('.turn-error-icon')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+  });
+
   it('yields to the streaming indicator while a new turn is in flight', () => {
     // Retrying shouldn't leave the old error sitting under a live spinner.
     render(MessageList, { props: { tab: tabWith(failure(), true), currentNotePath: null } });

--- a/tests/renderer/components/ToolPanel.test.ts
+++ b/tests/renderer/components/ToolPanel.test.ts
@@ -15,7 +15,7 @@
  * these assert the actual streamed-buffer → rendered-output path.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/svelte';
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
 import type { ThinkingToolInfo } from '../../../src/shared/tools/types';
 
 vi.mock('../../../src/renderer/lib/ipc/client', () => ({
@@ -28,6 +28,7 @@ vi.mock('../../../src/renderer/lib/tools/output', () => ({ handleToolOutput: vi.
 
 import ToolPanel from '../../../src/renderer/lib/components/ToolPanel.svelte';
 import { getToolPanelStore } from '../../../src/renderer/lib/stores/tool-panel.svelte';
+import { handleToolOutput } from '../../../src/renderer/lib/tools/output';
 
 const panel = getToolPanelStore();
 
@@ -39,6 +40,7 @@ const TOOL = {
 } as unknown as ThinkingToolInfo;
 
 beforeEach(() => {
+  vi.clearAllMocks();
   cleanup();
   panel.close();
 });
@@ -61,24 +63,42 @@ describe('ToolPanel review state', () => {
     expect(screen.getByText(/Anthropic is overloaded right now/)).toBeTruthy();
   });
 
-  it('offers Copy for a partial, but not Save as Note — there is no result to file', () => {
+  it('lets a partial be filed, labelled as the partial it is', () => {
     streamSomeOutput();
     panel.fail('Couldn\'t reach Anthropic. Check your internet connection.');
     render(ToolPanel);
 
+    // Keeping the text on screen but refusing to let the user keep it would be
+    // half a fix — an incomplete answer is still theirs.
+    expect(screen.getByText('Save Partial as Note')).toBeTruthy();
+    expect(screen.getByText('Append Partial')).toBeTruthy();
     expect(screen.getByText('Copy')).toBeTruthy();
-    expect(screen.queryByText('Save as Note')).toBeNull();
     expect(screen.getByText('Close')).toBeTruthy();
+  });
+
+  it('files the streamed text when there is no result object to file', async () => {
+    streamSomeOutput('Only the first paragraph');
+    panel.fail('Anthropic is overloaded right now.');
+    render(ToolPanel);
+
+    await fireEvent.click(screen.getByText('Save Partial as Note'));
+
+    expect(handleToolOutput).toHaveBeenCalledWith(
+      { toolId: TOOL.id, output: 'Only the first paragraph' },
+      'newNote',
+      {},
+    );
   });
 
   it('keeps what a cancelled run had already written', () => {
     // Same principle as a stopped conversation turn: pressing Cancel stops the
     // work, it doesn't retract the words.
     streamSomeOutput('Half an essay');
-    panel.fail('Cancelled');
+    panel.fail('Stopped. This output is partial.');
     render(ToolPanel);
 
     expect(screen.getByText(/Half an essay/)).toBeTruthy();
+    expect(screen.getByText(/Stopped\./)).toBeTruthy();
   });
 
   it('shows only the error when a run failed before producing anything', () => {

--- a/tests/renderer/components/ToolPanel.test.ts
+++ b/tests/renderer/components/ToolPanel.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * What the thinking-tool panel shows once a run finishes — and, the reason this
+ * file exists, once a run *fails* (#1809).
+ *
+ * The panel streams the model's output live, then swaps to a review state. The
+ * review state used to render the error INSTEAD of the output, so text the user
+ * had just watched arrive vanished the moment the failure landed. #1804 made
+ * the conversation transcript keep its partial reply; this surface kept the
+ * old behaviour, and it is the one reachable straight from the Learning /
+ * Research / Analysis menus.
+ *
+ * Drives the real tool-panel store (a runes singleton) rather than a stub, so
+ * these assert the actual streamed-buffer → rendered-output path.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import type { ThinkingToolInfo } from '../../../src/shared/tools/types';
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: {
+    tools: { execute: vi.fn(), cancel: vi.fn().mockResolvedValue(undefined) },
+    notebase: { readFile: vi.fn() },
+  },
+}));
+vi.mock('../../../src/renderer/lib/tools/output', () => ({ handleToolOutput: vi.fn() }));
+
+import ToolPanel from '../../../src/renderer/lib/components/ToolPanel.svelte';
+import { getToolPanelStore } from '../../../src/renderer/lib/stores/tool-panel.svelte';
+
+const panel = getToolPanelStore();
+
+const TOOL = {
+  id: 'analysis.antithesize',
+  name: 'Antithesize',
+  description: 'Argue the other side',
+  context: [],
+} as unknown as ThinkingToolInfo;
+
+beforeEach(() => {
+  cleanup();
+  panel.close();
+});
+
+/** Put the panel where a half-finished run leaves it. */
+function streamSomeOutput(text = 'The strongest counter-argument is that') {
+  panel.open(TOOL, {});
+  panel.startRunning();
+  panel.appendChunk(text);
+}
+
+describe('ToolPanel review state', () => {
+  it('keeps the streamed output on screen when the run fails', () => {
+    streamSomeOutput();
+    panel.fail('Anthropic is overloaded right now. This is temporary and not a problem with your setup.');
+    render(ToolPanel);
+
+    // Both, not either: the partial output AND why it stopped.
+    expect(screen.getByText(/The strongest counter-argument is that/)).toBeTruthy();
+    expect(screen.getByText(/Anthropic is overloaded right now/)).toBeTruthy();
+  });
+
+  it('offers Copy for a partial, but not Save as Note — there is no result to file', () => {
+    streamSomeOutput();
+    panel.fail('Couldn\'t reach Anthropic. Check your internet connection.');
+    render(ToolPanel);
+
+    expect(screen.getByText('Copy')).toBeTruthy();
+    expect(screen.queryByText('Save as Note')).toBeNull();
+    expect(screen.getByText('Close')).toBeTruthy();
+  });
+
+  it('keeps what a cancelled run had already written', () => {
+    // Same principle as a stopped conversation turn: pressing Cancel stops the
+    // work, it doesn't retract the words.
+    streamSomeOutput('Half an essay');
+    panel.fail('Cancelled');
+    render(ToolPanel);
+
+    expect(screen.getByText(/Half an essay/)).toBeTruthy();
+  });
+
+  it('shows only the error when a run failed before producing anything', () => {
+    // e.g. the pre-run "needs a text selection" guard — nothing streamed, so
+    // there is no empty output box to render.
+    panel.open(TOOL, {});
+    panel.fail('Antithesize needs a text selection. Highlight some text in the editor and try again.');
+    render(ToolPanel);
+
+    expect(screen.getByText(/needs a text selection/)).toBeTruthy();
+    expect(screen.queryByText('Copy')).toBeNull();
+  });
+
+  it('shows the finished result with the full action set on success', () => {
+    streamSomeOutput();
+    panel.complete({ output: 'The finished essay', toolId: TOOL.id });
+    render(ToolPanel);
+
+    expect(screen.getByText('The finished essay')).toBeTruthy();
+    expect(screen.getByText('Save as Note')).toBeTruthy();
+    expect(screen.getByText('Append to Current')).toBeTruthy();
+    expect(screen.getByText('Discard')).toBeTruthy();
+  });
+});

--- a/tests/renderer/stores/conversations-store.test.ts
+++ b/tests/renderer/stores/conversations-store.test.ts
@@ -331,6 +331,25 @@ describe('send()', () => {
     expect(tab.streaming).toBe(false);
   });
 
+  it('keeps what a stopped turn had already written, and says it was not saved', async () => {
+    // Quiet is not the same as destructive (#1809): main only appends the
+    // assistant message on success, so the block in the transcript is the only
+    // copy of a cancelled turn's output.
+    const tab = await freshTab();
+    conv().send.mockImplementationOnce(async () => {
+      h.cbs.onStream?.('three useful paragraphs');
+      throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+    });
+
+    await store.send('write me something');
+
+    expect(tab.failure?.kind).toBe('cancelled');
+    expect(tab.failure?.partial).toBe('three useful paragraphs');
+    expect(tab.failure?.retryable).toBe(false);
+    expect(tab.failure?.message).toContain('wasn\'t saved');
+    expect(tab.streaming).toBe(false);
+  });
+
   it('does not mistake a provider error that merely mentions "abort" for a cancel', async () => {
     // The old check was String(e).includes('abort'), which swallowed this.
     const tab = await freshTab();
@@ -418,14 +437,17 @@ describe('send()', () => {
 // ───────────────────── cancel / model / effort / composer ─────────────────────
 
 describe('cancel / setModel / setEffort / setComposer', () => {
-  it('cancel routes through api and clears the streaming flags', async () => {
+  it('cancel routes through api and leaves the partial for the rejection to keep', async () => {
+    // It used to clear `streamedChunks` here, milliseconds before the code
+    // that wants to preserve them ran — so stopping a turn erased what the
+    // model had already written (#1809). The abort makes the in-flight send()
+    // reject; that path owns the teardown.
     const tab = await freshTab();
     tab.streaming = true;
-    tab.streamedChunks = 'partial';
+    tab.streamedChunks = 'three useful paragraphs';
     await store.cancel();
     expect(conv().cancel).toHaveBeenCalledTimes(1);
-    expect(tab.streaming).toBe(false);
-    expect(tab.streamedChunks).toBe('');
+    expect(tab.streamedChunks).toBe('three useful paragraphs');
   });
 
   it('setModel routes through api and swaps in the updated conversation', async () => {


### PR DESCRIPTION
A user reported that a conversation failure sometimes shows a reply and then clears it. #1804/#1805 fixed exactly that for the conversation transcript, so what's left are the paths it didn't reach. Three of them.

## The tool panel replaced the output with the error

`ToolPanel.svelte`'s review state rendered `{#if panel.error}` … `{:else}` the output, so anything launched from the Learning / Research / Analysis menus streamed text into the panel and then, the moment it failed, swapped everything the user had just watched arrive for a one-line error. The text was still in `streamedOutput` — just no longer rendered. It now makes the same call the transcript does: keep the partial, put the error underneath. Copy stays available for a partial; Save as Note / Append don't, since there's no result to file.

## Cancel erased the partial, then reported a failure anyway

Two bugs meeting. `cancel()` cleared `streamedChunks` immediately — milliseconds before the rejection reached `handleTurnFailure`, whose whole job is to preserve that buffer. And the cancel wasn't recognised as one: `classifyProviderError` looked for `err.name === 'AbortError'`, but Stainless generates the Anthropic and OpenAI error classes without assigning `.name`, so `APIUserAbortError` reports the inherited `'Error'`:

```
new APIUserAbortError() → name="Error", status=undefined, message="Request was aborted."
```

Pressing Stop therefore wiped the reply *and* raised "Request was aborted." as an anonymous failure. Cancel now only aborts; the rejection path keeps the partial as a stopped-turn block (no warning glyph — the user's own Stop isn't an alarm) and says the partial wasn't saved, which is true: main appends the assistant message only on success.

## The same dead name-checks cost network failures their Retry

`.name` was also how `looksLikeNetwork` recognised `APIConnectionError` / `APIConnectionTimeoutError`, and the haystack never read `err.cause` — where undici keeps the real `ECONNRESET` / `fetch failed` under a message that says only "Connection error." A dropped connection mid-stream classified as `unknown`, which isn't retryable: **no Retry button on the failure most likely to succeed on a second try.** Detection now matches the SDKs' stable messages when there's no HTTP status, walks the cause chain, and lets our own abort signal outrank whatever the SDK called the error.

## Testing

The old cancellation tests passed against hand-built `{ name: 'AbortError' }` fixtures the SDKs never produce; they now run against real SDK error instances. New `ToolPanel.test.ts` drives the real runes store through stream → fail and asserts the partial survives — verified failing against the pre-fix template (3 of 5 cases). Full suite green (5887 tests), `pnpm lint` clean.

Fixes #1809

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: the panel now lets the partial be kept

Second commit. Keeping a partial on screen but only offering Copy was half a fix — Save as Note and Append hung off `panel.result`, which only exists on success. Both now fall back to the streamed buffer, filed under the tool's id like any other output, with labels that say which one is being filed ("Save Partial as Note") rather than passing a truncated essay off as a finished one. Cancel also says "Stopped." now, matching the transcript's wording for the same event.
