### PR TITLE
feat(cli): enforce the CLI's electron-free boundary (#1839)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -275,6 +275,42 @@ export default tseslint.config(
       }],
     },
   },
+  // ── CLI boundary (#1839, epic #1145 — Substrate) ───────────────────────
+  // `src/cli` is the fifth layer and the only one that runs OUTSIDE Electron:
+  // `node .vite/build/cli.js …` (and the same bundle under
+  // ELECTRON_RUN_AS_NODE inside the packaged app). It deliberately DOES import
+  // `src/main` — the read engine reuses the app's graph / search / tables /
+  // proposal modules rather than forking them — so there is no cli→main rule to
+  // add here. What it must never reach for is a window: `src/renderer` is
+  // Svelte + DOM (there is no DOM in this process) and `src/preload` is a
+  // contextBridge shim that only means anything inside a BrowserWindow;
+  // importing either would evaluate Electron-only code at module load and turn
+  // a headless run into a crash. `electron` itself is out too — the CLI build
+  // aliases it to the all-undefined `src/cli/electron-stub.ts` precisely so no
+  // `require('electron')` survives into a bundle the packaged app can't
+  // resolve, and CLI code written against that stub would be reading
+  // `undefined`. Runtime counterpart: tests/cli/electron-free.test.ts.
+  {
+    files: ['src/cli/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: ['**/renderer/**', '**/preload/**'],
+            message:
+              'src/cli runs under plain Node — it must not import renderer (DOM/Svelte) or preload ' +
+              '(contextBridge) code, which only exist inside an Electron window (#1839).',
+          },
+          {
+            group: ['electron'],
+            message:
+              'src/cli must not import electron — the CLI build aliases it to an all-undefined stub, ' +
+              'so anything read from it is undefined at runtime (#1839).',
+          },
+        ],
+      }],
+    },
+  },
   // ── Renderer data-flow rule (#1086 / #1674) ────────────────────────────
   // Components may call `api.*` only for reads + stateless OS side-effects.
   // A mutation `api.<domain>.<method>(…)` (or an `api.*.on*` event

--- a/tests/cli/electron-free.test.ts
+++ b/tests/cli/electron-free.test.ts
@@ -1,0 +1,240 @@
+/**
+ * The CLI's "electron-free read core" guarantee, enforced (#1839, epic #1145).
+ *
+ * `src/cli` is the one layer that runs OUTSIDE Electron. That property used to
+ * be held entirely by a build-time alias (`vite.cli.config.mts` maps `electron`
+ * to the all-undefined `src/cli/electron-stub.ts`) plus the happy accident of
+ * which functions the CLI's commands happen to reach at runtime — nothing at
+ * lint or test time noticed when new `src/main` code on the CLI's import graph
+ * started calling an Electron API. The eslint block for `src/cli/**` covers the
+ * layer's own imports; this file covers the transitive graph, in two ways:
+ *
+ *  1. **The runtime proof.** Build the real bundle and run it under plain
+ *     `node` (not Electron, no ELECTRON_RUN_AS_NODE), against a real temp
+ *     thoughtbase, asserting the exit-code + JSON contract. This is the
+ *     `.vite/build/cli.js` shipping artifact, not a vitest-transformed import,
+ *     so a bundle that can't boot headless fails here rather than in someone's
+ *     terminal. The build is a rolldown SSR pass over ~2900 modules and takes
+ *     about a second, which is why it's affordable to do inline.
+ *
+ *  2. **The static ratchet.** Walk the import graph from the CLI entry and pin
+ *     the set of modules that import `electron` at all. Every one of them is
+ *     latent-only — the Electron reference sits inside a function no CLI
+ *     command calls — and the list below says so per module. That's a claim a
+ *     reviewer has to re-make deliberately: adding an eighth electron importer
+ *     to the CLI's graph fails this test and forces the question "is this one
+ *     reached?" The runtime proof above can't ask it, because it can only
+ *     observe the paths the tested commands happen to take.
+ *
+ * The durable fix for the list is the follow-up named in #1839: route every
+ * `app.getPath('userData')` through a single `main/config/user-data-path.ts`
+ * the CLI can stub, instead of the independent reach-throughs pinned below.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { createRequire } from 'node:module';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const CLI_ENTRY = path.join(REPO_ROOT, 'src', 'cli', 'main.ts');
+const CLI_BUNDLE = path.join(REPO_ROOT, '.vite', 'build', 'cli.js');
+
+/**
+ * Modules on the CLI's import graph that import `electron`.
+ *
+ * Importing it is harmless on its own: every entry below reads `app` / `dialog`
+ * / `safeStorage` from inside a function body, never at module scope, and the
+ * CLI build swaps the module for a stub whose exports are all `undefined`. What
+ * would NOT be harmless is a CLI command reaching one of those function bodies
+ * — `app.getPath(…)` on an undefined `app` throws. None do today, for the
+ * reasons noted per entry.
+ */
+const ELECTRON_IMPORTERS_ON_CLI_GRAPH = [
+  // `app.getPath('userData')` for the on-disk embedding cache, behind
+  // `app?.isPackaged` — already undefined-safe, and the CLI passes its own
+  // `resourcesBase` anyway (run.ts derives it from __dirname).
+  'src/main/embeddings/shared-embedder.ts',
+  // `app.getPath` for the packaged help corpus, also behind `app?.isPackaged`.
+  // Help docs are an in-app search surface; no CLI command exposes them.
+  'src/main/help-docs/corpus-store.ts',
+  // `app.getPath('userData')` for history-settings.json. Reachable because
+  // notebase/fs's write path calls history's capture hooks — but no CLI command
+  // writes a note through it: `propose-note` files a pending proposal and
+  // approval (the thing that actually writes) is app-only. Flagged as the
+  // newest reach-through in #1839; allowlisted rather than patched because the
+  // call is ALREADY lazy — it sits inside `settingsPath()`, which only runs
+  // when `getHistorySettings()` is called — so there is nothing local left to
+  // make lazier. The remaining exposure is shared with the six entries around
+  // it, and its fix is the shared user-data-path module, not a bespoke
+  // undefined-check here.
+  'src/main/history/settings.ts',
+  // `app.getPath('userData')` for the model/provider settings file. The CLI
+  // runs no LLM calls; `propose-note` takes its content from stdin.
+  'src/main/llm/settings.ts',
+  // `dialog` for the native project picker. The CLI resolves its root from
+  // `--project` / cwd and never opens a picker.
+  'src/main/notebase/fs.ts',
+  // `app.getPath('userData')` for the recent-projects list — a window-reopening
+  // convenience with no CLI equivalent.
+  'src/main/recent-projects.ts',
+  // `safeStorage` for encrypted secrets (clipper token, API keys). Nothing the
+  // read core touches.
+  'src/main/secret-storage.ts',
+].sort();
+
+/** Import specifiers in a TS source: `from '…'`, bare `import '…'`, `import('…')`. */
+function importSpecifiers(source: string): string[] {
+  const re =
+    /(?:import|export)\s[^;]*?from\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)|import\s*['"]([^'"]+)['"]/g;
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source))) out.push(m[1] ?? m[2] ?? m[3] ?? '');
+  return out.filter(Boolean);
+}
+
+/** Resolve a relative specifier the way the bundler does (`.ts`, then `/index.ts`). */
+function resolveRelative(fromFile: string, spec: string): string | null {
+  if (!spec.startsWith('.')) return null;
+  const base = path.resolve(path.dirname(fromFile), spec);
+  for (const candidate of [`${base}.ts`, path.join(base, 'index.ts')]) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+  }
+  return null;
+}
+
+/** Every in-repo module transitively reachable from `entry`. */
+function reachableModules(entry: string): Set<string> {
+  const seen = new Set<string>();
+  const stack = [entry];
+  while (stack.length > 0) {
+    const file = stack.pop() as string;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    for (const spec of importSpecifiers(fs.readFileSync(file, 'utf-8'))) {
+      const resolved = resolveRelative(file, spec);
+      if (resolved) stack.push(resolved);
+    }
+  }
+  return seen;
+}
+
+describe('CLI import graph — electron reach-through ratchet (#1839)', () => {
+  const graph = reachableModules(CLI_ENTRY);
+
+  it('reaches the read core it is supposed to reuse', () => {
+    // Sanity check on the walker itself: if a regex or resolution change made it
+    // silently traverse nothing, the assertion below would pass vacuously.
+    expect(graph.size).toBeGreaterThan(100);
+    expect(graph).toContain(path.join(REPO_ROOT, 'src', 'main', 'notebase', 'fs.ts'));
+  });
+
+  it('pins the set of modules that import electron', () => {
+    const found = [...graph]
+      .filter((f) => importSpecifiers(fs.readFileSync(f, 'utf-8')).includes('electron'))
+      .map((f) => path.relative(REPO_ROOT, f))
+      .sort();
+    // A diff here means the CLI's graph gained (or dropped) an electron
+    // importer. Adding one is allowed — but only after checking that no CLI
+    // command can reach the Electron call, and saying so in the list above.
+    expect(found).toEqual(ELECTRON_IMPORTERS_ON_CLI_GRAPH);
+  });
+
+  it('has no electron import in src/cli itself', () => {
+    // Belt to the eslint block's braces: the layer's own code is stub-free too,
+    // so `electron-stub.ts` stays the single place that shape is described.
+    const own = [...graph].filter((f) => f.startsWith(path.join(REPO_ROOT, 'src', 'cli')));
+    expect(own.length).toBeGreaterThan(0);
+    for (const file of own) {
+      expect(importSpecifiers(fs.readFileSync(file, 'utf-8'))).not.toContain('electron');
+    }
+  });
+});
+
+describe('built CLI runs under plain Node (#1839)', () => {
+  let root: string;
+
+  beforeAll(() => {
+    // The shipping artifact, built the way `pnpm cli:build` builds it. Vite's
+    // JS entry is resolved rather than reached for at `node_modules/.bin` so
+    // this works from a git worktree too, where deps resolve upward to the
+    // parent checkout's tree.
+    const vitePkg = createRequire(import.meta.url).resolve('vite/package.json');
+    const viteBin = path.join(path.dirname(vitePkg), 'bin', 'vite.js');
+    execFileSync(process.execPath, [viteBin, 'build', '--config', 'vite.cli.config.mts'], {
+      cwd: REPO_ROOT,
+      stdio: 'pipe',
+    });
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-cli-headless-'));
+    fs.mkdirSync(path.join(root, 'notes'));
+    fs.writeFileSync(
+      path.join(root, 'notes', 'photosynthesis.md'),
+      '---\ntitle: Photosynthesis\ntags: [biology, energy]\n---\n\n' +
+        'Photosynthesis converts light into chemical energy. See [[chlorophyll]].\n',
+      'utf-8',
+    );
+  }, 180_000);
+
+  afterAll(async () => {
+    if (root) await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  /** Spawn the bundle with THIS process's node binary — vitest runs under plain
+   *  Node, so there is no Electron anywhere in the child's environment. */
+  function runBundle(args: string[], stdin = ''): { code: number | null; stdout: string; stderr: string } {
+    const r = spawnSync(process.execPath, [CLI_BUNDLE, ...args, '--project', root], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      input: stdin,
+      timeout: 120_000,
+    });
+    return { code: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+  }
+
+  it('emits no require("electron") into the bundle', () => {
+    // The packaged app ships no npm `electron` package, so a surviving require
+    // would fail to resolve there (#1437) — and in a dev checkout it would
+    // resolve to the binary-path string, quietly reinstating the undefined
+    // exports the alias exists to make explicit.
+    const bundle = fs.readFileSync(CLI_BUNDLE, 'utf-8');
+    expect(bundle).not.toMatch(/require\(\s*['"]electron['"]\s*\)/);
+  });
+
+  it('answers a SPARQL query with grounded node IRIs and exits 0', () => {
+    const r = runBundle(['query', 'PREFIX dc: <http://purl.org/dc/terms/> SELECT ?s ?t WHERE { ?s dc:title ?t }']);
+    expect(r.stderr).toBe('');
+    expect(r.code).toBe(0);
+    const parsed = JSON.parse(r.stdout) as { columns: string[]; results: Record<string, string>[] };
+    expect(parsed.columns).toContain('s');
+    expect(parsed.results.map((row) => row.t)).toContain('Photosynthesis');
+    expect(parsed.results.some((row) => (row.s ?? '').includes('/note/notes/photosynthesis'))).toBe(true);
+  }, 120_000);
+
+  it('reads a note and exits 0', () => {
+    const r = runBundle(['read', 'notes/photosynthesis.md']);
+    expect(r.stderr).toBe('');
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout)).toMatchObject({ path: 'notes/photosynthesis.md' });
+  }, 120_000);
+
+  it('files a proposal — the only write path — and exits 0', () => {
+    // The CLI's write surface, headless. Empty stderr matters as much as the
+    // exit code: history's capture hooks and the graph indexer swallow their own
+    // errors and only console.error, so a silent Electron failure on this path
+    // would show up here as noise on stderr rather than a non-zero exit.
+    const r = runBundle(['propose-note', 'notes/chlorophyll.md'], '# Chlorophyll\n\nThe green pigment.\n');
+    expect(r.stderr).toBe('');
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout)).toMatchObject({ status: 'pending', relativePath: 'notes/chlorophyll.md' });
+    // Still a proposal, not a note: the CLI never writes into the thoughtbase.
+    expect(fs.existsSync(path.join(root, 'notes', 'chlorophyll.md'))).toBe(false);
+  }, 120_000);
+
+  it('reports a usage error with exit code 2, not a crash', () => {
+    const r = runBundle(['query']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('SPARQL string is required');
+  }, 120_000);
+});


### PR DESCRIPTION
Closes #1839.

`src/cli` was the fifth layer with no boundary rule. Its "electron-free read core" guarantee (epic #1145) rested entirely on a build-time alias mapping `electron` to an all-undefined stub, plus the happy accident of which functions the CLI's commands happen to reach. Nothing at lint or test time noticed when new `src/main` code on the CLI's import graph started calling an Electron API — the failure mode was a silent no-op at runtime.

### The lint half

An `eslint.config.mjs` block for `src/cli/**/*.ts` in the style of the #668 layer blocks, forbidding `src/renderer` / `src/preload` (DOM and contextBridge code that only means anything inside a BrowserWindow) and `electron` itself (the build aliases it to a stub, so anything read from it is `undefined`).

Deliberately **no** cli→main restriction: `cli/engine.ts` importing eight `src/main` modules is the design — the read engine reuses the app's graph/search/tables/proposal modules rather than forking them.

### The test half

`tests/cli/electron-free.test.ts`, in two parts:

1. **Runtime proof.** Builds the real `.vite/build/cli.js` (a ~0.6s rolldown pass, cheap enough to do inline) and runs it under plain `node` — no Electron, no `ELECTRON_RUN_AS_NODE` — against a temp thoughtbase, asserting the exit-code and JSON contract for `query`, `read`, `propose-note` via stdin, and a missing-argument case. Plus: the bundle contains no `require("electron")`.
2. **Static ratchet.** Walks the import graph from `src/cli/main.ts` (165 modules) and pins the exact set that imports `electron` — currently seven — each with a comment on why no CLI command reaches its Electron call. An eighth importer fails the test and forces the question the runtime half can't ask, since it only observes the paths the tested commands take.

### On `history/settings.ts`

The issue framed this as the newest reach-through to fix. It's allowlisted with a reason instead, and the reasoning is worth recording: it isn't special — it's one of seven identical shapes — and its `app.getPath('userData')` is *already* lazy, inside `settingsPath()`, which `loadConfigFile` only invokes when `getHistorySettings()` is called. Nothing local is left to make lazier. It's unreachable from the CLI because the CLI never writes a note through `notebase/fs.writeFile` (which is what fires history's capture hooks) — `propose-note` files a pending proposal, and approval is app-only.

The real fix is the single `main/config/user-data-path.ts` the issue names as a follow-up, tracked in #1853. A bespoke undefined-check here would have been a seventh workaround, not a fix.

`pnpm lint` clean; full suite 6,065 passing (601 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy