### PR TITLE
feat(history): date-and-time stamps and a cause for every revision (#1158)

### DIFF
--- a/src/main/history/index.ts
+++ b/src/main/history/index.ts
@@ -13,7 +13,7 @@
  * reverse.
  */
 import { captureSnapshot } from './store';
-import type { RevisionOrigin } from './policy';
+import type { RevisionSource } from './policy';
 
 export {
   listRevisions,
@@ -21,23 +21,29 @@ export {
   moveHistory,
   setRevisionLabel,
 } from './store';
-export type { RevisionMeta, RevisionOrigin } from './policy';
+export type { RevisionMeta, RevisionOrigin, RevisionSource } from './policy';
 
-// Ambient origin for the next capture. Note writes are serialized per note, so a
-// simple module var is sufficient to tag a restore / AI-applied write without
-// threading `origin` through the whole write pipeline. Defaults to a manual edit.
-let ambientOrigin: RevisionOrigin = 'edit';
+// Ambient source for the next capture. Note writes are serialized per note, so
+// a simple module var is sufficient to tag a restore / AI-applied write without
+// threading it through the whole write pipeline. Defaults to a manual edit.
+const MANUAL_EDIT: RevisionSource = { origin: 'edit' };
+let ambientSource: RevisionSource = MANUAL_EDIT;
 
-/** Run `fn` (a note write) tagging any revisions it produces with `origin` —
- *  e.g. `runWithHistoryOrigin('restore', () => writeAndReindex(...))`. Restores
- *  to the ambient default afterward even if `fn` throws. */
-export async function runWithHistoryOrigin<T>(origin: RevisionOrigin, fn: () => Promise<T>): Promise<T> {
-  const prev = ambientOrigin;
-  ambientOrigin = origin;
+/**
+ * Run `fn` (a note write) recording any revisions it produces as `source` —
+ * e.g. `runWithHistorySource({ origin: 'restore', cause: 'Restored from …' },
+ * () => writeAndReindex(...))`. The `cause` is what the History panel shows in
+ * its "what did this?" column, so name the user's action ("Auto-tag",
+ * "Antithesize"), not the module doing the write. Restores the previous source
+ * afterward even if `fn` throws.
+ */
+export async function runWithHistorySource<T>(source: RevisionSource, fn: () => Promise<T>): Promise<T> {
+  const prev = ambientSource;
+  ambientSource = source;
   try {
     return await fn();
   } finally {
-    ambientOrigin = prev;
+    ambientSource = prev;
   }
 }
 
@@ -55,7 +61,7 @@ function isCapturable(relPath: string): boolean {
 export async function onNoteWritten(rootPath: string, relPath: string, content: string): Promise<void> {
   if (!isCapturable(relPath)) return;
   try {
-    await captureSnapshot(rootPath, relPath, content, ambientOrigin);
+    await captureSnapshot(rootPath, relPath, content, ambientSource);
   } catch (err) {
     console.error(`[history] capture failed for "${relPath}":`, err);
   }

--- a/src/main/history/policy.ts
+++ b/src/main/history/policy.ts
@@ -12,7 +12,7 @@
  */
 
 import type { RevisionMeta } from '../../shared/history';
-export type { RevisionMeta, RevisionOrigin } from '../../shared/history';
+export type { RevisionMeta, RevisionOrigin, RevisionSource } from '../../shared/history';
 
 /** Keep a note's history at most this many days (unlabeled). */
 export const RETENTION_DAYS = 30;

--- a/src/main/history/store.ts
+++ b/src/main/history/store.ts
@@ -15,7 +15,7 @@ import {
   selectForRetention,
   shouldCapture,
   type RevisionMeta,
-  type RevisionOrigin,
+  type RevisionSource,
 } from './policy';
 
 const HISTORY_DIR = '.minerva/history';
@@ -66,7 +66,8 @@ async function latestContent(dir: string, entries: RevisionMeta[]): Promise<stri
 
 /**
  * Record `content` as a new revision of `relPath`, unless it's byte-identical to
- * the latest one. Then prune the note's history to the retention window. `now`
+ * the latest one. `source` says how the write came about (origin + the
+ * user-facing cause shown in the timeline). Then prune the note's history to the retention window. `now`
  * is injectable for tests. No-op (returns null) when nothing was captured;
  * otherwise returns the new revision's metadata.
  */
@@ -74,7 +75,7 @@ export async function captureSnapshot(
   rootPath: string,
   relPath: string,
   content: string,
-  origin: RevisionOrigin,
+  source: RevisionSource,
   now: number = Date.now(),
 ): Promise<RevisionMeta | null> {
   const dir = noteDir(rootPath, relPath);
@@ -87,7 +88,11 @@ export async function captureSnapshot(
   let ts = now;
   while (entries.some((e) => e.ts === ts)) ts++;
 
-  const meta: RevisionMeta = { ts, origin };
+  const meta: RevisionMeta = {
+    ts,
+    origin: source.origin,
+    ...(source.cause ? { cause: source.cause } : {}),
+  };
   await fs.writeFile(snapPath(dir, ts), content, 'utf-8');
   entries.push(meta);
 

--- a/src/main/ipc/register-bibliography.ts
+++ b/src/main/ipc/register-bibliography.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { Channels } from '../../shared/channels';
 import * as notebaseFs from '../notebase/fs';
 import { writeAndReindex } from '../notebase/write-pipeline';
+import { runWithHistorySource } from '../history';
 import { generateBibliography } from '../bibliography/generate';
 import {
   getBibliographyStyleId,
@@ -130,7 +131,8 @@ export function registerBibliography(): void {
     if (result.changed) {
       // 6-step pipeline keeps graph + search + open editors in sync
       // with on-disk content, just like a manual save.
-      await writeAndReindex(rootPath, relativePath, result.content, hooks);
+      await runWithHistorySource({ origin: 'edit', cause: 'Bibliography' }, () =>
+        writeAndReindex(rootPath, relativePath, result.content, hooks));
     }
     return {
       entriesCount: result.entriesCount,

--- a/src/main/ipc/register-conversation-drafts.ts
+++ b/src/main/ipc/register-conversation-drafts.ts
@@ -17,6 +17,7 @@ import * as notebaseFs from '../notebase/fs';
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import { writeAndReindex } from '../notebase/write-pipeline';
+import { runWithHistorySource } from '../history';
 import { ingestUrl } from '../sources/ingest';
 import { ingestIdentifier } from '../sources/ingest-identifier';
 import { privilegedFetch } from '../privileged-sites';
@@ -592,7 +593,8 @@ export function registerConversationDrafts(): void {
       const next = existing
         ? `${existing.replace(/\s*$/, '')}\n\n${block}\n`
         : `# Conversation: ${draft.conversationId}\n\n${block}\n`;
-      await writeAndReindex(rootPath, dest, next, hooks);
+      await runWithHistorySource({ origin: 'edit', cause: 'Compute cell' }, () =>
+        writeAndReindex(rootPath, dest, next, hooks));
       return { destinationPath: dest };
     }),
   );

--- a/src/main/ipc/register-conversation.ts
+++ b/src/main/ipc/register-conversation.ts
@@ -5,7 +5,7 @@ import * as graph from '../graph/index';
 import * as conversation from '../llm/conversation';
 import { currentDateContext } from '../llm/date-context';
 import { readThoughtbaseDoc, thoughtbaseDocPromptBlock } from '../llm/thoughtbase-doc';
-import type { ContextBundle, ConversationMessage } from '../../shared/types';
+import type { ContextBundle, ConversationCreateOptions, ConversationMessage } from '../../shared/types';
 import type { ConversationDraftBase } from '../../shared/conversation-draft-base';
 import { rootPathFromEvent, winFromEvent, withRootPath, withRootPathOr } from './helpers';
 import { broadcast } from './broadcast';
@@ -215,7 +215,7 @@ export function registerConversation(): void {
   // Every handler resolves the project from the CALLING WINDOW (#1743). These
   // used to reach module state that the last-opened project owned, so with two
   // thoughtbases open both windows read and wrote the same one's conversations.
-  handle(Channels.CONVERSATION_CREATE, withRootPath((rootPath, contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string }) =>
+  handle(Channels.CONVERSATION_CREATE, withRootPath((rootPath, contextBundle: ContextBundle, triggerNodeUri?: string, options?: ConversationCreateOptions) =>
     conversation.create(rootPath, contextBundle, triggerNodeUri, options)));
   handle(Channels.CONVERSATION_APPEND, withRootPath((rootPath, id: string, role: ConversationMessage['role'], content: string) =>
     conversation.appendMessage(rootPath, id, role, content)));

--- a/src/main/ipc/register-history.ts
+++ b/src/main/ipc/register-history.ts
@@ -7,6 +7,7 @@ import { Channels } from '../../shared/channels';
 import { handle } from './typed-ipc';
 import { withRootPath, hooks } from './helpers';
 import { writeAndReindex } from '../notebase/write-pipeline';
+import { formatDateTime } from '../../shared/format-datetime';
 import * as history from '../history';
 
 export function registerHistory(): void {
@@ -24,7 +25,11 @@ export function registerHistory(): void {
     // Restore = write the old content back as a NEW save (non-destructive; the
     // restore itself becomes a fresh `restore`-tagged revision). Not
     // broadcast-suppressed, so the open editor reloads via NOTEBASE_REWRITTEN.
-    await history.runWithHistoryOrigin('restore', () =>
-      writeAndReindex(rootPath, relativePath, content, hooks));
+    // The cause names WHICH version came back, so a timeline with several
+    // restores in it stays readable.
+    await history.runWithHistorySource(
+      { origin: 'restore', cause: `Restored from ${formatDateTime(ts)}` },
+      () => writeAndReindex(rootPath, relativePath, content, hooks),
+    );
   }));
 }

--- a/src/main/ipc/register-refactor.ts
+++ b/src/main/ipc/register-refactor.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
 import { writeAndReindex } from '../notebase/write-pipeline';
+import { runWithHistorySource } from '../history';
 import { markPathHandled } from '../window-manager';
 import { runAutoTag, applyAutoTag } from '../llm/auto-tag';
 import {
@@ -55,7 +56,10 @@ export function registerRefactor(): void {
   handle(Channels.REFACTOR_APPLY_SUGGESTED_LINK, withRootPath(async (rootPath, activeRelPath: string, targetRelPath: string) => {
     const content = await notebaseFs.readFile(rootPath, activeRelPath);
     const { content: next, changed } = appendSeeAlsoLink(content, targetRelPath);
-    if (changed) await writeAndReindex(rootPath, activeRelPath, next, hooks);
+    if (changed) {
+      await runWithHistorySource({ origin: 'edit', cause: 'Suggested link' }, () =>
+        writeAndReindex(rootPath, activeRelPath, next, hooks));
+    }
     return { changed };
   }));
 

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -21,6 +21,9 @@ import type {
   ProposedWrite,
 } from './proposal-types';
 import { applyBundle, collectAffectsNodes, wiredPayloadKinds } from './apply-dispatch';
+import * as conversation from './conversation';
+import { runWithHistorySource } from '../history';
+import { describeProposalCause } from '../../shared/history';
 import { emitProposalsChanged } from './proposal-events';
 import {
   getProposal,
@@ -92,6 +95,32 @@ export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): P
   return proposal;
 }
 
+const CONVERSATION_PROPOSER = 'llm:conversation:';
+
+/**
+ * The name a proposal's note revisions should carry in the History panel.
+ * Skill-launched conversations are the interesting case: their proposals are
+ * only stamped `llm:conversation:<id>`, so the skill's name has to come off the
+ * conversation itself. Best-effort — a failed lookup degrades to "Conversation"
+ * rather than failing the approval.
+ */
+async function proposalCause(ctx: ProjectContext, proposal: Proposal): Promise<string> {
+  let skillName: string | undefined;
+  if (proposal.proposedBy.startsWith(CONVERSATION_PROPOSER)) {
+    const convId = proposal.proposedBy.slice(CONVERSATION_PROPOSER.length);
+    try {
+      skillName = (await conversation.load(ctx.rootPath, convId))?.skill?.name;
+    } catch (err) {
+      console.warn(`[approval] could not resolve the skill behind ${proposal.uri}:`, err);
+    }
+  }
+  return describeProposalCause({
+    proposedBy: proposal.proposedBy,
+    operationType: proposal.operationType,
+    skillName,
+  });
+}
+
 /**
  * Approve a pending proposal: apply its bundle and update status.
  */
@@ -113,7 +142,13 @@ export async function approveProposal(ctx: ProjectContext, uri: string): Promise
     proposal.payloads.map((p) => p.kind).join(', '),
   );
 
-  const applied = await applyBundle(ctx, proposal.payloads);
+  // Record the note revisions this apply produces under the user-facing name of
+  // whatever caused them ("Auto-tag", "Antithesize"), so the History panel can
+  // say what happened rather than just "AI".
+  const applied = await runWithHistorySource(
+    { origin: 'proposal', cause: await proposalCause(ctx, proposal) },
+    () => applyBundle(ctx, proposal.payloads),
+  );
   await updateProposalStatus(ctx, uri, 'approved');
   emitProposalsChanged(ctx.rootPath);
   const filedPaths = applied

--- a/src/main/llm/conversation.ts
+++ b/src/main/llm/conversation.ts
@@ -6,6 +6,7 @@ import { escapeTurtleLiteral } from './turtle';
 import { costForUsage } from '../../shared/tools/models';
 import type {
   Conversation,
+  ConversationCreateOptions,
   ConversationMessage,
   ContextBundle,
   ConversationStatus,
@@ -84,7 +85,7 @@ export async function create(
   rootPath: string,
   contextBundle: ContextBundle,
   triggerNodeUri?: string,
-  options?: { systemPrompt?: string; model?: string; webEnabled?: boolean },
+  options?: ConversationCreateOptions,
 ): Promise<Conversation> {
   const dir = convDir(rootPath);
   await fs.mkdir(dir, { recursive: true });
@@ -101,6 +102,7 @@ export async function create(
   if (options?.systemPrompt) conv.systemPrompt = options.systemPrompt;
   if (options?.model) conv.model = options.model;
   if (options?.webEnabled !== undefined) conv.webEnabled = options.webEnabled;
+  if (options?.skill) conv.skill = options.skill;
 
   await persist(rootPath, conv);
   writeConversationToGraph(rootPath, conv);

--- a/src/main/tools/executor.ts
+++ b/src/main/tools/executor.ts
@@ -106,6 +106,7 @@ export function buildConversationPayload(
 
   return {
     toolId: tool.id,
+    toolName: tool.name,
     systemPrompt: tool.buildSystemPrompt(request.context),
     firstMessage: tool.buildFirstMessage ? tool.buildFirstMessage(request.context) : '',
     ...(model ? { model } : {}),

--- a/src/renderer/lib/app/conversation-ops.ts
+++ b/src/renderer/lib/app/conversation-ops.ts
@@ -161,6 +161,9 @@ export function createConversationOps(ctx: ConversationOpsCtx) {
     await conversationsStore.openConversationTab({
       notePath,
       systemPrompt: prep.systemPrompt,
+      // Name the skill on the conversation, so a note revision it later
+      // produces reads as "Antithesize" in the History panel (#1158).
+      skill: { id: prep.toolId, name: prep.toolName },
       ...(prep.model ? { model: prep.model } : {}),
       ...(prep.firstMessage ? { initialMessage: prep.firstMessage } : {}),
       // Honor the skill's declared web preference on the conversation (#1533).

--- a/src/renderer/lib/components/right-sidebar/HistoryPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/HistoryPanel.svelte
@@ -7,9 +7,9 @@
   // rule; restore is a mutation, so it routes out through `onRestore` (App owns
   // the confirm + the `api.history.restore` call).
   import { api } from '../../ipc/client';
-  import { formatRelativeTime } from '../../utils/format-relative-time';
+  import { formatDateTime } from '../../../../shared/format-datetime';
   import { diffLines, diffStats } from '../../history/line-diff';
-  import type { RevisionMeta } from '../../../../shared/history';
+  import { describeRevisionCause, type RevisionMeta } from '../../../../shared/history';
 
   interface Props {
     activeFilePath: string | null;
@@ -70,12 +70,6 @@
   const stats = $derived(diffStats(diff));
   const isCurrent = $derived(selectedContent !== null && selectedContent === content);
 
-  function originLabel(origin: RevisionMeta['origin']): string | null {
-    if (origin === 'restore') return 'restored';
-    if (origin === 'proposal') return 'AI';
-    return null;
-  }
-
   async function restore(): Promise<void> {
     if (!activeFilePath || selectedTs === null || !onRestore) return;
     await onRestore(activeFilePath, selectedTs);
@@ -93,16 +87,15 @@
   {:else}
     <ul class="timeline">
       {#each revisions as rev (rev.ts)}
-        {@const label = originLabel(rev.origin)}
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
         <li
           class:selected={rev.ts === selectedTs}
           onclick={() => activeFilePath && select(activeFilePath, rev.ts)}
         >
-          <span class="when">{formatRelativeTime(rev.ts, now)}</span>
+          <span class="when">{formatDateTime(rev.ts, now)}</span>
+          <span class="cause" class:ai={rev.origin === 'proposal'}>{describeRevisionCause(rev)}</span>
           {#if rev.label}<span class="tag">{rev.label}</span>{/if}
-          {#if label}<span class="origin">{label}</span>{/if}
         </li>
       {/each}
     </ul>
@@ -133,19 +126,26 @@
 
   .timeline { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 0 0 auto; max-height: 45%; }
   .timeline li {
-    display: flex; align-items: baseline; gap: 8px;
+    display: grid; grid-template-columns: 1fr auto; align-items: baseline;
+    column-gap: 8px;
     padding: 6px 12px; cursor: pointer; border-bottom: 1px solid var(--border);
     font-size: 13px;
   }
   .timeline li:hover { background: var(--bg-button); }
   .timeline li.selected { background: color-mix(in oklch, var(--accent) 14%, transparent); }
   .when { color: var(--text); }
+  /* What produced this version — the IntelliJ Local History "action" column. */
+  .cause {
+    grid-column: 1 / -1;
+    font-size: 11px; color: var(--text-muted);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .cause.ai { color: color-mix(in oklch, var(--accent) 70%, var(--text-muted)); }
   .tag {
     font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px;
     color: var(--accent); border: 1px solid color-mix(in oklch, var(--accent) 40%, var(--border));
     border-radius: 3px; padding: 0 4px;
   }
-  .origin { font-size: 10px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.3px; }
 
   .diff-head {
     display: flex; align-items: center; justify-content: space-between; gap: 8px;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1,4 +1,4 @@
-import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SavedView, SavedViewInput, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate, MenuEditorState, InspectionFix } from '../../../shared/types';
+import type { NoteFile, NotebaseMeta, TagInfo, TaggedNote, TaggedSource, SavedQuery, SavedView, SavedViewInput, SearchResult, OutgoingLink, Backlink, TabSession, LayoutSession, Conversation, ConversationCreateOptions, ContextBundle, ConversationMessage, BookmarkNode, SourceDetail, SearchInNotesOptions, SearchInNotesFileResult, ReplaceInNotesOptions, ReplaceInNotesResult, HeadingRenameCandidate, MenuEditorState, InspectionFix } from '../../../shared/types';
 import type { ToolExecutionRequest, ToolExecutionResult, ConversationToolPayload } from '../../../shared/tools/types';
 import type { InspectionSettings } from '../../../shared/inspections';
 import type { ClipperState } from '../../../shared/clipper-pairing';
@@ -598,7 +598,7 @@ export interface ClipperApi {
 }
 
 export interface ConversationsApi {
-  create(contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string; webEnabled?: boolean }): Promise<Conversation>;
+  create(contextBundle: ContextBundle, triggerNodeUri?: string, options?: ConversationCreateOptions): Promise<Conversation>;
   append(id: string, role: ConversationMessage['role'], content: string): Promise<Conversation>;
   archive(id: string): Promise<Conversation>;
   load(id: string): Promise<Conversation | null>;

--- a/src/renderer/lib/stores/conversations.svelte.ts
+++ b/src/renderer/lib/stores/conversations.svelte.ts
@@ -4,6 +4,8 @@ import { ensureComputeConsent } from '../compute/run-cell-with-trust';
 import { getDialogStore } from './dialogs.svelte';
 import type {
   Conversation,
+  ConversationCreateOptions,
+  ConversationSkill,
   ContextBundle,
   ConversationsUIState,
 } from '../../../shared/types';
@@ -458,13 +460,18 @@ async function openConversationTab(opts: {
    *  scope for this conversation. Mirrors ConversationTemplate's
    *  `requiresTools` and ThinkingTool's `requiresTools` (#514). */
   extraTools?: ConversationToolKey[];
+  /** The skill this conversation was launched from (#1158). Persisted on the
+   *  conversation so a note revision it eventually produces can be labeled with
+   *  the skill's name in the History panel. */
+  skill?: ConversationSkill;
 }): Promise<TabRuntime> {
   ensureSubscriptions();
   const bundle: ContextBundle = opts.notePath ? { notePath: opts.notePath } : {};
-  const createOpts: { systemPrompt?: string; model?: string; webEnabled?: boolean } = {};
+  const createOpts: ConversationCreateOptions = {};
   if (opts.systemPrompt) createOpts.systemPrompt = opts.systemPrompt;
   if (opts.model) createOpts.model = opts.model;
   if (opts.webEnabled !== undefined) createOpts.webEnabled = opts.webEnabled;
+  if (opts.skill) createOpts.skill = opts.skill;
   const conv = await api.conversations.create(
     bundle,
     undefined,

--- a/src/shared/format-datetime.ts
+++ b/src/shared/format-datetime.ts
@@ -1,0 +1,28 @@
+/**
+ * Absolute date+time stamps, shared by main and the renderer so a timestamp
+ * written into text (a restore's cause line) reads identically to the same
+ * moment rendered in the History panel.
+ *
+ * Distinct from `renderer/lib/utils/format-relative-time`, which collapses to a
+ * single unit ("2h", "5d") because it shares a 24px file row. A revision
+ * timeline is the opposite case: "now" and "1m" are useless for telling two
+ * versions apart, so we always show the date and the time to the minute.
+ */
+
+/** Time to the minute, locale-aware (12h/24h follows the user's locale). */
+const TIME: Intl.DateTimeFormatOptions = { hour: 'numeric', minute: '2-digit' };
+const DATE: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
+
+/**
+ * e.g. `Aug 22, 2:07 PM` — with the year added when the timestamp is from
+ * another year, since "Aug 22" alone would be a lie about which one.
+ */
+export function formatDateTime(ts: number, now: number = Date.now()): string {
+  const when = new Date(ts);
+  const sameYear = when.getFullYear() === new Date(now).getFullYear();
+  return when.toLocaleString(undefined, {
+    ...DATE,
+    ...(sameYear ? {} : { year: 'numeric' }),
+    ...TIME,
+  });
+}

--- a/src/shared/history.ts
+++ b/src/shared/history.ts
@@ -3,6 +3,8 @@
  * contract, and the renderer History panel.
  */
 
+import { describeProposer } from './provenance';
+
 /** How a revision came to exist. `proposal` is populated when an AI-applied
  *  write produces a revision — the cheap #1159 guardrail so a future
  *  provenance-over-time view can correlate note history with gate events. */
@@ -12,7 +14,84 @@ export interface RevisionMeta {
   /** Epoch millis the revision was captured (also its stable id). */
   ts: number;
   origin: RevisionOrigin;
+  /**
+   * Short human description of *what* produced this revision — the "action"
+   * column in IntelliJ's Local History ("Auto-tag", "Antithesize", "Restored
+   * from Aug 22, 2:07 PM"). Undefined means a plain editor save; the panel
+   * falls back to a label derived from `origin` (see `describeRevisionCause`)
+   * so revisions captured before this field existed still read sensibly.
+   */
+  cause?: string;
   /** Optional version tag; labeled revisions are exempt from pruning. Stored
    *  from day one so tagging is a UI-only add later, never a migration. */
   label?: string;
+}
+
+/**
+ * What the write currently in flight should be recorded as. Set ambiently
+ * around a write (`runWithHistorySource` in `main/history`) rather than
+ * threaded through the whole write pipeline, since note writes are serialized
+ * per note.
+ */
+export interface RevisionSource {
+  origin: RevisionOrigin;
+  cause?: string;
+}
+
+/** Display text for a revision's cause, with an origin-derived fallback for
+ *  revisions captured before causes were recorded. */
+export function describeRevisionCause(rev: Pick<RevisionMeta, 'origin' | 'cause'>): string {
+  if (rev.cause) return rev.cause;
+  if (rev.origin === 'restore') return 'Restored';
+  if (rev.origin === 'proposal') return 'Minerva AI';
+  return 'Edit';
+}
+
+/** Minerva's own non-conversational write paths, named as the user invoked
+ *  them (the menu command, not the module behind it). */
+const BUILT_IN_PROPOSER_CAUSES: Record<string, string> = {
+  'llm:auto-tag': 'Auto-tag',
+  'llm:auto-link': 'Auto-link',
+  'llm:auto-link-inbound': 'Auto-link (inbound)',
+  'llm:source-properties': 'Source properties',
+  'user:attach-evidence': 'Attach evidence',
+};
+
+/** Last-resort naming when the proposer stamp says nothing more specific. */
+const OPERATION_CAUSES: Record<string, string> = {
+  new_claim: 'Claim filed',
+  evidence_link: 'Evidence linked',
+  component_creation: 'Component added',
+  note_refactor: 'Note moved',
+  note_delete: 'Note deleted',
+  note_rewrite: 'Note rewritten',
+  source_properties: 'Source updated',
+};
+
+/**
+ * Cause text for a revision produced by applying an approved proposal.
+ *
+ * Preference order: the launching skill's own name ("Antithesize"), then a
+ * known built-in write path ("Auto-tag"), then the proposer's label (a fleet
+ * agent's name, "CLI", "Minerva AI"), then the operation type. The point is
+ * that the timeline row answers "what did this?" the way the user thinks about
+ * it — by the command they ran, not by the plumbing that ran it.
+ */
+export function describeProposalCause(input: {
+  proposedBy: string;
+  operationType: string;
+  /** Name of the skill whose conversation filed the proposal, when known. */
+  skillName?: string | undefined;
+}): string {
+  if (input.skillName) return input.skillName;
+
+  const builtIn = BUILT_IN_PROPOSER_CAUSES[input.proposedBy];
+  if (builtIn) return builtIn;
+
+  const proposer = describeProposer(input.proposedBy);
+  if (proposer.kind === 'external' || proposer.kind === 'cli') return proposer.label;
+  if (proposer.kind === 'internal') {
+    return input.proposedBy.startsWith('llm:conversation:') ? 'Conversation' : proposer.label;
+  }
+  return OPERATION_CAUSES[input.operationType] ?? proposer.label;
 }

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -89,7 +89,7 @@ import type {
 } from './types';
 import type { ParsedReference } from './mine-references';
 import type { ResolveCandidate } from './resolve-stub';
-import type { Conversation, ConversationMessage, ContextBundle, ConversationsUIState, CompactResult } from './types';
+import type { Conversation, ConversationCreateOptions, ConversationMessage, ContextBundle, ConversationsUIState, CompactResult } from './types';
 import type { ConversationToolKey, AskUserRequest } from './conversation-tools';
 import type { ConversationDraftBase } from './conversation-draft-base';
 import type { ThemeMode } from './theme';
@@ -532,7 +532,7 @@ export interface ChannelMap {
   'proposals:notifyArrival': (arg: { count: number; proposer: string }) => void;
 
   // Conversations
-  'conversation:create': (contextBundle: ContextBundle, triggerNodeUri?: string, options?: { systemPrompt?: string; model?: string; webEnabled?: boolean }) => Conversation;
+  'conversation:create': (contextBundle: ContextBundle, triggerNodeUri?: string, options?: ConversationCreateOptions) => Conversation;
   'conversation:append': (id: string, role: ConversationMessage['role'], content: string) => Conversation;
   'conversation:archive': (id: string) => Conversation;
   'conversation:load': (id: string) => Conversation | null;

--- a/src/shared/tools/types.ts
+++ b/src/shared/tools/types.ts
@@ -217,6 +217,10 @@ export interface ToolExecutionResult {
 /** Payload returned by the `prepareConversationTool` path for `outputMode: 'openConversation'`. */
 export interface ConversationToolPayload {
   toolId: string;
+  /** The skill's display name ("Antithesize"), pinned on the conversation it
+   *  launches so downstream provenance — note-history causes (#1158) — can name
+   *  the command the user ran. */
+  toolName: string;
   systemPrompt: string;
   firstMessage: string;
   /** Model to pin on the created conversation. Undefined means track the global default. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -656,6 +656,22 @@ export interface ConversationsUIState {
   activeTabId: string | null;
 }
 
+/** The skill (thinking tool) a conversation was launched from, when it was —
+ *  e.g. `{ id: 'antithesize', name: 'Antithesize' }`. Kept as the user-facing
+ *  name alongside the id so provenance downstream (note-history causes, #1158)
+ *  can say "Antithesize" without re-resolving a possibly-uninstalled skill. */
+export interface ConversationSkill {
+  id: string;
+  name: string;
+}
+
+export interface ConversationCreateOptions {
+  systemPrompt?: string;
+  model?: string;
+  webEnabled?: boolean;
+  skill?: ConversationSkill;
+}
+
 export interface Conversation {
   id: string;
   triggerNodeUri?: string;
@@ -692,6 +708,13 @@ export interface Conversation {
    * still apply. Mirrors the `model` / `effort` override pattern.
    */
   webEnabled?: boolean;
+  /**
+   * The skill this conversation was launched from (#1158). Set when the
+   * conversation came from a `outputMode: 'openConversation'` skill; absent for
+   * a freeform chat. Read back when an approved proposal lands a note revision,
+   * so the History panel can name the command the user actually ran.
+   */
+  skill?: ConversationSkill;
   /**
    * Code-execution sandbox id returned by Anthropic when the model used a
    * `code_execution` server-side tool (which is how `web_search_20260209`

--- a/tests/main/history/store.test.ts
+++ b/tests/main/history/store.test.ts
@@ -25,7 +25,7 @@ describe('history store (#1158)', () => {
   const NOTE = 'notes/a.md';
 
   it('appends a revision and stores it under .minerva/history', async () => {
-    await captureSnapshot(root, NOTE, 'v1', 'edit', 1000);
+    await captureSnapshot(root, NOTE, 'v1', { origin: 'edit' }, 1000);
     const revs = await listRevisions(root, NOTE);
     expect(revs).toHaveLength(1);
     expect(revs[0]!.origin).toBe('edit');
@@ -34,17 +34,24 @@ describe('history store (#1158)', () => {
     expect((await fs.readdir(dir)).some((f) => f.endsWith('.snap'))).toBe(true);
   });
 
+  it('records the cause alongside the origin, and omits it for a plain edit', async () => {
+    await captureSnapshot(root, NOTE, 'v1', { origin: 'proposal', cause: 'Antithesize' }, 1000);
+    await captureSnapshot(root, NOTE, 'v2', { origin: 'edit' }, 2000);
+    const revs = await listRevisions(root, NOTE);
+    expect(revs.map((r) => r.cause)).toEqual([undefined, 'Antithesize']);
+  });
+
   it('dedupes an identical consecutive save', async () => {
-    await captureSnapshot(root, NOTE, 'same', 'edit', 1000);
-    const second = await captureSnapshot(root, NOTE, 'same', 'edit', 2000);
+    await captureSnapshot(root, NOTE, 'same', { origin: 'edit' }, 1000);
+    const second = await captureSnapshot(root, NOTE, 'same', { origin: 'edit' }, 2000);
     expect(second).toBeNull();
     expect(await listRevisions(root, NOTE)).toHaveLength(1);
   });
 
   it('lists revisions newest-first and reads each one back', async () => {
-    await captureSnapshot(root, NOTE, 'v1', 'edit', 1000);
-    await captureSnapshot(root, NOTE, 'v2', 'edit', 2000);
-    await captureSnapshot(root, NOTE, 'v3', 'restore', 3000);
+    await captureSnapshot(root, NOTE, 'v1', { origin: 'edit' }, 1000);
+    await captureSnapshot(root, NOTE, 'v2', { origin: 'edit' }, 2000);
+    await captureSnapshot(root, NOTE, 'v3', { origin: 'restore' }, 3000);
     const revs = await listRevisions(root, NOTE);
     expect(revs.map((r) => r.ts)).toEqual([3000, 2000, 1000]);
     expect(await getRevisionContent(root, NOTE, 1000)).toBe('v1');
@@ -55,8 +62,8 @@ describe('history store (#1158)', () => {
   it('prunes revisions older than the retention window on capture', async () => {
     const now = 500 * DAY;
     // An "old" capture, then a fresh one far later → the old one ages out.
-    await captureSnapshot(root, NOTE, 'ancient', 'edit', now - 40 * DAY);
-    await captureSnapshot(root, NOTE, 'fresh', 'edit', now);
+    await captureSnapshot(root, NOTE, 'ancient', { origin: 'edit' }, now - 40 * DAY);
+    await captureSnapshot(root, NOTE, 'fresh', { origin: 'edit' }, now);
     const revs = await listRevisions(root, NOTE);
     expect(revs.map((r) => r.ts)).toEqual([now]);
     // The pruned snapshot file is gone too.
@@ -66,16 +73,16 @@ describe('history store (#1158)', () => {
   it('keeps a labeled revision even when it would otherwise age out', async () => {
     const now = 500 * DAY;
     const oldTs = now - 40 * DAY;
-    await captureSnapshot(root, NOTE, 'milestone', 'edit', oldTs);
+    await captureSnapshot(root, NOTE, 'milestone', { origin: 'edit' }, oldTs);
     await setRevisionLabel(root, NOTE, oldTs, 'v1.0');
-    await captureSnapshot(root, NOTE, 'fresh', 'edit', now);
+    await captureSnapshot(root, NOTE, 'fresh', { origin: 'edit' }, now);
     const revs = await listRevisions(root, NOTE);
     expect(revs.map((r) => r.ts)).toEqual([now, oldTs]); // labeled survived
     expect(await getRevisionContent(root, NOTE, oldTs)).toBe('milestone');
   });
 
   it('history follows a note rename', async () => {
-    await captureSnapshot(root, NOTE, 'v1', 'edit', 1000);
+    await captureSnapshot(root, NOTE, 'v1', { origin: 'edit' }, 1000);
     await moveHistory(root, NOTE, 'archive/a.md');
     expect(await listRevisions(root, NOTE)).toHaveLength(0);       // old path empty
     expect((await listRevisions(root, 'archive/a.md')).map((r) => r.ts)).toEqual([1000]);
@@ -83,8 +90,8 @@ describe('history store (#1158)', () => {
   });
 
   it('a folder-style move relocates every contained note (path-parallel mirror)', async () => {
-    await captureSnapshot(root, 'notes/a.md', 'a1', 'edit', 1000);
-    await captureSnapshot(root, 'notes/b.md', 'b1', 'edit', 1000);
+    await captureSnapshot(root, 'notes/a.md', 'a1', { origin: 'edit' }, 1000);
+    await captureSnapshot(root, 'notes/b.md', 'b1', { origin: 'edit' }, 1000);
     await moveHistory(root, 'notes', 'archive'); // move the whole folder's history
     expect(await getRevisionContent(root, 'archive/a.md', 1000)).toBe('a1');
     expect(await getRevisionContent(root, 'archive/b.md', 1000)).toBe('b1');

--- a/tests/main/ipc/register-history.test.ts
+++ b/tests/main/ipc/register-history.test.ts
@@ -2,8 +2,8 @@
  * History IPC handlers (#1158). Drives the real `registerHistory()` with the
  * store + write-pipeline mocked, pinning: list/getRevision delegate to the
  * store, and restore reads the revision then writes it back through
- * `writeAndReindex` under the `restore` origin — throwing (not silently) when
- * the revision is gone.
+ * `writeAndReindex` under the `restore` origin (with a cause naming the version
+ * restored) — throwing (not silently) when the revision is gone.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -15,7 +15,7 @@ const { handlers, h } = vi.hoisted(() => ({
   h: {
     listRevisions: vi.fn(),
     getRevisionContent: vi.fn(),
-    runWithHistoryOrigin: vi.fn(<T>(_o: string, fn: () => Promise<T>) => fn()),
+    runWithHistorySource: vi.fn(<T>(_s: unknown, fn: () => Promise<T>) => fn()),
     writeAndReindex: vi.fn(),
   },
 }));
@@ -32,7 +32,7 @@ vi.mock('../../../src/main/notebase/write-pipeline', () => ({ writeAndReindex: h
 vi.mock('../../../src/main/history', () => ({
   listRevisions: h.listRevisions,
   getRevisionContent: h.getRevisionContent,
-  runWithHistoryOrigin: h.runWithHistoryOrigin,
+  runWithHistorySource: h.runWithHistorySource,
 }));
 
 import { registerHistory } from '../../../src/main/ipc/register-history';
@@ -59,7 +59,12 @@ describe('register-history (#1158)', () => {
   it('HISTORY_RESTORE writes the revision back through the pipeline under the restore origin', async () => {
     h.getRevisionContent.mockResolvedValue('restored body');
     await call(Channels.HISTORY_RESTORE, 'notes/a.md', 7);
-    expect(h.runWithHistoryOrigin).toHaveBeenCalledWith('restore', expect.any(Function));
+    expect(h.runWithHistorySource).toHaveBeenCalledWith(
+      // The cause names the version that came back, so a timeline with several
+      // restores in it stays readable.
+      { origin: 'restore', cause: expect.stringMatching(/^Restored from .+\d/) },
+      expect.any(Function),
+    );
     expect(h.writeAndReindex).toHaveBeenCalledWith(ROOT, 'notes/a.md', 'restored body', { HOOKS: true });
   });
 

--- a/tests/main/llm/proposal-history-cause.test.ts
+++ b/tests/main/llm/proposal-history-cause.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Note-history causes for AI-applied writes (#1158).
+ *
+ * A revision the user didn't type should say what produced it. The chain under
+ * test is the real one, end to end: a proposal is approved → `applyBundle`
+ * writes the note → the capture hook records a revision → its `cause` names the
+ * skill behind the conversation (or the built-in write path), not the module
+ * that happened to call `writeFile`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { proposeWrite, approveProposal } from '../../../src/main/llm/approval';
+import * as conversation from '../../../src/main/llm/conversation';
+import { listRevisions } from '../../../src/main/history';
+import { initGraph } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+describe('revision causes for approved proposals (#1158)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-history-cause-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function fileAndApprove(proposedBy: string, relativePath: string): Promise<void> {
+    const proposal = await proposeWrite(ctx, {
+      operationType: 'new_claim',
+      payloads: [{ kind: 'note', relativePath, content: '# Filed\n' }],
+      note: 'test',
+      proposedBy,
+    });
+    expect((await approveProposal(ctx, proposal.uri)).ok).toBe(true);
+  }
+
+  it('names the skill that launched the conversation behind the proposal', async () => {
+    const conv = await conversation.create(root, {}, undefined, {
+      skill: { id: 'antithesize', name: 'Antithesize' },
+    });
+    await fileAndApprove(`llm:conversation:${conv.id}`, 'notes/from-skill.md');
+
+    const revs = await listRevisions(root, 'notes/from-skill.md');
+    expect(revs).toHaveLength(1);
+    expect(revs[0]!.origin).toBe('proposal');
+    expect(revs[0]!.cause).toBe('Antithesize');
+  });
+
+  it('falls back to "Conversation" for a freeform chat with no skill', async () => {
+    const conv = await conversation.create(root, {});
+    await fileAndApprove(`llm:conversation:${conv.id}`, 'notes/from-chat.md');
+    expect((await listRevisions(root, 'notes/from-chat.md'))[0]!.cause).toBe('Conversation');
+  });
+
+  it('names a built-in write path even with no conversation to look up', async () => {
+    await fileAndApprove('llm:auto-tag', 'notes/tagged.md');
+    expect((await listRevisions(root, 'notes/tagged.md'))[0]!.cause).toBe('Auto-tag');
+  });
+
+  it('survives a conversation that is gone — the label degrades, the approval does not', async () => {
+    await fileAndApprove('llm:conversation:conv-vanished', 'notes/orphan.md');
+    expect((await listRevisions(root, 'notes/orphan.md'))[0]!.cause).toBe('Conversation');
+  });
+});

--- a/tests/main/skills-compile.test.ts
+++ b/tests/main/skills-compile.test.ts
@@ -83,6 +83,9 @@ describe('compiled skill through the conversation payload builder', () => {
     );
     expect(payload).toEqual({
       toolId: 'learning.sample',
+      // Carried so a conversation the skill launches can be labeled with its
+      // name downstream (note-history causes, #1158).
+      toolName: 'Sample',
       systemPrompt: 'SYS C',
       firstMessage: 'FIRST T',
       model: 'claude-opus-4-8', // differs from default → pinned

--- a/tests/renderer/components/HistoryPanel.test.ts
+++ b/tests/renderer/components/HistoryPanel.test.ts
@@ -38,15 +38,33 @@ describe('HistoryPanel (#1158)', () => {
     expect(screen.getByText(/No history yet/)).toBeTruthy();
   });
 
-  it('renders the revision timeline newest-first', async () => {
+  it('renders the revision timeline newest-first, stamped with date and time', async () => {
+    const ts = new Date(2026, 7, 22, 14, 7).getTime();
     h.api.history.list.mockResolvedValue([
-      { ts: 2000, origin: 'restore' },
-      { ts: 1000, origin: 'edit' },
+      { ts, origin: 'restore', cause: 'Restored from Aug 21, 9:30 AM' },
+      { ts: ts - 60_000, origin: 'edit' },
     ]);
     render(HistoryPanel, props());
     await waitFor(() => expect(screen.getAllByRole('listitem')).toHaveLength(2));
-    // The restore-origin revision shows its badge.
-    expect(screen.getByText('restored')).toBeTruthy();
+    // Absolute stamps, not "now" / "1m" — a minute apart has to be legible.
+    const [newest, older] = screen.getAllByRole('listitem');
+    expect(newest!.textContent).toMatch(/22.*\d{1,2}:07/);
+    expect(older!.textContent).toMatch(/22.*\d{1,2}:06/);
+    expect(newest!.textContent).not.toMatch(/\bnow\b/);
+  });
+
+  it('names what caused each revision, falling back to the origin', async () => {
+    h.api.history.list.mockResolvedValue([
+      { ts: 3000, origin: 'proposal', cause: 'Antithesize' },
+      { ts: 2000, origin: 'restore', cause: 'Restored from Aug 21, 9:30 AM' },
+      { ts: 1000, origin: 'edit' },
+    ]);
+    render(HistoryPanel, props());
+    await waitFor(() => expect(screen.getAllByRole('listitem')).toHaveLength(3));
+    expect(screen.getByText('Antithesize')).toBeTruthy();
+    expect(screen.getByText('Restored from Aug 21, 9:30 AM')).toBeTruthy();
+    // Pre-cause revisions still read sensibly.
+    expect(screen.getByText('Edit')).toBeTruthy();
   });
 
   it('selecting a revision loads it and diffs it against the current text', async () => {

--- a/tests/shared/format-datetime.test.ts
+++ b/tests/shared/format-datetime.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Absolute date+time stamps (#1158). A revision timeline needs to distinguish
+ * two versions saved minutes apart, so these always carry a date and a
+ * to-the-minute time — never a relative "now" / "1m".
+ */
+import { describe, it, expect } from 'vitest';
+import { formatDateTime } from '../../src/shared/format-datetime';
+
+describe('formatDateTime', () => {
+  const aug22 = new Date(2026, 7, 22, 14, 7).getTime();
+
+  it('shows the date and the time to the minute', () => {
+    const out = formatDateTime(aug22, aug22);
+    expect(out).toMatch(/22/);
+    expect(out).toMatch(/\d{1,2}:07/);
+  });
+
+  it('never collapses to a relative stamp, however recent', () => {
+    expect(formatDateTime(aug22, aug22 + 30_000)).toBe(formatDateTime(aug22, aug22));
+  });
+
+  it('adds the year only when it differs from the current one', () => {
+    const now = new Date(2026, 7, 22, 14, 7).getTime();
+    expect(formatDateTime(aug22, now)).not.toMatch(/2026/);
+    expect(formatDateTime(new Date(2025, 7, 22, 14, 7).getTime(), now)).toMatch(/2025/);
+  });
+});

--- a/tests/shared/history-cause.test.ts
+++ b/tests/shared/history-cause.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Revision cause naming (#1158) — the "what did this?" column in the History
+ * panel. The rule under test: a revision is named after the command the USER
+ * ran (the skill, the menu action), not after the plumbing that wrote the file.
+ */
+import { describe, it, expect } from 'vitest';
+import { describeProposalCause, describeRevisionCause } from '../../src/shared/history';
+
+describe('describeProposalCause', () => {
+  it('prefers the launching skill name over anything else', () => {
+    expect(describeProposalCause({
+      proposedBy: 'llm:conversation:conv-123',
+      operationType: 'note_rewrite',
+      skillName: 'Antithesize',
+    })).toBe('Antithesize');
+  });
+
+  it('names Minerva\'s own built-in write paths as the user invoked them', () => {
+    expect(describeProposalCause({ proposedBy: 'llm:auto-tag', operationType: 'note_rewrite' }))
+      .toBe('Auto-tag');
+    expect(describeProposalCause({ proposedBy: 'llm:auto-link', operationType: 'note_rewrite' }))
+      .toBe('Auto-link');
+    expect(describeProposalCause({ proposedBy: 'llm:auto-link-inbound', operationType: 'note_rewrite' }))
+      .toBe('Auto-link (inbound)');
+  });
+
+  it('falls back to "Conversation" for a chat with no skill behind it', () => {
+    expect(describeProposalCause({ proposedBy: 'llm:conversation:conv-9', operationType: 'note_rewrite' }))
+      .toBe('Conversation');
+  });
+
+  it('names the fleet agent for an external proposer', () => {
+    expect(describeProposalCause({ proposedBy: 'mcp:claude-code', operationType: 'new_claim' }))
+      .toBe('claude-code');
+    expect(describeProposalCause({ proposedBy: 'cli', operationType: 'new_claim' }))
+      .toBe('CLI');
+  });
+
+  it('falls back to the operation when the proposer stamp says nothing useful', () => {
+    expect(describeProposalCause({ proposedBy: '', operationType: 'note_rewrite' }))
+      .toBe('Note rewritten');
+    // An unrecognized stamp with an unrecognized operation still shows the
+    // stamp rather than an empty cell.
+    expect(describeProposalCause({ proposedBy: 'e2e', operationType: 'mystery' }))
+      .toBe('e2e');
+  });
+});
+
+describe('describeRevisionCause', () => {
+  it('shows the recorded cause verbatim', () => {
+    expect(describeRevisionCause({ origin: 'proposal', cause: 'Auto-tag' })).toBe('Auto-tag');
+  });
+
+  it('derives a label from the origin for revisions captured before causes existed', () => {
+    expect(describeRevisionCause({ origin: 'edit' })).toBe('Edit');
+    expect(describeRevisionCause({ origin: 'restore' })).toBe('Restored');
+    expect(describeRevisionCause({ origin: 'proposal' })).toBe('Minerva AI');
+  });
+});


### PR DESCRIPTION
The History panel showed relative stamps ("now", "1m") — exactly backwards for a version list, since the two revisions you most need to tell apart are the ones a minute apart. Revisions now show an absolute date + time to the minute, plus (the IntelliJ Local History move) a line naming what produced them.

### What a row looks like now

```
Aug 22, 2:07 PM
Antithesize

Aug 22, 2:03 PM
Auto-tag

Aug 22, 1:58 PM
Edit
```

### How the cause gets there

- `RevisionMeta.cause` — optional, so revisions captured before this change still render (the panel derives a label from `origin` via `describeRevisionCause`).
- The ambient capture tag becomes a `RevisionSource` (`runWithHistoryOrigin` → `runWithHistorySource`): a write path names itself once instead of threading provenance through the write pipeline.
- `approveProposal` wraps its `applyBundle` in that source, so **every** AI-originated revision is named — auto-tag/auto-link by their command, a fleet agent (`mcp:` / `cli`) by its name, and a skill-launched conversation by the skill.
- Naming a skill needed the name to survive the trip from launch to approval: conversations now persist the `skill` they were launched from (`ConversationCreateOptions.skill`, fed by the new `ConversationToolPayload.toolName`). A missing/vanished conversation degrades to "Conversation" — it never fails the approval.
- Direct (non-proposal) writes get causes too: `Bibliography`, `Suggested link`, `Compute cell`. A plain editor save stays uncaused and reads as "Edit".

### Tests

- `tests/shared/history-cause.test.ts` — the naming precedence (skill > built-in path > proposer > operation).
- `tests/shared/format-datetime.test.ts` — always absolute, year only when it differs.
- `tests/main/llm/proposal-history-cause.test.ts` — end to end on a real temp project: propose → approve → the note's revision comes back labeled with the skill.
- `tests/main/history/store.test.ts`, `tests/main/ipc/register-history.test.ts`, `tests/renderer/components/HistoryPanel.test.ts` extended.

`pnpm lint` and the full `pnpm test` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy