### PR TITLE
test(arch): store-ownership and config-roots checks (#1852, #1853)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,17 @@ The `no-restricted-syntax` block in `eslint.config.js` (scoped to
 to a component fails `pnpm lint`. When you add a new mutation channel, add its
 method name there too.
 
+Two tests hold the other halves. `tests/renderer/dataflow-rule-coverage.test.ts`
+makes the denylist fail CLOSED (an unclassified new method in a component
+fails). `tests/architecture/store-ownership.test.ts` (#1852) enforces the
+POSITIVE half: every `api.<domain>` with a mutating method must have an owner
+under `stores/` or `lib/app/`, and a mutation may not land only in `App.svelte`.
+That's the gap #1834 fell through — history shipped four mutating channels with
+no store, and the panel polled a timer instead of listening for a change event.
+Note what it can't tell you: it doesn't distinguish a real store from a
+passthrough, and it says nothing about whether a mutating channel ships a change
+event (a main-side question).
+
 ### UI & UX Philosophy
 This is a **professional tool**. Design accordingly:
 
@@ -164,9 +175,15 @@ can't quietly grow while nobody re-reads it:
   via `reportConfigError` (loud, not swallowed) then defaults; per-field coercion
   through the shared `as*` decoders (`asString`/`asBool`/`asFiniteNumber`/`asEnum`/
   `asRecord`/`asStringArray`), so each config's `decode(raw)` reads as its schema.
-- Migrated so far: `ingest-settings`, `python-settings`, `project-config`. Still
+- Migrated so far: `sources/ingest-settings`, `compute/python-settings`,
+  `project-config`, `config/inspection-settings`, `history/settings`. Still
   hand-rolled (migrate when you touch them): `clipper-config` (decrypt + lazy
   secret upgrade), `llm/settings` (nested providers/models), `menu-config-store`.
+- **Where each config lives** is inventoried in `docs/config-roots.md` — the
+  three roots (`userData/`, `~/.minerva/`, `<thoughtbase>/.minerva/`) and which
+  ones hold secrets. The `userData/` table is checked against the code by
+  `tests/architecture/config-roots-doc.test.ts` (#1853), so a new
+  `app.getPath('userData')` path that isn't documented fails a test.
 
 ### File System
 - All paths are relative to the project root

--- a/docs/config-roots.md
+++ b/docs/config-roots.md
@@ -9,12 +9,20 @@ all three.
 `app.getPath('userData')` (macOS: `~/Library/Application Support/Minerva/`).
 Machine-/OS-user-scoped settings that don't belong to any one thoughtbase.
 
+This table is checked against the code by
+`tests/architecture/config-roots-doc.test.ts` (#1853): every
+`app.getPath('userData')` call site in `src/main/**` must name a file or folder
+listed here. Adding a config without documenting it fails a test.
+
 | File | Holds |
 |---|---|
 | `llm-settings.json` | LLM providers, model, effort, web settings. **API keys are encrypted** at rest via `safeStorage` (`enc:v1:` prefix). |
 | `clipper-config.json` | Browser-clipper enable flag + the loopback **shared secret (encrypted)**. |
 | `ingest-settings.json` | Source-ingest defaults. |
 | `python-settings.json` | Python interpreter path + run consent. |
+| `compute-consent.json` | Content-addressed code-cell consent, keyed on each cell's code hash (#1412). Machine-scoped so it never rides along with a shared thoughtbase. |
+| `inspection-settings.json` | Which graph-health inspections run, plus their staleness thresholds (#1792). |
+| `history-settings.json` | Local note-history retention limits — days, revisions per note, max file size (#1158). |
 | `privileged-sites.json` | Clipper privileged-site list. |
 | `recent-projects.json` | Recently opened thoughtbases. |
 | `session.json` | Window / layout / tab session. |
@@ -47,6 +55,7 @@ Lives inside each thoughtbase root and travels **with** it. `.minerva/` carries 
 | `queries/` | Saved queries at **project** scope. |
 | `formatter.json` | Per-thoughtbase formatter settings. |
 | `csl/` | User citation styles. |
+| `history/` | Local per-note history: snapshots as `<mirrored-note-path>/<ts>.snap` plus an `index.json` (#1158). Gitignored; plain files so a note's past stays recoverable without the app. |
 | `cache/`, `assets/` | Derived caches (external images, YouTube thumbnails) + publish assets. |
 
 ## Secrets, at a glance

--- a/tests/architecture/config-roots-doc.test.ts
+++ b/tests/architecture/config-roots-doc.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @vitest-environment node
+ *
+ * `docs/config-roots.md` matches the code (#1853, epic #1855).
+ *
+ * The doc (#1642) is a hand-maintained inventory of every place Minerva keeps
+ * configuration, written because those places are otherwise scattered and
+ * because secrets sit in three of them. Hand-maintained inventories drift, and
+ * this one already had: by the time this test was written it omitted
+ * `compute-consent.json`, `inspection-settings.json`, `history-settings.json`,
+ * and `<thoughtbase>/.minerva/history/` entirely. An inventory nobody checks is
+ * a document that tells you something false with confidence — worse than no
+ * document, because it gets believed.
+ *
+ * The check: fourteen sites in `src/main/**` hand-roll
+ * `path.join(app.getPath('userData'), '<name>')`. Every `<name>` must appear in
+ * the doc.
+ *
+ * ── Scope, honestly ─────────────────────────────────────────────────────────
+ * This covers root 1 (`userData/`) only, because that root has a single
+ * machine-checkable spelling — `getPath('userData')`. Root 2 (`~/.minerva/`)
+ * and root 3 (`<thoughtbase>/.minerva/`) are still hand-maintained: their paths
+ * are built from `os.homedir()` and from a project root passed down through
+ * dozens of call sites, with no one literal to anchor on. The doc's other two
+ * tables can still drift; only this one can't.
+ *
+ * It also checks presence, not accuracy — a row whose description is wrong
+ * still passes. Naming the file is the part that was actually being forgotten.
+ *
+ * If `src/main/config/user-data-path.ts` ever lands (one call site instead of
+ * fourteen, as #1853 suggests), point `USER_DATA_CALL` at it and this gets
+ * simpler rather than obsolete.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const MAIN_DIR = 'src/main';
+const DOC = 'docs/config-roots.md';
+
+/**
+ * `app.getPath('userData')` immediately followed by the path segment joined
+ * onto it. Anchoring on the `, '<name>'` is what separates a real call site
+ * from the several places that merely *mention* `getPath('userData')` in prose.
+ */
+const USER_DATA_CALL = /getPath\(\s*['"]userData['"]\s*\)\s*,\s*['"]([^'"]+)['"]/g;
+
+/** Bare mentions, to catch a call site written in a shape the pattern misses. */
+const USER_DATA_MENTION = /getPath\(\s*['"]userData['"]\s*\)/g;
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...tsFilesUnder(full));
+    else if (full.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+/** Drop block and line comments so a doc-comment mention never counts as a call. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+interface Site { file: string; name: string }
+
+function userDataSites(): { sites: Site[]; mentionFiles: string[] } {
+  const sites: Site[] = [];
+  const mentionFiles: string[] = [];
+  for (const file of tsFilesUnder(MAIN_DIR)) {
+    const src = stripComments(readFileSync(file, 'utf8'));
+    if (USER_DATA_MENTION.test(src)) mentionFiles.push(relative('.', file));
+    USER_DATA_MENTION.lastIndex = 0;
+    for (const m of src.matchAll(USER_DATA_CALL)) {
+      sites.push({ file: relative('.', file), name: m[1]! });
+    }
+  }
+  return { sites, mentionFiles };
+}
+
+describe('docs/config-roots.md matches the code (#1853)', () => {
+  const { sites, mentionFiles } = userDataSites();
+  const doc = readFileSync(DOC, 'utf8');
+
+  it('finds the userData call sites it is meant to police', () => {
+    // Without this, a regex that stopped matching would make the whole file
+    // pass by checking nothing.
+    expect(sites.length, `no getPath('userData') call sites found under ${MAIN_DIR}`).toBeGreaterThan(10);
+    expect(doc.length, `${DOC} looks empty`).toBeGreaterThan(1000);
+    // Anchors: one file, one directory — the two shapes the doc has to cover.
+    const names = new Set(sites.map((s) => s.name));
+    expect(names.has('recent-projects.json')).toBe(true);
+    expect(names.has('queries')).toBe(true);
+  });
+
+  /**
+   * The doc names paths in backticks, and writes directories with a trailing
+   * slash (`` `queries/` ``) where the code joins a bare segment (`'queries'`).
+   * Accept either spelling — the check is "is this path named", not "is it
+   * punctuated my way".
+   */
+  const documented = (name: string): boolean =>
+    doc.includes(`\`${name}\``) || doc.includes(`\`${name}/\``);
+
+  it('documents every userData path built in src/main', () => {
+    const undocumented = [...new Set(
+      sites
+        .filter((s) => !documented(s.name))
+        .map((s) => `  ${s.name}  (${s.file})`),
+    )].sort();
+    expect(
+      undocumented,
+      `Config path(s) under userData/ that ${DOC} doesn't mention.\n\n` +
+        `${undocumented.join('\n')}\n\n` +
+        `Add a row to the "1. \`userData/\` — per machine" table in ${DOC} saying what the file ` +
+        'holds — and, if it holds a secret, list it under "Secrets, at a glance" too. The doc is ' +
+        'the only inventory of where Minerva keeps state; a config that isn\'t in it is a config ' +
+        'nobody can find, back up, or reason about.',
+    ).toEqual([]);
+  });
+
+  it('sees every file that mentions userData at all (no call site in an unparsed shape)', () => {
+    // If a file talks about userData but yields no `, '<name>'` site, either it
+    // only mentions it in a string/identifier, or it builds the path in a shape
+    // this test can't read — and an unreadable call site is an undocumented one
+    // waiting to happen. Listed explicitly so a new one has to be looked at.
+    const KNOWN_MENTION_ONLY: Record<string, string> = {
+      // The shared config loader takes an absolute path from its callers; it
+      // names userData only to explain what it's protecting.
+      'src/main/config/config-store.ts': 'loader — takes an absolute path, builds none',
+    };
+    const withSite = new Set(sites.map((s) => s.file));
+    const unexplained = mentionFiles
+      .filter((f) => !withSite.has(f) && !(f in KNOWN_MENTION_ONLY))
+      .sort();
+    expect(
+      unexplained,
+      'File(s) referencing getPath(\'userData\') without a path this test can read:\n' +
+        `${unexplained.join('\n')}\n` +
+        'Build the path as `path.join(app.getPath(\'userData\'), \'<name>\')` so the inventory check ' +
+        'can see it, or add the file to KNOWN_MENTION_ONLY in this test with a reason.',
+    ).toEqual([]);
+  });
+});

--- a/tests/architecture/store-ownership.test.ts
+++ b/tests/architecture/store-ownership.test.ts
@@ -1,0 +1,202 @@
+/**
+ * @vitest-environment node
+ *
+ * Every mutating `api.*` domain has a store that owns it (#1852, epic #1855).
+ *
+ * CLAUDE.md's renderer data-flow rule says every state mutation and every
+ * main→renderer subscription routes through a store
+ * (`src/renderer/lib/stores/*.svelte.ts`) or an App ops handler
+ * (`src/renderer/lib/app/*`). Eslint enforces the *negative* half — a component
+ * may not call a mutating method. Nothing enforced the positive half: that the
+ * mutation lands somewhere that owns the resulting state.
+ *
+ * #1834 is what that gap costs. Local history shipped seven IPC channels, four
+ * of them mutating, with no store — and the panel polled a timer to compensate.
+ * The convention held 26 domains out of 27. This makes the 27th fail.
+ *
+ * ── What this test can and cannot tell you ──────────────────────────────────
+ * Be honest about the limits, because a fitness function that is trusted for
+ * more than it checks is worse than none:
+ *
+ *   • It CANNOT tell a well-designed store from a one-line passthrough. A file
+ *     under `stores/` that forwards `api.x.mutate()` and updates nothing
+ *     satisfies this test completely. "There is an owner" is a much weaker
+ *     claim than "the owner is any good".
+ *   • It would NOT have caught the other half of #1834 — the missing
+ *     `history:changed` event. Whether a mutating channel ships a change event
+ *     is a main-side channel-shape question, invisible from the renderer, and
+ *     it is not checked anywhere here.
+ *   • It is a lexical scan (see the note in `tests/helpers/renderer-api-surface.ts`):
+ *     an `api.*` call reached through a destructured alias or a computed member
+ *     is not seen.
+ *
+ * What it DOES catch is the half that actually recurred: mutations landing in
+ * `App.svelte` (or nowhere) instead of behind a store. `App.svelte` is the
+ * composition root, which makes it the exemption every new feature reaches for.
+ *
+ * ── The two rules ───────────────────────────────────────────────────────────
+ *   1. DOMAIN OWNERSHIP — every `api.<domain>` namespace exposing at least one
+ *      denylisted method has some file under `stores/` or `lib/app/` calling a
+ *      denylisted method on it. This is the #1834 shape.
+ *   2. NO APP-ONLY MUTATIONS — a mutating method called from `App.svelte` is
+ *      also called from a store/ops file. A budget, in the style of
+ *      `pattern-ratchets.test.ts`: the two that exist today are listed with
+ *      their reasons, and the list may shrink but not grow.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { apiNamespaceMethods, dataflowMutationMethods } from '../helpers/renderer-api-surface';
+
+/** Where a mutation is allowed to live: the stores and the App ops handlers. */
+const OWNER_DIRS = ['src/renderer/lib/stores', 'src/renderer/lib/app'];
+const APP_SVELTE = 'src/renderer/App.svelte';
+
+/**
+ * Domains whose mutating methods legitimately have no store owner, each with
+ * its reason. Empty today — every mutating domain has an owner, which is the
+ * point: this test is holding ground that already exists.
+ *
+ * Note that project lifecycle (`notebase.open` / `close` / `newProject`), the
+ * canonical "genuine App-level orchestration" case, needs no entry here: those
+ * methods are not on the eslint mutation denylist at all, so they never reach
+ * this check. That is a deliberate classification, not an oversight — they
+ * replace the entire window's state rather than mutating a store's slice, and
+ * they are wired in `lib/app/project-ops.ts` regardless.
+ *
+ * If you add an entry, say WHY the domain is App-level orchestration rather
+ * than owned state. "It was easier" is not a reason.
+ */
+const DOMAIN_EXCEPTIONS: Record<string, string> = {};
+
+/**
+ * Mutating methods called from `App.svelte` and nowhere in `stores/` or
+ * `lib/app/`. A budget, not an approval list — both entries are real
+ * data-flow-rule debt, small enough to leave for a targeted PR and named here
+ * so a third one has to be argued for in a diff.
+ */
+const APP_ONLY_MUTATIONS: Record<string, string> = {
+  // #1073 evidence dialog. Files a proposal, then refreshes the proposals store
+  // and raises a toast — so the observable state IS store-owned; only the
+  // invoke sits in App. Belongs behind a proposals-store method.
+  'graph.attachExcerptEvidence': 'Excerpt-evidence proposal filed inline from the App-hosted dialog; refresh already goes through proposalsStore.',
+  // Save-query dialog: App owns the prompt, and the saved-queries store owns
+  // the list. The write should move to `savedQueriesStore.save`, which already
+  // owns delete/rename/move/setGroup/setOrder.
+  'queries.save': 'Save-query dialog is App-hosted; the sibling mutations already live in the saved-queries store.',
+};
+
+function filesUnder(dir: string, ext: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...filesUnder(full, ext));
+    else if (full.endsWith(ext)) out.push(full);
+  }
+  return out;
+}
+
+/** Drop block, line, and HTML comments so a commented example call never counts. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1')
+    .replace(/<!--[\s\S]*?-->/g, '');
+}
+
+/** `domain.method` for every `(window.)?api.<domain>.<method>(` call in `files`. */
+function apiCallsIn(files: string[]): Set<string> {
+  const calls = new Set<string>();
+  for (const file of files) {
+    const src = stripComments(readFileSync(file, 'utf8'));
+    for (const m of src.matchAll(/(?:window\.)?\bapi\.(\w+)\.(\w+)\s*\(/g)) {
+      calls.add(`${m[1]!}.${m[2]!}`);
+    }
+  }
+  return calls;
+}
+
+const ownerFiles = OWNER_DIRS.flatMap((d) => filesUnder(d, '.ts'));
+const ownerCalls = apiCallsIn(ownerFiles);
+const appCalls = apiCallsIn([APP_SVELTE]);
+
+const deny = dataflowMutationMethods();
+const namespaces = apiNamespaceMethods();
+
+/** domain → its denylisted (mutating) method names, for domains that have any. */
+const mutatingDomains = new Map<string, string[]>();
+for (const [domain, methods] of Object.entries(namespaces)) {
+  const mutating = [...methods].filter((m) => deny.has(m));
+  if (mutating.length > 0) mutatingDomains.set(domain, mutating.sort());
+}
+
+describe('every mutating api domain has a store (#1852)', () => {
+  it('parses a non-trivial surface — a broken parser would pass vacuously', () => {
+    // The failure mode that would quietly turn this whole file into decoration:
+    // an empty denylist, an empty bridge parse, or an owner scan that finds no
+    // files would make every assertion below trivially true.
+    expect(deny.size, 'eslint mutation denylist looks empty').toBeGreaterThan(40);
+    expect(Object.keys(namespaces).length, 'preload namespace parse looks empty').toBeGreaterThan(30);
+    expect(ownerFiles.length, 'no store/ops files found').toBeGreaterThan(20);
+    expect(mutatingDomains.size, 'no mutating domains found').toBeGreaterThan(15);
+    expect(ownerCalls.size, 'no api.* calls found in stores/ops').toBeGreaterThan(50);
+    // history is the #1834 domain — if it stops parsing as mutating, this test
+    // has stopped watching the thing it was written for.
+    expect(mutatingDomains.has('history')).toBe(true);
+  });
+
+  it('gives every mutating domain an owner under stores/ or lib/app/', () => {
+    const orphans: string[] = [];
+    for (const [domain, mutating] of mutatingDomains) {
+      if (domain in DOMAIN_EXCEPTIONS) continue;
+      const owned = mutating.some((m) => ownerCalls.has(`${domain}.${m}`));
+      if (!owned) orphans.push(`  api.${domain} — mutating: ${mutating.join(', ')}`);
+    }
+    expect(
+      orphans.sort(),
+      'Mutating api domain(s) with no owner under src/renderer/lib/stores/ or src/renderer/lib/app/.\n\n' +
+        `${orphans.join('\n')}\n\n` +
+        'A domain with mutating channels needs a store that owns them and the state they change ' +
+        '(CLAUDE.md → Renderer data flow). This is exactly what #1834 shipped without: history had ' +
+        'four mutating channels, no store, and a polling timer standing in for a change event. ' +
+        'Add a store under src/renderer/lib/stores/ (or an ops handler under src/renderer/lib/app/) ' +
+        'that owns the api calls and the resulting state, and have components call it. If the domain ' +
+        'genuinely is App-level orchestration, add it to DOMAIN_EXCEPTIONS in this test with a reason.',
+    ).toEqual([]);
+  });
+
+  it('does not let a new mutation land only in App.svelte', () => {
+    const appOnly = [...appCalls]
+      .filter((c) => deny.has(c.split('.')[1]!) && !ownerCalls.has(c))
+      .filter((c) => !(c in APP_ONLY_MUTATIONS))
+      .sort();
+    expect(
+      appOnly,
+      'Mutating api.* call(s) in App.svelte with no counterpart in a store or ops handler.\n\n' +
+        `${appOnly.map((c) => `  api.${c}`).join('\n')}\n\n` +
+        'App.svelte is the composition root, which makes it the exemption every new feature reaches ' +
+        'for — that is the habit this check exists to interrupt. Move the call into the store that ' +
+        'owns the state it changes and have App call the store method. If it truly is top-level ' +
+        'orchestration, add it to APP_ONLY_MUTATIONS in this test with a reason.',
+    ).toEqual([]);
+  });
+
+  it('keeps the documented exceptions live (no stale entries)', () => {
+    const staleDomains = Object.keys(DOMAIN_EXCEPTIONS).filter((d) => !mutatingDomains.has(d));
+    expect(
+      staleDomains,
+      `DOMAIN_EXCEPTIONS entries that are no longer mutating domains — remove: ${staleDomains.join(', ')}`,
+    ).toEqual([]);
+
+    // The budget only ratchets DOWN if fixing an entry also removes it. Anything
+    // still listed but no longer App-only is debt someone paid — take it off.
+    const staleAppOnly = Object.keys(APP_ONLY_MUTATIONS)
+      .filter((c) => !appCalls.has(c) || ownerCalls.has(c))
+      .sort();
+    expect(
+      staleAppOnly,
+      'APP_ONLY_MUTATIONS entries that now have a store owner (or are gone from App.svelte) — ' +
+        `nice, remove them so the budget holds the new ground: ${staleAppOnly.join(', ')}`,
+    ).toEqual([]);
+  });
+});

--- a/tests/helpers/renderer-api-surface.ts
+++ b/tests/helpers/renderer-api-surface.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared parsers for the renderer `api.*` surface, used by the data-flow tests.
+ *
+ * Two facts about the renderer boundary live in source files rather than in a
+ * machine-readable manifest, and more than one test needs them:
+ *
+ *   1. **Which method names count as mutations** — the `DATAFLOW_MUTATION_METHODS`
+ *      denylist in `eslint.config.mjs` (the renderer data-flow rule, #1086/#1626).
+ *   2. **Which namespace exposes which methods** — the `contextBridge` object in
+ *      `src/preload/preload.ts`.
+ *
+ * Parsing either one twice is how the copies drift, so both live here:
+ * `tests/renderer/dataflow-rule-coverage.test.ts` (#1626) and
+ * `tests/architecture/store-ownership.test.ts` (#1852) share them.
+ *
+ * ── On lexical parsing ──────────────────────────────────────────────────────
+ * These read source text, not an AST — same trade as the ratchets in
+ * `tests/architecture/pattern-ratchets.test.ts`: cheap enough for the normal
+ * suite, simple enough that a failure points at something real. The cost is
+ * that both parsers depend on the current *formatting* of the files they read
+ * (a one-line `DATAFLOW_MUTATION_METHODS`, two-space namespace keys in the
+ * bridge object). Each parser therefore throws rather than returning an empty
+ * result when its anchor is missing, and callers assert a non-trivial size —
+ * a reformat that defeats the regex must fail loudly, never pass vacuously.
+ */
+import { readFileSync } from 'node:fs';
+
+const ESLINT_CONFIG = 'eslint.config.mjs';
+const PRELOAD = 'src/preload/preload.ts';
+
+/**
+ * Mutation / event-subscription method names the eslint data-flow denylist
+ * forbids components from calling directly.
+ *
+ * The names live in the `DATAFLOW_MUTATION_METHODS` const — a `'a|b|' + 'c|d'`
+ * series of single-quoted fragments shared by both eslint selectors. Slice the
+ * assignment (from `=` to the terminating `;`), pull the quoted contents, and
+ * split on `|`; the interleaved `//` section comments carry no quotes, so they
+ * drop out.
+ */
+export function dataflowMutationMethods(): Set<string> {
+  const cfg = readFileSync(ESLINT_CONFIG, 'utf8');
+  const decl = cfg.indexOf('const DATAFLOW_MUTATION_METHODS');
+  if (decl < 0) {
+    throw new Error(`DATAFLOW_MUTATION_METHODS not found in ${ESLINT_CONFIG} — did the const get renamed?`);
+  }
+  const eq = cfg.indexOf('=', decl);
+  const semi = cfg.indexOf(';', eq);
+  if (semi <= eq) throw new Error(`Could not find the end of the DATAFLOW_MUTATION_METHODS assignment in ${ESLINT_CONFIG}.`);
+  const names = new Set<string>();
+  for (const m of cfg.slice(eq, semi).matchAll(/'([^']*)'/g)) {
+    for (const n of m[1]!.split('|')) if (/^\w+$/.test(n)) names.add(n);
+  }
+  return names;
+}
+
+/**
+ * `api.<namespace>` → the method names it exposes, from the preload
+ * `contextBridge.exposeInMainWorld('api', { … })` object.
+ *
+ * The bridge is a flat two-level object (namespace keys at two-space indent,
+ * method keys at four), which is what makes the indent-anchored match safe. If
+ * a nested sub-namespace is ever introduced, this returns its inner methods
+ * under the outer namespace — the `preload-bridge` snapshot test (#676) is what
+ * pins the surface shape; this is only a namespace→method index.
+ */
+export function apiNamespaceMethods(): Record<string, Set<string>> {
+  const src = readFileSync(PRELOAD, 'utf8');
+  const start = src.indexOf("exposeInMainWorld('api', {");
+  if (start < 0) throw new Error(`exposeInMainWorld('api', …) not found in ${PRELOAD}.`);
+  const body = src.slice(start);
+
+  const out: Record<string, Set<string>> = {};
+  let depth = 0;
+  let ns: string | null = null;
+  for (const line of body.split('\n')) {
+    const nsMatch = line.match(/^ {2}(\w+):\s*\{/);
+    if (depth === 1 && nsMatch) {
+      ns = nsMatch[1]!;
+      out[ns] ??= new Set();
+    }
+    if (ns && depth >= 2) {
+      // `    method: (args) => …` — a bridged function, not a nested object.
+      const methodMatch = line.match(/^\s{4}(\w+):\s*\(/);
+      if (methodMatch) out[ns]!.add(methodMatch[1]!);
+    }
+    for (const c of line) {
+      if (c === '{') depth++;
+      else if (c === '}') depth--;
+    }
+    if (depth <= 0) break;
+  }
+  return out;
+}

--- a/tests/renderer/dataflow-rule-coverage.test.ts
+++ b/tests/renderer/dataflow-rule-coverage.test.ts
@@ -28,9 +28,9 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { dataflowMutationMethods } from '../helpers/renderer-api-surface';
 
 const COMPONENTS_DIR = 'src/renderer/lib/components';
-const ESLINT_CONFIG = 'eslint.config.mjs';
 
 /**
  * Read / stateless-OS-side-effect `api.*` methods a component may call directly
@@ -88,27 +88,6 @@ function stripComments(src: string): string {
     .replace(/<!--[\s\S]*?-->/g, '');
 }
 
-/** Mutation/subscription method names the eslint denylist forbids in components. */
-function denylistNames(): Set<string> {
-  const cfg = readFileSync(ESLINT_CONFIG, 'utf8');
-  // The mutation method names live in the DATAFLOW_MUTATION_METHODS const — a
-  // `'a|b|' + 'c|d'` series of single-quoted fragments shared by both selectors.
-  // Slice the assignment (from `=` to the terminating `;`), pull the quoted
-  // contents, and split on `|`; the interleaved `//` section comments carry no
-  // quotes, so they drop out.
-  const decl = cfg.indexOf('const DATAFLOW_MUTATION_METHODS');
-  expect(decl, 'DATAFLOW_MUTATION_METHODS not found in eslint.config.mjs').toBeGreaterThan(-1);
-  const eq = cfg.indexOf('=', decl);
-  const semi = cfg.indexOf(';', eq);
-  expect(semi).toBeGreaterThan(eq);
-  const region = cfg.slice(eq, semi);
-  const names = new Set<string>();
-  for (const m of region.matchAll(/'([^']*)'/g)) {
-    for (const n of m[1]!.split('|')) if (/^\w+$/.test(n)) names.add(n);
-  }
-  return names;
-}
-
 /** Every `(window.)?api.<domain>.<method>(` call site across components. */
 function componentApiCalls(): { file: string; method: string }[] {
   const calls: { file: string; method: string }[] = [];
@@ -122,7 +101,7 @@ function componentApiCalls(): { file: string; method: string }[] {
 }
 
 describe('renderer data-flow rule — fail-closed method coverage (#1626)', () => {
-  const deny = denylistNames();
+  const deny = dataflowMutationMethods();
   const calls = componentApiCalls();
 
   it('parses a non-trivial mutation denylist from eslint.config.mjs', () => {


### PR DESCRIPTION
Closes #1852 and #1853. The last two fitness functions from epic #1855.

### #1852 — every mutating api domain has a store

For every `api.<domain>` namespace with at least one denylisted (mutating) method, some file under `src/renderer/lib/stores/` or `src/renderer/lib/app/` must call it. Equivalently: no mutating method is called **only** from `App.svelte`, which is the exemption every new feature reaches for.

This is the #1834 shape made into a test — history shipped four mutating channels, no store, and a polling timer standing in for a change event, and nothing flagged it. Measured surface today: 38 namespaces, 24 of them mutating, all currently owned.

The denylist parsing that `dataflow-rule-coverage.test.ts` already did is now a shared helper (`tests/helpers/renderer-api-surface.ts`) that both tests import, rather than a second copy that could drift from the first.

**Two exceptions, documented as debt rather than dressed up as design:** `graph.attachExcerptEvidence` and `queries.save` are called from `App.svelte` with no store counterpart. Both should move; the comments say so. A follow-up would empty the list.

The docstring is honest about the limit: this cannot tell a well-designed store from a passthrough, and it would **not** have caught the missing-change-event half of #1834. It catches the half that actually recurred.

### #1853 — the config inventory can't drift again

Greps `src/main/**` for `getPath('userData')`, extracts the adjacent filename, and asserts each appears in `docs/config-roots.md`.

**The doc was wrong in four places**, all fixed here: `inspection-settings.json`, `history-settings.json`, `<thoughtbase>/.minerva/history/`, and — one the issue didn't know about — **`compute-consent.json`**. The test found that last one, which is the point of writing it. CLAUDE.md's "Migrated so far" config list is corrected too.

There's a third assertion for a shape the regex can't read: hoisting `const root = app.getPath('userData')` and joining later fails with *"File(s) referencing getPath('userData') without a path this test can read"*. So the check can't be evaded by reformatting — it demands you either write the readable form or come edit the test deliberately.

Stated limit: this covers the `userData/` root only. `~/.minerva/` and `<thoughtbase>/.minerva/` have no single machine-checkable literal to anchor on, so those two tables can still drift. The `user-data-path.ts` extraction (#1853's follow-up, also wanted by #1839) would make this simpler.

### Verification

Both were probed by the author in three ways each, and **I re-probed both independently in the main checkout**:

```
Config path(s) under userData/ that docs/config-roots.md doesn't mention.
  probe-thing.json  (src/main/session.ts)

Mutating api domain(s) with no owner under src/renderer/lib/stores/ or src/renderer/lib/app/.
  api.bookmarks — mutating: save
```

The store-ownership failure message then explains the rule, names #1834 as the precedent, and says how to fix it — including how to add a documented exception if the domain really is App-level orchestration.

The author also verified the ratchet-down direction (adding `queries.save` to a store fails, asking you to remove the exception) and that the config test catches the *real* historical drift, not just synthetic probes: run against the pre-fix doc, it flags exactly the three files that had gone missing.

`pnpm lint` clean; full suite 6,247 passing (609 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy