### PR TITLE
fix(llm): stream every completion, and stop hiding truncated output

### DIFF
--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -392,12 +392,25 @@ async function compactConversation(
 
   let usage: import('../../shared/types').TurnUsage | undefined;
   let usageModel: string | undefined;
+  let truncated = false;
   const { complete } = await import('../llm/index');
   const summary = await complete(buildSummaryPrompt(plan.transcript), {
     system: COMPACT_SYSTEM_PROMPT,
     model: conv.model,
     onUsage: (u, m) => { usage = u; usageModel = m; },
+    onTruncated: () => { truncated = true; },
   });
+  // A summary cut off at the token cap is the one truncation we refuse to live
+  // with (#1811): compaction archives the original and makes this summary the
+  // model's entire memory of it. Better to leave the conversation as it is and
+  // say why than to install a half-written account of it.
+  if (truncated) {
+    return {
+      compacted: false,
+      reason: 'The summary of your earlier turns was cut off at the length limit, '
+        + 'so nothing was compacted. Try again, or start a fresh conversation.',
+    };
+  }
   const summaryMsg = buildSummaryMessage(
     plan.prefix.length,
     summary,

--- a/src/main/llm/classify-error.ts
+++ b/src/main/llm/classify-error.ts
@@ -52,7 +52,8 @@ interface ErrorShape {
  * a genuine `DOMException` named `AbortError`).
  */
 const SDK_ABORT_MESSAGE = 'request was aborted.';
-const SDK_CONNECTION_MESSAGES = ['connection error.', 'request timed out.'];
+const SDK_CONNECTION_MESSAGE = 'connection error.';
+const SDK_TIMEOUT_MESSAGE = 'request timed out.';
 
 /** A status-less SDK error whose message is one of `messages`. */
 function isBareSdkError(e: ErrorShape, messages: readonly string[]): boolean {
@@ -133,15 +134,36 @@ function looksLikeContextLength(text: string): boolean {
   );
 }
 
+/**
+ * We waited, and nothing came back. Separate from `network` because the cure is
+ * different: a timeout usually means the request was too big to finish inside
+ * the window, not that the machine is offline. Node's `fetch` enforces its own
+ * 300s `headersTimeout` / `bodyTimeout`, and reports them through `cause`.
+ */
+function looksLikeTimeout(e: ErrorShape, text: string): boolean {
+  if (typeof e.status === 'number') return false;
+  // A connect-phase failure says "timeout" but means unreachable; that reading
+  // wins. Checked here rather than by ordering the two probes, because Node
+  // reports BOTH as a bare `TypeError: fetch failed` and only the cause chain
+  // tells them apart.
+  if (/\b(connecttimeouterror|und_err_connect_timeout|enotfound|econnrefused|eai_again)\b/.test(text)) {
+    return false;
+  }
+  return (
+    isBareSdkError(e, [SDK_TIMEOUT_MESSAGE])
+    || e.name === 'APIConnectionTimeoutError'
+    || /\b(und_err_headers_timeout|und_err_body_timeout|headerstimeouterror|bodytimeouterror|timed out|timeout)\b/.test(text)
+  );
+}
+
 /** No HTTP status at all ⇒ we never got an answer from the provider. */
 function looksLikeNetwork(e: ErrorShape, text: string): boolean {
   if (typeof e.status === 'number') return false;
   return (
-    isBareSdkError(e, SDK_CONNECTION_MESSAGES)
+    isBareSdkError(e, [SDK_CONNECTION_MESSAGE])
     || e.name === 'APIConnectionError'
-    || e.name === 'APIConnectionTimeoutError'
     || e.name === 'FetchError'
-    || /\b(enotfound|econnrefused|econnreset|etimedout|eai_again|epipe|certificate|self[- ]signed|socket hang up|network|fetch failed|timed out|timeout)\b/.test(text)
+    || /\b(enotfound|econnrefused|econnreset|etimedout|eai_again|epipe|certificate|self[- ]signed|socket hang up|connecttimeouterror|und_err_connect_timeout|network|fetch failed)\b/.test(text)
   );
 }
 
@@ -162,6 +184,11 @@ export function classifyProviderError(err: unknown): LlmFailureKind {
   const text = haystack(e);
   const status = e.status;
 
+  // Timeout first: Node reports its own 300s header/body timeouts as a generic
+  // `fetch failed`, which the network probe would otherwise claim. The timeout
+  // probe stands aside for connect-phase failures, so unreachable still reads as
+  // a network problem.
+  if (looksLikeTimeout(e, text)) return 'timeout';
   if (looksLikeNetwork(e, text)) return 'network';
 
   if (status === 401) return 'auth';
@@ -204,6 +231,8 @@ function describe(kind: LlmFailureKind, label: string, e: ErrorShape): string {
       return `${label} had a server error${typeof e.status === 'number' ? ` (${e.status})` : ''}. Nothing wrong on your side — try again shortly.`;
     case 'network':
       return `Couldn't reach ${label}. Check your internet connection${detail ? ` (${detail})` : ''}.`;
+    case 'timeout':
+      return `${label} didn't answer in time. Large requests are the usual cause — try again, or ask for less in one go.`;
     case 'context_length':
       return `This conversation is too long for the model's context window. Run /compact to summarise earlier turns, or start a fresh conversation.`;
     case 'invalid_request':

--- a/src/main/llm/index.ts
+++ b/src/main/llm/index.ts
@@ -180,6 +180,16 @@ export interface CompleteOptions {
    * summarization call's own tokens.
    */
   onUsage?: (usage: TurnUsage, model: string) => void;
+  /**
+   * Fired when the model stopped because it hit the token cap, i.e. the string
+   * this returns is cut off mid-thought (#1811). Out-of-band for the same
+   * reason as `onUsage`. Callers decide what that means for them: a skill
+   * marks its output as incomplete, `/compact` refuses to install a
+   * half-written summary as a conversation's memory, and a tag list doesn't
+   * care. Silence here was the bug — a truncated answer looked exactly like a
+   * finished one.
+   */
+  onTruncated?: () => void;
 }
 
 export interface CompleteWithToolsOptions {
@@ -249,6 +259,7 @@ export async function complete(
   let modelOverride: string | undefined;
   let effortOverride: Effort | undefined;
   let onUsage: ((usage: TurnUsage, model: string) => void) | undefined;
+  let onTruncated: (() => void) | undefined;
 
   if (callbacksOrOptions && 'onChunk' in callbacksOrOptions) {
     callbacks = callbacksOrOptions;
@@ -260,6 +271,7 @@ export async function complete(
     modelOverride = opts.model;
     effortOverride = opts.effort;
     onUsage = opts.onUsage;
+    onTruncated = opts.onTruncated;
     messages = opts.messages ?? [{ role: 'user', content: prompt }];
   } else {
     messages = [{ role: 'user', content: prompt }];
@@ -276,13 +288,17 @@ export async function complete(
       system,
       messages,
       effort,
-      // Streaming callers historically got a larger budget than one-shots.
-      maxTokens: cb ? 64000 : 16000,
+      // One budget for every caller. The old `cb ? 64000 : 16000` split existed
+      // because the SDK refuses a non-streaming request whose `max_tokens`
+      // implies over ten minutes of work — and every call streams now (#1811),
+      // so the paths most likely to truncate no longer get the smaller ceiling.
+      maxTokens: 64000,
       signal: cb?.signal,
     },
     cb ? (delta) => cb.onChunk(delta) : undefined,
   ), cb?.signal);
   if (onUsage) onUsage(result.usage, model);
+  if (result.stopReason === 'max_tokens' && onTruncated) onTruncated();
   return result.text;
 }
 
@@ -390,6 +406,16 @@ export async function completeWithTools(
     // cap and pause; re-send the same conversation so it resumes — no extra
     // user message.
     if (turn.stopReason === 'pause') continue;
+    // Cut off at the token cap. Say so in the transcript rather than letting a
+    // reply that stops mid-sentence read as a complete answer (#1811) — same
+    // treatment as the wedged-tool bail-out below.
+    if (turn.stopReason === 'max_tokens') {
+      const msg = '\n\n_(I hit the length limit for one reply and stopped here. '
+        + 'Ask me to continue if you want the rest.)_';
+      textPieces.push(msg);
+      if (callbacks) callbacks.onChunk(msg);
+      break;
+    }
     if (turn.stopReason !== 'tool_use') break;
     // Stopped for tool_use but only server-side blocks (which we don't execute)
     // — nothing to run, so stop rather than loop forever.

--- a/src/main/llm/provider/anthropic.ts
+++ b/src/main/llm/provider/anthropic.ts
@@ -107,6 +107,7 @@ function collectCitations(content: Anthropic.ContentBlock[]): Citation[] {
 function mapStopReason(reason: Anthropic.Message['stop_reason']): StopReason {
   if (reason === 'pause_turn') return 'pause';
   if (reason === 'tool_use') return 'tool_use';
+  if (reason === 'max_tokens') return 'max_tokens';
   return 'end';
 }
 
@@ -232,21 +233,23 @@ export class AnthropicProvider implements LLMProvider {
       messages,
     };
 
-    if (!onDelta) {
-      const response = await this.client.messages.create(
-        { ...base, max_tokens: req.maxTokens },
-        req.signal ? { signal: req.signal } : undefined,
-      );
-      return { text: extractText(response.content), usage: foldUsage(emptyUsage(), response.usage) };
-    }
-
+    // Always stream, even when nobody wants the deltas (#1811). A non-streaming
+    // request sends no bytes until the whole response is generated, so Node's
+    // 300s `headersTimeout` covers the entire generation — which is why the
+    // one-shot proposal paths (auto-tag, auto-link, /compact) timed out on large
+    // outputs while conversations, which stream, never did. Streaming also lifts
+    // the SDK's refusal to accept a big `max_tokens` off the non-streaming path.
     const stream = this.client.messages.stream(
       { ...base, max_tokens: req.maxTokens },
       { signal: req.signal },
     );
-    stream.on('text', (delta) => onDelta(delta));
+    if (onDelta) stream.on('text', (delta) => onDelta(delta));
     const finalMessage = await stream.finalMessage();
-    return { text: extractText(finalMessage.content), usage: foldUsage(emptyUsage(), finalMessage.usage) };
+    return {
+      text: extractText(finalMessage.content),
+      usage: foldUsage(emptyUsage(), finalMessage.usage),
+      stopReason: mapStopReason(finalMessage.stop_reason),
+    };
   }
 
   async checkConnection(): Promise<ConnectionCheckResult> {

--- a/src/main/llm/provider/google.ts
+++ b/src/main/llm/provider/google.ts
@@ -39,6 +39,7 @@ import type {
   ProviderMessage,
   ProviderToolCall,
   ProviderToolResult,
+  StopReason,
   ToolSpec,
   TurnHooks,
   TurnRequest,
@@ -61,6 +62,12 @@ export function thinkingBudgetFor(effort: Effort | undefined): number | undefine
   if (effort === 'low') return 2048;
   if (effort === 'medium') return 8192;
   return 16384; // high / xhigh / max
+}
+
+/** Gemini's `finishReason` → the neutral stop reason. Only the truncation case
+ *  needs distinguishing; everything else is a normal end (#1811). */
+export function mapFinishReason(reason: string | undefined): StopReason {
+  return reason === 'MAX_TOKENS' ? 'max_tokens' : 'end';
 }
 
 export function foldGeminiUsage(u: GenerateContentResponseUsageMetadata | undefined): TurnUsage {
@@ -154,6 +161,7 @@ export class GoogleProvider implements LLMProvider {
     let text = '';
     const calls: { id?: string; name: string; args: Record<string, unknown> }[] = [];
     let usage: GenerateContentResponseUsageMetadata | undefined;
+    let finishReason: string | undefined;
 
     for await (const chunk of stream) {
       const t = chunk.text;
@@ -170,6 +178,8 @@ export class GoogleProvider implements LLMProvider {
         calls.push({ ...(fc.id ? { id: fc.id } : {}), name, args });
       }
       if (chunk.usageMetadata) usage = chunk.usageMetadata;
+      const reason = chunk.candidates?.[0]?.finishReason;
+      if (reason) finishReason = reason;
     }
 
     const toolCalls: ProviderToolCall[] = calls.map((c) => ({
@@ -190,7 +200,7 @@ export class GoogleProvider implements LLMProvider {
       toolCalls,
       citations: [],
       usage: foldGeminiUsage(usage),
-      stopReason: calls.length > 0 ? 'tool_use' : 'end',
+      stopReason: calls.length > 0 ? 'tool_use' : mapFinishReason(finishReason),
     };
   }
 
@@ -201,23 +211,24 @@ export class GoogleProvider implements LLMProvider {
     }));
     const config = this.buildConfig(req.system, [], req.effort, req.signal);
 
-    if (!onDelta) {
-      const res = await this.ai.models.generateContent({ model: req.model, contents, config });
-      return { text: res.text ?? '', usage: foldGeminiUsage(res.usageMetadata) };
-    }
-
+    // Always stream — see the note in `anthropic.ts`: a non-streaming request
+    // sends nothing until the whole response exists, so Node's 300s
+    // `headersTimeout` becomes a ceiling on generation length (#1811).
     const stream = await this.ai.models.generateContentStream({ model: req.model, contents, config });
     let text = '';
     let usage: GenerateContentResponseUsageMetadata | undefined;
+    let finishReason: string | undefined;
     for await (const chunk of stream) {
       const t = chunk.text;
       if (t) {
         text += t;
-        onDelta(t);
+        if (onDelta) onDelta(t);
       }
       if (chunk.usageMetadata) usage = chunk.usageMetadata;
+      const reason = chunk.candidates?.[0]?.finishReason;
+      if (reason) finishReason = reason;
     }
-    return { text, usage: foldGeminiUsage(usage) };
+    return { text, usage: foldGeminiUsage(usage), stopReason: mapFinishReason(finishReason) };
   }
 
   async checkConnection(): Promise<ConnectionCheckResult> {

--- a/src/main/llm/provider/openai.ts
+++ b/src/main/llm/provider/openai.ts
@@ -76,6 +76,9 @@ export function toChatTools(specs: ToolSpec[]): OpenAI.Chat.Completions.ChatComp
 
 export function mapFinishReason(reason: string | null | undefined): StopReason {
   if (reason === 'tool_calls') return 'tool_use';
+  // OpenAI's name for hitting the cap. Distinct from 'end' so a truncated
+  // answer can say it is one (#1811).
+  if (reason === 'length') return 'max_tokens';
   return 'end';
 }
 
@@ -228,26 +231,26 @@ export class OpenAIProvider implements LLMProvider {
       ...(reasoning ? { reasoning_effort: reasoning } : {}),
     };
 
-    if (!onDelta) {
-      const res = await this.client.chat.completions.create(base, { signal: req.signal });
-      return { text: res.choices[0]?.message?.content ?? '', usage: foldOpenAIUsage(res.usage) };
-    }
-
+    // Always stream — see the note in `anthropic.ts`: a non-streaming request
+    // sends nothing until the whole response exists, so Node's 300s
+    // `headersTimeout` becomes a ceiling on generation length (#1811).
     const stream = await this.client.chat.completions.create(
       { ...base, stream: true, stream_options: { include_usage: true } },
       { signal: req.signal },
     );
     let text = '';
     let usage: OpenAI.Completions.CompletionUsage | undefined;
+    let finishReason: string | null | undefined;
     for await (const chunk of stream) {
       const d = chunk.choices[0]?.delta?.content;
       if (d) {
         text += d;
-        onDelta(d);
+        if (onDelta) onDelta(d);
       }
+      if (chunk.choices[0]?.finish_reason) finishReason = chunk.choices[0].finish_reason;
       if (chunk.usage) usage = chunk.usage;
     }
-    return { text, usage: foldOpenAIUsage(usage) };
+    return { text, usage: foldOpenAIUsage(usage), stopReason: mapFinishReason(finishReason) };
   }
 
   async checkConnection(): Promise<ConnectionCheckResult> {

--- a/src/main/llm/provider/types.ts
+++ b/src/main/llm/provider/types.ts
@@ -97,8 +97,16 @@ export interface TurnRequest {
   signal?: AbortSignal | undefined;
 }
 
-/** Why the model stopped: neutral over provider-specific stop-reason strings. */
-export type StopReason = 'end' | 'tool_use' | 'pause';
+/**
+ * Why the model stopped: neutral over provider-specific stop-reason strings.
+ *
+ * `max_tokens` (OpenAI calls it `length`) used to fall through to `'end'`, which
+ * made a response cut off at the cap indistinguishable from one that finished
+ * its sentence — nothing downstream *could* react to a truncation, however much
+ * it wanted to (#1811). It is its own reason now, and callers are expected to
+ * say so rather than passing half an answer off as a whole one.
+ */
+export type StopReason = 'end' | 'tool_use' | 'pause' | 'max_tokens';
 
 export interface TurnResult {
   /** Append to `history` before the next turn. */
@@ -127,6 +135,8 @@ export interface CompletionRequest {
 export interface CompletionResult {
   text: string;
   usage: TurnUsage;
+  /** Why this one-shot stopped. `'max_tokens'` means the text is cut off. */
+  stopReason: StopReason;
 }
 
 /**

--- a/src/main/tools/executor.ts
+++ b/src/main/tools/executor.ts
@@ -57,15 +57,22 @@ export async function executeTool(
   const settings = await getSettings();
   const { prompt, model } = buildOneShotPayload(tool, settings, request);
 
+  // A skill's output usually becomes a note, so a reply cut off at the token
+  // cap would be filed as if it were the finished piece. Mark it instead (#1811)
+  // — the user can delete the line; they can't recover the fact it was lost.
+  let truncated = false;
   const output = await complete(prompt, {
     ...(onChunk ? { callbacks: { onChunk, signal } } : {}),
     ...(model ? { model } : {}),
+    onTruncated: () => { truncated = true; },
   });
 
   const noteTitle = request.context.fullNoteTitle ?? 'Untitled';
   return {
     toolId: request.toolId,
-    output,
+    output: truncated
+      ? `${output}\n\n_(Output stopped at the length limit — this is incomplete.)_`
+      : output,
     suggestedTitle: `${tool.name}: ${noteTitle}`,
     suggestedFilename: `${tool.outputNotePrefix ?? tool.id.replace('.', '-')}-${noteTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-+$/, '')}.md`,
   };

--- a/src/shared/llm-errors.ts
+++ b/src/shared/llm-errors.ts
@@ -67,8 +67,12 @@ export type LlmFailureKind =
   | 'overloaded'
   /** Provider-side 5xx. Temporary. */
   | 'server'
-  /** Never reached the provider — offline, DNS, TLS, timeout. */
+  /** Never reached the provider — offline, DNS, TLS. */
   | 'network'
+  /** Reached the provider, but no answer came back in time. Temporary, and
+   *  distinct from `network`: telling someone to check their connection when
+   *  the request was simply too big to finish is a wrong diagnosis (#1811). */
+  | 'timeout'
   /** The request exceeded the model's context window. */
   | 'context_length'
   /** The provider refused the request as malformed / not permitted (4xx). */
@@ -91,7 +95,7 @@ export interface LlmFailure {
 
 /** Kinds where the same request may well succeed on a second attempt. */
 const RETRYABLE: ReadonlySet<LlmFailureKind> = new Set<LlmFailureKind>([
-  'rate_limited', 'overloaded', 'server', 'network',
+  'rate_limited', 'overloaded', 'server', 'network', 'timeout',
 ]);
 
 export function isRetryableKind(kind: LlmFailureKind): boolean {

--- a/tests/main/ipc/register-conversation.test.ts
+++ b/tests/main/ipc/register-conversation.test.ts
@@ -32,9 +32,13 @@ const h = vi.hoisted(() => {
     enterLLMContext: vi.fn(),
     exitLLMContext: vi.fn(),
     completeWithTools: vi.fn(),
+    complete: vi.fn(),
     appendMessage: vi.fn(),
     load: vi.fn(),
     setContainerId: vi.fn(),
+    archive: vi.fn(),
+    create: vi.fn(),
+    replaceMessages: vi.fn(),
     proposeWrite: vi.fn(),
     approveProposal: vi.fn(),
   };
@@ -83,13 +87,19 @@ vi.mock('../../../src/main/graph/index', () => ({
 }));
 
 // The LLM client (dynamically imported inside the handler).
-vi.mock('../../../src/main/llm/index', () => ({ completeWithTools: h.completeWithTools }));
+vi.mock('../../../src/main/llm/index', () => ({
+  completeWithTools: h.completeWithTools,
+  complete: h.complete,
+}));
 
 // Conversation persistence.
 vi.mock('../../../src/main/llm/conversation', () => ({
   appendMessage: h.appendMessage,
   setContainerId: h.setContainerId,
   load: h.load,
+  archive: h.archive,
+  create: h.create,
+  replaceMessages: h.replaceMessages,
 }));
 
 // Approval engine — the trust gate.
@@ -116,6 +126,7 @@ const cancel = h.handlers.get(Channels.CONVERSATION_CANCEL)!;
 const retry = h.handlers.get(Channels.CONVERSATION_RETRY)!;
 const fileDraft = h.handlers.get(Channels.CONVERSATION_FILE_DRAFT)!;
 const fileDeleteDraft = h.handlers.get(Channels.CONVERSATION_FILE_DELETE_DRAFT)!;
+const compact = h.handlers.get(Channels.CONVERSATION_COMPACT)!;
 
 const CONV = {
   id: 'conv-1',
@@ -355,5 +366,55 @@ describe('CONVERSATION_RETRY (#1804)', () => {
     h.load.mockResolvedValue(null);
     await expect(retry(evt, 'conv-1')).rejects.toThrow(/not found/i);
     expect(h.completeWithTools).not.toHaveBeenCalled();
+  });
+});
+
+// ── /compact refuses a truncated summary (#1811) ───────────────────────────
+// Compaction archives the original and makes the summary the model's entire
+// memory of it. Every other truncation in the app is worth keeping and
+// labelling; this one is worth refusing, because a half-written summary
+// silently becomes the conversation's past.
+
+describe('CONVERSATION_COMPACT with a truncated summary (#1811)', () => {
+  /** A conversation long enough for planCompaction to have something to do. */
+  function longConversation() {
+    return {
+      ...CONV,
+      status: 'active',
+      messages: Array.from({ length: 10 }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' : 'assistant',
+        content: `turn ${i}`,
+        timestamp: 't',
+      })),
+    };
+  }
+
+  it('reports instead of compacting, and leaves the conversation alone', async () => {
+    h.load.mockResolvedValue(longConversation());
+    h.complete.mockImplementation(async (_prompt: string, opts: { onTruncated?: () => void }) => {
+      opts.onTruncated?.();
+      return 'A summary that stops mid-';
+    });
+
+    const result = await compact(evt, 'conv-1') as { compacted: boolean; reason?: string };
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toMatch(/length limit/i);
+    // The original must survive: no archive, no replacement conversation.
+    expect(h.archive).not.toHaveBeenCalled();
+    expect(h.create).not.toHaveBeenCalled();
+    expect(h.replaceMessages).not.toHaveBeenCalled();
+  });
+
+  it('compacts normally when the summary came back whole', async () => {
+    h.load.mockResolvedValue(longConversation());
+    h.complete.mockResolvedValue('A complete summary.');
+    h.create.mockResolvedValue({ ...CONV, id: 'conv-2' });
+    h.replaceMessages.mockResolvedValue({ ...CONV, id: 'conv-2' });
+
+    const result = await compact(evt, 'conv-1') as { compacted: boolean };
+
+    expect(result.compacted).toBe(true);
+    expect(h.archive).toHaveBeenCalledWith('conv-1');
   });
 });

--- a/tests/main/llm/classify-error.test.ts
+++ b/tests/main/llm/classify-error.test.ts
@@ -110,8 +110,32 @@ describe('classifyProviderError', () => {
       expect(failure?.retryable).toBe(true);
     });
 
-    it('reads a timeout as network', () => {
-      expect(classifyProviderError(new APIConnectionTimeoutError({}))).toBe('network');
+    it('reads a timeout as its own kind, not as "check your connection"', () => {
+      // The request reached the provider; it just didn't answer in time. Usually
+      // because it was large — telling the user to check their wifi sends them
+      // looking in the wrong place (#1811).
+      expect(classifyProviderError(new APIConnectionTimeoutError({}))).toBe('timeout');
+      const failure = classifyLlmFailure(toLlmFailureError(new APIConnectionTimeoutError({}), 'anthropic'));
+      expect(failure?.retryable).toBe(true);
+      expect(failure?.message).toContain('didn\'t answer in time');
+    });
+
+    it('still calls a connect-phase failure a network problem', () => {
+      // "Connect Timeout Error" says timeout but means unreachable.
+      const err = Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('Connect Timeout Error (attempted address: api.anthropic.com:443)'), {
+          code: 'UND_ERR_CONNECT_TIMEOUT',
+        }),
+      });
+      expect(classifyProviderError(err)).toBe('network');
+    });
+
+    it('reads Node\'s own headers/body timeouts as a timeout', () => {
+      // undici enforces 300s on both, and reports them through `cause`.
+      const headers = Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('Headers Timeout Error'), { code: 'UND_ERR_HEADERS_TIMEOUT' }),
+      });
+      expect(classifyProviderError(headers)).toBe('timeout');
     });
   });
 

--- a/tests/main/llm/conversation-tool-dispatch.test.ts
+++ b/tests/main/llm/conversation-tool-dispatch.test.ts
@@ -122,6 +122,27 @@ describe('completeWithTools() dispatch loop (#342)', () => {
     await fsp.rm(root, { recursive: true, force: true });
   });
 
+  it('says so in the transcript when a reply is cut off at the token cap', async () => {
+    // `max_tokens` used to map to the same 'end' as a finished sentence, so a
+    // truncated turn just stopped talking mid-thought and looked complete
+    // (#1811). The marker is the only thing that tells the user to ask for more.
+    const truncated = { ...textMessage('The first half of the argu'), stop_reason: 'max_tokens' } as never;
+    setupStreamWith([truncated]);
+    const chunks: string[] = [];
+
+    const result = await completeWithTools({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'explain at length' }],
+      toolContext: { rootPath: root },
+      callbacks: { onChunk: (c) => chunks.push(c) },
+    });
+
+    expect(result.text).toContain('The first half of the argu');
+    expect(result.text).toContain('length limit');
+    // Streamed too, so it appears live rather than only after the reload.
+    expect(chunks.join('')).toContain('length limit');
+  });
+
   it('runs a real notebase tool and feeds the result into the next iteration', async () => {
     // Plant a note for read_note to actually read.
     const notePath = 'notes/hello.md';

--- a/tests/main/llm/gemini-provider.test.ts
+++ b/tests/main/llm/gemini-provider.test.ts
@@ -131,14 +131,28 @@ describe('GoogleProvider — runTurn (injected stream)', () => {
   });
 });
 
-describe('GoogleProvider — complete (non-streaming)', () => {
-  it('returns text + usage', async () => {
+describe('GoogleProvider — complete', () => {
+  it('streams even when the caller wants no deltas, returning text + usage', async () => {
+    // See the OpenAI/Anthropic equivalents: a non-streaming request puts the
+    // entire generation under Node's 300s headers timeout (#1811).
     const provider = new GoogleProvider('key', fakeAi({
-      response: { text: 'the answer', usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 2 } },
+      streamChunks: [
+        { text: 'the ' },
+        { text: 'answer', usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 2 } },
+      ],
     }));
     const res = await provider.complete({ model: 'gemini-2.5-pro', messages: [{ role: 'user', content: 'q' }], maxTokens: 100 });
     expect(res.text).toBe('the answer');
     expect(res.usage.inputTokens).toBe(4);
     expect(res.usage.outputTokens).toBe(2);
+    expect(res.stopReason).toBe('end');
+  });
+
+  it('reports a reply cut off at the cap as truncated', async () => {
+    const provider = new GoogleProvider('key', fakeAi({
+      streamChunks: [{ text: 'half an ans', candidates: [{ finishReason: 'MAX_TOKENS' }] }],
+    }));
+    const res = await provider.complete({ model: 'gemini-2.5-pro', messages: [{ role: 'user', content: 'q' }], maxTokens: 100 });
+    expect(res.stopReason).toBe('max_tokens');
   });
 });

--- a/tests/main/llm/openai-provider.test.ts
+++ b/tests/main/llm/openai-provider.test.ts
@@ -20,12 +20,17 @@ import {
 import type { ToolSpec } from '../../../src/main/llm/provider/types';
 
 /** A fake OpenAI client: streaming `create` yields `streamChunks`, non-streaming
- *  returns `response`. */
-function fakeClient(opts: { streamChunks?: unknown[]; response?: unknown }): OpenAI {
+ *  returns `response`. `onCreate` observes the params the provider sent. */
+function fakeClient(opts: {
+  streamChunks?: unknown[];
+  response?: unknown;
+  onCreate?: (params: { stream?: boolean }) => void;
+}): OpenAI {
   return {
     chat: {
       completions: {
         create: async (params: { stream?: boolean }) => {
+          opts.onCreate?.(params);
           if (params.stream) {
             return (async function* () {
               for (const c of opts.streamChunks ?? []) yield c;
@@ -67,10 +72,12 @@ describe('OpenAIProvider — pure mappers', () => {
     ]);
   });
 
-  it('mapFinishReason: tool_calls → tool_use, everything else → end', () => {
+  it('mapFinishReason: tool_calls → tool_use, length → max_tokens, else end', () => {
     expect(mapFinishReason('tool_calls')).toBe('tool_use');
     expect(mapFinishReason('stop')).toBe('end');
-    expect(mapFinishReason('length')).toBe('end');
+    // 'length' is OpenAI's truncation signal — folding it into 'end' is what
+    // made a cut-off answer indistinguishable from a finished one (#1811).
+    expect(mapFinishReason('length')).toBe('max_tokens');
     expect(mapFinishReason(null)).toBe('end');
   });
 
@@ -160,14 +167,36 @@ describe('OpenAIProvider — runTurn (injected stream)', () => {
   });
 });
 
-describe('OpenAIProvider — complete (non-streaming)', () => {
-  it('returns the message content + usage', async () => {
+describe('OpenAIProvider — complete', () => {
+  it('streams even when the caller wants no deltas, returning text + usage', async () => {
+    // A caller with no `onDelta` used to get a non-streaming request, whose
+    // response arrives only when generation finishes — putting the whole
+    // generation under Node's 300s headers timeout (#1811). Every completion
+    // streams now; the deltas are simply accumulated when nobody is listening.
+    let sawStream = false;
     const provider = new OpenAIProvider('sk-test', undefined, fakeClient({
-      response: { choices: [{ message: { content: 'the answer' } }], usage: { prompt_tokens: 4, completion_tokens: 2 } },
+      streamChunks: [
+        { choices: [{ delta: { content: 'the ' } }] },
+        { choices: [{ delta: { content: 'answer' }, finish_reason: 'stop' }] },
+        { choices: [{}], usage: { prompt_tokens: 4, completion_tokens: 2 } },
+      ],
+      onCreate: (params) => { sawStream = params.stream === true; },
     }));
     const res = await provider.complete({ model: 'gpt-5', messages: [{ role: 'user', content: 'q' }], maxTokens: 100 });
+    expect(sawStream).toBe(true);
     expect(res.text).toBe('the answer');
     expect(res.usage.inputTokens).toBe(4);
     expect(res.usage.outputTokens).toBe(2);
+    expect(res.stopReason).toBe('end');
+  });
+
+  it('reports a reply cut off at the cap as truncated, not as a normal end', async () => {
+    const provider = new OpenAIProvider('sk-test', undefined, fakeClient({
+      streamChunks: [
+        { choices: [{ delta: { content: 'half an ans' }, finish_reason: 'length' }] },
+      ],
+    }));
+    const res = await provider.complete({ model: 'gpt-5', messages: [{ role: 'user', content: 'q' }], maxTokens: 100 });
+    expect(res.stopReason).toBe('max_tokens');
   });
 });

--- a/tests/main/tools/execute-tool-truncation.test.ts
+++ b/tests/main/tools/execute-tool-truncation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * What a skill's output says when the model ran out of room (#1811).
+ *
+ * A one-shot skill's output usually becomes a note — the panel offers "Save as
+ * Note" the moment it lands. Truncation used to be invisible all the way down:
+ * `max_tokens` mapped to the same stop reason as a finished sentence, so an
+ * answer cut off mid-word was filed as though it were the whole thing. The
+ * marker is the only signal the user gets, and it has to survive into the text
+ * that becomes the note, not just a console line.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { CompleteOptions } from '../../../src/main/llm/index';
+import type { ThinkingToolDef } from '../../../src/shared/tools/types';
+
+const h = vi.hoisted(() => ({ complete: vi.fn(), getSettings: vi.fn() }));
+
+vi.mock('../../../src/main/llm/index', () => ({ complete: h.complete }));
+vi.mock('../../../src/main/llm/settings', () => ({ getSettings: h.getSettings }));
+
+import { executeTool } from '../../../src/main/tools/executor';
+import { registerTool, unregisterTool } from '../../../src/shared/tools/registry';
+
+const TOOL: ThinkingToolDef = {
+  id: 'analysis.antithesize',
+  name: 'Antithesize',
+  category: 'analysis',
+  description: '',
+  longDescription: '',
+  context: ['fullNote'],
+  outputMode: 'newNote',
+  buildPrompt: () => 'Argue the other side.',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getSettings.mockResolvedValue({ model: 'claude-opus-5', toolModelOverrides: {} });
+  registerTool(TOOL);
+});
+
+afterEach(() => unregisterTool(TOOL.id));
+
+describe('executeTool truncation marker', () => {
+  it('marks output that stopped at the token cap as incomplete', async () => {
+    h.complete.mockImplementation(async (_prompt: string, opts: CompleteOptions) => {
+      opts.onTruncated?.();
+      return 'The strongest counter-argument is that the premi';
+    });
+
+    const result = await executeTool({ toolId: TOOL.id, context: {} });
+
+    expect(result.output).toContain('The strongest counter-argument is that the premi');
+    expect(result.output).toContain('length limit');
+  });
+
+  it('leaves a complete answer exactly as the model wrote it', async () => {
+    h.complete.mockResolvedValue('A finished essay.');
+
+    const result = await executeTool({ toolId: TOOL.id, context: {} });
+
+    expect(result.output).toBe('A finished essay.');
+  });
+});


### PR DESCRIPTION
A tester reported frequent timeouts when creating large proposals. The number that needed changing wasn't ours — and checking the truncation angle turned up a second problem on the same paths.

## The 5-minute ceiling belongs to Node

undici defaults `headersTimeout` to 300s (`node_modules/undici/lib/dispatcher/client.js:240`). A streaming request gets its headers immediately, so the timer never matters. A non-streaming request sends nothing until the whole response exists, so those 300s cover the entire generation.

`provider.complete()` skipped streaming whenever the caller passed no delta callback — which is exactly the proposal-building set: `auto-tag.ts:54`, both `auto-link.ts` passes, `/compact`, and any skill run without an `onChunk`. Conversations go through `completeWithTools`, which always streams, which is why they never showed the symptom. The Anthropic SDK's own 600s timeout never got a chance to fire, so raising it would have changed nothing.

All three providers now stream unconditionally and accumulate the deltas when nobody is listening. That also retires the `cb ? 64000 : 16000` token split: the smaller budget existed only because the SDK refuses a non-streaming request whose `max_tokens` implies over ten minutes of work (`client.js:402`), so the paths most likely to truncate had been getting the smallest ceiling.

## Truncation was structurally invisible

`StopReason` was `'end' | 'tool_use' | 'pause'`, and Anthropic's `max_tokens` and OpenAI's `length` both fell through to `'end'`. A reply cut off at the cap was indistinguishable from one that finished its sentence — nothing downstream *could* react to it, however much it wanted to.

It's a reason of its own now, threaded through `CompletionResult`, with an out-of-band `onTruncated` hook on `complete()` alongside the existing `onUsage`. Each caller does what its situation warrants:

| caller | on truncation |
|---|---|
| conversation turn | appends a length-limit note to the transcript, like the wedged-tool bail-out already does |
| skill / tool panel | marks the output incomplete — that text becomes a note |
| `/compact` | **refuses** — it archives the original and makes the summary the model's whole memory of it |
| auto-tag / auto-link | nothing; they parse a list out of it and genuinely don't care |

## A timeout no longer blames the network

Since #1810 an `APIConnectionTimeoutError` classified as `network`, telling a user to check their internet for a request that reached the provider fine. `timeout` is its own kind now, retryable, with copy pointing at the actual cause — too much asked for in one go. Connect-phase failures still read as `network` even when their text says "timeout", since undici reports both as a bare `fetch failed` and only the cause chain tells them apart.

## Testing

Provider tests now assert the streaming call is used with no delta callback, and that `length` / `MAX_TOKENS` come back as `max_tokens`. New coverage for the truncated conversation turn, the skill marker, and `/compact` refusing (with the original left unarchived). `pnpm lint` clean, full suite green (5897 tests).

Fixes #1811

🤖 Generated with [Claude Code](https://claude.com/claude-code)
