### PR TITLE
fix(renderer): move the last two App-only mutations behind their stores (#1870, #1871)

### DIFF
--- a/src/renderer/App.svelte
+++ b/src/renderer/App.svelte
@@ -93,6 +93,7 @@
   import { getConversationsStore } from './lib/stores/conversations.svelte';
   import { getBookmarksStore, collectBookmarksForPath } from './lib/stores/bookmarks.svelte';
   import { getProposalsStore } from './lib/stores/proposals.svelte';
+  import { savedQueriesStore } from './lib/stores/saved-queries.svelte';
   import { getToastStore } from './lib/stores/toasts.svelte';
   import Toasts from './lib/components/Toasts.svelte';
   import { describeProposer } from '../shared/provenance';
@@ -418,9 +419,9 @@
     const excerptId = attachEvidenceExcerptId;
     attachEvidenceExcerptId = null;
     if (!excerptId) return;
-    const res = await api.graph.attachExcerptEvidence(excerptId, claimPath, role);
+    // The store files it and re-lists itself; App keeps the dialog and the toast.
+    const res = await proposalsStore.attachExcerptEvidence(excerptId, claimPath, role);
     if (res.ok) {
-      void proposalsStore.refresh();
       toasts.push({ message: `Evidence proposal filed — review it in Proposals`, onClick: openProposals });
     } else {
       toasts.push({ message: `Could not attach evidence: ${res.error ?? 'unknown error'}` });
@@ -684,7 +685,7 @@
       };
     });
     if (!result) return;
-    await api.queries.save(result.scope, result.name, '', tab.query, tab.language);
+    await savedQueriesStore.save(result.scope, result.name, '', tab.query, tab.language);
     tab.title = result.name;
   }
 

--- a/src/renderer/lib/stores/proposals.svelte.ts
+++ b/src/renderer/lib/stores/proposals.svelte.ts
@@ -105,6 +105,23 @@ export function getProposalsStore() {
     },
     /** Force a re-list (first paint / manual). Subscriptions handle the rest. */
     refresh,
+    /**
+     * File an excerpt as evidence for a claim (#1073) and re-list on success.
+     *
+     * The refresh belongs here rather than at the call site (#1871): the state
+     * this changes is the pending-proposal set, which this store owns, so a
+     * caller that forgets to refresh gets a stale badge and no hint why. The
+     * `{ ok, error? }` result comes back so the caller can say what happened.
+     */
+    async attachExcerptEvidence(
+      excerptId: string,
+      claimPath: string,
+      role: 'grounds' | 'supports' | 'rebuts',
+    ): Promise<{ ok: boolean; error?: string }> {
+      const result = await api.graph.attachExcerptEvidence(excerptId, claimPath, role);
+      if (result.ok) await refresh();
+      return result;
+    },
     /** Subscribe to coalesced proposal arrivals (newly-pending proposals, #1541).
      *  The callback gets the batch; returns an unsubscribe. */
     onArrival(cb: (arrived: Proposal[]) => void): () => void {

--- a/src/renderer/lib/stores/saved-queries.svelte.ts
+++ b/src/renderer/lib/stores/saved-queries.svelte.ts
@@ -1,7 +1,8 @@
 /**
  * Saved-queries store (#314 / #315, #1674). Owns the `api.queries.*` mutations
  * so the Edit Saved Queries dialog never calls them directly (renderer data-flow
- * rule #1086).
+ * rule #1086). Every write on this domain goes through here — `save` joined
+ * its siblings in #1870, closing the last gap.
  *
  * The dialog formerly reached these through raw `window.api.queries.*`, which
  * slipped the data-flow eslint rule entirely — its selector matched only the
@@ -13,6 +14,16 @@ import { api } from '../ipc/client';
 import type { SavedQuery } from '../../../shared/types';
 
 export const savedQueriesStore = {
+  /** Save a new query under `name`, in the project or global scope. */
+  save(
+    scope: SavedQuery['scope'],
+    name: string,
+    description: string,
+    query: string,
+    language: SavedQuery['language'],
+  ): Promise<SavedQuery> {
+    return api.queries.save(scope, name, description, query, language);
+  },
   /** Rename a saved query; resolves to its (possibly new) file path. */
   rename(filePath: string, newName: string): Promise<string> {
     return api.queries.rename(filePath, newName);

--- a/tests/architecture/store-ownership.test.ts
+++ b/tests/architecture/store-ownership.test.ts
@@ -75,16 +75,20 @@ const DOMAIN_EXCEPTIONS: Record<string, string> = {};
  * data-flow-rule debt, small enough to leave for a targeted PR and named here
  * so a third one has to be argued for in a diff.
  */
-const APP_ONLY_MUTATIONS: Record<string, string> = {
-  // #1073 evidence dialog. Files a proposal, then refreshes the proposals store
-  // and raises a toast — so the observable state IS store-owned; only the
-  // invoke sits in App. Belongs behind a proposals-store method.
-  'graph.attachExcerptEvidence': 'Excerpt-evidence proposal filed inline from the App-hosted dialog; refresh already goes through proposalsStore.',
-  // Save-query dialog: App owns the prompt, and the saved-queries store owns
-  // the list. The write should move to `savedQueriesStore.save`, which already
-  // owns delete/rename/move/setGroup/setOrder.
-  'queries.save': 'Save-query dialog is App-hosted; the sibling mutations already live in the saved-queries store.',
-};
+/**
+ * Mutating calls that legitimately live in `App.svelte` alone.
+ *
+ * Empty, and worth keeping that way. It was seeded with two entries and both
+ * turned out to be debt rather than orchestration — `queries.save` skipped the
+ * store its five siblings already used (#1870), and `attachExcerptEvidence`
+ * left the proposals refresh to whichever caller remembered it (#1871). Both
+ * moved behind their stores.
+ *
+ * If you add one, it has to be a real App-level concern — something the
+ * composition root does because no single store owns it — and the value is the
+ * reason, which someone will read when deciding whether it still holds.
+ */
+const APP_ONLY_MUTATIONS: Record<string, string> = {};
 
 function filesUnder(dir: string, ext: string): string[] {
   const out: string[] = [];


### PR DESCRIPTION
Closes #1870 and #1871.

**Stacked on #1868** — it introduces `store-ownership.test.ts` and its exception list, so this targets that branch. GitHub will retarget to `main` when #1868 merges.

The store-ownership check shipped with two documented exceptions. Both turned out to be debt rather than orchestration, so this clears them and empties the list.

### `api.queries.save` (#1870)

Skipped the store its five siblings already used. `savedQueriesStore` exists precisely to be the single write path for that domain — its docstring says so, and it was created after the Edit Saved Queries dialog was found reaching `window.api.queries.*` directly. The prompt and the name/scope result stay in App, which genuinely is App's job; only the write moved.

### `api.graph.attachExcerptEvidence` (#1871)

Left the proposals refresh to its caller:

```ts
const res = await api.graph.attachExcerptEvidence(…);
if (res.ok) {
  void proposalsStore.refresh();   // ← caller's job to remember
```

The state this changes is the pending-proposal set, which the store owns. It now files the proposal and re-lists itself, returning `{ ok, error? }` so App can raise the right toast. The old arrangement worked exactly as long as every caller remembered the refresh, and the second caller would have found out by forgetting.

Both changes are behaviour-preserving. `App.svelte` no longer calls `api.*` for either.

### What probing the check turned up

Verified it still bites by removing the store method *and* putting the call back in App — the actual #1834 shape:

```
Mutating api.* call(s) in App.svelte with no counterpart in a store or ops handler.
  api.queries.save
```

But my **first** probe put the call back in App while leaving the store method in place, and the test passed. That's correct behaviour — the domain still has an owner, so "every mutating domain has a store" still holds — but it means **App can call a store-owned mutation directly and nothing complains**, because App is exempt from the eslint rule.

So the check catches "no store at all", not "App went around the store". That's a narrower guarantee than the test's name suggests, and it's now written down in the commit rather than left as something a future reader assumes away. Closing it would mean either narrowing App's eslint exemption or asserting that App only ever calls store methods — both bigger changes than this PR, and worth deciding on their own merits.

`pnpm lint` clean; full suite 6,247 passing (609 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy