### PR TITLE
chore(deps): ignore @retorquere/bibtex-parser 10.x, not just 10.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,14 +31,26 @@ updates:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
     ignore:
-      # @retorquere/bibtex-parser@10.0.0 is an upstream packaging bug: its
+      # @retorquere/bibtex-parser 10.x is an upstream packaging bug: its
       # package.json advertises `types: ./dist/types/index.d.ts` but the
-      # published tarball ships zero .d.ts files, so `tsc --noEmit` fails
-      # (TS7016) at src/main/sources/import-bibtex.ts. Pin out this exact
-      # broken release only — a fixed 10.0.1+/10.1.0 will still be proposed.
-      # Remove this entry once upstream republishes with declarations. (#1464)
+      # published tarball ships zero .d.ts files. The import degrades to
+      # `any`, so the lint gate fails three ways — tsc (TS7016) and
+      # svelte-check on the missing declaration file, plus 21
+      # @typescript-eslint/no-unsafe-* errors in
+      # src/main/sources/import-bibtex.ts.
+      #
+      # This is packaging, not API. parse() still takes `sentenceCase: false`,
+      # still returns { entries, errors }, and entries still carry
+      # type/key/fields/input; all 18 import-bibtex tests pass on 10.0.1.
+      # Nothing here is worth a hand-written .d.ts shim that would silently
+      # outrank the real types once they come back.
+      #
+      # Originally pinned at the exact broken 10.0.0 (#1464) on the assumption
+      # a fix would follow; 10.0.1 shipped the same way (#1821), so widen to
+      # the whole 10 line. Remove this entry — and re-check dist/types is
+      # actually in the tarball — once upstream republishes declarations.
       - dependency-name: "@retorquere/bibtex-parser"
-        versions: ["10.0.0"]
+        versions: ["10.x"]
 
   # ── GitHub Actions themselves ────────────────────────────────────────────
   # The workflows pin actions by major tag (actions/checkout@v4, …); those


### PR DESCRIPTION
Widens the existing dependabot ignore for `@retorquere/bibtex-parser` from the single version `10.0.0` to the whole `10.x` line, and closes #1821.

## Why

`10.0.0` shipped a `package.json` advertising `"types": "./dist/types/index.d.ts"` with **zero** `.d.ts` files in the published tarball. We pinned that exact version out in #1464, on the stated assumption that a fixed `10.0.1+` would follow and should still be proposed.

`10.0.1` shipped identically:

```
$ npm pack @retorquere/bibtex-parser@10.0.1 && tar tzf *.tgz | grep dist/types
(no matches — dist/{cjs,esm,data} only)

$ node -p "require('./package/package.json').types"
./dist/types/index.d.ts
```

`9.0.29` ships `dist/types/` normally, so this is a regression in the 10 line, not a deliberate drop.

The import therefore degrades to `any` and the lint gate fails three ways — `tsc` (TS7016) and `svelte-check` on the missing declaration file, plus 21 `@typescript-eslint/no-unsafe-*` errors in `src/main/sources/import-bibtex.ts`. That's exactly the CI failure on #1821.

## Why ignore rather than shim

The breakage is packaging, not API. On `10.0.1` unchanged, `parse()` still accepts `sentenceCase: false`, still returns `{ entries, errors }`, and entries still carry `type` / `key` / `fields` / `input`. I verified this on a worktree with `10.0.1` installed: all 18 `tests/main/sources/import-bibtex.test.ts` cases pass, and with a local ambient shim the full gate went green (`pnpm lint` clean; `pnpm test` 588 files / 5923 tests, exit 0).

So a hand-written `.d.ts` would work — but an ambient `declare module` silently outranks a package's own types, meaning it would keep winning after upstream republishes real declarations, with nothing to signal the drift. Not worth carrying for a bump with no functional payoff.

Twice is a pattern, so this ignores the whole `10` line rather than replaying the same review on every `10.0.x` release. The comment records what to re-check (`dist/types` actually present in the tarball) before dropping the entry.

## Note

There's no upstream issue filed for this yet. Worth reporting to retorquere/bibtex-parser so the 10 line becomes usable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)