### PR TITLE
test(arch): registrar-test coverage and file-size ratchets (#1851, #1854)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,33 @@ can't quietly grow while nobody re-reads it:
   hand-rolled (migrate when you touch them): `clipper-config` (decrypt + lazy
   secret upgrade), `llm/settings` (nested providers/models), `menu-config-store`.
 
+### File-size budgets (#1854)
+
+`tests/architecture/file-size-budgets.test.ts` carries a committed
+`path → line count` map for every `src/` file over 600 lines, and fails when a
+listed file **grows**. It is deliberately not a "no file over N lines" rule —
+the point is the derivative, not the absolute. A 1,178-line file that stays
+1,178 lines is not today's problem; one that reaches 1,300 is.
+
+When it fires you have exactly two moves, and picking between them is the whole
+value of the check:
+
+1. **Extract a seam.** If what you added doesn't belong in the same file as the
+   rest, this is the cheapest moment to notice.
+2. **Raise the number in the same PR.** Sometimes the file really is the right
+   home and the seam doesn't exist yet — say so in the diff and move on.
+
+Shrinking a budgeted file also fails, asking you to lower the number (or drop
+the entry once the file is under 600 lines) so reclaimed space doesn't quietly
+become headroom for the next addition. Same shape as the pattern ratchets in
+`tests/architecture/pattern-ratchets.test.ts` and the coverage floors in
+`vitest.config.mts`.
+
+Its sibling `tests/architecture/ipc-registrar-coverage.test.ts` makes the
+"every `register-*` handler ships with a main-process test" checklist item
+above executable: a **new** registrar with no test fails, and the pre-existing
+untested ones sit in a `KNOWN_UNTESTED` list that may only shrink.
+
 ### File System
 - All paths are relative to the project root
 - `assertSafePath()` in `fs.ts` prevents path traversal — always use it//

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @vitest-environment node
+ *
+ * Ratcheted file-size budgets (#1854, epic #1855).
+ *
+ * Every large module in this codebase got large the same way: gradually, with
+ * each addition individually reasonable. `graph/queries.ts` reached ~1,200
+ * lines exactly as `indexers.ts` and the old `ipc.ts` did before it — nobody
+ * ever added 600 lines, everyone added 30.
+ *
+ * This is deliberately NOT a blanket "no file over N lines" rule. That rule
+ * produces artificial splits and a wave of `eslint-disable`, and it would fail
+ * on 28 files today for no actionable reason. The point is the derivative, not
+ * the absolute: a 1,178-line file that stays 1,178 lines is not today's
+ * problem; one that reaches 1,300 is, and the moment to notice is the PR that
+ * does it rather than the next architecture review.
+ *
+ * A budget is not a verdict on the file. Several of these are long because
+ * they are honest catalogs — `shared/channels.ts` is a list of channel names,
+ * and splitting it would make it worse. The claim is only that growing one
+ * should be a line in a diff.
+ *
+ * ── When this fails ─────────────────────────────────────────────────────────
+ * Two options, and picking between them is the entire value of the check:
+ *
+ *   1. Extract a seam. If the addition doesn't belong in the same file as the
+ *      rest, this is the moment that's easiest to see.
+ *   2. Raise the number in the same PR. Sometimes the file really is the right
+ *      home and the seam doesn't exist yet. Saying so in the diff is fine —
+ *      the check is asking the question, not forbidding the answer.
+ *
+ * Also noted in CLAUDE.md → Conventions → File-size budgets.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * Only files above this earn a budget. Below it, size is nobody's business —
+ * a 400-line file growing to 450 is just a file being edited.
+ */
+const THRESHOLD = 600;
+
+/**
+ * Baseline generated from the tree at #1854, not hand-typed: every `.ts` /
+ * `.svelte` file under `src/` measuring more than THRESHOLD lines, with the
+ * count it had that day.
+ *
+ * Sorted largest-first so the shape of the problem is readable at a glance.
+ * Numbers here may go DOWN freely (lower the entry, or delete it once the file
+ * drops under THRESHOLD) and may go UP only on purpose.
+ */
+const BUDGETS: Record<string, number> = {
+  'src/renderer/App.svelte': 2080,
+  'src/renderer/lib/components/Preview.svelte': 1531,
+  'src/renderer/lib/components/SourceDetail.svelte': 1329,
+  'src/renderer/lib/components/SourcesPanel.svelte': 1297,
+  'src/renderer/lib/ipc/client.ts': 1241,
+  'src/renderer/lib/stores/conversations.svelte.ts': 1212,
+  'src/renderer/lib/components/Editor.svelte': 1206,
+  'src/renderer/lib/stores/editor.svelte.ts': 1183,
+  'src/main/graph/queries.ts': 1178,
+  'src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte': 1156,
+  'src/main/menu.ts': 1072,
+  'src/main/graph/indexers.ts': 991,
+  'src/renderer/lib/components/Sidebar.svelte': 990,
+  'src/renderer/lib/app/refactor-ops.svelte.ts': 827,
+  'src/renderer/lib/components/SettingsDialog.svelte': 779,
+  'src/main/graph/health-checks.ts': 777,
+  'src/renderer/lib/components/ExportDialog.svelte': 756,
+  'src/renderer/lib/components/QueryPanel.svelte': 755,
+  'src/renderer/lib/components/conversations/DraftCards.svelte': 740,
+  'src/shared/types.ts': 732,
+  'src/shared/ipc-contract.ts': 720,
+  'src/shared/channels.ts': 701,
+  'src/renderer/lib/app/note-ops.ts': 687,
+  'src/renderer/lib/editor/formatting.ts': 671,
+  'src/main/sources/tables.ts': 665,
+  'src/renderer/lib/components/FindInNotesDialog.svelte': 634,
+  'src/preload/preload.ts': 614,
+  'src/main/ipc/register-conversation-drafts.ts': 601,
+};
+
+/** Source files this applies to: authored `.ts` / `.svelte` under `src/`. */
+function sourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (current: string): void => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) walk(full);
+      // `.d.ts` files are hand-written ambient declarations for untyped deps,
+      // not code with a design in it.
+      else if (/\.(ts|svelte)$/.test(entry.name) && !entry.name.endsWith('.d.ts')) out.push(full);
+    }
+  };
+  walk(path.join(ROOT, 'src'));
+  return out;
+}
+
+/**
+ * `wc -l` semantics for a newline-terminated file, and one more than `wc -l`
+ * for a file without a trailing newline (which is the count a human reading
+ * the file in an editor would give). Whichever it is, it has to be the SAME
+ * function that generated the baseline, or every entry is off by one.
+ */
+function lineCount(text: string): number {
+  if (text === '') return 0;
+  const lines = text.split('\n');
+  if (lines[lines.length - 1] === '') lines.pop();
+  return lines.length;
+}
+
+/**
+ * Measured sizes for everything the budget map should cover: files currently
+ * over THRESHOLD, plus every budgeted file even if it has since dropped below
+ * — so a file that shrank reports its real new number instead of vanishing.
+ */
+function measured(): Record<string, number> {
+  const sizes: Record<string, number> = {};
+  for (const file of sourceFiles()) {
+    const relative = path.relative(ROOT, file).split(path.sep).join('/');
+    const count = lineCount(fs.readFileSync(file, 'utf-8'));
+    if (count > THRESHOLD || relative in BUDGETS) sizes[relative] = count;
+  }
+  return sizes;
+}
+
+describe('file-size budgets (#1854)', () => {
+  it('the scan still finds files — an empty walk would pass vacuously', () => {
+    // A budget map compared against nothing agrees with nothing. Floors here
+    // rather than an exact count, so ordinary churn doesn't flap.
+    expect(sourceFiles().length).toBeGreaterThan(500);
+    expect(sourceFiles().some((f) => f.endsWith('.svelte'))).toBe(true);
+    expect(Object.keys(measured()).length).toBeGreaterThan(20);
+  });
+
+  it('no budgeted file grows', () => {
+    const sizes = measured();
+    const grown: string[] = [];
+    const fresh: string[] = [];
+
+    for (const [file, count] of Object.entries(sizes)) {
+      const budget = BUDGETS[file];
+      if (budget === undefined) fresh.push(`  + ${file}: ${count} lines (no budget)`);
+      else if (count > budget) grown.push(`  + ${file}: ${budget} → ${count} (+${count - budget})`);
+    }
+
+    if (grown.length > 0) {
+      expect.fail(
+        `File-size budget exceeded — the count went UP.\n\n${grown.join('\n')}\n\n` +
+        'Two ways forward, and choosing is the point of this check: extract a seam (if the ' +
+        'addition does not belong in the same file as the rest, now is when that is easiest to ' +
+        'see), or raise the number in BUDGETS in this same PR because the file really is the ' +
+        'right home. Both are fine. Neither happening silently is the goal.',
+      );
+    }
+
+    if (fresh.length > 0) {
+      expect.fail(
+        `New file(s) over the ${THRESHOLD}-line threshold:\n\n${fresh.join('\n')}\n\n` +
+        'Landing over the threshold on day one is the one case worth a second look, since ' +
+        'nothing forced it to be one file. If it should be, add it to BUDGETS in this file at ' +
+        'its current size and the ratchet takes over from there.',
+      );
+    }
+  });
+
+  it('a file that shrinks has its budget lowered', () => {
+    const sizes = measured();
+    const shrunk: string[] = [];
+    const gone: string[] = [];
+
+    for (const [file, budget] of Object.entries(BUDGETS)) {
+      const count = sizes[file];
+      if (count === undefined) gone.push(`  − ${file} (was ${budget}, no longer in src/)`);
+      else if (count < budget) shrunk.push(`  − ${file}: ${budget} → ${count} (−${budget - count})`);
+    }
+
+    if (shrunk.length > 0) {
+      expect.fail(
+        `File(s) got smaller — nice.\n\n${shrunk.join('\n')}\n\n` +
+        `Lower the number in BUDGETS so the ratchet holds the new ground, or delete the entry ` +
+        `outright if the file is now under ${THRESHOLD} lines. Otherwise the reclaimed space ` +
+        'quietly becomes headroom for the next addition.',
+      );
+    }
+
+    if (gone.length > 0) {
+      expect.fail(
+        `BUDGETS names file(s) that are not in src/ any more:\n\n${gone.join('\n')}\n\n` +
+        'Moved or deleted? Either way, update the path or drop the entry so the map keeps ' +
+        'describing the tree.',
+      );
+    }
+  });
+});

--- a/tests/architecture/ipc-registrar-coverage.test.ts
+++ b/tests/architecture/ipc-registrar-coverage.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment node
+ *
+ * Every IPC registrar is reached by some test (#1851, epic #1855).
+ *
+ * CLAUDE.md's review checklist asks: "Does every new `register-*` IPC handler
+ * ship with a main-process test?" It's a good question, and it was answered
+ * "no" 19 times out of 24 — not by anyone deciding to skip it, but because a
+ * checklist item that nothing executes is a suggestion. It did work for the
+ * newest registrar at the time (`register-history` shipped with its test); it
+ * simply was never applied to what already existed.
+ *
+ * So this makes the convention fail closed for *new* registrars and leaves the
+ * existing gap as a list that may only shrink. That's the whole trade: it
+ * costs one PR instead of a nineteen-file test-writing marathon, and the
+ * backlog becomes visible and countable rather than implied. Writing the
+ * missing tests is #1840's job and proceeds independently; this only stops the
+ * list growing.
+ *
+ * ── What "has a test" means here ────────────────────────────────────────────
+ * A registrar counts as covered when some file under `tests/` imports it. That
+ * is a low bar on purpose, and it is worth being honest about what it does and
+ * doesn't claim:
+ *
+ *   - it does NOT claim the registrar is thoroughly tested — four of the
+ *     eleven currently-covered ones are reached only by the shared no-project
+ *     contract test, which asserts one thing about each;
+ *   - it DOES catch the case this test exists for: a brand-new registrar
+ *     landing with nothing exercising it at all.
+ *
+ * Only real import specifiers count — `from '…'`, `import('…')`, `require('…')`.
+ * A `vi.mock('…/register-x')` deliberately does not, since stubbing a module
+ * out is the opposite of testing it. (No test mocks a registrar today; the
+ * scanner is written this way so that none starts to.)
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const IPC_DIR = path.join(ROOT, 'src', 'main', 'ipc');
+
+/**
+ * The untested set as of #1851, ordered largest-first — which is #1840's
+ * target order ("the largest untested registrars, one PR each"), so working
+ * down this list top to bottom is working that issue.
+ *
+ * This list may only SHRINK. Deleting an entry because you wrote its test is
+ * the intended way to change this file; adding one is not.
+ */
+const KNOWN_UNTESTED: readonly string[] = [
+  'register-sources',      // 343 lines
+  'register-publish',      // 171 lines
+  'register-bibliography', // 144 lines
+  'register-compute',      // 119 lines
+  'register-tools',        // 108 lines
+  'register-types',        //  78 lines
+  'register-queries',      //  63 lines
+  'register-app',          //  48 lines
+  'register-clipper',      //  40 lines
+  'register-views',        //  25 lines
+  'register-tags',         //  23 lines
+  'register-sites',        //  22 lines
+  'register-git',          //  17 lines
+];
+
+/** Module names (no extension) of every `src/main/ipc/register-*.ts`. */
+function registrars(): string[] {
+  return fs
+    .readdirSync(IPC_DIR)
+    .filter((name) => /^register-.*\.ts$/.test(name))
+    .map((name) => name.replace(/\.ts$/, ''))
+    .sort();
+}
+
+/** Every `.ts` file under `tests/`, recursively. */
+function testFiles(): string[] {
+  const out: string[] = [];
+  const walk = (current: string): void => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.ts')) out.push(full);
+    }
+  };
+  walk(path.join(ROOT, 'tests'));
+  return out;
+}
+
+/** Static, dynamic and CJS import specifiers — but not `vi.mock`. */
+const IMPORT_SPECIFIER = /(?:from\s*|\bimport\s*\(\s*|\brequire\s*\(\s*)['"]([^'"]+)['"]/g;
+
+/**
+ * Basenames of everything the test tree imports. Matching on the basename
+ * rather than a resolved path keeps this indifferent to how deep a test sits
+ * (`../../../src/main/ipc/register-shell` and any future alias both land on
+ * `register-shell`), and registrar names are unique across the repo.
+ */
+function modulesImportedByTests(): Set<string> {
+  const imported = new Set<string>();
+  for (const file of testFiles()) {
+    const text = fs.readFileSync(file, 'utf-8');
+    for (const match of text.matchAll(IMPORT_SPECIFIER)) {
+      imported.add(path.basename(match[1]).replace(/\.(ts|js)$/, ''));
+    }
+  }
+  return imported;
+}
+
+function untestedRegistrars(): string[] {
+  const imported = modulesImportedByTests();
+  return registrars().filter((name) => !imported.has(name));
+}
+
+describe('IPC registrar test coverage (#1851)', () => {
+  it('the enumeration still finds things — a broken scan would pass vacuously', () => {
+    // If `registrars()` returned nothing, "every registrar has a test" would
+    // be trivially true and this file would be decoration. Same for the import
+    // scan: if it stopped matching, every registrar would read as untested and
+    // the ratchet below would fail loudly — that direction is safe, so it's
+    // the empty-enumeration direction that needs a floor.
+    expect(registrars().length).toBeGreaterThan(20);
+    expect(modulesImportedByTests().size).toBeGreaterThan(100);
+    // And the scanner really does see registrar imports, not just package names.
+    expect(modulesImportedByTests().has('register-shell')).toBe(true);
+  });
+
+  it('a new registrar ships with a test', () => {
+    const unexpected = untestedRegistrars().filter((name) => !KNOWN_UNTESTED.includes(name));
+    if (unexpected.length > 0) {
+      expect.fail(
+        `Registrar(s) with no test:\n\n${unexpected.map((n) => `  + ${n}`).join('\n')}\n\n` +
+        'Add a main-process test under `tests/main/ipc/` that imports the registrar and ' +
+        'exercises its handlers — `tests/main/ipc/register-shell.test.ts` is the smallest ' +
+        'template, `register-notebase.test.ts` the fullest. CLAUDE.md → "Code Review Checklist ' +
+        'for LLM/Graph PRs": an untested handler is how the CONVERSATION_SEND gap slipped in ' +
+        '(#1612), so a new handler needs both a test and a coverage threshold.\n\n' +
+        'The KNOWN_UNTESTED list in this file is the pre-existing backlog and may only shrink — ' +
+        'it is not where new registrars go.',
+      );
+    }
+  });
+
+  it('the untested list only shrinks', () => {
+    const untested = new Set(untestedRegistrars());
+    const existing = new Set(registrars());
+
+    const nowTested = KNOWN_UNTESTED.filter((name) => existing.has(name) && !untested.has(name));
+    if (nowTested.length > 0) {
+      expect.fail(
+        `These registrars now have tests — nice.\n\n${nowTested.map((n) => `  − ${n}`).join('\n')}\n\n` +
+        'Delete them from KNOWN_UNTESTED in this file so the ratchet holds the new ground. ' +
+        `That would take the backlog from ${KNOWN_UNTESTED.length} to ${KNOWN_UNTESTED.length - nowTested.length}.`,
+      );
+    }
+
+    const gone = KNOWN_UNTESTED.filter((name) => !existing.has(name));
+    if (gone.length > 0) {
+      expect.fail(
+        `KNOWN_UNTESTED names registrars that no longer exist:\n\n${gone.map((n) => `  − ${n}`).join('\n')}\n\n` +
+        'Renamed or removed? Either way, drop the stale entry from this file so the list keeps ' +
+        'meaning "registrars that still need a test".',
+      );
+    }
+  });
+});


### PR DESCRIPTION
Closes #1851 and #1854. Two more fitness functions from epic #1855, in the shape #1864 established.

### #1851 — a registrar can't ship without a test

Enumerates `src/main/ipc/register-*.ts` and asserts each is imported by some file under `tests/`, with the currently-untested ones in a `KNOWN_UNTESTED` list that may only shrink. A new registrar fails immediately; the backlog is countable.

**The issue's number was stale, and the test measured rather than trusted it.** #1840 said 5 of 24 were tested; the real current state is **11 of 24** — #1861 landed three, and `no-project-contract.test.ts` (#1860) reaches three more. `KNOWN_UNTESTED` carries 13, ordered largest-first to match #1840's remaining plan: sources (343), publish (171), bibliography (144), compute (119), tools (108)…

Coverage means "imported by a real import specifier"; `vi.mock` is deliberately excluded, since stubbing a module out is the opposite of testing it. The header states plainly that this is a low bar — it catches "no test at all", not "badly tested".

### #1854 — file-size budgets, watching the derivative

A committed `path → line count` map for the 28 files over 600 lines, failing when a listed file **grows**. Not a blanket cap: an artificial split is worse than a long file, and the point is the direction of travel, not the absolute. Baseline generated from the tree with the same `lineCount` the test uses, so the numbers can't be off by one.

Another stale number found: `graph/queries.ts` is **1,178**, not the 1,294 the issue quotes — #1858 already took three families out of it.

A brand-new file landing over the threshold fails as "no budget" rather than being absorbed silently. Slightly stricter than pure derivative-watching, and the message says to add it to `BUDGETS` if the size is right.

### Verification

Both ratchets were probed in both directions by the author, and **I re-probed them independently in the main checkout** rather than taking the report on trust:

```
File-size budget exceeded — the count went UP.
  + src/main/sources/tables.ts: 665 → 669 (+4)

Registrar(s) with no test:
  + register-probe
```

Also verified: a registrar gaining a test fails asking you to lower the backlog; a renamed registrar fails because `KNOWN_UNTESTED` names something that no longer exists; a file shrinking fails asking you to lower its budget; a renamed file fails the same way. Both files carry vacuity guards, so a broken enumeration can't pass silently.

CLAUDE.md gains a short section on what to do when either fires.

`pnpm lint` clean; full suite 6,246 passing (609 files).

### One thing worth an issue

Both agents working on this epic hit `tests/main/graph/n3-cache-yielding.test.ts` timing out at 5s under full-suite load — **including on a clean `origin/main` tree**, so it's pre-existing and load-sensitive, not caused by any of this work. It has flaked for me twice today too. Worth raising its per-test timeout before it flakes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy