### PR TITLE
feat(history): always keep an initial version, and say "contents are identical" (#1158)

### DIFF
--- a/src/main/history/index.ts
+++ b/src/main/history/index.ts
@@ -12,7 +12,7 @@
  * which composes this facade with `notebase`'s `writeAndReindex` — never the
  * reverse.
  */
-import { captureSnapshot } from './store';
+import { captureSnapshot, ensureInitialRevision } from './store';
 import type { RevisionSource } from './policy';
 
 export {
@@ -51,6 +51,21 @@ export async function runWithHistorySource<T>(source: RevisionSource, fn: () => 
  *  ttl/csv/py) are out of scope for note time-travel. */
 function isCapturable(relPath: string): boolean {
   return relPath.endsWith('.md') && !relPath.startsWith('.minerva/') && !relPath.startsWith('.minerva\\');
+}
+
+/**
+ * Pre-write hook, called from `notebase/fs.ts:writeFile` BEFORE the file is
+ * overwritten. Gives a note that has no history yet a baseline revision from
+ * its current on-disk content, so the state before the user's first edit stays
+ * recoverable. No-op once a note has any history. Best-effort, like capture.
+ */
+export async function onNoteWriting(rootPath: string, relPath: string): Promise<void> {
+  if (!isCapturable(relPath)) return;
+  try {
+    await ensureInitialRevision(rootPath, relPath);
+  } catch (err) {
+    console.error(`[history] initial-revision capture failed for "${relPath}":`, err);
+  }
 }
 
 /**

--- a/src/main/history/policy.ts
+++ b/src/main/history/policy.ts
@@ -35,8 +35,10 @@ export function shouldCapture(newContent: string, latestContent: string | undefi
  * Split a note's revisions (any order) into the ones to keep and the ones to
  * prune. Pruned when OLDER than the retention window, or beyond the newest
  * `MAX_REVISIONS_PER_NOTE` — but a LABELED revision is never pruned (an
- * explicitly-marked version is a deliberate keepsake). Returns newest-first
- * `kept` and the `removed` set.
+ * explicitly-marked version is a deliberate keepsake), and neither is the
+ * INITIAL one (the note's baseline; without it there's no "undo everything",
+ * and it's the oldest revision so ordinary retention would take it first).
+ * Returns newest-first `kept` and the `removed` set.
  */
 export function selectForRetention(
   revisions: RevisionMeta[],
@@ -53,7 +55,8 @@ export function selectForRetention(
   let unlabeledKept = 0;
 
   for (const rev of byNewest) {
-    if (rev.label) { kept.push(rev); continue; } // labeled: always survives
+    // Labeled (a deliberate keepsake) and initial (the baseline): always survive.
+    if (rev.label || rev.initial) { kept.push(rev); continue; }
     const tooOld = rev.ts < cutoff;
     const overCap = unlabeledKept >= maxPerNote;
     if (tooOld || overCap) { removed.push(rev); continue; }

--- a/src/main/history/store.ts
+++ b/src/main/history/store.ts
@@ -92,6 +92,10 @@ export async function captureSnapshot(
     ts,
     origin: source.origin,
     ...(source.cause ? { cause: source.cause } : {}),
+    // The first revision of a note is its baseline: it's what "restore
+    // everything back to the start" restores to, so it's marked (and exempt
+    // from pruning) rather than being the first thing retention drops.
+    ...(entries.length === 0 ? { initial: true } : {}),
   };
   await fs.writeFile(snapPath(dir, ts), content, 'utf-8');
   entries.push(meta);
@@ -102,6 +106,46 @@ export async function captureSnapshot(
   );
   await writeIndex(dir, kept);
   return meta;
+}
+
+/**
+ * Back-fill the baseline for a note that has no history yet, from whatever is
+ * on disk right now — call it BEFORE overwriting the file. Without this, the
+ * first save of a note that pre-dates its history (opened from an existing
+ * thoughtbase, imported, written by another tool) captures only the *edited*
+ * state, and the version the user actually wants back — the one before they
+ * touched it — is gone.
+ *
+ * No-ops when the note already has revisions, or when there's nothing on disk
+ * yet (a brand-new file: the write that follows becomes the baseline itself).
+ * The revision is stamped with the file's mtime, not `now`, so the timeline
+ * says when the note actually last changed.
+ */
+export async function ensureInitialRevision(
+  rootPath: string,
+  relPath: string,
+  now: number = Date.now(),
+): Promise<RevisionMeta | null> {
+  // noteDir() re-validates `relPath` (it throws on anything that escapes the
+  // history root), so it runs before we resolve the note path to read it.
+  const dir = noteDir(rootPath, relPath);
+  if ((await readIndex(dir)).length > 0) return null;
+
+  const filePath = path.resolve(rootPath, relPath);
+  let content: string;
+  let mtimeMs: number;
+  try {
+    [content, { mtimeMs }] = await Promise.all([
+      fs.readFile(filePath, 'utf-8'),
+      fs.stat(filePath),
+    ]);
+  } catch {
+    return null; // nothing on disk to preserve
+  }
+  // Strictly before the write that's about to land, even if the mtime is in
+  // the future (clock skew, a copied file), so the timeline stays ordered.
+  const ts = Math.min(Math.floor(mtimeMs), now - 1);
+  return captureSnapshot(rootPath, relPath, content, { origin: 'edit', cause: 'Initial version' }, ts);
 }
 
 /** A note's revisions, newest first (metadata only — no content). */

--- a/src/main/llm/apply-dispatch.ts
+++ b/src/main/llm/apply-dispatch.ts
@@ -148,7 +148,11 @@ register({
   kind: 'note',
   apply: async (ctx, p): Promise<{ resolvedPath: string }> => {
     const finalPath = await resolveCollidingPath(ctx.rootPath, p.relativePath);
-    await notebaseFs.createFile(ctx.rootPath, finalPath);
+    // `writeFile` creates the file (and its parents) itself. A `createFile`
+    // first would only touch an empty file into place — which the note's
+    // history then has to record as its baseline, leaving every AI-filed note
+    // with a junk empty first revision (#1158). Payloads apply sequentially, so
+    // the write still claims the path before the next payload resolves its own.
     await notebaseFs.writeFile(ctx.rootPath, finalPath, p.content);
     await graph.indexNote(ctx, finalPath, p.content);
     if (p.backlink) {

--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import type { NoteFile, NotebaseMeta } from '../../shared/types';
 import { resolveDisplayName } from '../project-config';
 import { defaultThoughtbaseDir } from '../recent-projects';
-import { onNoteWritten, moveHistory } from '../history';
+import { onNoteWriting, onNoteWritten, moveHistory, runWithHistorySource } from '../history';
 
 const IGNORED_DIRS = new Set(['.git', 'node_modules', '.minerva', '.obsidian']);
 
@@ -168,6 +168,10 @@ export async function fileExists(rootPath: string, relativePath: string): Promis
 export async function writeFile(rootPath: string, relativePath: string, content: string): Promise<void> {
   const fullPath = assertSafePath(rootPath, relativePath);
   await fs.mkdir(path.dirname(fullPath), { recursive: true });
+  // Before clobbering: give a note that has no history yet a baseline revision
+  // from what's on disk, so the pre-edit state of a note that pre-dates its
+  // history is still recoverable (#1158).
+  await onNoteWriting(rootPath, relativePath);
   await fs.writeFile(fullPath, content, 'utf-8');
   // Record the saved state in local per-note history (#1158). Best-effort — the
   // hook swallows its own errors so a history failure can't fail the save.
@@ -178,6 +182,10 @@ export async function createFile(rootPath: string, relativePath: string): Promis
   const fullPath = assertSafePath(rootPath, relativePath);
   await fs.mkdir(path.dirname(fullPath), { recursive: true });
   await fs.writeFile(fullPath, '', 'utf-8');
+  // A new note starts with an empty baseline in its history, so "back to the
+  // beginning" is a real destination from the very first edit.
+  await runWithHistorySource({ origin: 'edit', cause: 'Initial version' }, () =>
+    onNoteWritten(rootPath, relativePath, ''));
 }
 
 export async function deleteFile(rootPath: string, relativePath: string): Promise<void> {

--- a/src/renderer/lib/components/right-sidebar/HistoryPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/HistoryPanel.svelte
@@ -63,12 +63,15 @@
   });
 
   // Diff the selected revision → current text (so restore visibly undoes what's
-  // shown). null selection or an identical revision shows nothing.
+  // shown). null selection or an identical revision shows nothing. Note
+  // `isIdentical` is about CONTENT, not recency — an older revision the note was
+  // later restored (or edited back) to matches too, which is why the panel says
+  // "Contents are identical" rather than "this is the current version".
   const diff = $derived(
     selectedContent === null ? [] : diffLines(selectedContent, content),
   );
   const stats = $derived(diffStats(diff));
-  const isCurrent = $derived(selectedContent !== null && selectedContent === content);
+  const isIdentical = $derived(selectedContent !== null && selectedContent === content);
 
   async function restore(): Promise<void> {
     if (!activeFilePath || selectedTs === null || !onRestore) return;
@@ -102,14 +105,14 @@
 
     {#if selectedTs !== null}
       <div class="diff-head">
-        {#if isCurrent}
-          <span class="same">This is the current version.</span>
+        {#if isIdentical}
+          <span class="same">Contents are identical.</span>
         {:else}
           <span class="counts"><span class="add">+{stats.added}</span> <span class="rem">−{stats.removed}</span></span>
           <button class="restore" type="button" onclick={restore} disabled={!onRestore}>Restore</button>
         {/if}
       </div>
-      {#if !isCurrent}
+      {#if !isIdentical}
         <div class="diff">
           {#each diff as line, i (i)}
             <div class="line {line.type}"><span class="gutter">{line.type === 'add' ? '+' : line.type === 'remove' ? '−' : ' '}</span>{line.text || ' '}</div>

--- a/src/shared/history.ts
+++ b/src/shared/history.ts
@@ -22,6 +22,13 @@ export interface RevisionMeta {
    * so revisions captured before this field existed still read sensibly.
    */
   cause?: string;
+  /**
+   * The note's baseline — the oldest state history knows about, captured
+   * before the note's first recorded change. Exempt from pruning: if the
+   * baseline ages out, "undo everything back to the start" stops being
+   * possible, which is most of the point of keeping history at all.
+   */
+  initial?: boolean;
   /** Optional version tag; labeled revisions are exempt from pruning. Stored
    *  from day one so tagging is a UI-only add later, never a migration. */
   label?: string;
@@ -40,8 +47,9 @@ export interface RevisionSource {
 
 /** Display text for a revision's cause, with an origin-derived fallback for
  *  revisions captured before causes were recorded. */
-export function describeRevisionCause(rev: Pick<RevisionMeta, 'origin' | 'cause'>): string {
+export function describeRevisionCause(rev: Pick<RevisionMeta, 'origin' | 'cause' | 'initial'>): string {
   if (rev.cause) return rev.cause;
+  if (rev.initial) return 'Initial version';
   if (rev.origin === 'restore') return 'Restored';
   if (rev.origin === 'proposal') return 'Minerva AI';
   return 'Edit';

--- a/tests/main/history/baseline-capture.test.ts
+++ b/tests/main/history/baseline-capture.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The "there is always an initial version" guarantee (#1158), exercised through
+ * the real `notebase/fs` write path rather than the history store directly —
+ * because the whole point is that no note write can slip past it.
+ *
+ * Without this, a note that pre-dates its own history (an existing thoughtbase,
+ * an import, a file another tool wrote) loses its pre-edit state on the very
+ * first save: the only revision captured is the edited one, and there is
+ * nothing to undo back to.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { createFile, writeFile } from '../../../src/main/notebase/fs';
+import { listRevisions, getRevisionContent } from '../../../src/main/history';
+
+describe('initial revision (#1158)', () => {
+  let root: string;
+  beforeEach(async () => { root = await fsp.mkdtemp(path.join(os.tmpdir(), 'minerva-baseline-')); });
+  afterEach(async () => { await fsp.rm(root, { recursive: true, force: true }); });
+
+  const NOTE = 'notes/a.md';
+
+  it('back-fills the pre-edit state of a note that has no history yet', async () => {
+    // A note that arrived from outside the app — written straight to disk.
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, NOTE), 'the original', 'utf-8');
+
+    await writeFile(root, NOTE, 'edited');
+
+    const revs = await listRevisions(root, NOTE);
+    expect(revs).toHaveLength(2);
+    expect(revs.map((r) => r.cause)).toEqual([undefined, 'Initial version']);
+    expect(revs[1]!.initial).toBe(true);
+    // The state before the edit is recoverable — the point of the exercise.
+    expect(await getRevisionContent(root, NOTE, revs[1]!.ts)).toBe('the original');
+    expect(await getRevisionContent(root, NOTE, revs[0]!.ts)).toBe('edited');
+  });
+
+  it('back-fills only once — later saves just append', async () => {
+    await fsp.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fsp.writeFile(path.join(root, NOTE), 'the original', 'utf-8');
+
+    await writeFile(root, NOTE, 'edit 1');
+    await writeFile(root, NOTE, 'edit 2');
+
+    const revs = await listRevisions(root, NOTE);
+    expect(revs).toHaveLength(3);
+    expect(revs.filter((r) => r.initial)).toHaveLength(1);
+  });
+
+  it('gives a note created empty in the app an initial version straight away', async () => {
+    await createFile(root, NOTE);
+    const revs = await listRevisions(root, NOTE);
+    expect(revs).toHaveLength(1);
+    expect(revs[0]).toMatchObject({ cause: 'Initial version', initial: true });
+    expect(await getRevisionContent(root, NOTE, revs[0]!.ts)).toBe('');
+  });
+
+  it('treats the first write of a brand-new note as the baseline itself', async () => {
+    await writeFile(root, NOTE, '# From a template\n');
+    const revs = await listRevisions(root, NOTE);
+    expect(revs).toHaveLength(1);
+    expect(revs[0]!.initial).toBe(true);
+  });
+
+  it('leaves non-note writes alone', async () => {
+    await writeFile(root, 'assets/data.csv', 'a,b\n');
+    expect(await listRevisions(root, 'assets/data.csv')).toEqual([]);
+  });
+});

--- a/tests/main/history/policy.test.ts
+++ b/tests/main/history/policy.test.ts
@@ -1,7 +1,7 @@
 /**
  * Local per-note history — capture + retention policy (#1158). Pure logic:
  * append-only capture (dedupe identical), and pruning that respects the 30-day
- * window + per-note cap while never dropping a labeled revision.
+ * window + per-note cap while never dropping a labeled or initial revision.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -50,6 +50,16 @@ describe('selectForRetention (#1158)', () => {
     const { kept, removed } = selectForRetention([labeledOld, ...filler], NOW, { maxPerNote: 2 });
     expect(kept.map((r) => r.ts)).toContain(labeledOld.ts); // survived age + cap
     expect(removed.map((r) => r.ts)).not.toContain(labeledOld.ts);
+  });
+
+  it('NEVER prunes the initial revision — the baseline is the point of the feature', () => {
+    // The baseline is always the OLDEST revision, so ordinary retention would
+    // take it first and quietly remove "undo everything back to the start".
+    const baseline = rev(NOW - (RETENTION_DAYS + 100) * DAY, { initial: true });
+    const filler = Array.from({ length: 5 }, (_, i) => rev(NOW - i * 1000));
+    const { kept, removed } = selectForRetention([baseline, ...filler], NOW, { maxPerNote: 2 });
+    expect(kept.map((r) => r.ts)).toContain(baseline.ts); // survived age + cap
+    expect(removed.map((r) => r.ts)).not.toContain(baseline.ts);
   });
 
   it('returns kept newest-first', () => {

--- a/tests/main/history/store.test.ts
+++ b/tests/main/history/store.test.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 import os from 'node:os';
 import {
   captureSnapshot,
+  ensureInitialRevision,
   listRevisions,
   getRevisionContent,
   moveHistory,
@@ -41,6 +42,13 @@ describe('history store (#1158)', () => {
     expect(revs.map((r) => r.cause)).toEqual([undefined, 'Antithesize']);
   });
 
+  it('marks the first revision of a note as its baseline', async () => {
+    await captureSnapshot(root, NOTE, 'v1', { origin: 'edit' }, 1000);
+    await captureSnapshot(root, NOTE, 'v2', { origin: 'edit' }, 2000);
+    const revs = await listRevisions(root, NOTE);
+    expect(revs.map((r) => r.initial)).toEqual([undefined, true]);
+  });
+
   it('dedupes an identical consecutive save', async () => {
     await captureSnapshot(root, NOTE, 'same', { origin: 'edit' }, 1000);
     const second = await captureSnapshot(root, NOTE, 'same', { origin: 'edit' }, 2000);
@@ -61,23 +69,38 @@ describe('history store (#1158)', () => {
 
   it('prunes revisions older than the retention window on capture', async () => {
     const now = 500 * DAY;
-    // An "old" capture, then a fresh one far later → the old one ages out.
-    await captureSnapshot(root, NOTE, 'ancient', { origin: 'edit' }, now - 40 * DAY);
+    const baseTs = now - 50 * DAY;
+    const ancientTs = now - 40 * DAY;
+    // Baseline, an "old" capture, then a fresh one far later → the middle one
+    // ages out. (The baseline is exempt — see the next test.)
+    await captureSnapshot(root, NOTE, 'base', { origin: 'edit' }, baseTs);
+    await captureSnapshot(root, NOTE, 'ancient', { origin: 'edit' }, ancientTs);
     await captureSnapshot(root, NOTE, 'fresh', { origin: 'edit' }, now);
     const revs = await listRevisions(root, NOTE);
-    expect(revs.map((r) => r.ts)).toEqual([now]);
+    expect(revs.map((r) => r.ts)).toEqual([now, baseTs]);
     // The pruned snapshot file is gone too.
-    expect(await getRevisionContent(root, NOTE, now - 40 * DAY)).toBeNull();
+    expect(await getRevisionContent(root, NOTE, ancientTs)).toBeNull();
+  });
+
+  it('keeps the baseline revision however old it gets — "back to the start" must stay reachable', async () => {
+    const now = 500 * DAY;
+    const baseTs = now - 400 * DAY;
+    await captureSnapshot(root, NOTE, 'the original', { origin: 'edit' }, baseTs);
+    await captureSnapshot(root, NOTE, 'fresh', { origin: 'edit' }, now);
+    expect(await getRevisionContent(root, NOTE, baseTs)).toBe('the original');
   });
 
   it('keeps a labeled revision even when it would otherwise age out', async () => {
     const now = 500 * DAY;
     const oldTs = now - 40 * DAY;
+    // A baseline first, so the labeled revision isn't exempt just for being
+    // the note's first.
+    await captureSnapshot(root, NOTE, 'base', { origin: 'edit' }, now - 50 * DAY);
     await captureSnapshot(root, NOTE, 'milestone', { origin: 'edit' }, oldTs);
     await setRevisionLabel(root, NOTE, oldTs, 'v1.0');
     await captureSnapshot(root, NOTE, 'fresh', { origin: 'edit' }, now);
     const revs = await listRevisions(root, NOTE);
-    expect(revs.map((r) => r.ts)).toEqual([now, oldTs]); // labeled survived
+    expect(revs.map((r) => r.ts)).toContain(oldTs); // labeled survived
     expect(await getRevisionContent(root, NOTE, oldTs)).toBe('milestone');
   });
 
@@ -95,5 +118,50 @@ describe('history store (#1158)', () => {
     await moveHistory(root, 'notes', 'archive'); // move the whole folder's history
     expect(await getRevisionContent(root, 'archive/a.md', 1000)).toBe('a1');
     expect(await getRevisionContent(root, 'archive/b.md', 1000)).toBe('b1');
+  });
+});
+
+describe('ensureInitialRevision (#1158)', () => {
+  let root: string;
+  beforeEach(async () => { root = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-hist-init-')); });
+  afterEach(async () => { await fs.rm(root, { recursive: true, force: true }); });
+
+  const NOTE = 'notes/a.md';
+
+  async function writeNote(content: string, mtime?: number): Promise<void> {
+    await fs.mkdir(path.join(root, 'notes'), { recursive: true });
+    await fs.writeFile(path.join(root, NOTE), content, 'utf-8');
+    if (mtime !== undefined) {
+      const when = new Date(mtime);
+      await fs.utimes(path.join(root, NOTE), when, when);
+    }
+  }
+
+  it('captures what is on disk as the baseline, stamped with the file mtime', async () => {
+    const mtime = 5_000_000;
+    await writeNote('the original', mtime);
+    const meta = await ensureInitialRevision(root, NOTE, mtime + 10_000);
+
+    expect(meta).toMatchObject({ ts: mtime, cause: 'Initial version', initial: true });
+    expect(await getRevisionContent(root, NOTE, mtime)).toBe('the original');
+  });
+
+  it('no-ops once the note has any history — the baseline is captured once', async () => {
+    await writeNote('the original');
+    await captureSnapshot(root, NOTE, 'already recorded', { origin: 'edit' }, 1000);
+    expect(await ensureInitialRevision(root, NOTE)).toBeNull();
+    expect(await listRevisions(root, NOTE)).toHaveLength(1);
+  });
+
+  it('no-ops for a note that does not exist yet — the write that follows is the baseline', async () => {
+    expect(await ensureInitialRevision(root, 'notes/brand-new.md')).toBeNull();
+    expect(await listRevisions(root, 'notes/brand-new.md')).toEqual([]);
+  });
+
+  it('keeps the baseline strictly before the write that follows, even with a future mtime', async () => {
+    const now = 5_000_000;
+    await writeNote('the original', now + 60_000); // clock skew / copied file
+    const meta = await ensureInitialRevision(root, NOTE, now);
+    expect(meta!.ts).toBe(now - 1);
   });
 });

--- a/tests/renderer/components/HistoryPanel.test.ts
+++ b/tests/renderer/components/HistoryPanel.test.ts
@@ -93,13 +93,25 @@ describe('HistoryPanel (#1158)', () => {
     expect(p.onRestore).toHaveBeenCalledWith('notes/a.md', 1000);
   });
 
-  it('shows "current version" (no Restore) when the selected revision equals the current text', async () => {
-    h.api.history.list.mockResolvedValue([{ ts: 1000, origin: 'edit' }]);
+  it('says the contents are identical (no Restore) when the selected revision matches the text', async () => {
+    // Deliberately an OLD revision that happens to match: the message is about
+    // content, not recency, so "this is the current version" would be a lie.
+    h.api.history.list.mockResolvedValue([
+      { ts: 2000, origin: 'edit' },
+      { ts: 1000, origin: 'edit', initial: true },
+    ]);
     h.api.history.getRevision.mockResolvedValue('line1\nline2\n'); // == current
     render(HistoryPanel, props({ content: 'line1\nline2\n' }));
-    await waitFor(() => expect(screen.getAllByRole('listitem')).toHaveLength(1));
-    await fireEvent.click(screen.getAllByRole('listitem')[0]!);
-    await waitFor(() => expect(screen.getByText(/current version/)).toBeTruthy());
+    await waitFor(() => expect(screen.getAllByRole('listitem')).toHaveLength(2));
+    await fireEvent.click(screen.getAllByRole('listitem')[1]!);
+    await waitFor(() => expect(screen.getByText('Contents are identical.')).toBeTruthy());
     expect(screen.queryByRole('button', { name: 'Restore' })).toBeNull();
+  });
+
+  it('names the baseline revision "Initial version" when nothing else caused it', async () => {
+    h.api.history.list.mockResolvedValue([{ ts: 1000, origin: 'edit', initial: true }]);
+    render(HistoryPanel, props());
+    await waitFor(() => expect(screen.getAllByRole('listitem')).toHaveLength(1));
+    expect(screen.getByText('Initial version')).toBeTruthy();
   });
 });


### PR DESCRIPTION
Two follow-ups on the History panel.

### "This is the current version." → "Contents are identical."

The check behind that message is about **content**, not recency — an older revision the note was later edited (or restored) back to matched it too, and got told it was "the current version". Renamed the derived flag to `isIdentical` while I was there.

### There is always an initial version

A note only got history once it was written through the app. So:

- a note that pre-dated its own history — an existing thoughtbase, an import, anything another tool wrote — lost its pre-edit state on the first save (the only revision captured was the *edited* one);
- a note created and never edited had no history at all.

Either way there was no way to undo **all** subsequent changes.

- `notebase/fs.writeFile` runs a new pre-write hook that back-fills a baseline revision from what's on disk, stamped with the file's **mtime** (so the timeline says when the note actually last changed), for any note with no history yet. Once per note; a no-op afterward, and a no-op for a file that doesn't exist yet — the write that follows is then the baseline itself.
- `createFile` records the new empty note as its own baseline, so "back to the beginning" is a real destination from the first edit onward.
- The first revision of a note is marked `initial` and **exempt from pruning**. It's always the oldest revision, so ordinary retention would take it first and quietly remove the one version the feature exists to preserve. It renders as "Initial version" unless something more specific caused it.
- The note-apply path no longer `createFile`s an empty placeholder before writing content — that placeholder would have become every AI-filed note's baseline (an empty first revision on every filed note). `writeFile` creates the file and its parents itself, and payloads apply sequentially, so path-collision resolution is unchanged.

### Tests

- `tests/main/history/baseline-capture.test.ts` (new) — drives the real `notebase/fs` write path: back-fills the pre-edit state, back-fills only once, empty baseline for `createFile`, first write of a brand-new note *is* the baseline, non-notes untouched.
- `ensureInitialRevision` unit tests (mtime stamping, no-op cases, future-mtime clamp) and a policy test that the baseline survives both the age window and the per-note cap.
- The retention/labeled store tests now seed a baseline first, so they still test what they claim to.
- Panel tests cover the new message (asserted against an *old* revision that happens to match) and the "Initial version" label.

`pnpm lint` and the full `pnpm test` suite (5,959 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy