### PR TITLE
fix(history): stop reporting a damaged history as an empty one (#1835)

### DIFF
--- a/src/main/history/store.ts
+++ b/src/main/history/store.ts
@@ -20,11 +20,19 @@ import {
   type RevisionSource,
 } from './policy';
 import { getHistorySettings } from './settings';
+// A leaf (only `node:fs/promises`), imported directly rather than through the
+// `ipc/helpers` barrel so this stays clear of electron.
+import { readJsonFileOr } from '../ipc/read-json';
 import { emitHistoryChanged } from './history-events';
 import type { HistorySettings } from '../../shared/history';
 
 const HISTORY_DIR = '.minerva/history';
 const INDEX_FILE = 'index.json';
+
+/** "The file isn't there" — the one absence these reads treat as expected. */
+function isENOENT(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException | null)?.code === 'ENOENT';
+}
 
 /** Absolute dir holding one note's revisions. `relPath` is a project-relative
  *  note path already validated by the caller (capture runs after the write's
@@ -42,15 +50,25 @@ function snapPath(dir: string, ts: number): string {
   return path.join(dir, `${ts}.snap`);
 }
 
+/**
+ * A note's revision index. Missing → no history yet, which is the overwhelmingly
+ * common case (every note before its first save). Corrupt or unreadable →
+ * throws (#1835).
+ *
+ * It used to catch everything and return `[]`, on the reasoning that a corrupt
+ * index shouldn't crash a save. It doesn't have to: the capture hook is
+ * best-effort and swallows at its own boundary. What returning `[]` did instead
+ * was make a note's entire past *disappear from the panel* while capture
+ * cheerfully appended to the file underneath — the note looked new, and the
+ * user was never told otherwise. Missing and corrupt are different facts and
+ * only one of them is expected.
+ */
 async function readIndex(dir: string): Promise<RevisionMeta[]> {
-  try {
-    const raw = await fs.readFile(path.join(dir, INDEX_FILE), 'utf-8');
-    const parsed = JSON.parse(raw) as unknown;
-    // A corrupt index shouldn't crash a save; treat it as "no history yet".
-    return Array.isArray(parsed) ? (parsed as RevisionMeta[]) : [];
-  } catch {
-    return [];
+  const parsed = await readJsonFileOr<unknown>(path.join(dir, INDEX_FILE), []);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`history: ${path.join(dir, INDEX_FILE)} is not a list of revisions`);
   }
+  return parsed as RevisionMeta[];
 }
 
 async function writeIndex(dir: string, entries: RevisionMeta[]): Promise<void> {
@@ -58,14 +76,17 @@ async function writeIndex(dir: string, entries: RevisionMeta[]): Promise<void> {
   await fs.writeFile(path.join(dir, INDEX_FILE), JSON.stringify(sorted, null, 2), 'utf-8');
 }
 
-/** The most-recent revision's content, or undefined if none — for dedupe. */
+/** The most-recent revision's content, or undefined if none — for dedupe.
+ *  A snapshot file that has gone missing means "treat the save as changed and
+ *  re-capture"; any other read failure is a real problem and throws. */
 async function latestContent(dir: string, entries: RevisionMeta[]): Promise<string | undefined> {
   const newest = entries.reduce<RevisionMeta | null>((a, b) => (!a || b.ts > a.ts ? b : a), null);
   if (!newest) return undefined;
   try {
     return await fs.readFile(snapPath(dir, newest.ts), 'utf-8');
-  } catch {
-    return undefined; // snapshot file vanished — treat as changed, re-capture
+  } catch (err) {
+    if (isENOENT(err)) return undefined;
+    throw err;
   }
 }
 
@@ -183,12 +204,19 @@ export async function listRevisions(rootPath: string, relPath: string): Promise<
   return entries.sort((a, b) => b.ts - a.ts);
 }
 
-/** The content of one revision, or null if it's gone. */
+/**
+ * The content of one revision, or `null` when there is no such revision — and
+ * ONLY that (#1835). A read that fails for any other reason (permissions, a
+ * truncated volume) throws, rather than telling the caller the revision was
+ * never there; `HISTORY_RESTORE` turns that `null` into "revision not found",
+ * and it should mean it.
+ */
 export async function getRevisionContent(rootPath: string, relPath: string, ts: number): Promise<string | null> {
   try {
     return await fs.readFile(snapPath(noteDir(rootPath, relPath), ts), 'utf-8');
-  } catch {
-    return null;
+  } catch (err) {
+    if (isENOENT(err)) return null;
+    throw err;
   }
 }
 

--- a/src/renderer/lib/components/right-sidebar/HistoryPanel.svelte
+++ b/src/renderer/lib/components/right-sidebar/HistoryPanel.svelte
@@ -3,11 +3,10 @@
   // the active note: a timeline of saved revisions, a diff of the selected one
   // against the current text, and one-click restore.
   //
-  // The revision list, the `history:changed` subscription and the three
-  // mutations live in the history store (#1834); this owns only view state —
-  // which revision is selected, its content, the diff, and the context menu.
-  // `getRevision` stays a direct `api.*` read, which the data-flow rule allows.
-  import { api } from '../../ipc/client';
+  // The revision list, the `history:changed` subscription, the reads and the
+  // three mutations live in the history store (#1834); this owns only view
+  // state — which revision is selected, its content, the diff, and the context
+  // menu.
   import { getHistoryStore } from '../../stores/history.svelte';
   import { clampMenuToViewport } from '../../utils/menuClamp';
   import { installDismissOnClickOutside } from '../../dismiss-menu';
@@ -58,7 +57,7 @@
 
   async function select(relativePath: string, ts: number): Promise<void> {
     selectedTs = ts;
-    selectedContent = await api.history.getRevision(relativePath, ts);
+    selectedContent = await history.readRevision(relativePath, ts);
   }
 
   // Point the store at the open note; it refetches on change and on every
@@ -101,6 +100,14 @@
 <div class="history-panel">
   {#if !activeFilePath}
     <p class="empty">No active note.</p>
+  {:else if history.error}
+    <!-- A damaged index reads as "no history yet" if we stay quiet about it,
+         which is how a note's whole past can look like it was never there. -->
+    <p class="empty">
+      This note's history couldn't be read. Its record in
+      <code>.minerva/history</code> may be damaged.
+      <span class="detail">{history.error}</span>
+    </p>
   {:else if revisions.length === 0}
     <p class="empty">No history yet — your edits are saved here as you go.</p>
   {:else}
@@ -155,7 +162,9 @@
 
 <style>
   .history-panel { display: flex; flex-direction: column; min-height: 0; height: 100%; }
-  .empty { color: var(--text-muted); font-size: 13px; padding: 12px; }
+  .empty { color: var(--text-muted); font-size: 13px; padding: 12px; line-height: 1.5; }
+  .empty code { font-family: var(--font-mono); font-size: 11px; }
+  .empty .detail { display: block; margin-top: 6px; color: var(--text-faint); font-size: 11px; }
 
   .timeline { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 0 0 auto; max-height: 45%; }
   .timeline li {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -750,7 +750,8 @@ export interface TabsApi {
 export interface HistoryApi {
   /** A note's revisions, newest first (metadata only). */
   list(relativePath: string): Promise<RevisionMeta[]>;
-  /** One revision's full content, or null if it's gone. */
+  /** One revision's full content. `null` means exactly one thing — there is no
+   *  such revision (#1835). A read that fails for any other reason rejects. */
   getRevision(relativePath: string, ts: number): Promise<string | null>;
   /** Restore a revision — writes it back as a new save (non-destructive). */
   restore(relativePath: string, ts: number): Promise<void>;

--- a/src/renderer/lib/stores/history.svelte.ts
+++ b/src/renderer/lib/stores/history.svelte.ts
@@ -24,6 +24,15 @@ import type { RevisionMeta } from '../../../shared/history';
 
 let watched = $state<string | null>(null);
 let revisions = $state<RevisionMeta[]>([]);
+/**
+ * Why the watched note's history couldn't be read, or null.
+ *
+ * Main now throws on a corrupt revision index instead of reporting it as "no
+ * history yet" (#1835). That's only an improvement if the renderer says so —
+ * swallowing the rejection here would put the panel right back to showing an
+ * empty timeline for a note whose past is sitting damaged on disk.
+ */
+let error = $state<string | null>(null);
 /** Bumped whenever `revisions` is replaced, so a panel can re-stamp "now" for
  *  its date formatting without diffing the list. */
 let revision = $state(0);
@@ -33,6 +42,7 @@ async function load(): Promise<void> {
   const path = watched;
   if (!path) {
     revisions = [];
+    error = null;
     revision += 1;
     return;
   }
@@ -42,9 +52,14 @@ async function load(): Promise<void> {
     // response must not overwrite the newer note's list.
     if (watched !== path) return;
     revisions = list;
+    error = null;
     revision += 1;
   } catch (err) {
+    if (watched !== path) return;
     console.error('[history] failed to list revisions:', err);
+    revisions = [];
+    error = err instanceof Error ? err.message : String(err);
+    revision += 1;
   }
 }
 
@@ -65,6 +80,25 @@ export function getHistoryStore() {
     get revisions(): RevisionMeta[] { return revisions; },
     /** Bumped on every list replacement. */
     get revision(): number { return revision; },
+    /** Why the watched note's history couldn't be read, or null. */
+    get error(): string | null { return error; },
+
+    /**
+     * One revision's content, for the diff. Returns null when the revision is
+     * gone; a real read failure surfaces through `error` rather than reading to
+     * the user as an empty version.
+     */
+    async readRevision(relativePath: string, ts: number): Promise<string | null> {
+      try {
+        const content = await api.history.getRevision(relativePath, ts);
+        error = null;
+        return content;
+      } catch (err) {
+        console.error('[history] failed to read a revision:', err);
+        error = err instanceof Error ? err.message : String(err);
+        return null;
+      }
+    },
 
     /**
      * Point the store at a note (or `null` for "no note open"). Idempotent, so

--- a/tests/main/history/store.test.ts
+++ b/tests/main/history/store.test.ts
@@ -3,7 +3,7 @@
  * append + dedupe, list newest-first, read a revision, prune to retention,
  * history-follows-rename, and labeled-survives-prune.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
@@ -17,6 +17,7 @@ import {
   moveHistory,
   setRevisionLabel,
 } from '../../../src/main/history/store';
+import { onNoteWritten } from '../../../src/main/history';
 
 const DAY = 24 * 60 * 60 * 1000;
 
@@ -284,5 +285,62 @@ describe('pruneAllHistory (#1158)', () => {
 
   it('is a no-op for a project with no history at all', async () => {
     expect(await pruneAllHistory(root, 5000, LOOSE)).toEqual({ notes: 0, removed: 0 });
+  });
+});
+
+describe('history store error conventions (#1835)', () => {
+  let root: string;
+  beforeEach(async () => { root = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-hist-errs-')); });
+  afterEach(async () => { await fs.rm(root, { recursive: true, force: true }); });
+
+  const NOTE = 'notes/a.md';
+  const indexPath = () => path.join(root, '.minerva', 'history', NOTE, 'index.json');
+
+  it('reads a missing index as "no history yet" — the expected absence', async () => {
+    expect(await listRevisions(root, NOTE)).toEqual([]);
+  });
+
+  it('surfaces a corrupt index instead of reporting it as empty', async () => {
+    await captureSnapshot(root, NOTE, 'v1', { origin: 'edit' }, 1000);
+    await fs.writeFile(indexPath(), '{ not json at all', 'utf-8');
+
+    // The old behaviour returned [] here, so a note with a damaged past looked
+    // like a note with no past — and capture kept appending underneath.
+    await expect(listRevisions(root, NOTE)).rejects.toThrow();
+  });
+
+  it('rejects an index that parses but is not a list', async () => {
+    await captureSnapshot(root, NOTE, 'v1', { origin: 'edit' }, 1000);
+    await fs.writeFile(indexPath(), '{"revisions": []}', 'utf-8');
+    await expect(listRevisions(root, NOTE)).rejects.toThrow(/not a list of revisions/);
+  });
+
+  it('keeps a corrupt index from breaking the save it interrupts', async () => {
+    // History is best-effort at its hook boundary: the capture fails loudly in
+    // the log, the user's write still lands.
+    await captureSnapshot(root, NOTE, 'v1', { origin: 'edit' }, 1000);
+    await fs.writeFile(indexPath(), 'broken', 'utf-8');
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(onNoteWritten(root, NOTE, 'v2')).resolves.toBeUndefined();
+      expect(err).toHaveBeenCalled();
+    } finally {
+      err.mockRestore();
+    }
+  });
+
+  it('returns null from getRevisionContent only when the revision is not there', async () => {
+    await captureSnapshot(root, NOTE, 'v1', { origin: 'edit' }, 1000);
+    expect(await getRevisionContent(root, NOTE, 1000)).toBe('v1');
+    expect(await getRevisionContent(root, NOTE, 999)).toBeNull();
+  });
+
+  it('throws rather than returning null when a revision cannot be read', async () => {
+    await captureSnapshot(root, NOTE, 'v1', { origin: 'edit' }, 1000);
+    // A directory where the snapshot file should be: present, but unreadable as
+    // a file. Not "no such revision" — and it must not claim to be.
+    await fs.rm(path.join(root, '.minerva', 'history', NOTE, '1000.snap'));
+    await fs.mkdir(path.join(root, '.minerva', 'history', NOTE, '1000.snap'));
+    await expect(getRevisionContent(root, NOTE, 1000)).rejects.toThrow();
   });
 });

--- a/tests/renderer/components/HistoryPanel.test.ts
+++ b/tests/renderer/components/HistoryPanel.test.ts
@@ -68,6 +68,17 @@ describe('HistoryPanel (#1158)', () => {
     expect(screen.getByText(/No history yet/)).toBeTruthy();
   });
 
+  it('says the history could not be read rather than claiming there is none (#1835)', async () => {
+    h.api.history.list.mockRejectedValue(new Error('index.json is not a list of revisions'));
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await rendered();
+
+    await waitFor(() => expect(screen.getByText(/couldn't be read/)).toBeTruthy());
+    // The old empty-state message would have been a lie about a damaged file.
+    expect(screen.queryByText(/No history yet/)).toBeNull();
+    err.mockRestore();
+  });
+
   it('renders the revision timeline newest-first, stamped with date and time', async () => {
     const ts = new Date(2026, 7, 22, 14, 7).getTime();
     h.api.history.list.mockResolvedValue([

--- a/tests/renderer/history-store.test.ts
+++ b/tests/renderer/history-store.test.ts
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => ({
   api: {
     history: {
       list: vi.fn(),
+      getRevision: vi.fn(),
       restore: vi.fn(),
       setLabel: vi.fn(),
       onChanged: vi.fn(),
@@ -34,6 +35,7 @@ let fireChanged: (relPath: string | null) => void;
 
 beforeEach(() => {
   h.api.history.list.mockResolvedValue([]);
+  h.api.history.getRevision.mockResolvedValue(null);
   h.api.history.restore.mockResolvedValue(undefined);
   h.api.history.setLabel.mockResolvedValue(undefined);
   h.api.history.onChanged.mockImplementation((cb: (p: string | null) => void) => {
@@ -134,6 +136,47 @@ describe('history store (#1834)', () => {
     releaseSlow([{ ts: 1, origin: 'edit' }]);
     await flush();
     expect(store.revisions.map((r) => r.ts)).toEqual([9]);
+  });
+
+  it('exposes a read failure instead of showing an empty timeline (#1835)', async () => {
+    h.api.history.list.mockRejectedValue(new Error('index.json is not a list of revisions'));
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const store = getHistoryStore();
+    store.watch('notes/a.md');
+    await flush();
+
+    // Main throws on a corrupt index now; swallowing it here would put the
+    // panel back to claiming the note has no history.
+    expect(store.error).toMatch(/not a list of revisions/);
+    expect(store.revisions).toEqual([]);
+    err.mockRestore();
+  });
+
+  it('clears the error once the note reads cleanly again', async () => {
+    h.api.history.list.mockRejectedValue(new Error('broken'));
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const store = getHistoryStore();
+    store.watch('notes/a.md');
+    await flush();
+    expect(store.error).toBe('broken');
+
+    h.api.history.list.mockResolvedValue([{ ts: 1, origin: 'edit' }]);
+    fireChanged('notes/a.md');
+    await flush();
+
+    expect(store.error).toBeNull();
+    expect(store.revisions).toHaveLength(1);
+    err.mockRestore();
+  });
+
+  it('surfaces a failed revision read rather than showing it as empty', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    h.api.history.getRevision.mockRejectedValue(new Error('EACCES'));
+    const store = getHistoryStore();
+
+    expect(await store.readRevision('notes/a.md', 1)).toBeNull();
+    expect(store.error).toBe('EACCES');
+    err.mockRestore();
   });
 
   it('confirms before restoring, and reports a decline', async () => {


### PR DESCRIPTION
Closes #1835. Finishes the high-priority tier from the architecture review.

Two anti-patterns CLAUDE.md names explicitly, both in code from the versioning work.

### `readIndex` swallowed corruption

It caught everything and returned `[]`, reasoning that a corrupt index shouldn't crash a save. It doesn't have to — the capture hook is best-effort and swallows at its own boundary. What returning `[]` actually did was make a note's **entire past disappear from the panel** while capture went on appending to the damaged file underneath. The note looked new; nothing told the user otherwise.

Now `readJsonFileOr`: missing → no history yet (the expected absence), corrupt → throws. Plus an explicit shape check, so an index that parses but isn't a list is also a failure rather than silently zero revisions.

### `getRevisionContent` overloaded `null`

It returned `null` for both "no such revision" and "the read failed", which means `HISTORY_RESTORE`'s "revision *not found*" could be a lie about a permissions error. Only ENOENT returns `null` now; anything else throws. `latestContent` got the same treatment — it swallowed to `undefined`, which reads as "re-capture", and a real IO error would have silently duplicated the previous snapshot.

### The part the issue didn't ask for, but the fix needs

Throwing is only an improvement if someone hears it — and the renderer was swallowing the rejection, leaving the panel on **"No history yet"** for a note whose past is damaged on disk. That's the exact symptom the issue is about, just moved one layer up. So:

- the store exposes the failure, and clears it when the note reads cleanly again;
- the panel says the history couldn't be read, and where to look, instead of claiming there is none;
- reading one revision moved into the store as well, so there's one error surface rather than two.

### Tests

Main: missing index reads as empty, corrupt index rejects, non-list index rejects with a specific message, a corrupt index doesn't break the save it interrupts (logged, write still lands), `null` only for a genuinely absent revision, and a revision that *exists but can't be read* rejects rather than reporting itself missing.

Renderer: the store exposes a read failure and clears it on recovery, a failed revision read surfaces rather than reading as empty content, and the panel shows the damaged-history message instead of the empty state.

`pnpm lint` and the full suite (6,051) pass.

One note for #1849: `readJsonFileOr` is imported from `ipc/read-json` — the leaf, not the barrel, so this stays clear of electron. But a generic JSON utility living under `ipc/` and being consumed by a lower layer is the seam being in the wrong place, which is exactly the kind of call that issue exists to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy