### PR TITLE
perf(history): four file reads per save down to one (#1836)

### DIFF
--- a/src/main/history/settings.ts
+++ b/src/main/history/settings.ts
@@ -9,6 +9,17 @@
  * Labeled revisions and a note's initial revision are exempt from the retention
  * rules regardless (see `policy.ts`) — a deliberate keepsake and the "undo
  * everything" baseline aren't what fills a disk.
+ *
+ * What these limits do and don't bound (#1836): they bound history PER NOTE —
+ * at most `maxRevisionsPerNote` unlabeled revisions, none older than
+ * `retentionDays`, none of a file over `maxFileSizeKb`. There is deliberately
+ * no limit ACROSS notes: a thoughtbase with 10,000 edited notes can hold
+ * 10,000 note-histories. That is the right shape — a global cap would have to
+ * evict one note's past to make room for another's, which is precisely the
+ * surprise this feature exists to avoid — but it does mean total usage scales
+ * with how much you write. Snapshots are whole copies, not deltas; a
+ * content-addressed store would collapse restore-to-a-previous-state to one
+ * copy and is the obvious next move if this ever bites.
  */
 import { app } from 'electron';
 import path from 'node:path';
@@ -39,7 +50,28 @@ function sanitize(raw: HistorySettings): HistorySettings {
   };
 }
 
+/**
+ * The limits, cached in memory after the first read (#1836).
+ *
+ * `getHistorySettings` is on the hot path of every save — the capture hook
+ * consults it before deciding whether to snapshot — and autosave fires a second
+ * after every typing pause. Re-reading and re-parsing a ~100-byte JSON file for
+ * each keystroke pause is pure waste.
+ *
+ * Safe to cache because this process is the only writer: `setHistorySettings`
+ * refreshes the cache with what it wrote. A file edited by hand underneath a
+ * running app is picked up on the next restart, which is the same deal every
+ * other `userData` config in the app offers.
+ */
+let cached: HistorySettings | null = null;
+
 export async function getHistorySettings(): Promise<HistorySettings> {
+  if (cached) return cached;
+  cached = await loadSettingsFromDisk();
+  return cached;
+}
+
+async function loadSettingsFromDisk(): Promise<HistorySettings> {
   return loadConfigFile(settingsPath, (raw) => {
     const o = asRecord(raw);
     return sanitize({
@@ -55,5 +87,6 @@ export async function getHistorySettings(): Promise<HistorySettings> {
 export async function setHistorySettings(settings: HistorySettings): Promise<HistorySettings> {
   const next = sanitize(settings);
   await fs.writeFile(settingsPath(), JSON.stringify(next, null, 2), 'utf-8');
+  cached = next;
   return next;
 }

--- a/src/main/history/store.ts
+++ b/src/main/history/store.ts
@@ -10,6 +10,7 @@
  * and its files must stay out of the graph/search index (`.minerva` is ignored).
  */
 import { promises as fs } from 'node:fs';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import {
   exceedsSizeLimit,
@@ -28,6 +29,12 @@ import type { HistorySettings } from '../../shared/history';
 
 const HISTORY_DIR = '.minerva/history';
 const INDEX_FILE = 'index.json';
+
+/** Content fingerprint stored on each revision, so an unchanged save can be
+ *  recognised without reading the previous snapshot back off disk (#1836). */
+function contentHash(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}
 
 /** "The file isn't there" — the one absence these reads treat as expected. */
 function isENOENT(err: unknown): boolean {
@@ -76,18 +83,44 @@ async function writeIndex(dir: string, entries: RevisionMeta[]): Promise<void> {
   await fs.writeFile(path.join(dir, INDEX_FILE), JSON.stringify(sorted, null, 2), 'utf-8');
 }
 
-/** The most-recent revision's content, or undefined if none — for dedupe.
- *  A snapshot file that has gone missing means "treat the save as changed and
- *  re-capture"; any other read failure is a real problem and throws. */
-async function latestContent(dir: string, entries: RevisionMeta[]): Promise<string | undefined> {
-  const newest = entries.reduce<RevisionMeta | null>((a, b) => (!a || b.ts > a.ts ? b : a), null);
-  if (!newest) return undefined;
+/** Does this note have any history? A stat, not a parse — see the call site. */
+async function hasIndex(dir: string): Promise<boolean> {
   try {
-    return await fs.readFile(snapPath(dir, newest.ts), 'utf-8');
+    await fs.stat(path.join(dir, INDEX_FILE));
+    return true;
   } catch (err) {
-    if (isENOENT(err)) return undefined;
+    if (isENOENT(err)) return false;
     throw err;
   }
+}
+
+function newestOf(entries: RevisionMeta[]): RevisionMeta | null {
+  return entries.reduce<RevisionMeta | null>((a, b) => (!a || b.ts > a.ts ? b : a), null);
+}
+
+/**
+ * Is this save a change worth capturing?
+ *
+ * The fast path never touches the disk: compare the incoming content's hash
+ * with the one stored on the newest revision. Only a revision written before
+ * hashes existed makes us read the snapshot back to compare content — so an
+ * older thoughtbase pays the old cost exactly once per note, then never again.
+ *
+ * A snapshot file that has gone missing means "treat the save as changed and
+ * re-capture"; any other read failure is a real problem and throws.
+ */
+async function isNewContent(dir: string, entries: RevisionMeta[], hash: string, content: string): Promise<boolean> {
+  const newest = newestOf(entries);
+  if (!newest) return true;
+  if (newest.hash) return newest.hash !== hash;
+
+  let previous: string | undefined;
+  try {
+    previous = await fs.readFile(snapPath(dir, newest.ts), 'utf-8');
+  } catch (err) {
+    if (!isENOENT(err)) throw err;
+  }
+  return shouldCapture(content, previous);
 }
 
 /**
@@ -113,7 +146,8 @@ export async function captureSnapshot(
   await fs.mkdir(dir, { recursive: true });
   const entries = await readIndex(dir);
 
-  if (!shouldCapture(content, await latestContent(dir, entries))) return null;
+  const hash = contentHash(content);
+  if (!await isNewContent(dir, entries, hash, content)) return null;
 
   // Avoid a filename collision if two captures land in the same millisecond.
   let ts = now;
@@ -122,6 +156,7 @@ export async function captureSnapshot(
   const meta: RevisionMeta = {
     ts,
     origin: source.origin,
+    hash,
     ...(source.cause ? { cause: source.cause } : {}),
     // The first revision of a note is its baseline: it's what "restore
     // everything back to the start" restores to, so it's marked (and exempt
@@ -176,7 +211,12 @@ export async function ensureInitialRevision(
   // noteDir() re-validates `relPath` (it throws on anything that escapes the
   // history root), so it runs before we resolve the note path to read it.
   const dir = noteDir(rootPath, relPath);
-  if ((await readIndex(dir)).length > 0) return null;
+  // This runs BEFORE every save, and its answer is "already done" for all but
+  // the first one per note — so ask the cheapest question that settles it. An
+  // index file existing means the note has history; parsing it to count the
+  // entries would read and parse a growing JSON file on every keystroke pause
+  // to learn something a stat already told us (#1836).
+  if (await hasIndex(dir)) return null;
 
   const filePath = path.resolve(rootPath, relPath);
   const settings = await getHistorySettings();
@@ -285,8 +325,7 @@ export async function labelCurrentVersion(
     now,
   );
 
-  const entries = await readIndex(dir);
-  const newest = captured ?? entries.reduce<RevisionMeta | null>((a, b) => (!a || b.ts > a.ts ? b : a), null);
+  const newest = captured ?? newestOf(await readIndex(dir));
   if (!newest) throw new Error(`history: no revision to label for "${relPath}"`);
 
   await setRevisionLabel(rootPath, relPath, newest.ts, label);

--- a/src/main/notebase/fs.ts
+++ b/src/main/notebase/fs.ts
@@ -175,6 +175,16 @@ export async function writeFile(rootPath: string, relativePath: string, content:
   await fs.writeFile(fullPath, content, 'utf-8');
   // Record the saved state in local per-note history (#1158). Best-effort — the
   // hook swallows its own errors so a history failure can't fail the save.
+  //
+  // Awaited on purpose, and it was worth re-deciding (#1836). Since the hook
+  // can't fail the save, the await buys no error handling — but it does buy
+  // ORDERING. Capture is read-modify-write on a shared `index.json`; drop the
+  // await and two rapid saves of the same note can interleave their
+  // read-index / write-index, losing one revision's metadata and orphaning its
+  // snapshot. There is no per-note write queue in main to lean on (that
+  // absence is what made #1833 a bug), so the await IS the serialization.
+  // Making this fire-and-forget needs that queue first; the cost was taken out
+  // of the work instead — see the settings cache and the hash-based dedupe.
   await onNoteWritten(rootPath, relativePath, content);
 }
 

--- a/src/shared/history.ts
+++ b/src/shared/history.ts
@@ -29,6 +29,14 @@ export interface RevisionMeta {
    * possible, which is most of the point of keeping history at all.
    */
   initial?: boolean;
+  /**
+   * SHA-256 of the revision's content (#1836). Lets the next save decide
+   * "unchanged, don't capture" by hashing what it already has in memory,
+   * instead of reading the previous snapshot off disk on every keystroke pause.
+   * Optional: revisions written before this existed have none, and the capture
+   * path falls back to comparing content for those.
+   */
+  hash?: string;
   /** Optional version tag; labeled revisions are exempt from pruning. Stored
    *  from day one so tagging is a UI-only add later, never a migration. */
   label?: string;

--- a/tests/main/history/capture-io.test.ts
+++ b/tests/main/history/capture-io.test.ts
@@ -1,0 +1,97 @@
+/**
+ * What a save costs in file reads (#1836).
+ *
+ * Capture is awaited inside `writeFile`, so every read it does is latency the
+ * user's save pays for — and autosave fires a second after every typing pause.
+ * These count the actual `fs.readFile` calls rather than trusting a comment,
+ * because the cost crept in the way costs do: each addition looked free.
+ *
+ * Awaiting is deliberate (it's the only thing serializing the read-modify-write
+ * on `index.json` — see the note at the call site in `notebase/fs.ts`), so the
+ * fix was to make the awaited work cheap, not to stop waiting for it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fsp } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { onNoteWriting, onNoteWritten } from '../../../src/main/history';
+import { listRevisions } from '../../../src/main/history/store';
+
+describe('per-save history I/O (#1836)', () => {
+  let root: string;
+  const NOTE = 'notes/a.md';
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-hist-io-'));
+    await fs.mkdir(path.join(root, 'notes'), { recursive: true });
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  /** Simulate what `notebase/fs.writeFile` does around a save. */
+  async function save(content: string): Promise<void> {
+    await onNoteWriting(root, NOTE);
+    await fs.writeFile(path.join(root, NOTE), content, 'utf-8');
+    await onNoteWritten(root, NOTE, content);
+  }
+
+  /** Count the reads a single save performs, once history already exists.
+   *  Every read on this path passes a plain string path. */
+  async function readsForSave(content: string): Promise<string[]> {
+    const spy = vi.spyOn(fsp, 'readFile');
+    await save(content);
+    const paths = spy.mock.calls.map(([target]) => (typeof target === 'string' ? target : ''));
+    spy.mockRestore();
+    return paths;
+  }
+
+  it('reads only the revision index on a steady-state save', async () => {
+    await save('v1');
+    await save('v2');
+
+    const reads = await readsForSave('v3');
+
+    // One read: the note's index. Not the previous snapshot (compared by
+    // hash), and not a second parse of the index from the pre-write hook
+    // (answered by a stat). The settings file doesn't appear here either, but
+    // this environment has no `app.getPath` so it was never read — the cache
+    // that removes it in the real app is pinned in settings.test.ts.
+    expect(reads).toHaveLength(1);
+    expect(reads[0]).toMatch(/index\.json$/);
+  });
+
+  it('decides "unchanged" without reading the previous snapshot back', async () => {
+    await save('v1');
+    const reads = await readsForSave('v1'); // byte-identical re-save
+
+    expect(reads.filter((p) => p.endsWith('.snap'))).toEqual([]);
+    expect(await listRevisions(root, NOTE)).toHaveLength(1); // still deduped
+  });
+
+  it('falls back to comparing content for revisions written before hashes', async () => {
+    await save('v1');
+    // An index from an older version: entries with no `hash`.
+    const dir = path.join(root, '.minerva', 'history', NOTE);
+    const index = JSON.parse(await fs.readFile(path.join(dir, 'index.json'), 'utf-8'));
+    for (const entry of index) delete entry.hash;
+    await fs.writeFile(path.join(dir, 'index.json'), JSON.stringify(index), 'utf-8');
+
+    // Dedupe still works — it just costs the snapshot read it used to cost.
+    const reads = await readsForSave('v1');
+    expect(reads.filter((p) => p.endsWith('.snap'))).toHaveLength(1);
+    expect(await listRevisions(root, NOTE)).toHaveLength(1);
+
+    // And the re-read is a one-off: the next real save writes a hashed entry.
+    await save('v2');
+    expect((await listRevisions(root, NOTE))[0]?.hash).toBeTruthy();
+  });
+
+  it('stores a content hash on each captured revision', async () => {
+    await save('v1');
+    const [rev] = await listRevisions(root, NOTE);
+    expect(rev?.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/tests/main/history/settings.test.ts
+++ b/tests/main/history/settings.test.ts
@@ -74,6 +74,33 @@ describe('history settings storage', () => {
     expect(saved).toEqual({ retentionDays: 4, maxRevisionsPerNote: 9, maxFileSizeKb: 101 });
   });
 
+  it('reads the file once and caches it — this is on the hot path of every save', async () => {
+    const { getHistorySettings, DEFAULT_HISTORY_SETTINGS } = await load();
+    expect(await getHistorySettings()).toEqual(DEFAULT_HISTORY_SETTINGS);
+
+    // Change the file underneath. A second call that still answers with the
+    // first value is the cache doing its job: autosave fires a second after
+    // every typing pause, and capture consults the limits before deciding
+    // whether to snapshot (#1836).
+    await fs.writeFile(
+      path.join(dir, 'history-settings.json'),
+      JSON.stringify({ retentionDays: 7, maxRevisionsPerNote: 20, maxFileSizeKb: 0 }),
+      'utf-8',
+    );
+    expect(await getHistorySettings()).toEqual(DEFAULT_HISTORY_SETTINGS);
+  });
+
+  it('refreshes the cache from what it wrote, without going back to disk', async () => {
+    const { getHistorySettings, setHistorySettings } = await load();
+    await getHistorySettings(); // prime the cache
+
+    const saved = await setHistorySettings({ retentionDays: 7, maxRevisionsPerNote: 20, maxFileSizeKb: 0 });
+    // Corrupt the file after the write: a value that came back from the cache
+    // proves the read wasn't repeated.
+    await fs.writeFile(path.join(dir, 'history-settings.json'), 'not json', 'utf-8');
+    await expect(getHistorySettings()).resolves.toEqual(saved);
+  });
+
   it('falls back per-field when the stored file is partial or wrong-typed', async () => {
     await fs.writeFile(
       path.join(dir, 'history-settings.json'),


### PR DESCRIPTION
Closes #1836.

Capture is awaited inside `writeFile`, so everything it reads is latency the user's save pays for — and autosave fires a second after every typing pause.

| Per save | Before | After |
| --- | --- | --- |
| Parse the note's revision index (pre-write hook) | ✔ | stat instead |
| Read + parse `history-settings.json` | ✔ | cached |
| Parse the index again (capture) | ✔ | ✔ |
| Read the previous snapshot back, to byte-compare | ✔ | hash compare |

Three of the four were avoidable:

- **The settings are cached** after the first read, refreshed by `setHistorySettings` from what it wrote. This process is the only writer; a file hand-edited under a running app is picked up on restart, the same deal every other `userData` config offers.
- **The pre-write hook stats instead of parsing.** Its question is "does this note have history yet?", its answer is "yes" for every save but the first, and an index file existing settles it. Parsing a growing JSON file to learn that was the wrong question asked expensively.
- **Dedupe compares hashes.** Each revision stores a SHA-256 of its content, so "unchanged, don't capture" is decided from what's already in memory. Revisions written before this have no hash and fall back to reading the snapshot — an older thoughtbase pays the old cost once per note, then never again.

Steady state is now one read: the note's index. Pinned by a test that counts actual `fs.readFile` calls rather than trusting that paragraph.

### The await stays, and that's the interesting part

The issue suggested making `onNoteWritten` fire-and-forget, on the grounds that it swallows its own errors so the await buys nothing. The premise is right and the conclusion isn't: the await isn't buying error handling, it's buying **ordering**. Capture is read-modify-write on a shared `index.json`. Drop the await and two rapid saves of the same note can interleave their read-index/write-index, losing one revision's metadata and orphaning its snapshot file.

There's no per-note write queue in main to lean on — that absence is exactly what made #1833 a bug. So making this async needs the queue first, and that's a design decision worth its own issue rather than a side effect of a performance pass. The cost came out of the work instead. The reasoning is recorded at the call site in `notebase/fs.ts` so the next person doesn't re-derive it.

### Disk budget

The third open question on the issue. Documented rather than changed: the limits bound history **per note** (revision count, age, file size) and deliberately not across notes — a global cap would have to evict one note's past to make room for another's, which is precisely the surprise this feature exists to avoid. Total usage therefore scales with how much you write, and snapshots are whole copies. A content-addressed store is the obvious next move if it ever bites; noted in the module rather than filed, since nothing suggests it bites today.

### Tests

`tests/main/history/capture-io.test.ts` counts reads for a steady-state save, asserts dedupe happens without touching a `.snap` file, and covers the unhashed-legacy-index fallback both ways (it reads once, then writes a hashed entry). The settings cache is pinned behaviourally in `settings.test.ts` — change the file underneath, assert the cached value still comes back — which also documents the restart caveat.

One thing I got wrong first time and fixed: my initial cache test spied on `fs.readFile` and passed for the wrong reason. `config-store.ts` destructures its import, so the spy never intercepted it, *and* the test environment has no `app.getPath`, so the settings file was never read at all. The behavioural test is honest where the spy was vacuous.

`pnpm lint` and the full suite (6,057) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy