### PR TITLE
fix(ipc): "no project open" throws instead of answering null (#1841)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,16 +140,17 @@ thrown error already propagates cleanly. Build on that:
 
 **Migration backlog** (audited outliers, fix incrementally per the rules above):
 
-- `null` no-project↔not-found: `GRAPH_SOURCE_DETAIL`, `GRAPH_EXCERPT_SOURCE`,
-  `PROPOSAL_DETAIL` (→ `withRootPath` so `null` means only "not found");
-  `TEMPLATES_GET`, `CONVERSATION_LOAD` (corrupt → throw).
+- `null` no-project↔not-found: *(cleared — `GRAPH_SOURCE_DETAIL`,
+  `GRAPH_EXCERPT_SOURCE`, `PROPOSAL_DETAIL`, `TEMPLATES_GET` and
+  `CONVERSATION_LOAD` are all `withRootPath` now, #1841.)*
 - boolean overloads: `NOTEBASE_FILE_EXISTS`, proposals `APPROVE` / `REJECT`
   (`false` = no-project ↔ failed).
 - in-band `error?` → union: `GRAPH_QUERY` (`{ results, columns, error? }` should
   match the `TABLES_QUERY` `{ ok:false; error }` shape).
 - swallows: `LINKS_CITATIONS_FOR_NOTE` (`.catch(()=>'')`), `CSL_REMOVE_STYLE` /
-  `CSL_REMOVE_LOCALE` (unlink swallows non-ENOENT), `FORMATTER_LOAD_SETTINGS`
-  (→ `readJsonFileOr`), `RUN_COMPUTE_DRAFT` (log-only append / audit-record).
+  `CSL_REMOVE_LOCALE` (unlink swallows non-ENOENT), `RUN_COMPUTE_DRAFT`
+  (log-only append / audit-record). `FORMATTER_LOAD_SETTINGS` uses
+  `readJsonFileOr` as of #1841.
 - vestigial: `GIT_COMMIT.success` (hardcoded `true` — any failure throws).
 
 ### Config files (#1640)

--- a/src/main/ipc/register-graph.ts
+++ b/src/main/ipc/register-graph.ts
@@ -57,10 +57,13 @@ export function registerGraph(): void {
   handle(Channels.GRAPH_SCHEMA_FOR_COMPLETION, withRootPathOr(null, (rootPath) =>
     graph.schemaForCompletion(projectContext(rootPath))));
 
-  handle(Channels.GRAPH_SOURCE_DETAIL, withRootPathOr(null, (rootPath, sourceId: string) =>
+  // `null` means exactly one thing here: no such source in the graph (#1841).
+  // "No project open" is a failure, not an absence, so it throws (withRootPath).
+  handle(Channels.GRAPH_SOURCE_DETAIL, withRootPath((rootPath, sourceId: string) =>
     graph.getSourceDetail(projectContext(rootPath), sourceId)));
 
-  handle(Channels.GRAPH_EXCERPT_SOURCE, withRootPathOr(null, (rootPath, excerptId: string) =>
+  // Same contract: `null` = no source anchors this excerpt, never "no project".
+  handle(Channels.GRAPH_EXCERPT_SOURCE, withRootPath((rootPath, excerptId: string) =>
     graph.getExcerptSource(projectContext(rootPath), excerptId)));
 
   handle(Channels.GRAPH_ATTACH_EXCERPT_EVIDENCE, withRootPathOr<[string, string, 'grounds' | 'supports' | 'rebuts'], AttachEvidenceResult | Promise<AttachEvidenceResult>>(

--- a/src/main/ipc/register-proposals.ts
+++ b/src/main/ipc/register-proposals.ts
@@ -11,13 +11,15 @@ import { broadcast } from './broadcast';
 import * as approval from '../llm/approval';
 import type { Proposal } from '../llm/approval';
 import { projectContext } from '../project-context-types';
-import { withRootPathOr, winFromEvent } from './helpers';
+import { withRootPath, withRootPathOr, winFromEvent } from './helpers';
 import { handle } from './typed-ipc';
 
 export function registerProposals(): void {
   handle(Channels.PROPOSAL_LIST, withRootPathOr<[string?], Proposal[] | Promise<Proposal[]>>([], (rootPath, status?: string) =>
     approval.listProposals(projectContext(rootPath), status)));
-  handle(Channels.PROPOSAL_DETAIL, withRootPathOr(null, (rootPath, uri: string) =>
+  // `null` = no proposal at that URI (expired, rejected-and-swept, bad URI).
+  // "No project open" throws instead of folding into the same `null` (#1841).
+  handle(Channels.PROPOSAL_DETAIL, withRootPath((rootPath, uri: string) =>
     approval.getProposal(projectContext(rootPath), uri)));
   handle(Channels.PROPOSAL_APPROVE, withRootPathOr<[string], boolean | Promise<boolean>>(false, async (rootPath, uri: string) => {
     const result = await approval.approveProposal(projectContext(rootPath), uri);

--- a/src/main/ipc/register-refactor.ts
+++ b/src/main/ipc/register-refactor.ts
@@ -21,7 +21,7 @@ import type { AutoLinkSuggestion } from '../../shared/refactor/auto-link';
 import type { AutoLinkInboundSuggestion } from '../../shared/refactor/auto-link-inbound';
 import { appendSeeAlsoLink } from '../../shared/refactor/see-also';
 import * as notebaseFs from '../notebase/fs';
-import { rootPathFromEvent, withRootPath, withRootPathOr, persistIndexes, broadcastRewritten, hooks } from './helpers';
+import { rootPathFromEvent, withRootPath, withRootPathOr, readJsonFileOr, persistIndexes, broadcastRewritten, hooks } from './helpers';
 import { handle } from './typed-ipc';
 
 export function registerRefactor(): void {
@@ -93,16 +93,20 @@ export function registerRefactor(): void {
   // Project-scoped formatter settings (#154). Stored in .minerva/formatter.json
   // so rule choices travel with the thoughtbase in git.
   type FormatterSettings = { enabled: Record<string, boolean>; configs: Record<string, unknown> };
-  handle(Channels.FORMATTER_LOAD_SETTINGS, withRootPathOr<[], FormatterSettings | Promise<FormatterSettings>>({ enabled: {}, configs: {} }, async (rootPath) => {
-    try {
-      const p = path.join(rootPath, '.minerva', 'formatter.json');
-      const data = await fs.readFile(p, 'utf-8');
-      const parsed = JSON.parse(data) as { enabled?: Record<string, boolean>; configs?: Record<string, unknown> };
-      return {
-        enabled: (parsed?.enabled && typeof parsed.enabled === 'object') ? parsed.enabled : {},
-        configs: (parsed?.configs && typeof parsed.configs === 'object') ? parsed.configs : {},
-      };
-    } catch { return { enabled: {}, configs: {} }; }
+  // Never written yet (ENOENT) → the house-style defaults, which is what an
+  // empty settings file genuinely means. Anything else — corrupt JSON, an
+  // unreadable file — throws rather than silently presenting itself as
+  // "defaults", which is how a user's rule choices would vanish without a word
+  // (#1841). `readJsonFileOr` draws exactly that line; `loadConfigFile` is the
+  // wrong helper here because it reports-then-falls-back to defaults, which is
+  // the masquerade we're removing. "No project open" throws too.
+  handle(Channels.FORMATTER_LOAD_SETTINGS, withRootPath(async (rootPath): Promise<FormatterSettings> => {
+    const p = path.join(rootPath, '.minerva', 'formatter.json');
+    const parsed = await readJsonFileOr<{ enabled?: Record<string, boolean>; configs?: Record<string, unknown> }>(p, {});
+    return {
+      enabled: (parsed?.enabled && typeof parsed.enabled === 'object') ? parsed.enabled : {},
+      configs: (parsed?.configs && typeof parsed.configs === 'object') ? parsed.configs : {},
+    };
   }));
 
   handle(Channels.FORMATTER_SAVE_SETTINGS, withRootPathOr(undefined, async (rootPath, settings: FormatSettings) => {

--- a/src/main/ipc/register-templates.ts
+++ b/src/main/ipc/register-templates.ts
@@ -10,11 +10,16 @@ export function registerTemplates(): void {
     return templates.listTemplates(rootPath);
   }));
 
-  handle(Channels.TEMPLATES_GET, withRootPathOr(null, async (rootPath, filename: string) => {
+  // `null` marks exactly one expected absence: the template file is gone (the
+  // user deleted it out from under the picker). "No project open" throws, and a
+  // genuine read failure — a bad filename, a permissions error — propagates
+  // rather than masquerading as a missing template (#1841).
+  handle(Channels.TEMPLATES_GET, withRootPath(async (rootPath, filename: string): Promise<string | null> => {
     try {
       return await templates.readTemplate(rootPath, filename);
-    } catch {
-      return null;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw err;
     }
   }));
 

--- a/src/renderer/lib/formatter/settings.ts
+++ b/src/renderer/lib/formatter/settings.ts
@@ -26,7 +26,11 @@ export async function loadFormatSettings(): Promise<FormatSettings> {
       enabled: loaded.enabled ?? {},
       configs: loaded.configs ?? {},
     };
-  } catch {
+  } catch (err) {
+    // The handler now rejects for a corrupt/unreadable formatter.json instead of
+    // quietly handing back defaults (#1841). We still fall back so the app works,
+    // but the reason is logged rather than lost.
+    console.error('[formatter] failed to load settings — using defaults', err);
     settings = { ...DEFAULT_FORMAT_SETTINGS };
   }
   return settings;

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -153,7 +153,11 @@ export interface GraphApi {
    *  a panel showing results can refresh instead of going stale (#1795). */
   onInspectionsChanged(cb: () => void): () => void;
   export(): Promise<void>;
+  /** `null` means exactly one thing: the graph has no such source. Rejects if
+   *  no project is open (#1841). */
   sourceDetail(sourceId: string): Promise<SourceDetail | null>;
+  /** `null` means exactly one thing: no source anchors that excerpt. Rejects if
+   *  no project is open (#1841). */
   excerptSource(excerptId: string): Promise<{ sourceId: string } | null>;
   /** Attach an excerpt as grounds/supports/rebuts evidence for a claim (#1073) —
    *  files a pending proposal reviewed in the Proposals panel. */
@@ -242,7 +246,8 @@ export interface TemplateInfo {
 
 export interface TemplatesApi {
   list(): Promise<TemplateInfo[]>;
-  /** Returns the template body, or `null` if not found. */
+  /** Returns the template body, or `null` for exactly one reason: the file is
+   *  gone. Rejects if no project is open, or on a genuine read failure (#1841). */
   get(filename: string): Promise<string | null>;
   saveAs(name: string, content: string): Promise<TemplateInfo>;
 }
@@ -725,6 +730,8 @@ export interface ConversationsApi {
 
 export interface ProposalsApi {
   list(status?: string): Promise<Proposal[]>;
+  /** `null` means exactly one thing: no proposal at that URI. Rejects if no
+   *  project is open (#1841). */
   detail(uri: string): Promise<Proposal | null>;
   approve(uri: string): Promise<boolean>;
   reject(uri: string): Promise<boolean>;
@@ -819,6 +826,9 @@ export interface FormatterApi {
     relDir: string,
     settings: import('../../../shared/formatter/engine').FormatSettings,
   ): Promise<{ changedPaths: string[]; cascadedPaths: string[]; totalScanned: number }>;
+  /** House-style defaults when nothing has been saved yet. Rejects if no project
+   *  is open, or if `.minerva/formatter.json` is corrupt/unreadable — a broken
+   *  file must not present itself as "defaults" (#1841). */
   loadSettings(): Promise<import('../../../shared/formatter/engine').FormatSettings>;
   saveSettings(settings: import('../../../shared/formatter/engine').FormatSettings): Promise<void>;
 }

--- a/tests/main/ipc/no-project-contract.test.ts
+++ b/tests/main/ipc/no-project-contract.test.ts
@@ -1,0 +1,252 @@
+/**
+ * "No project open" is a failure, not an absence (#1841 / the #1631 IPC error
+ * convention in CLAUDE.md).
+ *
+ * These five handlers used to answer `withRootPathOr(null, …)` — so a caller
+ * that got `null` couldn't tell "the graph has no such source" from "there's no
+ * thoughtbase open at all", and FORMATTER_LOAD_SETTINGS additionally handed back
+ * its defaults when `.minerva/formatter.json` was corrupt. This file pins the
+ * converted contract for all five together:
+ *
+ *   - no project open        → rejects with "No project open"
+ *   - the thing isn't there  → `null` (its ONE remaining meaning)
+ *   - a real IO/parse error  → rejects (never a sentinel, never defaults)
+ *
+ * Style follows register-bookmarks.test.ts: only electron + the project-scoping
+ * helpers are mocked, and the mocked `withRootPath` / `withRootPathOr` reproduce
+ * the real wrappers' semantics — so a handler that regressed back to
+ * `withRootPathOr(null, …)` would resolve `null` here and fail the assertion.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+const { handlers, state, domain } = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  state: { root: null as string | null },
+  domain: {
+    getSourceDetail: vi.fn(),
+    getExcerptSource: vi.fn(),
+    getProposal: vi.fn(),
+    readTemplate: vi.fn(),
+  },
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { handlers.set(channel, fn); } },
+  dialog: { showOpenDialog: vi.fn(), showSaveDialog: vi.fn() },
+  Notification: Object.assign(vi.fn(), { isSupported: () => false }),
+  BrowserWindow: { fromWebContents: () => null },
+  app: { getPath: () => os.tmpdir() },
+  shell: {},
+}));
+
+// Keep the REAL readJsonFileOr (it's what FORMATTER_LOAD_SETTINGS now leans on);
+// only the project-scoping wrappers are stubbed, with the real semantics, so we
+// can steer/clear the open project.
+vi.mock('../../../src/main/ipc/helpers', async () => {
+  const { readJsonFileOr } = await import('../../../src/main/ipc/read-json');
+  return {
+    readJsonFileOr,
+    rootPathFromEvent: () => state.root,
+    withRootPath:
+      <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A) => {
+        if (!state.root) throw new Error('No project open');
+        return fn(state.root, ...args);
+      },
+    withRootPathOr:
+      <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A) => (state.root ? fn(state.root, ...args) : fallback),
+    withRootPathWin:
+      <A extends unknown[], R>(fn: (rootPath: string, win: unknown, ...a: A) => R) =>
+      (_e: unknown, ...args: A) => {
+        if (!state.root) throw new Error('No project open');
+        return fn(state.root, null, ...args);
+      },
+    winFromEvent: () => null,
+    persistIndexes: vi.fn(),
+    broadcastRewritten: vi.fn(),
+    hooks: {},
+  };
+});
+
+// Domain modules the handlers delegate to — stubbed so the test exercises the
+// project-scoping contract, not the graph/approval engines.
+vi.mock('../../../src/main/graph/index', () => ({
+  getSourceDetail: domain.getSourceDetail,
+  getExcerptSource: domain.getExcerptSource,
+  queryGraph: vi.fn(),
+  setBaseUri: vi.fn(),
+  indexAllNotes: vi.fn(),
+  schemaForCompletion: vi.fn(),
+  getAliasMap: vi.fn(),
+  getAliasEntries: vi.fn(),
+  getAllFrontmatterKeys: vi.fn(),
+}));
+vi.mock('../../../src/main/search/index', () => ({ indexAllNotes: vi.fn() }));
+vi.mock('../../../src/main/sources/tables', () => ({
+  runQuery: vi.fn(), listTables: vi.fn(), registerAllCsvs: vi.fn(), registerAllNoteTables: vi.fn(),
+}));
+vi.mock('../../../src/main/graph/health-checks', () => ({ getInspections: vi.fn(), runAllChecks: vi.fn() }));
+vi.mock('../../../src/main/project-config', () => ({ patchProjectConfig: vi.fn(), readProjectConfig: () => ({}) }));
+vi.mock('../../../src/main/graph/rebase-guard', () => ({ checkRebase: vi.fn() }));
+vi.mock('../../../src/main/llm/attach-evidence', () => ({ proposeExcerptEvidence: vi.fn() }));
+vi.mock('../../../src/main/config/inspection-settings', () => ({
+  getInspectionSettings: vi.fn(), saveInspectionSettings: vi.fn(),
+}));
+vi.mock('../../../src/main/project-context-types', () => ({ projectContext: (root: string) => ({ rootPath: root }) }));
+
+vi.mock('../../../src/main/llm/approval', () => ({
+  getProposal: domain.getProposal,
+  listProposals: vi.fn(),
+  approveProposal: vi.fn(),
+  rejectProposal: vi.fn(),
+  expireProposals: vi.fn(),
+}));
+
+vi.mock('../../../src/main/notebase/templates', () => ({
+  readTemplate: domain.readTemplate,
+  listTemplates: vi.fn(),
+  saveTemplate: vi.fn(),
+}));
+
+// register-refactor's LLM / formatter / write-pipeline neighbours.
+vi.mock('../../../src/main/notebase/write-pipeline', () => ({ writeAndReindex: vi.fn() }));
+vi.mock('../../../src/main/history', () => ({ runWithHistorySource: vi.fn() }));
+vi.mock('../../../src/main/window-manager', () => ({ markPathHandled: vi.fn() }));
+vi.mock('../../../src/main/llm/auto-tag', () => ({ runAutoTag: vi.fn(), applyAutoTag: vi.fn() }));
+vi.mock('../../../src/main/llm/auto-link', () => ({
+  suggestLinksTo: vi.fn(), fileAutoLinkOutbound: vi.fn(),
+  suggestLinksInbound: vi.fn(), fileAutoLinkInbound: vi.fn(),
+}));
+vi.mock('../../../src/main/formatter/orchestrator', () => ({
+  formatNoteContent: vi.fn(), formatFile: vi.fn(), formatFolder: vi.fn(),
+}));
+vi.mock('../../../src/main/notebase/fs', () => ({ readFile: vi.fn(), writeFile: vi.fn() }));
+
+import { registerGraph } from '../../../src/main/ipc/register-graph';
+import { registerProposals } from '../../../src/main/ipc/register-proposals';
+import { registerTemplates } from '../../../src/main/ipc/register-templates';
+import { registerRefactor } from '../../../src/main/ipc/register-refactor';
+import { Channels } from '../../../src/shared/channels';
+
+registerGraph();
+registerProposals();
+registerTemplates();
+registerRefactor();
+
+const call = (channel: string, ...args: unknown[]) => handlers.get(channel)!({}, ...args);
+/** `call` wrapped so a SYNCHRONOUS throw (withRootPath fires before the async
+ *  body runs) is assertable with the same `rejects` matcher as an async one. */
+const callAsync = async (channel: string, ...args: unknown[]) => call(channel, ...args);
+
+const enoent = (): NodeJS.ErrnoException =>
+  Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' });
+
+describe('no-project contract (#1841)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-noproj-'));
+    await fs.mkdir(path.join(dir, '.minerva'), { recursive: true });
+    state.root = dir;
+  });
+  afterEach(async () => {
+    state.root = null;
+    await fs.rm(dir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  describe('with no project open, every one of them rejects', () => {
+    beforeEach(() => { state.root = null; });
+
+    it.each([
+      [Channels.GRAPH_SOURCE_DETAIL, ['paxos']],
+      [Channels.GRAPH_EXCERPT_SOURCE, ['ex-1']],
+      [Channels.PROPOSAL_DETAIL, ['minerva:proposal/1']],
+      [Channels.TEMPLATES_GET, ['Meeting.md']],
+      [Channels.FORMATTER_LOAD_SETTINGS, []],
+    ])('%s throws "No project open" instead of answering null/defaults', async (channel, args) => {
+      await expect(callAsync(channel, ...args)).rejects.toThrow(/No project open/);
+    });
+
+    it('none of them reached its domain module', async () => {
+      await expect(callAsync(Channels.GRAPH_SOURCE_DETAIL, 'paxos')).rejects.toThrow();
+      await expect(callAsync(Channels.PROPOSAL_DETAIL, 'u')).rejects.toThrow();
+      await expect(callAsync(Channels.TEMPLATES_GET, 'a.md')).rejects.toThrow();
+      expect(domain.getSourceDetail).not.toHaveBeenCalled();
+      expect(domain.getProposal).not.toHaveBeenCalled();
+      expect(domain.readTemplate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with a project open, `null` keeps its one meaning: not found', () => {
+    it('GRAPH_SOURCE_DETAIL passes through the graph\'s null', async () => {
+      domain.getSourceDetail.mockReturnValue(null);
+      await expect(callAsync(Channels.GRAPH_SOURCE_DETAIL, 'nope')).resolves.toBeNull();
+      expect(domain.getSourceDetail).toHaveBeenCalledWith({ rootPath: dir }, 'nope');
+    });
+
+    it('GRAPH_EXCERPT_SOURCE passes through the graph\'s null', async () => {
+      domain.getExcerptSource.mockReturnValue(null);
+      await expect(callAsync(Channels.GRAPH_EXCERPT_SOURCE, 'nope')).resolves.toBeNull();
+    });
+
+    it('PROPOSAL_DETAIL passes through the approval store\'s null', async () => {
+      domain.getProposal.mockReturnValue(null);
+      await expect(callAsync(Channels.PROPOSAL_DETAIL, 'minerva:proposal/gone')).resolves.toBeNull();
+    });
+
+    it('TEMPLATES_GET returns the body when the template is there', async () => {
+      domain.readTemplate.mockResolvedValue('# {{title}}');
+      await expect(callAsync(Channels.TEMPLATES_GET, 'Meeting.md')).resolves.toBe('# {{title}}');
+    });
+
+    it('TEMPLATES_GET returns null ONLY for a deleted template (ENOENT)', async () => {
+      domain.readTemplate.mockRejectedValue(enoent());
+      await expect(callAsync(Channels.TEMPLATES_GET, 'Gone.md')).resolves.toBeNull();
+    });
+
+    it('TEMPLATES_GET rethrows a real failure rather than calling it "not found"', async () => {
+      domain.readTemplate.mockRejectedValue(new Error('Invalid template filename: ../etc/passwd'));
+      await expect(callAsync(Channels.TEMPLATES_GET, '../etc/passwd')).rejects.toThrow(/Invalid template filename/);
+    });
+  });
+
+  describe('FORMATTER_LOAD_SETTINGS separates "never saved" from "broken"', () => {
+    const settingsPath = () => path.join(dir, '.minerva', 'formatter.json');
+
+    it('returns empty house-style defaults when the file was never written', async () => {
+      await expect(callAsync(Channels.FORMATTER_LOAD_SETTINGS))
+        .resolves.toEqual({ enabled: {}, configs: {} });
+    });
+
+    it('returns the persisted rule choices', async () => {
+      await fs.writeFile(
+        settingsPath(),
+        JSON.stringify({ enabled: { 'trim-trailing': true }, configs: { 'wrap': { width: 80 } } }),
+        'utf-8',
+      );
+      await expect(callAsync(Channels.FORMATTER_LOAD_SETTINGS)).resolves.toEqual({
+        enabled: { 'trim-trailing': true },
+        configs: { 'wrap': { width: 80 } },
+      });
+    });
+
+    it('rejects on corrupt JSON instead of masquerading as defaults', async () => {
+      await fs.writeFile(settingsPath(), '{ "enabled": {', 'utf-8');
+      // The user's rule choices are still on disk, mangled. Silently answering
+      // `{ enabled: {}, configs: {} }` would let the next save overwrite them.
+      await expect(callAsync(Channels.FORMATTER_LOAD_SETTINGS)).rejects.toThrow();
+    });
+
+    it('coerces a structurally-wrong (but valid JSON) payload to empty maps', async () => {
+      await fs.writeFile(settingsPath(), JSON.stringify({ enabled: 'yes', configs: 7 }), 'utf-8');
+      await expect(callAsync(Channels.FORMATTER_LOAD_SETTINGS))
+        .resolves.toEqual({ enabled: {}, configs: {} });
+    });
+  });
+});


### PR DESCRIPTION
Closes #1841. Clears the `null` no-project↔not-found row of CLAUDE.md's #1631 backlog.

Five handlers returned `null` (or a fallback object) for two different facts: "there's no project open" and "that thing doesn't exist". A caller can't tell those apart, and only one of them is an expected answer.

| Handler | Change |
| --- | --- |
| `GRAPH_SOURCE_DETAIL` | `withRootPathOr(null, …)` → `withRootPath` |
| `GRAPH_EXCERPT_SOURCE` | same |
| `PROPOSAL_DETAIL` | same |
| `TEMPLATES_GET` | `withRootPath`, plus the blanket `catch { return null }` narrowed to ENOENT — a bad filename or a permissions error no longer poses as "template deleted" |
| `FORMATTER_LOAD_SETTINGS` | `withRootPath` + `readJsonFileOr` |

**Helper choice worth noting.** The formatter one uses `readJsonFileOr`, not `loadConfigFile`. `loadConfigFile` reports-then-returns defaults, which is exactly the masquerade being removed: a corrupt `.minerva/formatter.json` would still read back as empty, and the next save would overwrite the user's rule choices. `readJsonFileOr` draws the line where it belongs — ENOENT → house-style defaults (what an absent file genuinely means), parse/IO error → throw.

### Every caller checked

The risk in this change is a renderer caller that relied on `null` when no project was open now seeing a rejection. All eleven call sites were traced:

- `PROPOSAL_DETAIL` has **no callers at all** outside the preload bridge.
- `templates.get` (×2), `sourceDetail` (×3), `excerptSource`, and the PdfViewer/SourceDetail/source-ops paths are each either behind an `if (!notebase.meta) return` guard, inside a try/catch, or only reachable from a mounted tab that requires an open project.
- `formatter/settings.ts` already caught and fell back to defaults — but silently, which would have defeated the whole change. It now logs the error before falling back, so a corrupt file is visible rather than absorbed.

None needed the old lenient behaviour.

### Tests

`tests/main/ipc/no-project-contract.test.ts` — 16 tests covering all five handlers in one file. The mocked `withRootPath`/`withRootPathOr` reproduce the real semantics, so a regression back to `withRootPathOr(null, …)` resolves `null` and fails the test. Covers: no-project rejects for all five, the domain modules aren't reached, `null` still flows for genuine not-found, `TEMPLATES_GET` ENOENT → `null` but other errors rethrow, and the formatter's absent / corrupt / structurally-wrong cases.

Client types now document what each `null` means (rule 5 requires it), and CLAUDE.md's backlog is updated to match reality.

`pnpm lint` clean; full suite 6,073 passing (601 files), verified in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy