### PR TITLE
fix(conversations): key conversation storage by project, not by module state

### DIFF
--- a/src/main/ipc/register-conversation-drafts.ts
+++ b/src/main/ipc/register-conversation-drafts.ts
@@ -548,7 +548,7 @@ export function registerConversationDrafts(): void {
       // user input.
       const contextMessage = formatComputeResultAsContext(draft, codeToRun, result);
       try {
-        await conversation.appendMessage(draft.conversationId, 'user', contextMessage);
+        await conversation.appendMessage(rootPath, draft.conversationId, 'user', contextMessage);
       } catch (err) {
         console.warn('[conv] failed to append compute output to conversation:', err);
       }

--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -7,7 +7,7 @@ import { currentDateContext } from '../llm/date-context';
 import { readThoughtbaseDoc, thoughtbaseDocPromptBlock } from '../llm/thoughtbase-doc';
 import type { ContextBundle, ConversationMessage } from '../../shared/types';
 import type { ConversationDraftBase } from '../../shared/conversation-draft-base';
-import { rootPathFromEvent, winFromEvent } from './helpers';
+import { rootPathFromEvent, winFromEvent, withRootPath, withRootPathOr } from './helpers';
 import { broadcast } from './broadcast';
 import { handle } from './typed-ipc';
 import type { EventMap } from '../../shared/ipc-contract';
@@ -173,6 +173,7 @@ function buildStreamCallbacks(
  *  second failure — propagates. */
 async function runCompletionWithContainerRecovery(
   completeWithTools: CompleteWithTools,
+  rootPath: string,
   convId: string,
   base: Omit<CompletionParams, 'messages' | 'callbacks' | 'initialContainerId'>,
   messages: LlmMessage[],
@@ -197,7 +198,7 @@ async function runCompletionWithContainerRecovery(
       `[conv] container_id 400 — recovering. conv=${convId} ` +
       `cachedContainer=${initialContainerId ?? 'none'} stripping code_execution turns`,
     );
-    await conversation.setContainerId(convId, undefined, undefined);
+    await conversation.setContainerId(rootPath, convId, undefined, undefined);
     return await completeWithTools({
       ...base,
       messages: stripCodeExecutionTurns(messages),
@@ -208,18 +209,25 @@ async function runCompletionWithContainerRecovery(
 
 export function registerConversation(): void {
   // Conversations
-  handle(Channels.CONVERSATION_CREATE, (_e, contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) =>
-    conversation.create(contextBundle, triggerNodeUri, options));
-  handle(Channels.CONVERSATION_APPEND, (_e, id: string, role: ConversationMessage['role'], content: string) =>
-    conversation.appendMessage(id, role, content));
-  handle(Channels.CONVERSATION_ARCHIVE, (_e, id: string) => conversation.archive(id));
-  handle(Channels.CONVERSATION_LOAD, (_e, id: string) => conversation.load(id));
-  handle(Channels.CONVERSATION_LIST, () => conversation.listAll());
-  handle(Channels.CONVERSATION_LIST_ACTIVE, () => conversation.listActive());
-  handle(Channels.CONVERSATION_UI_STATE_LOAD, () => conversation.loadUIState());
+  // Every handler resolves the project from the CALLING WINDOW (#1743). These
+  // used to reach module state that the last-opened project owned, so with two
+  // thoughtbases open both windows read and wrote the same one's conversations.
+  handle(Channels.CONVERSATION_CREATE, withRootPath((rootPath, contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) =>
+    conversation.create(rootPath, contextBundle, triggerNodeUri, options)));
+  handle(Channels.CONVERSATION_APPEND, withRootPath((rootPath, id: string, role: ConversationMessage['role'], content: string) =>
+    conversation.appendMessage(rootPath, id, role, content)));
+  handle(Channels.CONVERSATION_ARCHIVE, withRootPath((rootPath, id: string) => conversation.archive(rootPath, id)));
+  handle(Channels.CONVERSATION_LOAD, withRootPath((rootPath, id: string) => conversation.load(rootPath, id)));
+  // The list + UI-state reads answer "nothing yet" for a window with no project
+  // open — the conversations panel calls them on mount, before any open. That's
+  // a legitimate empty value, not a swallowed failure (CLAUDE.md, IPC rule 2).
+  handle(Channels.CONVERSATION_LIST, withRootPathOr(Promise.resolve([]), (rootPath) => conversation.listAll(rootPath)));
+  handle(Channels.CONVERSATION_LIST_ACTIVE, withRootPathOr(Promise.resolve([]), (rootPath) => conversation.listActive(rootPath)));
+  handle(Channels.CONVERSATION_UI_STATE_LOAD, withRootPathOr(Promise.resolve({ ...conversation.DEFAULT_UI_STATE }), (rootPath) => conversation.loadUIState(rootPath)));
   handle(
     Channels.CONVERSATION_UI_STATE_SAVE,
-    (_e, state: import('../../shared/types').ConversationsUIState) => conversation.saveUIState(state),
+    withRootPath((rootPath, state: import('../../shared/types').ConversationsUIState) =>
+      conversation.saveUIState(rootPath, state)),
   );
 
   // Conversation send + LLM streaming
@@ -267,9 +275,12 @@ export function registerConversation(): void {
 
     graph.enterLLMContext();
     try {
+      if (!rootPath) {
+        throw new Error('No thoughtbase is open — cannot send conversation message.');
+      }
       const conv = userMessage === null
-        ? await conversation.load(convId)
-        : await conversation.appendMessage(convId, 'user', userMessage);
+        ? await conversation.load(rootPath, convId)
+        : await conversation.appendMessage(rootPath, convId, 'user', userMessage);
       if (!conv) throw new Error(`Conversation not found: ${convId}`);
 
       const { completeWithTools } = await import('../llm/index');
@@ -284,10 +295,6 @@ export function registerConversation(): void {
         rootPath,
       );
 
-      if (!rootPath) {
-        throw new Error('No thoughtbase is open — cannot send conversation message.');
-      }
-
       // Every draft kind shares one streaming callback set; the divergent
       // per-kind work is in the CONVERSATION_FILE_*_DRAFT handlers, not here (#980).
       const streamCallbacks = buildStreamCallbacks(win, convId, controller.signal, pendingAskUser);
@@ -300,6 +307,7 @@ export function registerConversation(): void {
 
       const result = await runCompletionWithContainerRecovery(
         completeWithTools,
+        rootPath,
         convId,
         {
           system: effectiveSystem,
@@ -315,6 +323,7 @@ export function registerConversation(): void {
       );
 
       const updated = await conversation.appendMessage(
+        rootPath,
         convId,
         'assistant',
         result.text,
@@ -327,6 +336,7 @@ export function registerConversation(): void {
       // can update mid-turn.
       if (result.containerId) {
         await conversation.setContainerId(
+          rootPath,
           convId,
           result.containerId,
           result.containerExpiresAt,
@@ -355,18 +365,19 @@ export function registerConversation(): void {
     }
   });
 
-  handle(Channels.CONVERSATION_SET_MODEL, async (_e, convId: string, model: string | undefined) => {
-    return conversation.setModel(convId, model);
-  });
+  handle(Channels.CONVERSATION_SET_MODEL, withRootPath(async (rootPath, convId: string, model: string | undefined) => {
+    return conversation.setModel(rootPath, convId, model);
+  }));
 
   handle(
     Channels.CONVERSATION_SET_EFFORT,
-    async (_e, convId: string, effort: import('../../shared/tools/effort').Effort | undefined) => {
-      return conversation.setEffort(convId, effort);
-    },
+    withRootPath(async (rootPath, convId: string, effort: import('../../shared/tools/effort').Effort | undefined) => {
+      return conversation.setEffort(rootPath, convId, effort);
+    }),
   );
 
-  handle(Channels.CONVERSATION_COMPACT, (_e, convId: string) => compactConversation(convId));
+  handle(Channels.CONVERSATION_COMPACT, withRootPath((rootPath, convId: string) =>
+    compactConversation(rootPath, convId)));
 }
 
 /**
@@ -378,9 +389,10 @@ export function registerConversation(): void {
  * summary message (#820). Decision/assembly logic is in `llm/compact.ts`.
  */
 async function compactConversation(
+  rootPath: string,
   convId: string,
 ): Promise<import('../../shared/types').CompactResult> {
-  const conv = await conversation.load(convId);
+  const conv = await conversation.load(rootPath, convId);
   if (!conv) throw new Error(`Conversation not found: ${convId}`);
   if (conv.status !== 'active') {
     return { compacted: false, reason: 'This conversation is archived and can\'t be compacted.' };
@@ -421,16 +433,17 @@ async function compactConversation(
 
   // Archive the original (files the full transcript as a thought:Source —
   // recoverable) before opening the compacted continuation.
-  await conversation.archive(convId);
+  await conversation.archive(rootPath, convId);
   const createOpts: { systemPrompt?: string; model?: string; webEnabled?: boolean } = {};
   if (conv.systemPrompt) createOpts.systemPrompt = conv.systemPrompt;
   if (conv.model) createOpts.model = conv.model;
   if (conv.webEnabled !== undefined) createOpts.webEnabled = conv.webEnabled;
   const fresh = await conversation.create(
+    rootPath,
     conv.contextBundle,
     conv.triggerNodeUri,
     Object.keys(createOpts).length > 0 ? createOpts : undefined,
   );
-  const updated = await conversation.replaceMessages(fresh.id, [summaryMsg, ...plan.recent]);
+  const updated = await conversation.replaceMessages(rootPath, fresh.id, [summaryMsg, ...plan.recent]);
   return { compacted: true, conversation: updated };
 }

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as graph from '../graph/index';
-import { projectContext, type ProjectContext } from '../project-context-types';
+import { projectContext } from '../project-context-types';
 import { escapeTurtleLiteral } from './turtle';
 import { costForUsage } from '../../shared/tools/models';
 import type {
@@ -12,19 +12,29 @@ import type {
   ConversationsUIState,
 } from '../../shared/types';
 
-const DEFAULT_UI_STATE: ConversationsUIState = {
+/** The panel's state for a window with no project open — also what the IPC
+ *  layer hands back in that case (#1743). */
+export const DEFAULT_UI_STATE: ConversationsUIState = {
   visible: false,
   height: 320,
   activeTabId: null,
 };
 
 const THOUGHT = 'https://minerva.dev/ontology/thought#';
-let conversationsDir: string | null = null;
-let activeRootPath: string | null = null;
 
-export function initConversations(rootPath: string): void {
-  conversationsDir = path.join(rootPath, '.minerva', 'conversations');
-  activeRootPath = rootPath;
+/**
+ * Every entry point takes the project it operates on (#1743). This module used
+ * to keep the open project in two module-level variables, set by an
+ * `initConversations(rootPath)` that `project-context` called once per project
+ * — so with two thoughtbases open, whichever was opened *second* silently owned
+ * conversation storage for BOTH windows: window A's transcripts were written
+ * into project B's `.minerva/conversations/`, its tab list came back as B's,
+ * and its conversation triples landed in B's graph. Every other per-project
+ * subsystem (graph, tables, search, vectors) is keyed by project; this one was
+ * the straggler. Passing the root path in leaves nowhere for that state to hide.
+ */
+function convDir(rootPath: string): string {
+  return path.join(rootPath, '.minerva', 'conversations');
 }
 
 /**
@@ -34,11 +44,11 @@ export function initConversations(rootPath: string): void {
  * (the #350 relative-path-as-IRI bug) get scrubbed and replaced with
  * the corrected IRI form. Cheap: small JSON files, in-memory rdflib.
  */
-export async function reindexAllConversations(): Promise<void> {
-  if (!conversationsDir) return;
+export async function reindexAllConversations(rootPath: string): Promise<void> {
+  const dir = convDir(rootPath);
   let files: string[];
   try {
-    files = await fs.readdir(conversationsDir);
+    files = await fs.readdir(dir);
   } catch { return; /* no conversations yet */ }
   for (const file of files) {
     // Skip the `_ui.json` UI-state file (and any other underscore-prefixed
@@ -47,12 +57,12 @@ export async function reindexAllConversations(): Promise<void> {
     // writeConversationToGraph dereferences it.
     if (!file.endsWith('.json') || file.startsWith('_')) continue;
     try {
-      const data = await fs.readFile(path.join(conversationsDir, file), 'utf-8');
+      const data = await fs.readFile(path.join(dir, file), 'utf-8');
       const conv = migrateOnLoad(JSON.parse(data) as Conversation);
-      writeConversationToGraph(conv);
+      writeConversationToGraph(rootPath, conv);
       if (conv.status !== 'active') {
         // Mirror the live status so archive doesn't get dropped on reload.
-        updateConversationInGraph(conv);
+        updateConversationInGraph(rootPath, conv);
       }
     } catch (err) {
       console.warn(`[conversation] reindex skipped ${file}:`, err);
@@ -60,18 +70,8 @@ export async function reindexAllConversations(): Promise<void> {
   }
 }
 
-function activeCtx(): ProjectContext {
-  if (!activeRootPath) throw new Error('Conversations not initialized — no project open');
-  return projectContext(activeRootPath);
-}
-
-function ensureDir(): string {
-  if (!conversationsDir) throw new Error('Conversations not initialized — no project open');
-  return conversationsDir;
-}
-
-function convPath(id: string): string {
-  return path.join(ensureDir(), `${id}.json`);
+function convPath(rootPath: string, id: string): string {
+  return path.join(convDir(rootPath), `${id}.json`);
 }
 
 function generateId(): string {
@@ -81,11 +81,12 @@ function generateId(): string {
 // ── CRUD ───────────────────────────────────────────────────────────────────
 
 export async function create(
+  rootPath: string,
   contextBundle: ContextBundle,
   triggerNodeUri?: string,
   options?: { systemPrompt?: string; model?: string; webEnabled?: boolean },
 ): Promise<Conversation> {
-  const dir = ensureDir();
+  const dir = convDir(rootPath);
   await fs.mkdir(dir, { recursive: true });
 
   const now = new Date().toISOString();
@@ -101,18 +102,19 @@ export async function create(
   if (options?.model) conv.model = options.model;
   if (options?.webEnabled !== undefined) conv.webEnabled = options.webEnabled;
 
-  await persist(conv);
-  writeConversationToGraph(conv);
+  await persist(rootPath, conv);
+  writeConversationToGraph(rootPath, conv);
   return conv;
 }
 
 export async function appendMessage(
+  rootPath: string,
   id: string,
   role: ConversationMessage['role'],
   content: string,
   extra?: Partial<Pick<ConversationMessage, 'citations' | 'usage' | 'usageModel'>>,
 ): Promise<Conversation> {
-  const conv = await load(id);
+  const conv = await load(rootPath, id);
   if (!conv) throw new Error(`Conversation not found: ${id}`);
   if (conv.status !== 'active') throw new Error(`Conversation ${id} is ${conv.status}, cannot append`);
 
@@ -137,7 +139,7 @@ export async function appendMessage(
     }
   }
   conv.messages.push(message);
-  await persist(conv);
+  await persist(rootPath, conv);
   return conv;
 }
 
@@ -147,17 +149,17 @@ export async function appendMessage(
  * with one archive state). Idempotent — archiving an already-archived
  * conversation no-ops past the load.
  */
-export async function archive(id: string): Promise<Conversation> {
-  const conv = await load(id);
+export async function archive(rootPath: string, id: string): Promise<Conversation> {
+  const conv = await load(rootPath, id);
   if (!conv) throw new Error(`Conversation not found: ${id}`);
   if (conv.status === 'archived') return conv;
 
   conv.status = 'archived';
   conv.archivedAt = new Date().toISOString();
 
-  await persist(conv);
-  updateConversationInGraph(conv);
-  await fileAsSource(conv);
+  await persist(rootPath, conv);
+  updateConversationInGraph(rootPath, conv);
+  await fileAsSource(rootPath, conv);
   return conv;
 }
 
@@ -169,11 +171,12 @@ export async function archive(id: string): Promise<Conversation> {
  * graph projection — this is purely API-protocol state.
  */
 export async function setContainerId(
+  rootPath: string,
   id: string,
   containerId: string | undefined,
   expiresAt: string | undefined,
 ): Promise<void> {
-  const conv = await load(id);
+  const conv = await load(rootPath, id);
   if (!conv) return;
   if (containerId) {
     conv.containerId = containerId;
@@ -183,19 +186,19 @@ export async function setContainerId(
     delete conv.containerId;
     delete conv.containerExpiresAt;
   }
-  await persist(conv);
+  await persist(rootPath, conv);
 }
 
 /**
  * Pin a specific model to this conversation. Pass `undefined` to clear the
  * override so the conversation again tracks the global default.
  */
-export async function setModel(id: string, model: string | undefined): Promise<Conversation> {
-  const conv = await load(id);
+export async function setModel(rootPath: string, id: string, model: string | undefined): Promise<Conversation> {
+  const conv = await load(rootPath, id);
   if (!conv) throw new Error(`Conversation not found: ${id}`);
   if (model) conv.model = model;
   else delete conv.model;
-  await persist(conv);
+  await persist(rootPath, conv);
   return conv;
 }
 
@@ -205,14 +208,15 @@ export async function setModel(id: string, model: string | undefined): Promise<C
  * `setModel`.
  */
 export async function setEffort(
+  rootPath: string,
   id: string,
   effort: import('../../shared/tools/effort').Effort | undefined,
 ): Promise<Conversation> {
-  const conv = await load(id);
+  const conv = await load(rootPath, id);
   if (!conv) throw new Error(`Conversation not found: ${id}`);
   if (effort) conv.effort = effort;
   else delete conv.effort;
-  await persist(conv);
+  await persist(rootPath, conv);
   return conv;
 }
 
@@ -223,19 +227,20 @@ export async function setEffort(
  * since the conversation subject's triples don't depend on message content.
  */
 export async function replaceMessages(
+  rootPath: string,
   id: string,
   messages: ConversationMessage[],
 ): Promise<Conversation> {
-  const conv = await load(id);
+  const conv = await load(rootPath, id);
   if (!conv) throw new Error(`Conversation not found: ${id}`);
   conv.messages = messages;
-  await persist(conv);
+  await persist(rootPath, conv);
   return conv;
 }
 
-export async function load(id: string): Promise<Conversation | null> {
+export async function load(rootPath: string, id: string): Promise<Conversation | null> {
   try {
-    const data = await fs.readFile(convPath(id), 'utf-8');
+    const data = await fs.readFile(convPath(rootPath, id), 'utf-8');
     return migrateOnLoad(JSON.parse(data) as Conversation);
   } catch {
     return null;
@@ -260,20 +265,17 @@ function migrateOnLoad(raw: Conversation & { resolvedAt?: string }): Conversatio
   return raw;
 }
 
-export async function listAll(): Promise<Conversation[]> {
-  // Tolerate "no project open" — the renderer's conversations panel
-  // calls this on app mount before any project has been acquired, and
-  // the natural answer is "no conversations" rather than an error.
-  if (!conversationsDir) return [];
+export async function listAll(rootPath: string): Promise<Conversation[]> {
+  const dir = convDir(rootPath);
   try {
-    const files = await fs.readdir(conversationsDir);
+    const files = await fs.readdir(dir);
     const convs: Conversation[] = [];
     for (const file of files) {
       // Skip the `_ui.json` UI-state file (and any other underscore-prefixed
       // sibling files we add later) so they don't get parsed as conversations.
       if (!file.endsWith('.json') || file.startsWith('_')) continue;
       try {
-        const data = await fs.readFile(path.join(conversationsDir, file), 'utf-8');
+        const data = await fs.readFile(path.join(dir, file), 'utf-8');
         convs.push(migrateOnLoad(JSON.parse(data) as Conversation));
       } catch { /* skip malformed */ }
     }
@@ -284,21 +286,20 @@ export async function listAll(): Promise<Conversation[]> {
   }
 }
 
-export async function listActive(): Promise<Conversation[]> {
-  const all = await listAll();
+export async function listActive(rootPath: string): Promise<Conversation[]> {
+  const all = await listAll(rootPath);
   return all.filter(c => c.status === 'active');
 }
 
 // ── Tool-window UI state ───────────────────────────────────────────────────
 
-function uiStatePath(): string {
-  return path.join(ensureDir(), '_ui.json');
+function uiStatePath(rootPath: string): string {
+  return path.join(convDir(rootPath), '_ui.json');
 }
 
-export async function loadUIState(): Promise<ConversationsUIState> {
-  if (!conversationsDir) return { ...DEFAULT_UI_STATE };
+export async function loadUIState(rootPath: string): Promise<ConversationsUIState> {
   try {
-    const raw = await fs.readFile(uiStatePath(), 'utf-8');
+    const raw = await fs.readFile(uiStatePath(rootPath), 'utf-8');
     const parsed = JSON.parse(raw) as Partial<ConversationsUIState>;
     return {
       visible: typeof parsed.visible === 'boolean' ? parsed.visible : DEFAULT_UI_STATE.visible,
@@ -310,18 +311,18 @@ export async function loadUIState(): Promise<ConversationsUIState> {
   }
 }
 
-export async function saveUIState(state: ConversationsUIState): Promise<void> {
-  const dir = ensureDir();
+export async function saveUIState(rootPath: string, state: ConversationsUIState): Promise<void> {
+  const dir = convDir(rootPath);
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(uiStatePath(), JSON.stringify(state, null, 2), 'utf-8');
+  await fs.writeFile(uiStatePath(rootPath), JSON.stringify(state, null, 2), 'utf-8');
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-async function persist(conv: Conversation): Promise<void> {
-  const dir = ensureDir();
+async function persist(rootPath: string, conv: Conversation): Promise<void> {
+  const dir = convDir(rootPath);
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(convPath(conv.id), JSON.stringify(conv, null, 2), 'utf-8');
+  await fs.writeFile(convPath(rootPath, conv.id), JSON.stringify(conv, null, 2), 'utf-8');
 }
 
 // ── Graph Integration ──────────────────────────────────────────────────────
@@ -345,8 +346,8 @@ const CONVERSATION_PREDICATES = [
   'conversationContent',
 ];
 
-function clearConversationTriples(uri: string): void {
-  const ctx = activeCtx();
+function clearConversationTriples(rootPath: string, uri: string): void {
+  const ctx = projectContext(rootPath);
   graph.removeMatchingTriples(ctx, uri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
   for (const p of CONVERSATION_PREDICATES) {
     graph.removeMatchingTriples(ctx, uri, `${THOUGHT}${p}`);
@@ -357,16 +358,16 @@ function clearConversationTriples(uri: string): void {
   graph.removeMatchingTriples(ctx, uri, 'http://purl.org/dc/terms/created');
 }
 
-function writeConversationToGraph(conv: Conversation): void {
+function writeConversationToGraph(rootPath: string, conv: Conversation): void {
   const uri = convUri(conv.id);
-  const ctx = activeCtx();
+  const ctx = projectContext(rootPath);
   // contextNote needs a real IRI, not the raw `notes/foo.md` string —
   // the prior shape (#350) made downstream joins against
   // minerva:relativePath silently mismatch.
   const contextNoteIri = conv.contextBundle.notePath
     ? graph.noteUriFor(ctx, conv.contextBundle.notePath)
     : null;
-  clearConversationTriples(uri);
+  clearConversationTriples(rootPath, uri);
   const turtle = `
     @prefix thought: <${THOUGHT}> .
     @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -380,7 +381,7 @@ function writeConversationToGraph(conv: Conversation): void {
   graph.parseIntoStore(ctx, turtle);
 }
 
-function updateConversationInGraph(conv: Conversation): void {
+function updateConversationInGraph(rootPath: string, conv: Conversation): void {
   const uri = convUri(conv.id);
   const turtle = `
     @prefix thought: <${THOUGHT}> .
@@ -389,10 +390,10 @@ function updateConversationInGraph(conv: Conversation): void {
     <${uri}> thought:conversationStatus thought:${conv.status}
       ${conv.archivedAt ? `; thought:archivedAt "${conv.archivedAt}"^^xsd:dateTime` : ''} .
   `;
-  graph.parseIntoStore(activeCtx(), turtle);
+  graph.parseIntoStore(projectContext(rootPath), turtle);
 }
 
-async function fileAsSource(conv: Conversation): Promise<void> {
+async function fileAsSource(rootPath: string, conv: Conversation): Promise<void> {
   const uri = convUri(conv.id);
   const transcript = conv.messages
     .map(m => `[${m.role}] ${m.content}`)
@@ -407,7 +408,7 @@ async function fileAsSource(conv: Conversation): Promise<void> {
       thought:conversationContent "${escapeTurtleLiteral(transcript)}" ;
       dc:created "${conv.startedAt}"^^xsd:dateTime .
   `;
-  const ctx = activeCtx();
+  const ctx = projectContext(rootPath);
   graph.parseIntoStore(ctx, turtle);
   await graph.persistGraph(ctx);
 }

--- a/src/main/project-context.ts
+++ b/src/main/project-context.ts
@@ -70,7 +70,6 @@ export async function acquireProject(rootPath: string, winId: number): Promise<P
       } catch (err) {
         console.warn(`[project-context] vector store init failed for ${rootPath}:`, err);
       }
-      conversation.initConversations(rootPath);
       // graph.indexAllNotes resets the rdflib store (`state.store = $rdf.graph()`)
       // then rebuilds it; registerAllCsvs writes the CSV table-schema overlay to
       // that same store via indexCsvTable. Running them concurrently is a latent
@@ -93,7 +92,7 @@ export async function acquireProject(rootPath: string, winId: number): Promise<P
       // indexed (so contextNote IRIs resolve against a populated note
       // namespace). Also self-heals stale relative-path triples from
       // before #350.
-      await conversation.reindexAllConversations();
+      await conversation.reindexAllConversations(rootPath);
       // Health checks run once at open, then a periodic timer takes over.
       // Fire-and-forget — no need to block project init on the result. Both
       // paths read the user's inspection settings (#1792 follow-up): without

--- a/tests/main/ipc/register-conversation.test.ts
+++ b/tests/main/ipc/register-conversation.test.ts
@@ -100,6 +100,7 @@ vi.mock('../../../src/main/llm/conversation', () => ({
   archive: h.archive,
   create: h.create,
   replaceMessages: h.replaceMessages,
+  DEFAULT_UI_STATE: { visible: false, height: 320, activeTabId: null },
 }));
 
 // Approval engine — the trust gate.
@@ -179,7 +180,10 @@ describe('CONVERSATION_SEND (#1612)', () => {
     });
     // The assistant turn is persisted with the LLM result.
     expect(h.appendMessage).toHaveBeenCalledWith(
-      'conv-1', 'assistant', 'assistant reply',
+      // Every conversation call now names the project the CALLING WINDOW has
+       // open (#1743), instead of reaching module state the last-opened project
+       // owned — the bug that made two thoughtbases share one conversation store.
+       '/root', 'conv-1', 'assistant', 'assistant reply',
       expect.objectContaining({ usageModel: 'claude-x' }),
     );
     // Context released in the finally.
@@ -195,7 +199,7 @@ describe('CONVERSATION_SEND (#1612)', () => {
 
     expect(h.completeWithTools).toHaveBeenCalledTimes(2);
     // The stale/absent container id is cleared before the retry.
-    expect(h.setContainerId).toHaveBeenCalledWith('conv-1', undefined, undefined);
+    expect(h.setContainerId).toHaveBeenCalledWith('/root', 'conv-1', undefined, undefined);
     expect(h.exitLLMContext).toHaveBeenCalledTimes(1);
   });
 
@@ -345,11 +349,11 @@ describe('CONVERSATION_RETRY (#1804)', () => {
     await retry(evt, 'conv-1');
 
     // Loaded, not appended-to: exactly one appendMessage call, the assistant's.
-    expect(h.load).toHaveBeenCalledWith('conv-1');
+    expect(h.load).toHaveBeenCalledWith('/root', 'conv-1');
     expect(h.completeWithTools).toHaveBeenCalledTimes(1);
     expect(h.appendMessage).toHaveBeenCalledTimes(1);
     expect(h.appendMessage).toHaveBeenCalledWith(
-      'conv-1', 'assistant', 'second attempt', expect.anything(),
+      '/root', 'conv-1', 'assistant', 'second attempt', expect.anything(),
     );
   });
 
@@ -415,6 +419,6 @@ describe('CONVERSATION_COMPACT with a truncated summary (#1811)', () => {
     const result = await compact(evt, 'conv-1') as { compacted: boolean };
 
     expect(result.compacted).toBe(true);
-    expect(h.archive).toHaveBeenCalledWith('conv-1');
+    expect(h.archive).toHaveBeenCalledWith('/root', 'conv-1');
   });
 });

--- a/tests/main/llm/conversation-context-iri.test.ts
+++ b/tests/main/llm/conversation-context-iri.test.ts
@@ -19,7 +19,6 @@ import {
   noteUriFor,
 } from '../../../src/main/graph/index';
 import {
-  initConversations,
   reindexAllConversations,
   create as createConversation,
 } from '../../../src/main/llm/conversation';
@@ -37,7 +36,6 @@ describe('Conversation thought:contextNote is a real IRI (#350)', () => {
     root = mkTempProject();
     ctx = projectContext(root);
     await initGraph(ctx);
-    initConversations(root);
   });
 
   afterEach(async () => {
@@ -49,7 +47,7 @@ describe('Conversation thought:contextNote is a real IRI (#350)', () => {
     await indexNote(ctx, 'notes/foo.md', '# Foo\nContent.\n');
 
     // Create a conversation whose contextBundle references that note.
-    await createConversation({ notePath: 'notes/foo.md' });
+    await createConversation(root, { notePath: 'notes/foo.md' });
 
     // The bug ticket's exact query: "what conversation was triggered
     // from this note?". The join only succeeds if contextNote is the
@@ -65,7 +63,7 @@ describe('Conversation thought:contextNote is a real IRI (#350)', () => {
   });
 
   it('omits contextNote entirely when there is no notePath', async () => {
-    const conv = await createConversation({});
+    const conv = await createConversation(root, {});
     const expectedIri = `https://minerva.dev/ontology/thought#conversation/${conv.id}`;
 
     const r = await queryGraph(ctx, `
@@ -104,7 +102,7 @@ describe('Conversation thought:contextNote is a real IRI (#350)', () => {
     }), 'utf-8');
 
     // Re-project. This is what acquireProject does on each open.
-    await reindexAllConversations();
+    await reindexAllConversations(root);
 
     // The corrected IRI is now present.
     const good = await queryGraph(ctx, `

--- a/tests/main/llm/conversation-model.test.ts
+++ b/tests/main/llm/conversation-model.test.ts
@@ -5,7 +5,6 @@ import os from 'node:os';
 import { initGraph } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
 import {
-  initConversations,
   create,
   setModel,
   load,
@@ -23,7 +22,6 @@ describe('conversation.setModel (issue #168)', () => {
     root = mkTempProject();
     ctx = projectContext(root);
     await initGraph(ctx);
-    initConversations(root);
   });
 
   afterEach(() => {
@@ -31,41 +29,41 @@ describe('conversation.setModel (issue #168)', () => {
   });
 
   it('new conversations have no model override (undefined = track global default)', async () => {
-    const conv = await create({ notePath: 'x.md' });
+    const conv = await create(root, { notePath: 'x.md' });
     expect(conv.model).toBeUndefined();
-    const reloaded = await load(conv.id);
+    const reloaded = await load(root, conv.id);
     expect(reloaded?.model).toBeUndefined();
   });
 
   it('pins a model and persists it', async () => {
-    const conv = await create({ notePath: 'x.md' });
-    await setModel(conv.id, 'claude-opus-4-7');
-    const reloaded = await load(conv.id);
+    const conv = await create(root, { notePath: 'x.md' });
+    await setModel(root, conv.id, 'claude-opus-4-7');
+    const reloaded = await load(root, conv.id);
     expect(reloaded?.model).toBe('claude-opus-4-7');
   });
 
   it('clears the override when passed undefined', async () => {
-    const conv = await create({ notePath: 'x.md' });
-    await setModel(conv.id, 'claude-opus-4-7');
-    await setModel(conv.id, undefined);
-    const reloaded = await load(conv.id);
+    const conv = await create(root, { notePath: 'x.md' });
+    await setModel(root, conv.id, 'claude-opus-4-7');
+    await setModel(root, conv.id, undefined);
+    const reloaded = await load(root, conv.id);
     expect(reloaded?.model).toBeUndefined();
   });
 
   it('each conversation carries its own model independently', async () => {
-    const a = await create({ notePath: 'a.md' });
-    const b = await create({ notePath: 'b.md' });
-    await setModel(a.id, 'claude-opus-4-7');
-    await setModel(b.id, 'claude-haiku-4-5');
+    const a = await create(root, { notePath: 'a.md' });
+    const b = await create(root, { notePath: 'b.md' });
+    await setModel(root, a.id, 'claude-opus-4-7');
+    await setModel(root, b.id, 'claude-haiku-4-5');
 
-    const reloadedA = await load(a.id);
-    const reloadedB = await load(b.id);
+    const reloadedA = await load(root, a.id);
+    const reloadedB = await load(root, b.id);
     expect(reloadedA?.model).toBe('claude-opus-4-7');
     expect(reloadedB?.model).toBe('claude-haiku-4-5');
   });
 
   it('throws on an unknown conversation id', async () => {
-    await expect(setModel('nope', 'claude-opus-4-7')).rejects.toThrow(/not found/i);
+    await expect(setModel(root, 'nope', 'claude-opus-4-7')).rejects.toThrow(/not found/i);
   });
 });
 
@@ -77,7 +75,6 @@ describe('conversation.create webEnabled (#1533 — per-conversation web)', () =
     root = mkTempProject();
     ctx = projectContext(root);
     await initGraph(ctx);
-    initConversations(root);
   });
 
   afterEach(() => {
@@ -85,19 +82,19 @@ describe('conversation.create webEnabled (#1533 — per-conversation web)', () =
   });
 
   it('defaults to undefined (inherit the global web setting)', async () => {
-    const conv = await create({ notePath: 'x.md' });
+    const conv = await create(root, { notePath: 'x.md' });
     expect(conv.webEnabled).toBeUndefined();
-    expect((await load(conv.id))?.webEnabled).toBeUndefined();
+    expect((await load(root, conv.id))?.webEnabled).toBeUndefined();
   });
 
   it('persists an explicit web:false from a launching skill', async () => {
-    const conv = await create({ notePath: 'x.md' }, undefined, { webEnabled: false });
+    const conv = await create(root, { notePath: 'x.md' }, undefined, { webEnabled: false });
     expect(conv.webEnabled).toBe(false);
-    expect((await load(conv.id))?.webEnabled).toBe(false);
+    expect((await load(root, conv.id))?.webEnabled).toBe(false);
   });
 
   it('persists an explicit web:true', async () => {
-    const conv = await create({ notePath: 'x.md' }, undefined, { webEnabled: true });
-    expect((await load(conv.id))?.webEnabled).toBe(true);
+    const conv = await create(root, { notePath: 'x.md' }, undefined, { webEnabled: true });
+    expect((await load(root, conv.id))?.webEnabled).toBe(true);
   });
 });

--- a/tests/main/llm/conversation-multi-project.test.ts
+++ b/tests/main/llm/conversation-multi-project.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Two thoughtbases open at once keep separate conversations (#1743).
+ *
+ * The module used to hold the open project in two module-level variables, set
+ * by an `initConversations(rootPath)` that ran once per project. Opening a
+ * second thoughtbase overwrote them, so from that moment BOTH windows read and
+ * wrote the same project's `.minerva/conversations/` — one window's transcripts
+ * filed under the other's thoughtbase, its tab list restored as the other's, and
+ * its conversation triples projected into the other's graph.
+ *
+ * These tests interleave two projects deliberately: every case creates in A,
+ * then in B, then reads back from A. Under the old code the second `init` won
+ * and the A-side reads came back as B's, so a regression here fails rather than
+ * quietly reappearing.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, queryGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import {
+  create,
+  load,
+  listActive,
+  appendMessage,
+  loadUIState,
+  saveUIState,
+} from '../../../src/main/llm/conversation';
+
+function mkTempProject(label: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `minerva-conv-${label}-`));
+}
+
+/** Conversation JSON files (not the `_ui.json` sibling) under a project. */
+function conversationFiles(root: string): string[] {
+  const dir = path.join(root, '.minerva', 'conversations');
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir).filter((f) => f.endsWith('.json') && !f.startsWith('_'));
+}
+
+describe('conversations with two thoughtbases open (#1743)', () => {
+  let rootA: string;
+  let rootB: string;
+  let ctxA: ProjectContext;
+  let ctxB: ProjectContext;
+
+  beforeEach(async () => {
+    rootA = mkTempProject('projA');
+    rootB = mkTempProject('projB');
+    ctxA = projectContext(rootA);
+    ctxB = projectContext(rootB);
+    // Order matters: B is initialised second, which is exactly what used to
+    // capture conversation storage for both.
+    await initGraph(ctxA);
+    await initGraph(ctxB);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(rootA, { recursive: true, force: true });
+    await fsp.rm(rootB, { recursive: true, force: true });
+  });
+
+  it('files each conversation under its own project', async () => {
+    const convA = await create(rootA, { notePath: 'a.md' });
+    const convB = await create(rootB, { notePath: 'b.md' });
+
+    expect(conversationFiles(rootA)).toEqual([`${convA.id}.json`]);
+    expect(conversationFiles(rootB)).toEqual([`${convB.id}.json`]);
+  });
+
+  it('lists only the calling project\'s conversations', async () => {
+    const convA = await create(rootA, { notePath: 'a.md' });
+    const convB = await create(rootB, { notePath: 'b.md' });
+
+    expect((await listActive(rootA)).map((c) => c.id)).toEqual([convA.id]);
+    expect((await listActive(rootB)).map((c) => c.id)).toEqual([convB.id]);
+  });
+
+  it('does not resolve one project\'s conversation id against the other', async () => {
+    const convA = await create(rootA, { notePath: 'a.md' });
+
+    expect(await load(rootA, convA.id)).not.toBeNull();
+    // Not "found in the wrong place" — not found at all.
+    expect(await load(rootB, convA.id)).toBeNull();
+  });
+
+  it('appends a turn to the project that owns the conversation', async () => {
+    const convA = await create(rootA, { notePath: 'a.md' });
+    await create(rootB, { notePath: 'b.md' });
+
+    await appendMessage(rootA, convA.id, 'user', 'build me a thoughtbase');
+
+    const reloaded = await load(rootA, convA.id);
+    expect(reloaded?.messages.map((m) => m.content)).toEqual(['build me a thoughtbase']);
+    // B's transcript is untouched by A's turn.
+    const bConvs = await listActive(rootB);
+    expect(bConvs[0]?.messages).toEqual([]);
+  });
+
+  it('keeps each project\'s panel state separate', async () => {
+    await saveUIState(rootA, { visible: true, height: 500, activeTabId: 'tab-a' });
+    await saveUIState(rootB, { visible: false, height: 200, activeTabId: 'tab-b' });
+
+    expect(await loadUIState(rootA)).toEqual({ visible: true, height: 500, activeTabId: 'tab-a' });
+    expect(await loadUIState(rootB)).toEqual({ visible: false, height: 200, activeTabId: 'tab-b' });
+  });
+
+  it('projects each conversation into its own graph', async () => {
+    // The half of the bug that outlives a restart: triples written into the
+    // wrong thoughtbase's graph stay there.
+    const convA = await create(rootA, { notePath: 'a.md' });
+
+    const inA = await queryGraph(ctxA, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?c WHERE { ?c a thought:Conversation }
+    `);
+    const inB = await queryGraph(ctxB, `
+      PREFIX thought: <https://minerva.dev/ontology/thought#>
+      SELECT ?c WHERE { ?c a thought:Conversation }
+    `);
+
+    expect(inA.results.map((r) => String(r.c))).toContain(
+      `https://minerva.dev/ontology/thought#conversation/${convA.id}`,
+    );
+    expect(inB.results).toEqual([]);
+  });
+
+  it('answers with an empty list for a project that has no conversations yet', async () => {
+    // The panel asks on mount. "Nothing yet" is a real answer, not a failure.
+    expect(await listActive(rootA)).toEqual([]);
+    expect(await loadUIState(rootA)).toEqual({ visible: false, height: 320, activeTabId: null });
+  });
+});


### PR DESCRIPTION
Found while investigating #1743 (two thoughtbases open, one window appearing not to run). **This is not that symptom** — see the issue thread for where that investigation landed — but it is a real bug in exactly that configuration, and a quiet one.

## The bug

`llm/conversation.ts` kept the open project in two module-level variables set by `initConversations(rootPath)`, which `project-context.ts` called once per project on first acquire. Opening a second thoughtbase overwrote them, and from that moment **both** windows resolved every conversation operation against the same project:

- transcripts written into the other thoughtbase's `.minerva/conversations/`
- `listActive()` restoring the other thoughtbase's tabs
- `_ui.json` — panel height, active tab — shared between the two windows
- `thought:Conversation` triples projected into the other project's graph

The last one is the part that outlives a restart and that a user couldn't undo by hand.

Every other per-project subsystem — graph, tables, search, vectors — is keyed by `ProjectContext` through `createProjectStore`. Conversations were the straggler.

## The fix

Each entry point takes the root path, so there is nowhere for the state to hide, and the IPC handlers resolve it from the **calling window** via `withRootPath` — which is what actually makes two windows independent. `initConversations` is gone.

The list and UI-state reads use `withRootPathOr` with a genuinely-empty value, matching the IPC convention in CLAUDE.md (rule 2): the conversations panel calls them on mount, before any project is open, and "nothing yet" is a real answer there rather than a swallowed failure.

## Testing

`tests/main/llm/conversation-multi-project.test.ts` interleaves two projects deliberately — create in A, create in B, read back from A — because that ordering is exactly what the old global lost. It covers file placement, listing, cross-project id resolution, appends, panel state, and the graph projection.

Worth being straight about what that test does and doesn't prove: it encodes the invariant, but it could not have been written against the old API at all, since those functions took no project. So this is not a red-green demo — the failure mode was structural, and the fix is that the structure can no longer express it.

`pnpm lint` clean, full suite green (5895 tests).

Refs #1743

🤖 Generated with [Claude Code](https://claude.com/claude-code)
