### PR TITLE
test(ipc): direct handler tests for the notebase, graph and links registrars (#1840)

### DIFF
--- a/tests/main/ipc/register-graph.test.ts
+++ b/tests/main/ipc/register-graph.test.ts
@@ -1,0 +1,391 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-graph.ts` (#1840).
+ *
+ * The graph registrar is where the #1631 rules are most visible in one file: a
+ * `withRootPath` throw (GRAPH_QUERY), a discriminated `{ ok: false }` failure
+ * arm (TABLES_QUERY), plain empty-value fallbacks (alias/frontmatter/inspection
+ * lists), and — in GRAPH_GROUND_CHECK — the one handler that deliberately
+ * REJECTS instead of passing an in-band `error` off as "no matches". All four
+ * are pinned here so a refactor can't quietly swap one for another.
+ *
+ * It also covers the rebase (#1443 B), whose ordering is load-bearing: the base
+ * is persisted, then every index is rebuilt from files with `rebaseFrom` so old
+ * IRIs are rewritten, and CSVs are registered before note tables.
+ *
+ * `withRootPath*` are re-implemented in the helpers mock with the real
+ * semantics (helpers.ts drags in electron + graph/search/vectors, so it can't
+ * be imported here); what's under test is WHICH wrapper each handler chose.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  win: { id: 1, isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
+  // electron / fs
+  showSaveDialog: vi.fn(),
+  copyFile: vi.fn(),
+  // graph
+  queryGraph: vi.fn(),
+  setBaseUri: vi.fn(),
+  graphIndexAllNotes: vi.fn(),
+  schemaForCompletion: vi.fn(),
+  getSourceDetail: vi.fn(),
+  getExcerptSource: vi.fn(),
+  getAliasMap: vi.fn(),
+  getAliasEntries: vi.fn(),
+  getAllFrontmatterKeys: vi.fn(),
+  persistGraph: vi.fn(),
+  // search / tables
+  searchIndexAllNotes: vi.fn(),
+  runQuery: vi.fn(),
+  listTables: vi.fn(),
+  registerAllCsvs: vi.fn(),
+  registerAllNoteTables: vi.fn(),
+  // health checks / settings
+  getInspections: vi.fn(),
+  runAllChecks: vi.fn(),
+  getInspectionSettings: vi.fn(),
+  saveInspectionSettings: vi.fn(),
+  // project config / evidence
+  patchProjectConfig: vi.fn(),
+  readProjectConfig: vi.fn(),
+  proposeExcerptEvidence: vi.fn(),
+  // call-order log — the rebuild sequence is load-bearing
+  order: [] as string[],
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+  dialog: { showSaveDialog: h.showSaveDialog },
+}));
+
+vi.mock('node:fs/promises', () => ({ default: { copyFile: h.copyFile }, copyFile: h.copyFile }));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+  withRootPathWin:
+    <A extends unknown[], R>(fn: (rootPath: string, win: unknown, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, h.win, ...args);
+      },
+}));
+
+vi.mock('../../../src/main/graph/index', () => ({
+  queryGraph: h.queryGraph,
+  setBaseUri: h.setBaseUri,
+  indexAllNotes: h.graphIndexAllNotes,
+  schemaForCompletion: h.schemaForCompletion,
+  getSourceDetail: h.getSourceDetail,
+  getExcerptSource: h.getExcerptSource,
+  getAliasMap: h.getAliasMap,
+  getAliasEntries: h.getAliasEntries,
+  getAllFrontmatterKeys: h.getAllFrontmatterKeys,
+  persistGraph: h.persistGraph,
+}));
+vi.mock('../../../src/main/search/index', () => ({ indexAllNotes: h.searchIndexAllNotes }));
+vi.mock('../../../src/main/sources/tables', () => ({
+  runQuery: h.runQuery,
+  listTables: h.listTables,
+  registerAllCsvs: h.registerAllCsvs,
+  registerAllNoteTables: h.registerAllNoteTables,
+}));
+vi.mock('../../../src/main/graph/health-checks', () => ({
+  getInspections: h.getInspections,
+  runAllChecks: h.runAllChecks,
+}));
+vi.mock('../../../src/main/config/inspection-settings', () => ({
+  getInspectionSettings: h.getInspectionSettings,
+  saveInspectionSettings: h.saveInspectionSettings,
+}));
+vi.mock('../../../src/main/project-config', () => ({
+  patchProjectConfig: h.patchProjectConfig,
+  readProjectConfig: h.readProjectConfig,
+}));
+vi.mock('../../../src/main/llm/attach-evidence', () => ({ proposeExcerptEvidence: h.proposeExcerptEvidence }));
+
+import { registerGraph } from '../../../src/main/ipc/register-graph';
+import { Channels } from '../../../src/shared/channels';
+
+registerGraph();
+
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!({}, ...args);
+/** Await a handler's answer whether it replied synchronously or with a promise
+ *  (the `withRootPathOr` fallbacks are returned synchronously). */
+const callAsync = async (channel: string, ...args: unknown[]): Promise<unknown> => call(channel, ...args);
+/** The ProjectContext the registrar builds from the root path. */
+const CTX = { rootPath: ROOT, _brand: 'ProjectContext' };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  openProject = ROOT;
+  h.order.length = 0;
+  h.win.isDestroyed.mockReturnValue(false);
+  h.readProjectConfig.mockReturnValue({});
+  h.queryGraph.mockResolvedValue({ results: [], columns: [] });
+});
+
+describe('register-graph — the #1631 project guard', () => {
+  it('GRAPH_QUERY throws with no project rather than answering "no rows"', () => {
+    // An empty result set would read as "your query matched nothing" — a
+    // different, and wrong, answer to "there is no graph to query".
+    openProject = null;
+    expect(() => call(Channels.GRAPH_QUERY, 'SELECT * WHERE {}')).toThrow('No project open');
+    expect(h.queryGraph).not.toHaveBeenCalled();
+  });
+
+  it('GRAPH_SET_BASE_URI throws with no project', () => {
+    openProject = null;
+    expect(() => call(Channels.GRAPH_SET_BASE_URI, 'https://example.org/kb/')).toThrow('No project open');
+    expect(h.patchProjectConfig).not.toHaveBeenCalled();
+  });
+
+  it('TABLES_QUERY reports the failure on its discriminated union, not by rejecting', async () => {
+    // Rule 3: the query panel renders `{ ok: false, error }` inline, so this
+    // handler's contract is "never rejects" — including for "no project".
+    openProject = null;
+    await expect(callAsync(Channels.TABLES_QUERY, 'SELECT 1')).resolves.toEqual({
+      ok: false, error: 'No project open',
+    });
+    expect(h.runQuery).not.toHaveBeenCalled();
+  });
+
+  it('GRAPH_ATTACH_EXCERPT_EVIDENCE reports "no project" on its union too', async () => {
+    openProject = null;
+    await expect(callAsync(Channels.GRAPH_ATTACH_EXCERPT_EVIDENCE, 'ex1', 'claim.md', 'grounds'))
+      .resolves.toEqual({ ok: false, error: 'no project open' });
+    expect(h.proposeExcerptEvidence).not.toHaveBeenCalled();
+  });
+
+  // Empty-value fallbacks: for each of these "no project" and "an empty
+  // thoughtbase" render identically, so the fallback is a value, not an error.
+  const emptyFallbacks: [string, unknown[], unknown][] = [
+    [Channels.TABLES_LIST, [], []],
+    [Channels.GRAPH_SCHEMA_FOR_COMPLETION, [], null],
+    [Channels.GRAPH_ALIAS_MAP, [], {}],
+    [Channels.GRAPH_ALIAS_ENTRIES, [], []],
+    [Channels.GRAPH_FRONTMATTER_KEYS, [], []],
+    [Channels.INSPECTIONS_LIST, [], []],
+    [Channels.INSPECTIONS_RUN, [], []],
+    [Channels.GRAPH_GROUND_CHECK, ['some claim'], []],
+  ];
+
+  it.each(emptyFallbacks)('%s answers with its empty value and no project', async (channel, args, expected) => {
+    openProject = null;
+    await expect(callAsync(channel, ...args)).resolves.toEqual(expected);
+  });
+
+  it('GRAPH_EXPORT does not even raise a Save panel with nothing to export', async () => {
+    openProject = null;
+    await call(Channels.GRAPH_EXPORT);
+    expect(h.showSaveDialog).not.toHaveBeenCalled();
+  });
+
+  // NOT pinned here, deliberately: GRAPH_SOURCE_DETAIL / GRAPH_EXCERPT_SOURCE
+  // return `null` for BOTH "no project" and "no such source" — the overloaded
+  // sentinel CLAUDE.md's #1631 migration backlog already lists. Asserting it
+  // would bless it; their with-project delegation is covered below instead.
+});
+
+describe('register-graph — queries and lookups', () => {
+  it('GRAPH_QUERY passes the SPARQL straight through to the store', async () => {
+    h.queryGraph.mockResolvedValue({ results: [{ s: 'x' }], columns: ['s'] });
+    await expect(callAsync(Channels.GRAPH_QUERY, 'SELECT ?s WHERE {}'))
+      .resolves.toEqual({ results: [{ s: 'x' }], columns: ['s'] });
+    expect(h.queryGraph).toHaveBeenCalledWith(CTX, 'SELECT ?s WHERE {}');
+  });
+
+  it('TABLES_QUERY hands a bad-SQL failure back verbatim', async () => {
+    // A user's malformed SQL is a normal input, not a bug — the union arm is
+    // the answer, so nothing here should throw.
+    h.runQuery.mockResolvedValue({ ok: false, error: 'Parser Error: syntax error' });
+    await expect(callAsync(Channels.TABLES_QUERY, 'SELEKT 1'))
+      .resolves.toEqual({ ok: false, error: 'Parser Error: syntax error' });
+  });
+
+  it('TABLES_LIST reports the registered tables', async () => {
+    h.listTables.mockResolvedValue([{ name: 'notes' }]);
+    await expect(callAsync(Channels.TABLES_LIST)).resolves.toEqual([{ name: 'notes' }]);
+    expect(h.listTables).toHaveBeenCalledWith(CTX);
+  });
+
+  it('GRAPH_SOURCE_DETAIL delegates to the graph with a project open', async () => {
+    h.getSourceDetail.mockReturnValue({ id: 's1', title: 'A Source' });
+    expect(call(Channels.GRAPH_SOURCE_DETAIL, 's1')).toEqual({ id: 's1', title: 'A Source' });
+    expect(h.getSourceDetail).toHaveBeenCalledWith(CTX, 's1');
+  });
+
+  it('GRAPH_EXCERPT_SOURCE delegates to the graph with a project open', () => {
+    h.getExcerptSource.mockReturnValue('s1');
+    expect(call(Channels.GRAPH_EXCERPT_SOURCE, 'ex1')).toBe('s1');
+    expect(h.getExcerptSource).toHaveBeenCalledWith(CTX, 'ex1');
+  });
+
+  it('GRAPH_ATTACH_EXCERPT_EVIDENCE routes the role through to the proposal', async () => {
+    h.proposeExcerptEvidence.mockResolvedValue({ ok: true, proposalId: 'p1' });
+    await expect(callAsync(Channels.GRAPH_ATTACH_EXCERPT_EVIDENCE, 'ex1', 'claim.md', 'rebuts'))
+      .resolves.toEqual({ ok: true, proposalId: 'p1' });
+    expect(h.proposeExcerptEvidence).toHaveBeenCalledWith(ROOT, 'ex1', 'claim.md', 'rebuts');
+  });
+});
+
+describe('register-graph — GRAPH_GROUND_CHECK (#1631 rule 1 in action)', () => {
+  it('rejects when the engine reports an in-band error instead of returning "no matches"', async () => {
+    // `queryGraph` reports failures in-band for its query-panel callers. This
+    // handler has no such surface, so a dropped `error` would silently read as
+    // "nothing grounds this claim" — the worst possible wrong answer here.
+    h.queryGraph.mockResolvedValue({ results: [], columns: [], error: 'engine exploded' });
+    await expect(callAsync(Channels.GRAPH_GROUND_CHECK, 'a claim'))
+      .rejects.toThrow(/grounding query failed: engine exploded/);
+  });
+
+  it('returns the matched nodes when the query succeeds', async () => {
+    const rows = [{ node: 'n1', label: 'Some Note', type: 'note' }];
+    h.queryGraph.mockResolvedValue({ results: rows, columns: ['node', 'label', 'type'] });
+    await expect(callAsync(Channels.GRAPH_GROUND_CHECK, 'Some')).resolves.toEqual(rows);
+  });
+
+  it('escapes quotes and newlines so the claim text cannot break out of the literal', async () => {
+    await call(Channels.GRAPH_GROUND_CHECK, 'he said "hi"\nthen left');
+    const sparql = h.queryGraph.mock.calls[0]![1] as string;
+    expect(sparql).toContain('LCASE("he said \\"hi\\" then left")');
+    // A raw quote would terminate the string literal and change the query.
+    expect(sparql).not.toContain('"hi"');
+  });
+});
+
+describe('register-graph — rebase to a new base IRI (#1443 B)', () => {
+  const NEW_BASE = 'https://example.org/kb/';
+
+  function trackOrder(): void {
+    h.graphIndexAllNotes.mockImplementation(async () => { h.order.push('graph'); });
+    h.searchIndexAllNotes.mockImplementation(async () => { h.order.push('search'); });
+    h.registerAllCsvs.mockImplementation(async () => { h.order.push('csvs'); });
+    h.registerAllNoteTables.mockImplementation(async () => { h.order.push('noteTables'); });
+  }
+
+  it('refuses an invalid base IRI without touching config or indexes', async () => {
+    const result = await call(Channels.GRAPH_SET_BASE_URI, 'not-a-url');
+    expect(result).toEqual({ ok: false, error: expect.stringContaining('absolute http(s) URL') });
+    expect(h.patchProjectConfig).not.toHaveBeenCalled();
+    expect(h.setBaseUri).not.toHaveBeenCalled();
+    expect(h.graphIndexAllNotes).not.toHaveBeenCalled();
+  });
+
+  it('persists the new base, then rebuilds every index from the files', async () => {
+    h.readProjectConfig.mockReturnValue({ baseUri: 'https://old.example/kb/' });
+    trackOrder();
+
+    await expect(callAsync(Channels.GRAPH_SET_BASE_URI, NEW_BASE)).resolves.toEqual({ ok: true });
+
+    expect(h.patchProjectConfig).toHaveBeenCalledWith(ROOT, { baseUri: NEW_BASE });
+    expect(h.setBaseUri).toHaveBeenCalledWith(CTX, NEW_BASE);
+    // Proposals aren't file-derived, so the OLD base has to be handed to the
+    // rebuild for their IRIs + payload turtle to be rewritten old→new.
+    expect(h.graphIndexAllNotes).toHaveBeenCalledWith(CTX, { rebaseFrom: 'https://old.example/kb/' });
+    // CSVs before note tables, both after the store reset, so the schema
+    // triples survive the rebuild (#1358).
+    expect(h.order).toEqual(['graph', 'search', 'csvs', 'noteTables']);
+  });
+
+  it('omits rebaseFrom entirely when the thoughtbase had no base IRI yet', async () => {
+    h.readProjectConfig.mockReturnValue({});
+    await call(Channels.GRAPH_SET_BASE_URI, NEW_BASE);
+    expect(h.graphIndexAllNotes).toHaveBeenCalledWith(CTX, undefined);
+  });
+
+  it('trims the submitted IRI before storing it', async () => {
+    await call(Channels.GRAPH_SET_BASE_URI, '  https://example.org/kb/  ');
+    expect(h.patchProjectConfig).toHaveBeenCalledWith(ROOT, { baseUri: NEW_BASE });
+  });
+
+  it('tells the window its tables changed once the rebuild lands', async () => {
+    await call(Channels.GRAPH_SET_BASE_URI, NEW_BASE);
+    expect(h.win.webContents.send).toHaveBeenCalledWith(Channels.TABLES_CHANGED);
+  });
+
+  it('skips the broadcast when the window closed mid-rebuild', async () => {
+    h.win.isDestroyed.mockReturnValue(true);
+    await expect(callAsync(Channels.GRAPH_SET_BASE_URI, NEW_BASE)).resolves.toEqual({ ok: true });
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-graph — inspections', () => {
+  it('INSPECTIONS_LIST returns the cached results', async () => {
+    h.getInspections.mockReturnValue([{ id: 'orphans', hits: [] }]);
+    await expect(callAsync(Channels.INSPECTIONS_LIST)).resolves.toEqual([{ id: 'orphans', hits: [] }]);
+  });
+
+  it('INSPECTIONS_RUN runs the checks under the current settings', async () => {
+    const settings = { enabled: ['orphans'], staleDays: 90 };
+    h.getInspectionSettings.mockResolvedValue(settings);
+    h.runAllChecks.mockResolvedValue([{ id: 'orphans', hits: ['a.md'] }]);
+
+    await expect(callAsync(Channels.INSPECTIONS_RUN)).resolves.toEqual([{ id: 'orphans', hits: ['a.md'] }]);
+    expect(h.runAllChecks).toHaveBeenCalledWith(CTX, settings);
+  });
+
+  it('INSPECTIONS_GET_SETTINGS works with no project — the prefs are per-machine', async () => {
+    // The Settings dialog is reachable from an empty window (#1792), so this
+    // handler deliberately takes no rootPath.
+    openProject = null;
+    h.getInspectionSettings.mockResolvedValue({ enabled: [], staleDays: 90 });
+    await expect(callAsync(Channels.INSPECTIONS_GET_SETTINGS)).resolves.toEqual({ enabled: [], staleDays: 90 });
+  });
+
+  it('INSPECTIONS_SET_SETTINGS returns what actually landed, not what was asked for', async () => {
+    const asked = { enabled: ['orphans', 'bogus-id'], staleDays: 0 };
+    const stored = { enabled: ['orphans'], staleDays: 1 };
+    h.getInspectionSettings.mockResolvedValue(stored);
+
+    // Saving clamps the day values and drops ids the panel can't offer, so the
+    // caller must not keep displaying its own input.
+    await expect(callAsync(Channels.INSPECTIONS_SET_SETTINGS, asked)).resolves.toEqual(stored);
+    expect(h.saveInspectionSettings).toHaveBeenCalledWith(asked);
+  });
+});
+
+describe('register-graph — GRAPH_EXPORT', () => {
+  it('flushes the graph to disk before copying the snapshot out', async () => {
+    // graph.ttl is a cold snapshot — copying without persisting first would
+    // export a stale file missing everything since the last flush.
+    h.showSaveDialog.mockResolvedValue({ canceled: false, filePath: '/out/graph.ttl' });
+    h.persistGraph.mockImplementation(async () => { h.order.push('persist'); });
+    h.copyFile.mockImplementation(async () => { h.order.push('copy'); });
+
+    await call(Channels.GRAPH_EXPORT);
+
+    expect(h.order).toEqual(['persist', 'copy']);
+    expect(h.copyFile).toHaveBeenCalledWith('/vault/.minerva/graph.ttl', '/out/graph.ttl');
+  });
+
+  it('writes nothing when the Save panel is cancelled', async () => {
+    h.showSaveDialog.mockResolvedValue({ canceled: true, filePath: undefined });
+    await call(Channels.GRAPH_EXPORT);
+    expect(h.persistGraph).not.toHaveBeenCalled();
+    expect(h.copyFile).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing when the panel returns no path', async () => {
+    h.showSaveDialog.mockResolvedValue({ canceled: false, filePath: '' });
+    await call(Channels.GRAPH_EXPORT);
+    expect(h.copyFile).not.toHaveBeenCalled();
+  });
+});

--- a/tests/main/ipc/register-links.test.ts
+++ b/tests/main/ipc/register-links.test.ts
@@ -1,0 +1,380 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-links.ts` (#1840).
+ *
+ * Every handler here is `withRootPathOr`, so the whole file is a test of #1631
+ * rule 2: each project-less fallback has to be an answer a panel can render
+ * ("nothing related", "no backlinks"), never an error in disguise. Those are
+ * pinned first.
+ *
+ * The rest is the ranking contract the Related / Unlinked-mentions / semantic
+ * query surfaces depend on and that no other test covers end-to-end: the
+ * limit is clamped and the chunk fetch over-fetches ×5 so best-per-ref de-dup
+ * still yields a full page; titles are resolved per hit KIND (a source's title,
+ * a literal "Excerpt", a note's title); already-linked is computed from links
+ * in BOTH directions; and the optional `kinds` / `excludePath` are omitted
+ * rather than passed as `undefined`.
+ *
+ * The pure ranking module (`embeddings/related`) is used for real — mocking it
+ * would leave the de-dup and ordering untested at this boundary.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  // vector store
+  isEnabled: vi.fn(),
+  relatedToNote: vi.fn(),
+  searchRelated: vi.fn(),
+  // graph
+  noteTitle: vi.fn(),
+  sourceTitle: vi.fn(),
+  aliasesForNote: vi.fn(),
+  outgoingLinks: vi.fn(),
+  backlinks: vi.fn(),
+  citationsForNote: vi.fn(),
+  findExternalInboundLinks: vi.fn(),
+  neighborhood: vi.fn(),
+  expandNode: vi.fn(),
+  // notebase fs
+  readFile: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+}));
+
+vi.mock('../../../src/main/embeddings/vector-store', () => ({
+  isEnabled: h.isEnabled,
+  relatedToNote: h.relatedToNote,
+  searchRelated: h.searchRelated,
+}));
+vi.mock('../../../src/main/graph/index', () => ({
+  noteTitle: h.noteTitle,
+  sourceTitle: h.sourceTitle,
+  aliasesForNote: h.aliasesForNote,
+  outgoingLinks: h.outgoingLinks,
+  backlinks: h.backlinks,
+  citationsForNote: h.citationsForNote,
+  findExternalInboundLinks: h.findExternalInboundLinks,
+  neighborhood: h.neighborhood,
+  expandNode: h.expandNode,
+}));
+vi.mock('../../../src/main/notebase/fs', () => ({ readFile: h.readFile }));
+
+import { registerLinks } from '../../../src/main/ipc/register-links';
+import { Channels } from '../../../src/shared/channels';
+
+registerLinks();
+
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!({}, ...args);
+/** Await a handler's answer whether it replied synchronously or with a promise
+ *  (the `withRootPathOr` fallbacks are returned synchronously). */
+const callAsync = async (channel: string, ...args: unknown[]): Promise<unknown> => call(channel, ...args);
+/** The ProjectContext the registrar builds from the root path. */
+const CTX = { rootPath: ROOT, _brand: 'ProjectContext' };
+
+/** A chunk hit as the vector store returns them. */
+const hit = (over: Partial<{ kind: string; ref: string; sectionHeading: string; chunkText: string; score: number }> = {}) => ({
+  kind: 'note', ref: 'a.md', sectionHeading: 'Intro', chunkText: 'text', score: 0.5, ...over,
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  openProject = ROOT;
+  h.isEnabled.mockReturnValue(true);
+  h.relatedToNote.mockResolvedValue([]);
+  h.searchRelated.mockResolvedValue([]);
+  h.outgoingLinks.mockReturnValue([]);
+  h.backlinks.mockReturnValue([]);
+  h.aliasesForNote.mockReturnValue([]);
+  h.noteTitle.mockImplementation((_c: unknown, ref: string) => `Title of ${ref}`);
+  h.sourceTitle.mockImplementation((_c: unknown, ref: string) => `Source ${ref}`);
+});
+
+describe('register-links — the #1631 project guard', () => {
+  // Every handler in this registrar is `withRootPathOr`. Each fallback below is
+  // a value a panel renders as "nothing here" — the same thing it shows for a
+  // note that genuinely has no links — so none of them is an error in disguise.
+  const fallbacks: [string, unknown[], unknown][] = [
+    [Channels.EMBEDDINGS_RELATED, ['a.md'], { enabled: false, notes: [] }],
+    [Channels.EMBEDDINGS_UNLINKED_MENTIONS, ['a.md'], { enabled: false, notes: [] }],
+    [Channels.EMBEDDINGS_SEARCH_TEXT, ['query'], { enabled: false, notes: [] }],
+    [Channels.LINKS_OUTGOING, ['a.md'], []],
+    [Channels.LINKS_BACKLINKS, ['a.md'], []],
+    [Channels.LINKS_BUNDLE, ['a.md'], { outgoing: [], backlinks: [] }],
+    [Channels.LINKS_CITATIONS_FOR_NOTE, ['a.md'], []],
+    [Channels.LINKS_EXTERNAL_INBOUND, [['a.md']], []],
+    [Channels.LINKS_NEIGHBORHOOD, ['a.md'], { nodes: [], edges: [], truncated: false }],
+    [Channels.LINKS_EXPAND_NODE, ['a.md'], { nodes: [], edges: [], expandTo: [] }],
+  ];
+
+  it.each(fallbacks)('%s answers with its empty value and no project', async (channel, args, expected) => {
+    openProject = null;
+    await expect(callAsync(channel, ...args)).resolves.toEqual(expected);
+  });
+
+  it('no graph or vector lookup is attempted with no project', async () => {
+    openProject = null;
+    for (const [channel, args] of fallbacks) await callAsync(channel, ...args);
+    expect(h.relatedToNote).not.toHaveBeenCalled();
+    expect(h.searchRelated).not.toHaveBeenCalled();
+    expect(h.outgoingLinks).not.toHaveBeenCalled();
+    expect(h.readFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-links — EMBEDDINGS_RELATED (#838/#839/#840)', () => {
+  it('reports the feature off — not an empty list — when embeddings are disabled', async () => {
+    // `enabled: false` is what makes the panel say "turn on semantic search"
+    // rather than "this note has no related notes".
+    h.isEnabled.mockReturnValue(false);
+    await expect(callAsync(Channels.EMBEDDINGS_RELATED, 'a.md')).resolves.toEqual({ enabled: false, notes: [] });
+    expect(h.relatedToNote).not.toHaveBeenCalled();
+  });
+
+  it('over-fetches five chunks per wanted result so best-per-ref de-dup still fills the page', async () => {
+    await call(Channels.EMBEDDINGS_RELATED, 'a.md');
+    expect(h.relatedToNote).toHaveBeenCalledWith(CTX, 'a.md', { limit: 40 }); // default 8 × 5
+  });
+
+  it.each([
+    [undefined, 40],  // default 8
+    [3, 15],
+    [0, 5],           // floored up to 1
+    [-7, 5],          // negative can't mean "none"
+    [100, 125],       // capped at 25
+    [3.9, 15],        // fractional limits are floored
+  ])('clamps a requested limit of %s to an over-fetch of %i', async (limit, expected) => {
+    await call(Channels.EMBEDDINGS_RELATED, 'a.md', limit);
+    expect(h.relatedToNote).toHaveBeenCalledWith(CTX, 'a.md', { limit: expected });
+  });
+
+  it('keeps only each note\'s best-scoring section', async () => {
+    h.relatedToNote.mockResolvedValue([
+      hit({ ref: 'b.md', sectionHeading: 'Weak', score: 0.3 }),
+      hit({ ref: 'b.md', sectionHeading: 'Strong', score: 0.9 }),
+    ]);
+    const result = await call(Channels.EMBEDDINGS_RELATED, 'a.md') as { notes: { sectionHeading: string }[] };
+    expect(result.notes).toHaveLength(1);
+    expect(result.notes[0]!.sectionHeading).toBe('Strong');
+  });
+
+  it('titles each hit by its kind — sources, excerpts and notes read differently', async () => {
+    h.relatedToNote.mockResolvedValue([
+      hit({ kind: 'note', ref: 'b.md', score: 0.9 }),
+      hit({ kind: 'source', ref: 'src1', score: 0.8 }),
+      hit({ kind: 'excerpt', ref: 'ex1', score: 0.7 }),
+    ]);
+    const result = await call(Channels.EMBEDDINGS_RELATED, 'a.md') as { notes: { title: string }[] };
+    expect(result.notes.map((n) => n.title)).toEqual(['Title of b.md', 'Source src1', 'Excerpt']);
+  });
+
+  it('flags a note as already linked from either direction', async () => {
+    // Only unlinked-but-related notes should be offered a "suggest link", and a
+    // link pointing the other way still counts as linked (#840).
+    h.relatedToNote.mockResolvedValue([
+      hit({ ref: 'out.md', score: 0.9 }),
+      hit({ ref: 'in.md', score: 0.8 }),
+      hit({ ref: 'free.md', score: 0.7 }),
+    ]);
+    h.outgoingLinks.mockReturnValue([{ target: 'out.md' }]);
+    h.backlinks.mockReturnValue([{ source: 'in.md' }]);
+
+    const result = await call(Channels.EMBEDDINGS_RELATED, 'a.md') as {
+      enabled: boolean; notes: { ref: string; alreadyLinked?: boolean }[];
+    };
+
+    expect(result.enabled).toBe(true);
+    expect(result.notes.map((n) => [n.ref, n.alreadyLinked])).toEqual([
+      ['out.md', true], ['in.md', true], ['free.md', false],
+    ]);
+  });
+});
+
+describe('register-links — EMBEDDINGS_UNLINKED_MENTIONS (#1074)', () => {
+  it('searches on the object\'s title AND aliases, not its body', async () => {
+    // Unlike EMBEDDINGS_RELATED this embeds the object's NAMES at query time,
+    // so a note that merely mentions it by any alias surfaces.
+    h.noteTitle.mockReturnValue('Bayes Theorem');
+    h.aliasesForNote.mockReturnValue(['Bayes rule', 'Bayes law']);
+
+    await call(Channels.EMBEDDINGS_UNLINKED_MENTIONS, 'objects/bayes.md', 4);
+
+    expect(h.searchRelated).toHaveBeenCalledWith(CTX, 'Bayes Theorem\nBayes rule\nBayes law', {
+      limit: 20,
+      kinds: ['note'],
+      exclude: { kind: 'note', ref: 'objects/bayes.md' }, // never mention itself
+    });
+  });
+
+  it('drops blank aliases from the query text', async () => {
+    h.noteTitle.mockReturnValue('Bayes');
+    h.aliasesForNote.mockReturnValue(['', '   ', 'Bayes rule']);
+    await call(Channels.EMBEDDINGS_UNLINKED_MENTIONS, 'a.md');
+    expect(h.searchRelated.mock.calls[0]![1]).toBe('Bayes\nBayes rule');
+  });
+
+  it('reports "enabled, nothing to match on" for an untitled, alias-less note', async () => {
+    // Searching on an empty string would rank the whole corpus at random.
+    h.noteTitle.mockReturnValue('');
+    h.aliasesForNote.mockReturnValue([]);
+    await expect(callAsync(Channels.EMBEDDINGS_UNLINKED_MENTIONS, 'a.md'))
+      .resolves.toEqual({ enabled: true, notes: [] });
+    expect(h.searchRelated).not.toHaveBeenCalled();
+  });
+
+  it('reports the feature off when embeddings are disabled', async () => {
+    h.isEnabled.mockReturnValue(false);
+    await expect(callAsync(Channels.EMBEDDINGS_UNLINKED_MENTIONS, 'a.md'))
+      .resolves.toEqual({ enabled: false, notes: [] });
+  });
+
+  it('flags the already-linked mentions so only the genuinely unlinked are offered', async () => {
+    h.noteTitle.mockImplementation((_c: unknown, ref: string) => (ref === 'a.md' ? 'Bayes' : `Title of ${ref}`));
+    h.searchRelated.mockResolvedValue([hit({ ref: 'linked.md', score: 0.9 }), hit({ ref: 'free.md', score: 0.8 })]);
+    h.backlinks.mockReturnValue([{ source: 'linked.md' }]);
+
+    const result = await call(Channels.EMBEDDINGS_UNLINKED_MENTIONS, 'a.md') as {
+      notes: { ref: string; alreadyLinked?: boolean }[];
+    };
+    expect(result.notes.map((n) => [n.ref, n.alreadyLinked])).toEqual([['linked.md', true], ['free.md', false]]);
+  });
+});
+
+describe('register-links — EMBEDDINGS_SEARCH_TEXT (#1128)', () => {
+  it('refuses to rank the corpus against a blank query', async () => {
+    await expect(callAsync(Channels.EMBEDDINGS_SEARCH_TEXT, '   ')).resolves.toEqual({ enabled: false, notes: [] });
+    expect(h.searchRelated).not.toHaveBeenCalled();
+  });
+
+  it('passes neither kinds nor exclude when the block set no options', async () => {
+    // Passing `kinds: undefined` / `exclude: undefined` would look like a real
+    // restriction to the store rather than "no restriction".
+    await call(Channels.EMBEDDINGS_SEARCH_TEXT, 'why is the sky blue');
+    expect(h.searchRelated).toHaveBeenCalledWith(CTX, 'why is the sky blue', { limit: 40 });
+  });
+
+  it('ignores an empty kinds array — restricting to nothing is not a restriction', async () => {
+    await call(Channels.EMBEDDINGS_SEARCH_TEXT, 'q', { kinds: [] });
+    expect(h.searchRelated).toHaveBeenCalledWith(CTX, 'q', { limit: 40 });
+  });
+
+  it('applies the block\'s kinds, limit, and host-note exclusion', async () => {
+    await call(Channels.EMBEDDINGS_SEARCH_TEXT, 'q', { limit: 2, kinds: ['source'], excludePath: 'host.md' });
+    expect(h.searchRelated).toHaveBeenCalledWith(CTX, 'q', {
+      limit: 10,
+      kinds: ['source'],
+      exclude: { kind: 'note', ref: 'host.md' },
+    });
+  });
+
+  it('ranks results without an already-linked flag — this is a read-only query', async () => {
+    h.searchRelated.mockResolvedValue([hit({ ref: 'b.md', score: 0.9 })]);
+    const result = await call(Channels.EMBEDDINGS_SEARCH_TEXT, 'q') as {
+      notes: { ref: string; alreadyLinked?: boolean }[];
+    };
+    expect(result.notes[0]).toMatchObject({ ref: 'b.md', title: 'Title of b.md' });
+    expect(result.notes[0]!.alreadyLinked).toBeUndefined();
+    expect(h.outgoingLinks).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-links — the link panels', () => {
+  it('LINKS_OUTGOING and LINKS_BACKLINKS each read one direction', () => {
+    h.outgoingLinks.mockReturnValue([{ target: 'b.md' }]);
+    h.backlinks.mockReturnValue([{ source: 'c.md' }]);
+    expect(call(Channels.LINKS_OUTGOING, 'a.md')).toEqual([{ target: 'b.md' }]);
+    expect(call(Channels.LINKS_BACKLINKS, 'a.md')).toEqual([{ source: 'c.md' }]);
+  });
+
+  it('LINKS_BUNDLE returns both directions from a single round-trip (#351)', () => {
+    h.outgoingLinks.mockReturnValue([{ target: 'b.md' }]);
+    h.backlinks.mockReturnValue([{ source: 'c.md' }]);
+
+    expect(call(Channels.LINKS_BUNDLE, 'a.md')).toEqual({
+      outgoing: [{ target: 'b.md' }],
+      backlinks: [{ source: 'c.md' }],
+    });
+    // One pass each — the point of the bundle is to replace two IPC calls.
+    expect(h.outgoingLinks).toHaveBeenCalledTimes(1);
+    expect(h.backlinks).toHaveBeenCalledTimes(1);
+  });
+
+  it('LINKS_EXTERNAL_INBOUND asks the graph about the whole path set at once', () => {
+    h.findExternalInboundLinks.mockReturnValue([{ source: 'x.md', target: 'a.md' }]);
+    expect(call(Channels.LINKS_EXTERNAL_INBOUND, ['a.md', 'b.md']))
+      .toEqual([{ source: 'x.md', target: 'a.md' }]);
+    expect(h.findExternalInboundLinks).toHaveBeenCalledWith(CTX, ['a.md', 'b.md']);
+  });
+
+  it('LINKS_NEIGHBORHOOD substitutes empty options when the view passed none', () => {
+    h.neighborhood.mockReturnValue({ nodes: [], edges: [], truncated: false });
+    call(Channels.LINKS_NEIGHBORHOOD, 'a.md');
+    expect(h.neighborhood).toHaveBeenCalledWith(CTX, 'a.md', {});
+  });
+
+  it('LINKS_NEIGHBORHOOD forwards the depth the view asked for', () => {
+    h.neighborhood.mockReturnValue({ nodes: [], edges: [], truncated: true });
+    expect(call(Channels.LINKS_NEIGHBORHOOD, 'a.md', { depth: 3 }))
+      .toEqual({ nodes: [], edges: [], truncated: true });
+    expect(h.neighborhood).toHaveBeenCalledWith(CTX, 'a.md', { depth: 3 });
+  });
+
+  it('LINKS_EXPAND_NODE reports the single hop out of a node', () => {
+    h.expandNode.mockReturnValue({ nodes: [{ id: 'b.md' }], edges: [], expandTo: ['b.md'] });
+    expect(call(Channels.LINKS_EXPAND_NODE, 'a.md'))
+      .toEqual({ nodes: [{ id: 'b.md' }], edges: [], expandTo: ['b.md'] });
+  });
+});
+
+describe('register-links — LINKS_CITATIONS_FOR_NOTE', () => {
+  it('counts against the live editor buffer when the renderer supplies one', async () => {
+    // The count has to track what the user is typing right now, so a supplied
+    // buffer must win over — and skip — the on-disk copy.
+    h.citationsForNote.mockReturnValue([{ sourceId: 's1', count: 2 }]);
+
+    await expect(callAsync(Channels.LINKS_CITATIONS_FOR_NOTE, 'a.md', 'live @s1 @s1 text'))
+      .resolves.toEqual([{ sourceId: 's1', count: 2 }]);
+
+    expect(h.readFile).not.toHaveBeenCalled();
+    expect(h.citationsForNote).toHaveBeenCalledWith(CTX, 'a.md', 'live @s1 @s1 text');
+  });
+
+  it('falls back to disk when refreshed from a graph event with no open buffer', async () => {
+    h.readFile.mockResolvedValue('on-disk @s1');
+    h.citationsForNote.mockReturnValue([]);
+
+    await call(Channels.LINKS_CITATIONS_FOR_NOTE, 'a.md');
+
+    expect(h.readFile).toHaveBeenCalledWith(ROOT, 'a.md');
+    expect(h.citationsForNote).toHaveBeenCalledWith(CTX, 'a.md', 'on-disk @s1');
+  });
+
+  it('an empty live buffer is used as-is, not treated as "no buffer"', async () => {
+    // `?? ` (not `||`) — a note the user just cleared has zero citations, and
+    // must not silently fall back to the stale file on disk.
+    h.citationsForNote.mockReturnValue([]);
+    await call(Channels.LINKS_CITATIONS_FOR_NOTE, 'a.md', '');
+    expect(h.readFile).not.toHaveBeenCalled();
+    expect(h.citationsForNote).toHaveBeenCalledWith(CTX, 'a.md', '');
+  });
+
+  // NOT pinned here, deliberately: the disk fallback is `.catch(() => '')`,
+  // which turns a real read failure (EACCES, a corrupt mount) into "this note
+  // cites nothing". That swallow is already on CLAUDE.md's #1631 backlog;
+  // asserting it would bless it.
+});

--- a/tests/main/ipc/register-notebase.test.ts
+++ b/tests/main/ipc/register-notebase.test.ts
@@ -1,0 +1,735 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-notebase.ts` (#1840).
+ *
+ * This is the write path — create / write / delete / rename / merge / copy —
+ * and it was the largest registrar with no direct test, against CLAUDE.md's
+ * "does every register-* handler ship with a main-process test?" checklist.
+ * It drives the REAL `registerNotebase()` (and the real `broadcast`) with its
+ * collaborators mocked, and pins the behaviour a renderer actually depends on:
+ *
+ *   - the #1631 project guard: every mutating handler THROWS "No project open",
+ *     while the genuinely list-shaped reads answer with an empty value;
+ *   - the write pipeline is invoked with `suppressRewrittenBroadcast` so a
+ *     renderer-initiated save doesn't get told about its own write;
+ *   - index bookkeeping happens in the order that makes it correct (a folder's
+ *     files are enumerated BEFORE the folder is deleted, `markPathHandled`
+ *     fires BEFORE the fs mutation the watcher would otherwise re-emit);
+ *   - rename / merge / rename-anchor broadcast the right channels to every
+ *     window on the project, and stay quiet when nothing changed;
+ *   - a cancelled picker is a no-op, never a half-open project.
+ *
+ * `withRootPath*` are re-implemented in the helpers mock with the real
+ * semantics (helpers.ts drags in electron + graph/search/vectors, so it can't
+ * be imported here). Their own contract is covered by
+ * tests/main/ipc/registration.test.ts; what matters here is WHICH wrapper each
+ * handler picked — throw vs fallback — which is exactly what #1631 governs.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'node:path';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => {
+  const makeWin = (id: number) => ({
+    id,
+    isDestroyed: () => false,
+    webContents: { send: vi.fn(), once: vi.fn() },
+  });
+  return {
+    handlers: new Map<string, Handler>(),
+    win: makeWin(1),
+    freshWin: makeWin(2),
+    // electron
+    showOpenDialog: vi.fn(),
+    showSaveDialog: vi.fn(),
+    // node:fs/promises
+    stat: vi.fn(),
+    // notebase/fs
+    openNotebase: vi.fn(),
+    listFiles: vi.fn(),
+    readFile: vi.fn(),
+    readBinaryFile: vi.fn(),
+    writeBinaryFile: vi.fn(),
+    fileExists: vi.fn(),
+    createFile: vi.fn(),
+    deleteFile: vi.fn(),
+    createFolder: vi.fn(),
+    deleteFolder: vi.fn(),
+    copyItem: vi.fn(),
+    // notebase collaborators
+    renameWithLinkRewrites: vi.fn(),
+    mergeNotes: vi.fn(),
+    previewMergeNotes: vi.fn(),
+    renameAnchor: vi.fn(),
+    renameSource: vi.fn(),
+    renameExcerpt: vi.fn(),
+    dropImport: vi.fn(),
+    installTutorialThoughtbase: vi.fn(),
+    searchInNotes: vi.fn(),
+    replaceInNotes: vi.fn(),
+    writeAndReindex: vi.fn(),
+    // offline caches
+    getOrFetchThumbnail: vi.fn(),
+    getOrFetchRemoteImage: vi.fn(),
+    // project config
+    resolveDisplayName: vi.fn(),
+    setDisplayName: vi.fn(),
+    getDisplayName: vi.fn(),
+    readProjectConfig: vi.fn(),
+    getOnboardingDismissed: vi.fn(),
+    setOnboardingDismissed: vi.fn(),
+    // indexes
+    indexNote: vi.fn(),
+    searchIndexNote: vi.fn(),
+    vectorsIndexNote: vi.fn(),
+    searchRemoveNote: vi.fn(),
+    vectorsRemoveNote: vi.fn(),
+    // window manager / menu / recents
+    createWindow: vi.fn(),
+    openProjectInWindow: vi.fn(),
+    closeProjectInWindow: vi.fn(),
+    markPathHandled: vi.fn(),
+    clearRecentProjects: vi.fn(),
+    rebuildMenu: vi.fn(),
+    // helpers
+    reindexFile: vi.fn(),
+    removeFromIndexes: vi.fn(),
+    listIndexableFiles: vi.fn(),
+    persistIndexes: vi.fn(),
+    broadcastRewritten: vi.fn(),
+    // call-order log — ordering is load-bearing in several handlers
+    order: [] as string[],
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+  dialog: { showOpenDialog: h.showOpenDialog, showSaveDialog: h.showSaveDialog },
+}));
+
+vi.mock('node:fs/promises', () => ({ default: { stat: h.stat }, stat: h.stat }));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  winFromEvent: () => h.win,
+  rootPathFromEvent: () => openProject,
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+  reindexFile: h.reindexFile,
+  removeFromIndexes: h.removeFromIndexes,
+  listIndexableFiles: h.listIndexableFiles,
+  persistIndexes: h.persistIndexes,
+  broadcastRewritten: h.broadcastRewritten,
+  hooks: { HOOKS: true },
+}));
+
+vi.mock('../../../src/main/notebase/fs', () => ({
+  openNotebase: h.openNotebase,
+  listFiles: h.listFiles,
+  readFile: h.readFile,
+  readBinaryFile: h.readBinaryFile,
+  writeBinaryFile: h.writeBinaryFile,
+  fileExists: h.fileExists,
+  createFile: h.createFile,
+  deleteFile: h.deleteFile,
+  createFolder: h.createFolder,
+  deleteFolder: h.deleteFolder,
+  copyItem: h.copyItem,
+}));
+
+vi.mock('../../../src/main/notebase/rename', () => ({ renameWithLinkRewrites: h.renameWithLinkRewrites }));
+vi.mock('../../../src/main/notebase/merge', () => ({ mergeNotes: h.mergeNotes, previewMergeNotes: h.previewMergeNotes }));
+vi.mock('../../../src/main/notebase/rename-anchor', () => ({ renameAnchor: h.renameAnchor }));
+vi.mock('../../../src/main/notebase/rename-source-excerpt', () => ({ renameSource: h.renameSource, renameExcerpt: h.renameExcerpt }));
+vi.mock('../../../src/main/notebase/drop-import', () => ({ dropImport: h.dropImport }));
+vi.mock('../../../src/main/notebase/install-tutorial', () => ({
+  installTutorialThoughtbase: h.installTutorialThoughtbase,
+  TUTORIAL_DEFAULT_NAME: 'Minerva Tutorial',
+}));
+vi.mock('../../../src/main/notebase/search-in-notes', () => ({ searchInNotes: h.searchInNotes, replaceInNotes: h.replaceInNotes }));
+vi.mock('../../../src/main/notebase/write-pipeline', () => ({ writeAndReindex: h.writeAndReindex }));
+vi.mock('../../../src/main/images/remote-image-cache', () => ({ getOrFetchRemoteImage: h.getOrFetchRemoteImage }));
+vi.mock('../../../src/main/youtube/thumbnail-cache', () => ({ getOrFetchThumbnail: h.getOrFetchThumbnail }));
+vi.mock('../../../src/main/project-config', () => ({
+  resolveDisplayName: h.resolveDisplayName,
+  setDisplayName: h.setDisplayName,
+  getDisplayName: h.getDisplayName,
+  readProjectConfig: h.readProjectConfig,
+  getOnboardingDismissed: h.getOnboardingDismissed,
+  setOnboardingDismissed: h.setOnboardingDismissed,
+}));
+vi.mock('../../../src/main/graph/index', () => ({ indexNote: h.indexNote }));
+vi.mock('../../../src/main/search/index', () => ({ indexNote: h.searchIndexNote, removeNote: h.searchRemoveNote }));
+vi.mock('../../../src/main/embeddings/vector-store', () => ({ indexNote: h.vectorsIndexNote, removeNote: h.vectorsRemoveNote }));
+vi.mock('../../../src/main/recent-projects', () => ({
+  clearRecentProjects: h.clearRecentProjects,
+  defaultThoughtbaseDir: () => '/home/user/Thoughtbases',
+}));
+vi.mock('../../../src/main/menu', () => ({ rebuildMenu: h.rebuildMenu }));
+vi.mock('../../../src/main/window-manager', () => ({
+  createWindow: h.createWindow,
+  openProjectInWindow: h.openProjectInWindow,
+  closeProjectInWindow: h.closeProjectInWindow,
+  markPathHandled: h.markPathHandled,
+  windowsForProject: () => [h.win],
+}));
+
+import { registerNotebase } from '../../../src/main/ipc/register-notebase';
+import { Channels } from '../../../src/shared/channels';
+
+registerNotebase();
+
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!({}, ...args);
+/** Every `webContents.send` a handler made on the project's window. */
+const sends = (): unknown[][] => h.win.webContents.send.mock.calls;
+/** The ProjectContext the registrar builds from the root path. */
+const CTX = { rootPath: ROOT, _brand: 'ProjectContext' };
+
+beforeEach(() => {
+  // reset (not just clear): several tests install ordering `mockImplementation`s
+  // that must not leak into the next one.
+  vi.resetAllMocks();
+  openProject = ROOT;
+  h.order.length = 0;
+  h.createWindow.mockReturnValue(h.freshWin);
+  h.resolveDisplayName.mockReturnValue('My Vault');
+  h.readProjectConfig.mockReturnValue({});
+});
+
+/** Fire the `did-finish-load` callback a "…in new window" handler registered. */
+async function finishLoad(): Promise<void> {
+  const last = h.freshWin.webContents.once.mock.calls.at(-1) as [string, () => Promise<void>];
+  expect(last[0]).toBe('did-finish-load');
+  await last[1]();
+}
+
+describe('register-notebase — the #1631 project guard', () => {
+  // CLAUDE.md rule 2: "no project open" throws. Each of these mutates or reads
+  // one specific file, so an empty answer would be a lie, not a value.
+  const throwers: [string, unknown[]][] = [
+    [Channels.NOTEBASE_READ_FILE, ['a.md']],
+    [Channels.NOTEBASE_READ_BINARY, ['img.png']],
+    [Channels.NOTEBASE_WRITE_BINARY, ['img.png', new Uint8Array([1])]],
+    [Channels.NOTEBASE_WRITE_FILE, ['a.md', 'body']],
+    [Channels.NOTEBASE_CREATE_FILE, ['a.md']],
+    [Channels.NOTEBASE_DELETE_FILE, ['a.md']],
+    [Channels.NOTEBASE_CREATE_FOLDER, ['dir']],
+    [Channels.NOTEBASE_DELETE_FOLDER, ['dir']],
+    [Channels.NOTEBASE_RENAME, ['a.md', 'b.md']],
+    [Channels.NOTEBASE_MERGE, ['a.md', 'b.md']],
+    [Channels.NOTEBASE_MERGE_PREVIEW, ['a.md', 'b.md']],
+    [Channels.NOTEBASE_RENAME_SOURCE, ['old', 'new']],
+    [Channels.NOTEBASE_RENAME_EXCERPT, ['old', 'new']],
+    [Channels.NOTEBASE_RENAME_ANCHOR, ['a.md', 'old', 'new']],
+    [Channels.NOTEBASE_COPY, ['a.md', 'b.md']],
+    [Channels.NOTEBASE_GET_PROPERTIES, []],
+    [Channels.NOTEBASE_SET_DISPLAY_NAME, ['name']],
+    [Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, [true]],
+    [Channels.FILES_DROP_IMPORT, ['dir', ['/tmp/x.pdf']]],
+    [Channels.YOUTUBE_THUMBNAIL, ['vid']],
+    [Channels.IMAGES_CACHE_EXTERNAL, ['https://x/y.png']],
+  ];
+
+  it.each(throwers)('%s throws with no project open', (channel, args) => {
+    openProject = null;
+    expect(() => call(channel, ...args)).toThrow('No project open');
+  });
+
+  it('no mutation reaches the filesystem when there is no project', () => {
+    openProject = null;
+    for (const [channel, args] of throwers) {
+      try { call(channel, ...args); } catch { /* asserted above */ }
+    }
+    expect(h.writeAndReindex).not.toHaveBeenCalled();
+    expect(h.createFile).not.toHaveBeenCalled();
+    expect(h.deleteFile).not.toHaveBeenCalled();
+    expect(h.deleteFolder).not.toHaveBeenCalled();
+    expect(h.renameWithLinkRewrites).not.toHaveBeenCalled();
+    expect(h.mergeNotes).not.toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_LIST_FILES answers with an empty listing, not a throw', async () => {
+    // A legitimate value per #1631 rule 2: "no project" and "a project with no
+    // files" both render as an empty sidebar, so the fallback isn't a lie.
+    openProject = null;
+    await expect(call(Channels.NOTEBASE_LIST_FILES)).resolves.toEqual([]);
+    expect(h.listFiles).not.toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_SEARCH_IN_NOTES answers with no matches, not a throw', async () => {
+    openProject = null;
+    await expect(call(Channels.NOTEBASE_SEARCH_IN_NOTES, { query: 'x' })).resolves.toEqual([]);
+    expect(h.searchInNotes).not.toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_GET_ONBOARDING_DISMISSED answers "not dismissed" with no project', async () => {
+    // The one `withRootPathOr` in this registrar. `false` is the same answer a
+    // brand-new thoughtbase gives, so the project-less fallback isn't an error
+    // signal wearing a value's clothes.
+    openProject = null;
+    expect(call(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED)).toBe(false);
+    expect(h.getOnboardingDismissed).not.toHaveBeenCalled();
+  });
+
+  // NOT pinned here, deliberately: NOTEBASE_FILE_EXISTS returns `false` with no
+  // project, conflating "no project" with "no such file" — the boolean overload
+  // CLAUDE.md's #1631 migration backlog already lists. Asserting it would bless
+  // it; its with-project delegation is covered below instead.
+});
+
+describe('register-notebase — reads', () => {
+  it('NOTEBASE_LIST_FILES delegates to the fs listing', async () => {
+    h.listFiles.mockResolvedValue([{ path: 'a.md' }]);
+    await expect(call(Channels.NOTEBASE_LIST_FILES)).resolves.toEqual([{ path: 'a.md' }]);
+    expect(h.listFiles).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('NOTEBASE_READ_FILE returns the file body', async () => {
+    h.readFile.mockResolvedValue('# Title');
+    await expect(call(Channels.NOTEBASE_READ_FILE, 'notes/a.md')).resolves.toBe('# Title');
+    expect(h.readFile).toHaveBeenCalledWith(ROOT, 'notes/a.md');
+  });
+
+  it('NOTEBASE_READ_BINARY returns the raw bytes', async () => {
+    h.readBinaryFile.mockResolvedValue(new Uint8Array([137, 80]));
+    await expect(call(Channels.NOTEBASE_READ_BINARY, 'img.png')).resolves.toEqual(new Uint8Array([137, 80]));
+  });
+
+  it('NOTEBASE_FILE_EXISTS reports the fs answer when a project is open', async () => {
+    h.fileExists.mockResolvedValue(true);
+    await expect(call(Channels.NOTEBASE_FILE_EXISTS, 'a.md')).resolves.toBe(true);
+    expect(h.fileExists).toHaveBeenCalledWith(ROOT, 'a.md');
+  });
+
+  it('NOTEBASE_SEARCH_IN_NOTES passes the search options straight through', async () => {
+    h.searchInNotes.mockResolvedValue([{ path: 'a.md', matches: [] }]);
+    const opts = { query: 'todo', regex: false, caseSensitive: true };
+    await expect(call(Channels.NOTEBASE_SEARCH_IN_NOTES, opts)).resolves.toEqual([{ path: 'a.md', matches: [] }]);
+    expect(h.searchInNotes).toHaveBeenCalledWith(ROOT, opts);
+  });
+
+  it('NOTEBASE_MERGE_PREVIEW returns the preview without touching disk', async () => {
+    h.previewMergeNotes.mockResolvedValue({ merged: 'a\n\nb' });
+    await expect(call(Channels.NOTEBASE_MERGE_PREVIEW, 'a.md', 'b.md')).resolves.toEqual({ merged: 'a\n\nb' });
+    expect(h.mergeNotes).not.toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_GET_PROPERTIES falls back to empty strings for an unnamed thoughtbase', async () => {
+    h.getDisplayName.mockReturnValue(undefined);
+    h.readProjectConfig.mockReturnValue({});
+    expect(call(Channels.NOTEBASE_GET_PROPERTIES)).toEqual({
+      displayName: '',
+      folderName: path.basename(ROOT),
+      baseUri: '',
+    });
+  });
+
+  it('NOTEBASE_GET_PROPERTIES reports the stored name and base IRI', async () => {
+    h.getDisplayName.mockReturnValue('My Vault');
+    h.readProjectConfig.mockReturnValue({ baseUri: 'https://example.org/kb/' });
+    expect(call(Channels.NOTEBASE_GET_PROPERTIES)).toMatchObject({
+      displayName: 'My Vault',
+      baseUri: 'https://example.org/kb/',
+    });
+  });
+
+  it('NOTEBASE_GET_ONBOARDING_DISMISSED reports the stored flag', () => {
+    h.getOnboardingDismissed.mockReturnValue(true);
+    expect(call(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED)).toBe(true);
+    expect(h.getOnboardingDismissed).toHaveBeenCalledWith(ROOT);
+  });
+});
+
+describe('register-notebase — the write path', () => {
+  it('NOTEBASE_WRITE_FILE suppresses the rewritten broadcast for a renderer save', async () => {
+    // The renderer already holds the content it just saved; re-broadcasting it
+    // would bounce the buffer back into the editor it came from.
+    await call(Channels.NOTEBASE_WRITE_FILE, 'notes/a.md', 'body');
+    expect(h.writeAndReindex).toHaveBeenCalledWith(
+      ROOT, 'notes/a.md', 'body', { HOOKS: true }, { suppressRewrittenBroadcast: true },
+    );
+  });
+
+  it('NOTEBASE_WRITE_FILE propagates a pipeline failure instead of swallowing it', async () => {
+    h.writeAndReindex.mockRejectedValue(new Error('EACCES'));
+    await expect(call(Channels.NOTEBASE_WRITE_FILE, 'a.md', 'body')).rejects.toThrow('EACCES');
+  });
+
+  it('NOTEBASE_CREATE_FILE claims the path before creating it, then indexes it empty', async () => {
+    h.markPathHandled.mockImplementation(() => { h.order.push('mark'); });
+    h.createFile.mockImplementation(async () => { h.order.push('create'); });
+
+    await call(Channels.NOTEBASE_CREATE_FILE, 'notes/new.md');
+
+    // The watcher must be told to ignore this path BEFORE the file appears, or
+    // it races the create and re-emits it as an external change.
+    expect(h.order).toEqual(['mark', 'create']);
+    expect(h.indexNote).toHaveBeenCalledWith(CTX, 'notes/new.md', '');
+    expect(h.searchIndexNote).toHaveBeenCalledWith(CTX, 'notes/new.md', '');
+  });
+
+  it('NOTEBASE_DELETE_FILE claims the path, deletes, de-indexes, then persists', async () => {
+    h.markPathHandled.mockImplementation(() => { h.order.push('mark'); });
+    h.deleteFile.mockImplementation(async () => { h.order.push('delete'); });
+    h.removeFromIndexes.mockImplementation(() => { h.order.push('deindex'); });
+    h.persistIndexes.mockImplementation(async () => { h.order.push('persist'); });
+
+    await call(Channels.NOTEBASE_DELETE_FILE, 'notes/a.md');
+
+    expect(h.order).toEqual(['mark', 'delete', 'deindex', 'persist']);
+    expect(h.removeFromIndexes).toHaveBeenCalledWith(ROOT, 'notes/a.md');
+  });
+
+  it('NOTEBASE_DELETE_FOLDER enumerates the folder BEFORE deleting it', async () => {
+    // Enumerating after the delete would list nothing, and every note in the
+    // folder would linger in the graph + search index as a ghost.
+    h.listIndexableFiles.mockImplementation(async () => { h.order.push('list'); return ['dir/a.md', 'dir/b.md']; });
+    h.deleteFolder.mockImplementation(async () => { h.order.push('delete'); });
+    h.removeFromIndexes.mockImplementation(() => { h.order.push('deindex'); });
+    h.persistIndexes.mockImplementation(async () => { h.order.push('persist'); });
+
+    await call(Channels.NOTEBASE_DELETE_FOLDER, 'dir');
+
+    expect(h.order).toEqual(['list', 'delete', 'deindex', 'deindex', 'persist']);
+    expect(h.removeFromIndexes.mock.calls).toEqual([[ROOT, 'dir/a.md'], [ROOT, 'dir/b.md']]);
+    expect(h.persistIndexes).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('NOTEBASE_CREATE_FOLDER delegates to the fs helper', async () => {
+    await call(Channels.NOTEBASE_CREATE_FOLDER, 'a/b');
+    expect(h.createFolder).toHaveBeenCalledWith(ROOT, 'a/b');
+  });
+
+  it('NOTEBASE_WRITE_BINARY re-wraps a structured-clone Buffer as a Uint8Array view', async () => {
+    // Electron's bridge hands a Buffer at this end; anything else is wrapped so
+    // `writeBinaryFile` always sees a strict Uint8Array.
+    await call(Channels.NOTEBASE_WRITE_BINARY, 'img.png', Buffer.from([1, 2, 3]));
+    const written = h.writeBinaryFile.mock.calls[0]![2] as Uint8Array;
+    expect(written).toBeInstanceOf(Uint8Array);
+    expect([...written]).toEqual([1, 2, 3]);
+  });
+
+  it('NOTEBASE_COPY reindexes every file under a copied directory', async () => {
+    h.stat.mockResolvedValue({ isDirectory: () => true });
+    h.listIndexableFiles.mockResolvedValue(['dest/a.md', 'dest/b.md']);
+
+    await call(Channels.NOTEBASE_COPY, 'src', 'dest');
+
+    expect(h.copyItem).toHaveBeenCalledWith(ROOT, 'src', 'dest');
+    expect(h.reindexFile.mock.calls).toEqual([[ROOT, 'dest/a.md'], [ROOT, 'dest/b.md']]);
+  });
+
+  it('NOTEBASE_COPY reindexes just the file when the copy is a single note', async () => {
+    h.stat.mockResolvedValue({ isDirectory: () => false });
+    await call(Channels.NOTEBASE_COPY, 'a.md', 'b.md');
+    expect(h.reindexFile.mock.calls).toEqual([[ROOT, 'b.md']]);
+    expect(h.listIndexableFiles).not.toHaveBeenCalled();
+  });
+
+  it('FILES_DROP_IMPORT defaults a null target folder to the project root', async () => {
+    h.dropImport.mockResolvedValue({ imported: [] });
+    await call(Channels.FILES_DROP_IMPORT, null, null);
+    expect(h.dropImport).toHaveBeenCalledWith(ROOT, '', []);
+  });
+
+  it('NOTEBASE_SET_ONBOARDING_DISMISSED stores a strict boolean', async () => {
+    await call(Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, 'yes');
+    expect(h.setOnboardingDismissed).toHaveBeenCalledWith(ROOT, false);
+    await call(Channels.NOTEBASE_SET_ONBOARDING_DISMISSED, true);
+    expect(h.setOnboardingDismissed).toHaveBeenLastCalledWith(ROOT, true);
+  });
+
+  it('NOTEBASE_SET_DISPLAY_NAME returns fresh meta so every label updates at once', () => {
+    h.resolveDisplayName.mockReturnValue('Renamed');
+    expect(call(Channels.NOTEBASE_SET_DISPLAY_NAME, 'Renamed')).toEqual({
+      rootPath: ROOT, name: 'Renamed',
+    });
+    expect(h.setDisplayName).toHaveBeenCalledWith(ROOT, 'Renamed');
+  });
+});
+
+describe('register-notebase — rename / merge broadcasts', () => {
+  it('NOTEBASE_RENAME tells open tabs about both the move and the rewritten links', async () => {
+    h.renameWithLinkRewrites.mockResolvedValue({
+      transitions: [{ old: 'a.md', new: 'b.md' }],
+      rewrittenPaths: ['c.md'],
+    });
+
+    await call(Channels.NOTEBASE_RENAME, 'a.md', 'b.md');
+
+    expect(sends()).toEqual([
+      [Channels.NOTEBASE_RENAMED, [{ old: 'a.md', new: 'b.md' }]],
+      [Channels.NOTEBASE_REWRITTEN, ['c.md']],
+    ]);
+    expect(h.persistIndexes).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('NOTEBASE_RENAME stays quiet when nothing moved and nothing was rewritten', async () => {
+    h.renameWithLinkRewrites.mockResolvedValue({ transitions: [], rewrittenPaths: [] });
+    await call(Channels.NOTEBASE_RENAME, 'a.md', 'a.md');
+    expect(sends()).toEqual([]);
+  });
+
+  it("NOTEBASE_RENAME's reindex hook routes only markdown to search + vectors", async () => {
+    h.renameWithLinkRewrites.mockImplementation(async (
+      _root: string, _old: string, _new: string,
+      opts: { reindexHook: (p: string, c: string) => void; removeHook: (p: string) => void },
+    ) => {
+      opts.reindexHook('b.md', 'body');
+      opts.reindexHook('data.csv', 'x,y'); // a first-class note, but not full-text/vector indexed
+      opts.removeHook('a.md');
+      return { transitions: [], rewrittenPaths: [] };
+    });
+
+    await call(Channels.NOTEBASE_RENAME, 'a.md', 'b.md');
+
+    expect(h.searchIndexNote.mock.calls).toEqual([[CTX, 'b.md', 'body']]);
+    expect(h.vectorsIndexNote).toHaveBeenCalledTimes(1);
+    expect(h.searchRemoveNote).toHaveBeenCalledWith(CTX, 'a.md');
+    expect(h.vectorsRemoveNote).toHaveBeenCalledWith(CTX, 'a.md');
+  });
+
+  it('NOTEBASE_MERGE signals the source note as deleted and refreshes the target', async () => {
+    h.mergeNotes.mockResolvedValue({ rewrittenPaths: ['c.md'] });
+
+    const result = await call(Channels.NOTEBASE_MERGE, 'a.md', 'b.md', '\n---\n');
+
+    // The empty `new` is the agreed deletion sentinel — editor tabs on the
+    // source close instead of pointing at a file that no longer exists.
+    expect(sends()).toEqual([
+      [Channels.NOTEBASE_RENAMED, [{ old: 'a.md', new: '' }]],
+      [Channels.NOTEBASE_REWRITTEN, ['c.md', 'b.md']],
+    ]);
+    expect(result).toEqual({ rewrittenPaths: ['c.md'] });
+    expect(h.mergeNotes).toHaveBeenCalledWith(ROOT, 'a.md', 'b.md', expect.objectContaining({ separator: '\n---\n' }));
+  });
+
+  it('NOTEBASE_MERGE still refreshes the target when no links were rewritten', async () => {
+    h.mergeNotes.mockResolvedValue({ rewrittenPaths: [] });
+    await call(Channels.NOTEBASE_MERGE, 'a.md', 'b.md');
+    expect(sends()).toEqual([
+      [Channels.NOTEBASE_RENAMED, [{ old: 'a.md', new: '' }]],
+      [Channels.NOTEBASE_REWRITTEN, ['b.md']],
+    ]);
+  });
+
+  it('NOTEBASE_MERGE omits the separator key entirely when the caller passed none', async () => {
+    h.mergeNotes.mockResolvedValue({ rewrittenPaths: [] });
+    await call(Channels.NOTEBASE_MERGE, 'a.md', 'b.md');
+    const opts = h.mergeNotes.mock.calls[0]![3] as Record<string, unknown>;
+    // Not `separator: undefined` — the merge module's own default must win.
+    expect(Object.hasOwn(opts, 'separator')).toBe(false);
+  });
+
+  it('NOTEBASE_RENAME_ANCHOR refreshes only the notes whose links moved', async () => {
+    h.renameAnchor.mockResolvedValue({ rewrittenPaths: ['c.md'] });
+    await expect(call(Channels.NOTEBASE_RENAME_ANCHOR, 'a.md', 'old', 'new'))
+      .resolves.toEqual({ rewrittenPaths: ['c.md'] });
+    expect(sends()).toEqual([[Channels.NOTEBASE_REWRITTEN, ['c.md']]]);
+  });
+
+  it('NOTEBASE_RENAME_ANCHOR broadcasts nothing when no link pointed at the heading', async () => {
+    h.renameAnchor.mockResolvedValue({ rewrittenPaths: [] });
+    await call(Channels.NOTEBASE_RENAME_ANCHOR, 'a.md', 'old', 'new');
+    expect(sends()).toEqual([]);
+  });
+
+  it('NOTEBASE_RENAME_SOURCE reports the rewritten notes and refreshes them', async () => {
+    h.renameSource.mockResolvedValue({ rewrittenPaths: ['a.md'] });
+    await expect(call(Channels.NOTEBASE_RENAME_SOURCE, 'old', 'new')).resolves.toEqual({ rewrittenPaths: ['a.md'] });
+    expect(h.broadcastRewritten).toHaveBeenCalledWith(ROOT, ['a.md']);
+  });
+
+  it('NOTEBASE_RENAME_EXCERPT reports the rewritten notes and refreshes them', async () => {
+    h.renameExcerpt.mockResolvedValue({ rewrittenPaths: ['a.md'] });
+    await expect(call(Channels.NOTEBASE_RENAME_EXCERPT, 'old', 'new')).resolves.toEqual({ rewrittenPaths: ['a.md'] });
+    expect(h.broadcastRewritten).toHaveBeenCalledWith(ROOT, ['a.md']);
+  });
+});
+
+describe('register-notebase — find & replace', () => {
+  it('NOTEBASE_REPLACE_IN_NOTES reindexes, persists, then refreshes the changed notes', async () => {
+    h.replaceInNotes.mockResolvedValue({ changedPaths: ['a.md', 'b.md'], replacedCount: 3 });
+
+    const result = await call(Channels.NOTEBASE_REPLACE_IN_NOTES, { query: 'x', replacement: 'y', selections: [] });
+
+    expect(result).toEqual({ changedPaths: ['a.md', 'b.md'], replacedCount: 3 });
+    expect(h.reindexFile.mock.calls).toEqual([[ROOT, 'a.md'], [ROOT, 'b.md']]);
+    expect(h.persistIndexes).toHaveBeenCalledWith(ROOT);
+    expect(h.broadcastRewritten).toHaveBeenCalledWith(ROOT, ['a.md', 'b.md']);
+  });
+
+  it('NOTEBASE_REPLACE_IN_NOTES skips the reindex when nothing matched', async () => {
+    h.replaceInNotes.mockResolvedValue({ changedPaths: [], replacedCount: 0 });
+    await call(Channels.NOTEBASE_REPLACE_IN_NOTES, { query: 'x', replacement: 'y', selections: [] });
+    expect(h.reindexFile).not.toHaveBeenCalled();
+    expect(h.broadcastRewritten).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-notebase — project lifecycle', () => {
+  it('NOTEBASE_OPEN opens the picked thoughtbase in the invoking window', async () => {
+    h.openNotebase.mockResolvedValue({ rootPath: '/picked', name: 'Picked' });
+    await expect(call(Channels.NOTEBASE_OPEN)).resolves.toEqual({ rootPath: '/picked', name: 'Picked' });
+    expect(h.openProjectInWindow).toHaveBeenCalledWith(h.win, '/picked');
+  });
+
+  it('NOTEBASE_OPEN leaves the current project alone when the picker is cancelled', async () => {
+    h.openNotebase.mockResolvedValue(null);
+    await expect(call(Channels.NOTEBASE_OPEN)).resolves.toBeNull();
+    expect(h.openProjectInWindow).not.toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_OPEN_PATH opens a known path and resolves its display name', async () => {
+    await expect(call(Channels.NOTEBASE_OPEN_PATH, '/other')).resolves.toEqual({ rootPath: '/other', name: 'My Vault' });
+    expect(h.openProjectInWindow).toHaveBeenCalledWith(h.win, '/other');
+  });
+
+  it('NOTEBASE_NEW_PROJECT is a no-op when the directory picker is cancelled', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+    await expect(call(Channels.NOTEBASE_NEW_PROJECT)).resolves.toBeNull();
+    expect(h.openProjectInWindow).not.toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_NEW_PROJECT is a no-op when the picker returns no path', async () => {
+    // "not cancelled but empty" is a real Electron shape; both arms have to
+    // read as "the user chose nothing".
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [] });
+    await expect(call(Channels.NOTEBASE_NEW_PROJECT)).resolves.toBeNull();
+    expect(h.openProjectInWindow).not.toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_NEW_PROJECT opens the chosen directory in this window', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/new'] });
+    await expect(call(Channels.NOTEBASE_NEW_PROJECT)).resolves.toEqual({ rootPath: '/new', name: 'My Vault' });
+    expect(h.openProjectInWindow).toHaveBeenCalledWith(h.win, '/new');
+  });
+
+  it('NOTEBASE_CLOSE releases the project held by the invoking window', () => {
+    expect(call(Channels.NOTEBASE_CLOSE)).toBeNull();
+    expect(h.closeProjectInWindow).toHaveBeenCalledWith(h.win.id);
+  });
+
+  it('RECENT_CLEAR empties the list and rebuilds the menu that shows it', () => {
+    call(Channels.RECENT_CLEAR);
+    expect(h.clearRecentProjects).toHaveBeenCalled();
+    expect(h.rebuildMenu).toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_OPEN_IN_NEW_WINDOW defers the open until the fresh window has loaded', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/other'] });
+
+    await call(Channels.NOTEBASE_OPEN_IN_NEW_WINDOW);
+    // Nothing opened yet — the renderer isn't listening until did-finish-load.
+    expect(h.openProjectInWindow).not.toHaveBeenCalled();
+
+    await finishLoad();
+    expect(h.openProjectInWindow).toHaveBeenCalledWith(h.freshWin, '/other');
+    expect(h.freshWin.webContents.send).toHaveBeenCalledWith(
+      Channels.PROJECT_OPENED, { rootPath: '/other', name: 'My Vault' },
+    );
+  });
+
+  it('NOTEBASE_OPEN_IN_NEW_WINDOW creates no window when the picker is cancelled', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+    await expect(call(Channels.NOTEBASE_OPEN_IN_NEW_WINDOW)).resolves.toBeNull();
+    expect(h.createWindow).not.toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_NEW_PROJECT_IN_NEW_WINDOW creates the window and opens after load', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/new'] });
+    await expect(call(Channels.NOTEBASE_NEW_PROJECT_IN_NEW_WINDOW))
+      .resolves.toEqual({ rootPath: '/new', name: 'My Vault' });
+    await finishLoad();
+    expect(h.openProjectInWindow).toHaveBeenCalledWith(h.freshWin, '/new');
+  });
+
+  it('NOTEBASE_NEW_PROJECT_IN_NEW_WINDOW creates no window when cancelled', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+    await expect(call(Channels.NOTEBASE_NEW_PROJECT_IN_NEW_WINDOW)).resolves.toBeNull();
+    expect(h.createWindow).not.toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_OPEN_PATH_IN_NEW_WINDOW needs no picker — it opens a known path', async () => {
+    expect(call(Channels.NOTEBASE_OPEN_PATH_IN_NEW_WINDOW, '/recent'))
+      .toEqual({ rootPath: '/recent', name: 'My Vault' });
+    await finishLoad();
+    expect(h.openProjectInWindow).toHaveBeenCalledWith(h.freshWin, '/recent');
+  });
+});
+
+describe('register-notebase — tutorial install (#1542/#1544)', () => {
+  it('installs at the confirmed destination and opens it in this window', async () => {
+    h.showSaveDialog.mockResolvedValue({ canceled: false, filePath: '/home/user/Thoughtbases/Minerva Tutorial' });
+    h.installTutorialThoughtbase.mockResolvedValue('/home/user/Thoughtbases/Minerva Tutorial 2');
+
+    await expect(call(Channels.NOTEBASE_INSTALL_TUTORIAL)).resolves.toEqual({
+      rootPath: '/home/user/Thoughtbases/Minerva Tutorial 2', name: 'My Vault',
+    });
+    // The Save panel is pre-filled beside the user's other thoughtbases (#1560).
+    expect(h.showSaveDialog).toHaveBeenCalledWith(h.win, expect.objectContaining({
+      defaultPath: path.join('/home/user/Thoughtbases', 'Minerva Tutorial'),
+    }));
+    expect(h.openProjectInWindow).toHaveBeenCalledWith(h.win, '/home/user/Thoughtbases/Minerva Tutorial 2');
+  });
+
+  it('creates nothing when the destination panel is cancelled', async () => {
+    h.showSaveDialog.mockResolvedValue({ canceled: true });
+    await expect(call(Channels.NOTEBASE_INSTALL_TUTORIAL)).resolves.toBeNull();
+    expect(h.installTutorialThoughtbase).not.toHaveBeenCalled();
+  });
+
+  it('creates nothing when the panel returns no path', async () => {
+    h.showSaveDialog.mockResolvedValue({ canceled: false, filePath: '' });
+    await expect(call(Channels.NOTEBASE_INSTALL_TUTORIAL)).resolves.toBeNull();
+    expect(h.installTutorialThoughtbase).not.toHaveBeenCalled();
+  });
+
+  it('the new-window variant leaves the current thoughtbase untouched', async () => {
+    h.showSaveDialog.mockResolvedValue({ canceled: false, filePath: '/dest' });
+    h.installTutorialThoughtbase.mockResolvedValue('/dest');
+
+    await call(Channels.NOTEBASE_INSTALL_TUTORIAL_IN_NEW_WINDOW);
+
+    // The user's open work stays put: the tutorial lands in a fresh window.
+    expect(h.openProjectInWindow).not.toHaveBeenCalledWith(h.win, expect.anything());
+    await finishLoad();
+    expect(h.openProjectInWindow).toHaveBeenCalledWith(h.freshWin, '/dest');
+    expect(h.freshWin.webContents.send).toHaveBeenCalledWith(
+      Channels.PROJECT_OPENED, { rootPath: '/dest', name: 'My Vault' },
+    );
+  });
+
+  it('the new-window variant creates no window when cancelled', async () => {
+    h.showSaveDialog.mockResolvedValue({ canceled: true });
+    await expect(call(Channels.NOTEBASE_INSTALL_TUTORIAL_IN_NEW_WINDOW)).resolves.toBeNull();
+    expect(h.createWindow).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-notebase — offline caches', () => {
+  it('YOUTUBE_THUMBNAIL returns null rather than throwing when offline + uncached', async () => {
+    h.getOrFetchThumbnail.mockResolvedValue(null);
+    await expect(call(Channels.YOUTUBE_THUMBNAIL, 'abc123')).resolves.toBeNull();
+    expect(h.getOrFetchThumbnail).toHaveBeenCalledWith(ROOT, 'abc123');
+  });
+
+  it('IMAGES_CACHE_EXTERNAL hands back the cached bytes + mime', async () => {
+    h.getOrFetchRemoteImage.mockResolvedValue({ bytes: new Uint8Array([1]), mime: 'image/png' });
+    await expect(call(Channels.IMAGES_CACHE_EXTERNAL, 'https://x/y.png')).resolves.toEqual({
+      bytes: new Uint8Array([1]), mime: 'image/png',
+    });
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -130,18 +130,22 @@ export default defineConfig({
           statements: 62,
           branches: 66,
         },
-        // IPC registrars — mostly thin channel→module glue that was entirely
-        // unfenced (QA C1 / #1612). The layer is deliberately low-covered (the
-        // underlying modules carry the real tests), so this is a BACKSTOP, not a
-        // target: it locks in the conversation-handler coverage (#1612) and
-        // stops a new registrar shipping at 0%. Measured ~27.6 L / 12.5 F /
-        // 25.3 S / 7.3 B; floors sit a few points below so a small change
-        // won't flap. Ratchet up as more handlers get direct tests.
+        // IPC registrars — channel→module glue that was entirely unfenced
+        // (QA C1 / #1612), then covered registrar by registrar. #1840 added
+        // direct handler tests for the three biggest untested ones —
+        // register-notebase (the write path), register-graph, register-links —
+        // taking the layer from ~33 L / 18.7 F / 30.7 S / 14.3 B to ~50.5 L /
+        // 38.1 F / 48.2 S / 31.6 B. The branch floor especially matters: this
+        // is the layer that owns `withRootPath` vs `withRootPathOr` semantics,
+        // so the #1631 no-project/not-found conflations can now regress into a
+        // test failure instead of passing silently. Floors sit ~10 points below
+        // measured so a refactor won't flap. Still a BACKSTOP, not a target —
+        // 16 registrars remain without a direct test; ratchet up as they land.
         'src/main/ipc/**': {
-          lines: 24,
-          functions: 10,
-          statements: 22,
-          branches: 5,
+          lines: 40,
+          functions: 28,
+          statements: 38,
+          branches: 21,
         },
         // Neglected top-level main modules — previously unfenced (#1100 / QA
         // H1). These sit at `src/main/*.ts` (no directory of their own), so


### PR DESCRIPTION
Part of #1840 (issue stays open — 16 registrars still have no direct test).

19 of 24 `register-*.ts` modules had no test, against an explicit CLAUDE.md checklist item. This covers the three biggest, starting with the one that owns the write path.

**154 new tests** across `register-notebase` (735 lines of test), `register-graph` (391), `register-links` (380).

### Coverage

| `src/main/ipc/**` | before | after | new floor |
| --- | --- | --- | --- |
| lines | 32.96 | 50.51 | 40 |
| functions | 18.67 | 38.13 | 28 |
| statements | 30.74 | 48.23 | 38 |
| branches | **14.31** | **31.58** | **21** |

I re-ran `pnpm coverage` in the main checkout to confirm these independently. Per-file: `register-notebase` 18.7→95.8 L, `register-graph` 32.7→92.3 L, `register-links` 19.2→98.1 L, each from 0% branch coverage.

The branch floor is the one that matters: this is the layer that owns `withRootPath` vs `withRootPathOr` semantics, so the #1631 no-project conflations can now regress into a test failure instead of passing silently. (The old config comment claimed ~27.6/12.5/25.3/7.3 — the layer had already drifted above that, so the real baseline was higher than the file said.)

### What the tests actually pin

Not "a channel got registered": the write pipeline's `suppressRewrittenBroadcast`, the index-bookkeeping *order* (a folder is enumerated before it's deleted; `markPathHandled` fires before the fs mutation), the rename/merge broadcast contract including the `new: ''` deletion sentinel, the #1443 rebase rebuild sequence (`rebaseFrom` old base, CSVs before note tables), the limit clamping and ×5 over-fetch in the Related ranking, and a no-project assertion on every handler in all three files.

### Findings, reported not fixed

Known backlog items were deliberately left untested, with in-file comments so nobody "closes the gap" by pinning the wrong behaviour: `NOTEBASE_FILE_EXISTS` (`false` for both no-project and no-file), `LINKS_CITATIONS_FOR_NOTE` (`.catch(() => '')` turns EACCES into "cites nothing"), and the two `GRAPH_*` handlers that #1860 is fixing.

**One new candidate worth acting on:** `NOTEBASE_REPLACE_IN_NOTES` (`register-notebase.ts:392`) hand-rolls a guard returning `{ changedPaths: [], replacedCount: 0 }` when no project is open. That's a *mutation* reporting "I replaced 0 occurrences" for a call that never ran — the UI shows a successful no-op rather than an error. Per #1631 rule 2 a fallback must mean the same thing as a genuinely-empty result, and "nothing matched" and "there was nothing to search" are different facts. Happy to file it.

Related: `NOTEBASE_LIST_FILES`, `NOTEBASE_SEARCH_IN_NOTES` and `NOTEBASE_FILE_EXISTS` also hand-roll `if (!rootPath) return …` instead of using `withRootPathOr`. Behaviour is correct for the first two — and asserted — but the hand-rolled form is why the one above slipped through: it doesn't force you to name the fallback as a deliberate choice.

`pnpm lint` clean; full suite 6,211 passing (603 files); `pnpm coverage` passes with the new floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy