### PR TITLE
fix(ui): lighten the modal backdrop so you can still read the app behind it

### DIFF
--- a/src/renderer/lib/components/AboutDialog.svelte
+++ b/src/renderer/lib/components/AboutDialog.svelte
@@ -81,8 +81,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/AddPropertyDialog.svelte
+++ b/src/renderer/lib/components/AddPropertyDialog.svelte
@@ -127,8 +127,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-spawned);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/AutoLinkDialog.svelte
+++ b/src/renderer/lib/components/AutoLinkDialog.svelte
@@ -120,8 +120,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/AutoTagDialog.svelte
+++ b/src/renderer/lib/components/AutoTagDialog.svelte
@@ -79,8 +79,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/BusyOverlay.svelte
+++ b/src/renderer/lib/components/BusyOverlay.svelte
@@ -40,8 +40,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-blocking);
-    background: rgba(20, 14, 6, 0.35);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/CollectionPickerDialog.svelte
+++ b/src/renderer/lib/components/CollectionPickerDialog.svelte
@@ -174,8 +174,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.45);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     justify-content: center;
     align-items: flex-start;

--- a/src/renderer/lib/components/ConfirmDialog.svelte
+++ b/src/renderer/lib/components/ConfirmDialog.svelte
@@ -85,8 +85,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-spawned);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/ExportDialog.svelte
+++ b/src/renderer/lib/components/ExportDialog.svelte
@@ -448,8 +448,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/FindInNotesDialog.svelte
+++ b/src/renderer/lib/components/FindInNotesDialog.svelte
@@ -333,8 +333,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     justify-content: center;
     align-items: flex-start;

--- a/src/renderer/lib/components/GotoNoteDialog.svelte
+++ b/src/renderer/lib/components/GotoNoteDialog.svelte
@@ -332,8 +332,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.45);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     justify-content: center;
     align-items: flex-start;

--- a/src/renderer/lib/components/MergeSourcesDialog.svelte
+++ b/src/renderer/lib/components/MergeSourcesDialog.svelte
@@ -85,8 +85,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-spawned);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/MineReferencesDialog.svelte
+++ b/src/renderer/lib/components/MineReferencesDialog.svelte
@@ -146,8 +146,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/NewNoteDialog.svelte
+++ b/src/renderer/lib/components/NewNoteDialog.svelte
@@ -232,8 +232,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-spawned);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/OnboardingDialog.svelte
+++ b/src/renderer/lib/components/OnboardingDialog.svelte
@@ -172,8 +172,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.55);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/OpenTargetDialog.svelte
+++ b/src/renderer/lib/components/OpenTargetDialog.svelte
@@ -69,8 +69,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-spawned);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/PromptDialog.svelte
+++ b/src/renderer/lib/components/PromptDialog.svelte
@@ -91,8 +91,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-spawned);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/PublishDialog.svelte
+++ b/src/renderer/lib/components/PublishDialog.svelte
@@ -397,7 +397,7 @@
 <style>
   .publish-backdrop {
     position: fixed; inset: 0; z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5); backdrop-filter: blur(2px);
+    background: var(--scrim-bg); backdrop-filter: var(--scrim-blur);
     display: flex; align-items: center; justify-content: center; padding: 32px;
   }
   .publish-dialog {

--- a/src/renderer/lib/components/ResolveStubDialog.svelte
+++ b/src/renderer/lib/components/ResolveStubDialog.svelte
@@ -122,8 +122,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/SafeDeleteBlockerDialog.svelte
+++ b/src/renderer/lib/components/SafeDeleteBlockerDialog.svelte
@@ -118,8 +118,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/SaveQueryDialog.svelte
+++ b/src/renderer/lib/components/SaveQueryDialog.svelte
@@ -116,8 +116,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/SettingsDialog.svelte
+++ b/src/renderer/lib/components/SettingsDialog.svelte
@@ -501,8 +501,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/ShortcutsDialog.svelte
+++ b/src/renderer/lib/components/ShortcutsDialog.svelte
@@ -62,8 +62,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/SmartCollectionEditorDialog.svelte
+++ b/src/renderer/lib/components/SmartCollectionEditorDialog.svelte
@@ -221,8 +221,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/SnippetPickerDialog.svelte
+++ b/src/renderer/lib/components/SnippetPickerDialog.svelte
@@ -117,8 +117,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-spawned);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/SourcePickerDialog.svelte
+++ b/src/renderer/lib/components/SourcePickerDialog.svelte
@@ -131,8 +131,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.45);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     justify-content: center;
     align-items: flex-start;

--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -1206,8 +1206,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/ThoughtbaseProperties.svelte
+++ b/src/renderer/lib/components/ThoughtbaseProperties.svelte
@@ -137,8 +137,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/ToolParamsDialog.svelte
+++ b/src/renderer/lib/components/ToolParamsDialog.svelte
@@ -134,8 +134,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/TypePickerDialog.svelte
+++ b/src/renderer/lib/components/TypePickerDialog.svelte
@@ -94,8 +94,8 @@
     position: fixed;
     inset: 0;
     z-index: var(--z-spawned);
-    background: rgba(20, 14, 6, 0.5);
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/renderer/lib/components/ui/Dialog.svelte
+++ b/src/renderer/lib/components/ui/Dialog.svelte
@@ -5,8 +5,6 @@
   interface Props {
     /** Card width in px. Spec defaults: confirm 440, prompt 460, palette 640. */
     width?: number;
-    /** Backdrop scrim opacity (0–1). Spec defaults around .45–.55. */
-    scrim?: number;
     /** Click on the backdrop / Escape key. Both are routed here. */
     onClose?: () => void;
     /** Optional aria-labelledby — typically the eyebrow + title elements id'd
@@ -26,7 +24,6 @@
 
   let {
     width = 440,
-    scrim = 0.5,
     onClose,
     'aria-labelledby': ariaLabelledBy,
     eyebrow,
@@ -57,7 +54,6 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="backdrop"
-  style:--scrim={scrim}
   onclick={onBackdropClick}
 >
   <div
@@ -100,8 +96,8 @@
     align-items: center;
     justify-content: center;
     padding: 32px;
-    background: rgba(20, 14, 6, var(--scrim, 0.5));
-    backdrop-filter: blur(2px);
+    background: var(--scrim-bg);
+    backdrop-filter: var(--scrim-blur);
   }
   .card {
     background: var(--bg-elev);

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -65,6 +65,20 @@
   --z-toast:    2800;  /* transient feedback — must clear every dialog */
   --z-drag:     2900;  /* pointer-following drag ghost/caret — it IS the cursor */
   --z-blocking: 3000;  /* busy overlay — blocks the whole app */
+
+  /* ── Modal scrim (#1753) ──────────────────────────────────────────
+     One backdrop for every modal, and a deliberately light one. A user
+     filling in a dialog is often reading the thing that prompted it —
+     the filename Minerva just suggested, the note the confirm is about —
+     so a backdrop that makes the app behind unreadable takes away the
+     information the dialog exists to collect.
+
+     Hence no blur: dimming separates the layers on its own, while blur
+     is what actually destroys small text. `--scrim-blur` stays a token
+     rather than being deleted at each call site, so reintroducing one is
+     a single edit here rather than thirty. */
+  --scrim-bg:   rgba(20, 14, 6, 0.32);
+  --scrim-blur: none;
 }
 
 [data-theme="light"] {

--- a/tests/renderer/modal-scrim.test.ts
+++ b/tests/renderer/modal-scrim.test.ts
@@ -1,0 +1,93 @@
+/**
+ * One backdrop for every modal (#1753).
+ *
+ * A user was filling in the New Note dialog with a filename Minerva had just
+ * suggested in the conversation behind it — and couldn't read it, because the
+ * backdrop blurred and dimmed the app. A dialog that hides the information it
+ * exists to collect is working against itself.
+ *
+ * Thirty components had each hand-rolled the same backdrop, drifting into four
+ * different opacities along the way, so "make it lighter" meant thirty edits
+ * and any new dialog started from whatever its neighbour happened to use. The
+ * scrim is a token now; these keep it that way, in the same spirit as the
+ * z-index-layering tests next door.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const RENDERER = path.join(ROOT, 'src/renderer');
+const globalCss = fs.readFileSync(path.join(RENDERER, 'styles/global.css'), 'utf-8');
+
+/** Every `.svelte` file under src/renderer, as [relativePath, source]. */
+function svelteFiles(): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.svelte')) {
+        out.push([path.relative(RENDERER, full), fs.readFileSync(full, 'utf-8')]);
+      }
+    }
+  };
+  walk(RENDERER);
+  return out;
+}
+
+describe('modal scrim', () => {
+  it('defines both scrim tokens', () => {
+    expect(globalCss).toMatch(/--scrim-bg:\s*rgba\(/);
+    expect(globalCss).toMatch(/--scrim-blur:/);
+  });
+
+  it('stays light enough to read the app through', () => {
+    // The number that matters to the reported bug. Not a style preference: at
+    // the old 0.5 the filename behind the dialog was unreadable, which is the
+    // whole complaint. If someone raises this, they should have to change a
+    // test that says why.
+    const alpha = /--scrim-bg:\s*rgba\([^)]*?,\s*([\d.]+)\s*\)/.exec(globalCss);
+    expect(alpha, '--scrim-bg must be an rgba() with an explicit alpha').not.toBeNull();
+    expect(Number(alpha![1])).toBeLessThanOrEqual(0.35);
+  });
+
+  it('applies no blur, because blur is what destroys small text', () => {
+    // Dimming separates the layers on its own. Kept as a token rather than
+    // deleted at each call site, so reintroducing one is a single edit.
+    expect(globalCss).toMatch(/--scrim-blur:\s*none/);
+  });
+
+  it('has no component hand-rolling its own scrim colour', () => {
+    // The warm ink the backdrops all used. A literal here means a dialog that
+    // won't follow when the token changes — which is how four opacities ended
+    // up in the tree.
+    const offenders = svelteFiles()
+      .filter(([, src]) => /rgba\(\s*20\s*,\s*14\s*,\s*6\s*,/.test(src))
+      .map(([file]) => file);
+    expect(
+      offenders,
+      'Use var(--scrim-bg) so every modal shares one backdrop:\n' + offenders.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('has no component hand-rolling a backdrop blur', () => {
+    const offenders = svelteFiles()
+      .filter(([, src]) => /backdrop-filter:\s*blur\(/.test(src))
+      .map(([file]) => file);
+    expect(
+      offenders,
+      'Use var(--scrim-blur) rather than a local blur:\n' + offenders.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('still paints a backdrop on the dialogs that had one', () => {
+    // The opposite failure: a search-and-replace that dropped the scrim
+    // entirely would leave dialogs floating with no separation at all.
+    for (const name of ['NewNoteDialog', 'PromptDialog', 'ConfirmDialog', 'SettingsDialog', 'ui/Dialog']) {
+      const src = fs.readFileSync(path.join(RENDERER, `lib/components/${name}.svelte`), 'utf-8');
+      expect(src, `${name} lost its backdrop`).toContain('var(--scrim-bg)');
+    }
+  });
+});


### PR DESCRIPTION
A user opened New Note to type a filename Minerva had just suggested in the conversation behind the dialog — and couldn't read it. The backdrop blurred and dimmed the app to the point where the information the dialog existed to collect was gone. They had to cancel, memorise, and reopen.

## What was actually causing it

Blur. 2px is enough to destroy 13px text, and dimming at 0.5 finished the job. Dimming on its own separates the layers perfectly well — the card has an elevated background and a border of its own — so the blur was buying nothing for what it cost.

I rendered the before/after against the real tokens to check rather than guess. At `0.5 + blur(2px)` the filename `ablations/04-four-ablations-framing.md` is an unreadable smear; at `0.32` with no blur it's fully legible, and the dialog still reads as clearly on top.

## Why it's thirty files

Every one of the thirty dialogs had hand-rolled the same two lines, drifting into four different opacities along the way (0.35 / 0.45 / 0.5 / 0.55). "Make it lighter" was therefore a thirty-file edit, and any new dialog started from whichever neighbour got copied. Now:

```css
--scrim-bg:   rgba(20, 14, 6, 0.32);
--scrim-blur: none;
```

`--scrim-blur` stays a token rather than being deleted at each call site, so reintroducing a blur later is one edit here instead of thirty.

Also drops `Dialog.svelte`'s per-instance `scrim` prop. Nothing passed it, and its doc ("spec defaults around .45–.55") pointed at exactly the heavy look this removes — a per-dialog opacity knob is how four values happened in the first place.

## Testing

`tests/renderer/modal-scrim.test.ts` is a source scan, in the spirit of the z-index-layering tests next door: no component may hand-roll the scrim colour or a backdrop blur, the alpha must stay at or under 0.35, and the dialogs that had a backdrop must still have one — so a search-and-replace that dropped the scrim entirely fails too.

`pnpm lint` clean, full suite green (5926 tests).

## Worth your eye before merging

0.32 is a judgement call, and I checked it in an isolated harness rather than in the running app — the tokens and content are the real ones, but it isn't Minerva. If it reads too light (or still too heavy) against the actual UI, it's one number in `global.css`. Same for the blur: `--scrim-blur: blur(1px)` would restore a hint of it without erasing text.

One deliberate scope call: `BusyOverlay` uses the same tokens. It's arguably a different animal — nothing behind it is meant to be read — but with the maintenance overlay from #1815 now sitting there during a long rebuild, being able to see what the app is doing behind it seemed like the same argument.

Fixes #1753

🤖 Generated with [Claude Code](https://claude.com/claude-code)
