### PR TITLE
refactor(graph): extract the tag queries out of queries.ts (#1838)

### DIFF
--- a/src/main/graph/queries.ts
+++ b/src/main/graph/queries.ts
@@ -15,7 +15,6 @@ import type { ProjectContext } from '../project-context-types';
 import { LINK_TYPES, type LinkType } from '../../shared/link-types';
 import { stripNoteExt } from '../../shared/note-extensions';
 import type {
-  TagInfo, TaggedNote, TaggedSource,
   OutgoingLink, Backlink, SafeDeleteBlocker,
   SourceDetail, SourceMetadata, SourceExcerpt, SourceBacklink, SourceAboutNote,
   SourceReference, ReadStatus,
@@ -25,9 +24,20 @@ import {
   getState, getEngine, ensureN3Cache,
   MINERVA, DC, RDF, BIBO, PROV, THOUGHT,
   STANDARD_PREFIXES,
-  noteUri, tagUri, sourceUri, excerptUri,
+  noteUri, sourceUri, excerptUri,
   linkPredicate, stripFragment,
 } from './state';
+
+// Tag queries live in `./queries/tags` (#1838). Re-exported here so
+// `graph/index` and every `import … from './queries'` caller is unchanged —
+// the same facade shape `indexers.ts` uses for `./indexers/*`.
+export {
+  listTags,
+  notesByTagPrefix,
+  notesByTag,
+  sourcesByTag,
+  allTags,
+} from './queries/tags';
 
 // ── Alias / frontmatter lookups ─────────────────────────────────────────────
 
@@ -345,117 +355,6 @@ export async function queryGraph(
   }
 }
 
-// ── Tag queries ─────────────────────────────────────────────────────────────
-
-export function listTags(ctx: ProjectContext): TagInfo[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  const { store } = state;
-
-  // Bucket per tag-name into note vs source counts. A subject is a
-  // source when it carries minerva:sourceId; otherwise we treat the
-  // hasTag edge as belonging to a note (this matches what notesByTag
-  // returns once the rdf:type filter has been applied).
-  const buckets = new Map<string, { noteCount: number; sourceCount: number }>();
-  const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), undefined);
-  for (const st of stmts) {
-    const tagNode = st.object;
-    const nameStmts = store.statementsMatching(tagNode as $rdf.NamedNode, MINERVA('tagName'), undefined);
-    const name = nameStmts[0]?.object.value ?? tagNode.value;
-    let bucket = buckets.get(name);
-    if (!bucket) {
-      bucket = { noteCount: 0, sourceCount: 0 };
-      buckets.set(name, bucket);
-    }
-    const isSource = store.statementsMatching(st.subject, MINERVA('sourceId'), undefined).length > 0;
-    if (isSource) bucket.sourceCount++;
-    else bucket.noteCount++;
-  }
-
-  return [...buckets.entries()]
-    .map(([tag, b]) => ({ tag, noteCount: b.noteCount, sourceCount: b.sourceCount }))
-    .sort((a, b) => a.tag.localeCompare(b.tag));
-}
-
-/**
- * Notes with any tag at-or-under `prefix` (#466). Matches the literal
- * `prefix` and any tag that starts with `prefix/…` so clicking a
- * parent row in the tree returns the same set the cumulative count
- * promised. Deduped by relativePath since one note can carry multiple
- * matching tags.
- */
-export function notesByTagPrefix(ctx: ProjectContext, prefix: string): TaggedNote[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  const { store } = state;
-
-  const seen = new Map<string, TaggedNote>();
-  const tagStmts = store.statementsMatching(undefined, MINERVA('hasTag'), undefined);
-  for (const tagStmt of tagStmts) {
-    const tagNode = tagStmt.object as $rdf.NamedNode;
-    const nameStmts = store.statementsMatching(tagNode, MINERVA('tagName'), undefined);
-    const name = nameStmts[0]?.object.value;
-    if (!name) continue;
-    if (name !== prefix && !name.startsWith(`${prefix}/`)) continue;
-    const subject = tagStmt.subject;
-    const isNote = store.statementsMatching(subject, RDF('type'), MINERVA('Note')).length > 0;
-    if (!isNote) continue;
-    const pathStmts = store.statementsMatching(subject, MINERVA('relativePath'), undefined);
-    const relativePath = pathStmts[0]?.object.value ?? '';
-    if (!relativePath || seen.has(relativePath)) continue;
-    const titleStmts = store.statementsMatching(subject, DC('title'), undefined);
-    seen.set(relativePath, {
-      title: titleStmts[0]?.object.value ?? subject.value,
-      relativePath,
-    });
-  }
-  return [...seen.values()].sort((a, b) => a.title.localeCompare(b.title));
-}
-
-export function notesByTag(ctx: ProjectContext, tag: string): TaggedNote[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  const { store } = state;
-
-  const tagNode = tagUri(state, tag);
-  const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), tagNode);
-  return stmts.flatMap((st) => {
-    const subject = st.subject;
-    // Sources also carry hasTag edges (body.md tags); filter them out —
-    // sourcesByTag handles those.
-    const isNote = store.statementsMatching(subject, RDF('type'), MINERVA('Note')).length > 0;
-    if (!isNote) return [];
-    const titleStmts = store.statementsMatching(subject, DC('title'), undefined);
-    const pathStmts = store.statementsMatching(subject, MINERVA('relativePath'), undefined);
-    const relativePath = pathStmts[0]?.object.value ?? '';
-    if (!relativePath) return [];
-    return [{
-      title: titleStmts[0]?.object.value ?? subject.value,
-      relativePath,
-    }];
-  });
-}
-
-export function sourcesByTag(ctx: ProjectContext, tag: string): TaggedSource[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  const { store } = state;
-
-  const tagNode = tagUri(state, tag);
-  const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), tagNode);
-  return stmts.flatMap((st) => {
-    const subject = st.subject;
-    const idStmts = store.statementsMatching(subject, MINERVA('sourceId'), undefined);
-    const sourceId = idStmts[0]?.object.value;
-    if (!sourceId) return [];
-    const titleStmts = store.statementsMatching(subject, DC('title'), undefined);
-    return [{
-      sourceId,
-      title: titleStmts[0]?.object.value ?? sourceId,
-    }];
-  });
-}
-
 /**
  * List every indexed source with its display metadata, sorted by title.
  * Used by the sidebar's Sources panel for navigation.
@@ -479,21 +378,6 @@ export function listAllSources(ctx: ProjectContext): SourceMetadata[] {
     return ta.localeCompare(tb);
   });
   return entries;
-}
-
-export function allTags(ctx: ProjectContext): string[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  const { store } = state;
-  const tags = new Set<string>();
-  const stmts = store.statementsMatching(undefined, RDF('type'), MINERVA('Tag'));
-  for (const st of stmts) {
-    const nameStmts = store.statementsMatching(st.subject, MINERVA('tagName'), undefined);
-    if (nameStmts[0]) {
-      tags.add(nameStmts[0].object.value);
-    }
-  }
-  return [...tags].sort();
 }
 
 // ── Link queries ────────────────────────────────────────────────────────────

--- a/src/main/graph/queries/tags.ts
+++ b/src/main/graph/queries/tags.ts
@@ -1,0 +1,145 @@
+/**
+ * Tag queries (#1838 — split by family out of `queries.ts`).
+ *
+ * Everything that answers a question keyed by TAG: the project-wide tag list
+ * with its counts, the notes and sources carrying a given tag, the prefix
+ * ("at or under this branch") variant the tag tree's parent rows need, and the
+ * bare vocabulary.
+ *
+ * Read-only, like the rest of the query side: these walk the per-project store
+ * from `../state` and never mutate it. `queries.ts` re-exports them, so
+ * `import * as graph from './graph/index'` callers are unchanged.
+ *
+ * Note what is deliberately NOT here: `listAllSources` sits between these
+ * functions in the old file but is a source query, not a tag one — it calls
+ * `collectSourceMetadata` and belongs with the source-detail family when that
+ * moves.
+ */
+import type * as $rdf from 'rdflib';
+import type { ProjectContext } from '../../project-context-types';
+import type { TagInfo, TaggedNote, TaggedSource } from '../../../shared/types';
+import { getState, MINERVA, RDF, DC, tagUri } from '../state';
+
+export function listTags(ctx: ProjectContext): TagInfo[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+
+  // Bucket per tag-name into note vs source counts. A subject is a
+  // source when it carries minerva:sourceId; otherwise we treat the
+  // hasTag edge as belonging to a note (this matches what notesByTag
+  // returns once the rdf:type filter has been applied).
+  const buckets = new Map<string, { noteCount: number; sourceCount: number }>();
+  const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), undefined);
+  for (const st of stmts) {
+    const tagNode = st.object;
+    const nameStmts = store.statementsMatching(tagNode as $rdf.NamedNode, MINERVA('tagName'), undefined);
+    const name = nameStmts[0]?.object.value ?? tagNode.value;
+    let bucket = buckets.get(name);
+    if (!bucket) {
+      bucket = { noteCount: 0, sourceCount: 0 };
+      buckets.set(name, bucket);
+    }
+    const isSource = store.statementsMatching(st.subject, MINERVA('sourceId'), undefined).length > 0;
+    if (isSource) bucket.sourceCount++;
+    else bucket.noteCount++;
+  }
+
+  return [...buckets.entries()]
+    .map(([tag, b]) => ({ tag, noteCount: b.noteCount, sourceCount: b.sourceCount }))
+    .sort((a, b) => a.tag.localeCompare(b.tag));
+}
+
+/**
+ * Notes with any tag at-or-under `prefix` (#466). Matches the literal
+ * `prefix` and any tag that starts with `prefix/…` so clicking a
+ * parent row in the tree returns the same set the cumulative count
+ * promised. Deduped by relativePath since one note can carry multiple
+ * matching tags.
+ */
+export function notesByTagPrefix(ctx: ProjectContext, prefix: string): TaggedNote[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+
+  const seen = new Map<string, TaggedNote>();
+  const tagStmts = store.statementsMatching(undefined, MINERVA('hasTag'), undefined);
+  for (const tagStmt of tagStmts) {
+    const tagNode = tagStmt.object as $rdf.NamedNode;
+    const nameStmts = store.statementsMatching(tagNode, MINERVA('tagName'), undefined);
+    const name = nameStmts[0]?.object.value;
+    if (!name) continue;
+    if (name !== prefix && !name.startsWith(`${prefix}/`)) continue;
+    const subject = tagStmt.subject;
+    const isNote = store.statementsMatching(subject, RDF('type'), MINERVA('Note')).length > 0;
+    if (!isNote) continue;
+    const pathStmts = store.statementsMatching(subject, MINERVA('relativePath'), undefined);
+    const relativePath = pathStmts[0]?.object.value ?? '';
+    if (!relativePath || seen.has(relativePath)) continue;
+    const titleStmts = store.statementsMatching(subject, DC('title'), undefined);
+    seen.set(relativePath, {
+      title: titleStmts[0]?.object.value ?? subject.value,
+      relativePath,
+    });
+  }
+  return [...seen.values()].sort((a, b) => a.title.localeCompare(b.title));
+}
+
+export function notesByTag(ctx: ProjectContext, tag: string): TaggedNote[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+
+  const tagNode = tagUri(state, tag);
+  const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), tagNode);
+  return stmts.flatMap((st) => {
+    const subject = st.subject;
+    // Sources also carry hasTag edges (body.md tags); filter them out —
+    // sourcesByTag handles those.
+    const isNote = store.statementsMatching(subject, RDF('type'), MINERVA('Note')).length > 0;
+    if (!isNote) return [];
+    const titleStmts = store.statementsMatching(subject, DC('title'), undefined);
+    const pathStmts = store.statementsMatching(subject, MINERVA('relativePath'), undefined);
+    const relativePath = pathStmts[0]?.object.value ?? '';
+    if (!relativePath) return [];
+    return [{
+      title: titleStmts[0]?.object.value ?? subject.value,
+      relativePath,
+    }];
+  });
+}
+
+export function sourcesByTag(ctx: ProjectContext, tag: string): TaggedSource[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+
+  const tagNode = tagUri(state, tag);
+  const stmts = store.statementsMatching(undefined, MINERVA('hasTag'), tagNode);
+  return stmts.flatMap((st) => {
+    const subject = st.subject;
+    const idStmts = store.statementsMatching(subject, MINERVA('sourceId'), undefined);
+    const sourceId = idStmts[0]?.object.value;
+    if (!sourceId) return [];
+    const titleStmts = store.statementsMatching(subject, DC('title'), undefined);
+    return [{
+      sourceId,
+      title: titleStmts[0]?.object.value ?? sourceId,
+    }];
+  });
+}
+
+export function allTags(ctx: ProjectContext): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const { store } = state;
+  const tags = new Set<string>();
+  const stmts = store.statementsMatching(undefined, RDF('type'), MINERVA('Tag'));
+  for (const st of stmts) {
+    const nameStmts = store.statementsMatching(st.subject, MINERVA('tagName'), undefined);
+    if (nameStmts[0]) {
+      tags.add(nameStmts[0].object.value);
+    }
+  }
+  return [...tags].sort();
+}


### PR DESCRIPTION
Closes #1838. Three families out; `queries.ts` 1,294 → 377 lines.

`queries.ts` was the largest module in main, carrying six unrelated query families behind section comments — the shape `indexers.ts` had before #1624 split it. Same treatment, one commit per family so review can go a family at a time.

| Module | Lines | Contents |
| --- | --- | --- |
| `queries/tags.ts` | 145 | tag list + counts, notes/sources by tag, the prefix variant, the vocabulary |
| `queries/sources.ts` | 523 | source detail, reading queue, per-note citations, excerpt→source |
| `queries/links.ts` | 345 | outgoing, backlinks, safe-delete blockers, title lookups |
| `queries.ts` | 377 | the note-lookup core: aliases/frontmatter, citation/anchor lookups, SPARQL |

All three are **pure moves** — no signature or logic changes — re-exported from `queries.ts`, so `graph/index` and every existing importer is untouched. **The whole suite (6,057) passes with no test edits**, which is the proof that matters for this kind of change.

### Two corrections to the plan in the issue

**The tag block wasn't what the issue said it was.** It named lines 348-497 as "six exported functions, no cross-family calls". `listAllSources` sits inside that range but is a *source* query, and it calls `collectSourceMetadata` from the source-detail family 400 lines further down. Moving the block as delimited would have dragged a cross-family dependency into a file called `tags.ts`. It moved with the source family instead — which is what made both files honest.

**I stopped at three families, not five.** What's left in `queries.ts` is ~340 lines of note lookups plus the SPARQL plumbing, and those genuinely belong together — they all answer "what does the store know about this note?". Splitting further would buy directory entries rather than clarity.

Each extraction was checked in both directions before moving: does the block call anything up-file, and does anything up-file call into the block. `DAY_MS` and `ReadingQueueView` moved with the reading-queue code that owns them and are re-exported, since `llm/approval` and `graph/index` import them from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy