### PR TITLE
feat(arch): module-level import rules within a layer (#1849, #1843)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,6 +62,12 @@ export default tseslint.config(
   {
     ignores: [
       '.vite/**',
+      // Agent worktrees (`git worktree add .claude/worktrees/…`) are full
+      // checkouts of this repo. Without this, `eslint .` type-checks the whole
+      // source tree once per worktree and runs the process out of heap — which
+      // presents as an unexplained OOM in the pre-push hook, not as anything
+      // to do with worktrees.
+      '.claude/**',
       'dist/**',
       'out/**',
       'coverage/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -311,6 +311,60 @@ export default tseslint.config(
       }],
     },
   },
+  // ── Module-level import rules within a layer (#1849) ───────────────────
+  // The blocks above fix the DIRECTION between layers. These fix a handful of
+  // edges *inside* a layer, where the layering rules have nothing to say and a
+  // wrong import is invisible until someone reads the file. Each one is a
+  // decision the codebase already documents in prose; freezing it here means
+  // the prose can't quietly stop being true.
+  //
+  // This list is deliberately short. It is not an attempt to describe the
+  // whole design — only the edges whose absence something else depends on.
+  {
+    files: ['src/main/llm/approval.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': ['error', {
+        patterns: [{
+          // Matched against the specifier as WRITTEN, not the resolved path —
+          // approval.ts imports it as './conversation', so a `**/llm/…` glob
+          // alone would never fire. (Found by probing the rule rather than
+          // trusting it.)
+          group: ['./conversation', '**/llm/conversation'],
+          message:
+            'approval.ts owns approval-tier policy and the proposal lifecycle — it should not read ' +
+            'conversation storage. Ask `llm/proposal-cause.ts` for a label instead (#1843).',
+        }],
+      }],
+    },
+  },
+  {
+    files: ['src/main/history/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': ['error', {
+        patterns: [{
+          group: ['**/notebase/**'],
+          message:
+            'history/ sits BELOW notebase/: `notebase/fs` calls the capture hooks, and restore ' +
+            'orchestration composes the two in the IPC layer. Importing back the other way is the ' +
+            'cycle that arrangement exists to avoid (#1849).',
+        }],
+      }],
+    },
+  },
+  {
+    files: ['src/main/graph/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': ['error', {
+        patterns: [{
+          group: ['**/llm/**'],
+          message:
+            'The graph is the substrate; the LLM is one of its clients. A graph module that reaches ' +
+            'into llm/ has the dependency backwards — and the approval engine, which is what would ' +
+            'want it, already depends on graph/ (#1849).',
+        }],
+      }],
+    },
+  },
   // ── Renderer data-flow rule (#1086 / #1674) ────────────────────────────
   // Components may call `api.*` only for reads + stateless OS side-effects.
   // A mutation `api.<domain>.<method>(…)` (or an `api.*.on*` event

--- a/src/main/llm/approval.ts
+++ b/src/main/llm/approval.ts
@@ -21,9 +21,8 @@ import type {
   ProposedWrite,
 } from './proposal-types';
 import { applyBundle, collectAffectsNodes, wiredPayloadKinds } from './apply-dispatch';
-import * as conversation from './conversation';
 import { runWithHistorySource } from '../history';
-import { describeProposalCause } from '../../shared/history';
+import { proposalCause } from './proposal-cause';
 import { emitProposalsChanged } from './proposal-events';
 import {
   getProposal,
@@ -93,32 +92,6 @@ export async function proposeWrite(ctx: ProjectContext, write: ProposedWrite): P
   await writeProposalToGraph(ctx, proposal);
   emitProposalsChanged(ctx.rootPath);
   return proposal;
-}
-
-const CONVERSATION_PROPOSER = 'llm:conversation:';
-
-/**
- * The name a proposal's note revisions should carry in the History panel.
- * Skill-launched conversations are the interesting case: their proposals are
- * only stamped `llm:conversation:<id>`, so the skill's name has to come off the
- * conversation itself. Best-effort — a failed lookup degrades to "Conversation"
- * rather than failing the approval.
- */
-async function proposalCause(ctx: ProjectContext, proposal: Proposal): Promise<string> {
-  let skillName: string | undefined;
-  if (proposal.proposedBy.startsWith(CONVERSATION_PROPOSER)) {
-    const convId = proposal.proposedBy.slice(CONVERSATION_PROPOSER.length);
-    try {
-      skillName = (await conversation.load(ctx.rootPath, convId))?.skill?.name;
-    } catch (err) {
-      console.warn(`[approval] could not resolve the skill behind ${proposal.uri}:`, err);
-    }
-  }
-  return describeProposalCause({
-    proposedBy: proposal.proposedBy,
-    operationType: proposal.operationType,
-    skillName,
-  });
 }
 
 /**

--- a/src/main/llm/proposal-cause.ts
+++ b/src/main/llm/proposal-cause.ts
@@ -1,0 +1,37 @@
+/**
+ * The name a proposal's note revisions carry in the History panel (#1843).
+ *
+ * Extracted from `approval.ts`, whose job is approval-tier policy and the
+ * propose/approve/reject/expire lifecycle — not reading conversation storage to
+ * build a UI string. The lifecycle still needs a label at apply time, so it
+ * asks this module for one instead of knowing how a label is found.
+ *
+ * Skill-launched conversations are the case that makes this non-trivial: their
+ * proposals are stamped only `llm:conversation:<id>`, so the skill's display
+ * name has to come off the conversation itself. Best-effort throughout — a
+ * failed lookup degrades to "Conversation" rather than failing an approval,
+ * because a missing label is a cosmetic loss and a blocked approval is not.
+ */
+import * as conversation from './conversation';
+import { describeProposalCause } from '../../shared/history';
+import type { ProjectContext } from '../project-context-types';
+import type { Proposal } from './proposal-types';
+
+const CONVERSATION_PROPOSER = 'llm:conversation:';
+
+export async function proposalCause(ctx: ProjectContext, proposal: Proposal): Promise<string> {
+  let skillName: string | undefined;
+  if (proposal.proposedBy.startsWith(CONVERSATION_PROPOSER)) {
+    const convId = proposal.proposedBy.slice(CONVERSATION_PROPOSER.length);
+    try {
+      skillName = (await conversation.load(ctx.rootPath, convId))?.skill?.name;
+    } catch (err) {
+      console.warn(`[proposal-cause] could not resolve the skill behind ${proposal.uri}:`, err);
+    }
+  }
+  return describeProposalCause({
+    proposedBy: proposal.proposedBy,
+    operationType: proposal.operationType,
+    skillName,
+  });
+}


### PR DESCRIPTION
Closes #1849 and #1843.

The #668 blocks fix the **direction** between layers. Inside a layer they have nothing to say, and a wrong import is invisible until someone reads the file — which is exactly how `approval.ts` came to import `./conversation` to build a UI string.

Three edges the codebase already documents in prose, now frozen in `eslint.config.mjs`:

| Rule | Why |
| --- | --- |
| `llm/approval.ts` ↛ `llm/conversation` | The approval engine owns tier policy and the proposal lifecycle, not conversation storage |
| `history/**` ↛ `notebase/**` | history sits *below* notebase — `notebase/fs` calls its capture hooks, and restore orchestration composes both in the IPC layer. The reverse is the cycle that arrangement exists to avoid |
| `graph/**` ↛ `llm/**` | The graph is the substrate, the LLM is a client of it, and the approval engine that would want the edge already depends on graph |

Deliberately a short list. It isn't an attempt to describe the design — only the edges whose absence something else depends on.

### #1843 came along, because rule 1 needed it

`proposalCause` moves to `llm/proposal-cause.ts`, so the lifecycle asks a named module for a label instead of knowing how a label is found. Behaviour unchanged; its tests pass untouched.

### The bug that verification caught

I wrote each rule, then wrote the import it forbids and watched it fail. Two fired. **The approval one didn't** — `no-restricted-imports` matches the specifier *as written*, not the resolved path, so `**/llm/conversation` never matched `'./conversation'`.

A rule that can't fire is worse than no rule: it reads as protection and isn't. The glob now covers both forms and the reason is recorded next to it. This is the argument for probing every guard rather than trusting that it's wired — the same thing that turned up the vacuous-pass risk in #1863 and #1864.

### One incidental fix

`eslint .` was running out of heap, presenting as an unexplained OOM in the pre-push hook. Cause: `git worktree add .claude/worktrees/…` puts full checkouts of the repo inside the repo, so eslint type-checked the whole source tree once per worktree. `.claude/**` is now ignored. It cost me three failed pushes to connect the two, so the comment says what it's for.

`pnpm lint` clean; full suite 6,240 passing (607 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy