### PR TITLE
fix(ipc): replace-in-notes throws instead of reporting a successful no-op (#1862)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,8 +157,8 @@ can't quietly grow while nobody re-reads it:
 - `null` no-project↔not-found: *(cleared — `GRAPH_SOURCE_DETAIL`,
   `GRAPH_EXCERPT_SOURCE`, `PROPOSAL_DETAIL`, `TEMPLATES_GET` and
   `CONVERSATION_LOAD` are all `withRootPath` now, #1841.)*
-- boolean overloads: `NOTEBASE_FILE_EXISTS`, proposals `APPROVE` / `REJECT`
-  (`false` = no-project ↔ failed).
+- boolean overloads: proposals `APPROVE` / `REJECT` (`false` = no-project ↔
+  failed). *(`NOTEBASE_FILE_EXISTS` cleared in #1862.)*
 - in-band `error?` → union: `GRAPH_QUERY` (`{ results, columns, error? }` should
   match the `TABLES_QUERY` `{ ok:false; error }` shape).
 - swallows: `LINKS_CITATIONS_FOR_NOTE` (`.catch(()=>'')`), `CSL_REMOVE_STYLE` /

--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -26,7 +26,6 @@ import { searchInNotes, replaceInNotes, type SearchOptions, type ReplaceSelectio
 import { handle } from './typed-ipc';
 import {
   winFromEvent,
-  rootPathFromEvent,
   withRootPath,
   withRootPathOr,
   reindexFile,
@@ -175,11 +174,15 @@ export function registerNotebase(): void {
     rebuildMenu();
   });
 
-  handle(Channels.NOTEBASE_LIST_FILES, async (e) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return notebaseFs.listFiles(rootPath);
-  });
+  // No project → an empty tree, which is what the sidebar renders as "no notes
+  // yet" anyway. That is a legitimate project-less ANSWER, not a failure
+  // signal, which is exactly the distinction `withRootPathOr` exists to make
+  // explicit (#1862) — the hand-rolled guard this replaces didn't force anyone
+  // to say which it was.
+  handle(Channels.NOTEBASE_LIST_FILES, withRootPathOr(
+    Promise.resolve([] as Awaited<ReturnType<typeof notebaseFs.listFiles>>),
+    (rootPath) => notebaseFs.listFiles(rootPath),
+  ));
 
   handle(Channels.NOTEBASE_READ_FILE, withRootPath(async (rootPath, relativePath: string) => {
     return notebaseFs.readFile(rootPath, relativePath);
@@ -211,11 +214,11 @@ export function registerNotebase(): void {
     getOrFetchRemoteImage(rootPath, url),
   ));
 
-  handle(Channels.NOTEBASE_FILE_EXISTS, async (e, relativePath: string) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return false;
-    return notebaseFs.fileExists(rootPath, relativePath);
-  });
+  // `false` means exactly one thing now: no such file (#1862). It used to mean
+  // that OR "no project open", so a caller checking before a write couldn't
+  // tell "safe to create" from "there is nowhere to create it".
+  handle(Channels.NOTEBASE_FILE_EXISTS, withRootPath((rootPath, relativePath: string) =>
+    notebaseFs.fileExists(rootPath, relativePath)));
 
   handle(Channels.NOTEBASE_WRITE_FILE, withRootPath(async (rootPath, relativePath: string, content: string) => {
     // Renderer-initiated save — it already has the content, so suppress
@@ -383,15 +386,18 @@ export function registerNotebase(): void {
     await persistIndexes(rootPath);
   }));
 
-  handle(Channels.NOTEBASE_SEARCH_IN_NOTES, async (e, opts: SearchOptions) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return [];
-    return searchInNotes(rootPath, opts);
-  });
+  // Same shape: no project → no results, which reads the same as "nothing
+  // matched" and is a fair answer to a search over nothing.
+  handle(Channels.NOTEBASE_SEARCH_IN_NOTES, withRootPathOr(
+    Promise.resolve([] as Awaited<ReturnType<typeof searchInNotes>>),
+    (rootPath, opts: SearchOptions) => searchInNotes(rootPath, opts),
+  ));
 
-  handle(Channels.NOTEBASE_REPLACE_IN_NOTES, async (e, opts: SearchOptions & { replacement: string; selections: ReplaceSelection[] }) => {
-    const rootPath = rootPathFromEvent(e);
-    if (!rootPath) return { changedPaths: [], replacedCount: 0 };
+  // NOT `withRootPathOr` (#1862). This is a write, and the old fallback said
+  // "I replaced 0 occurrences" for a call that never ran — so the dialog
+  // reported a successful no-op. "Nothing matched" and "there was nothing to
+  // search" are different facts and only one of them is a success.
+  handle(Channels.NOTEBASE_REPLACE_IN_NOTES, withRootPath(async (rootPath, opts: SearchOptions & { replacement: string; selections: ReplaceSelection[] }) => {
     const result = await replaceInNotes(rootPath, opts);
     if (result.changedPaths.length > 0) {
       // Re-index each rewritten file so the graph + search index stay in
@@ -401,7 +407,7 @@ export function registerNotebase(): void {
       broadcastRewritten(rootPath, result.changedPaths);
     }
     return result;
-  });
+  }));
 
   handle(Channels.NOTEBASE_GET_ONBOARDING_DISMISSED, withRootPathOr(false, (rootPath) =>
     getOnboardingDismissed(rootPath)));

--- a/src/renderer/lib/components/FindInNotesDialog.svelte
+++ b/src/renderer/lib/components/FindInNotesDialog.svelte
@@ -149,6 +149,11 @@
       // Re-run the search so the UI reflects the post-replace state —
       // any still-matching hits stay, replaced ones disappear.
       runSearch();
+    } catch (err) {
+      // The replace now rejects rather than answering "0 replaced" for a call
+      // that never ran (#1862). Without this the dialog would just stop
+      // spinning with no message, which is a quieter version of the same lie.
+      statusMsg = `Replace failed: ${err instanceof Error ? err.message : String(err)}`;
     } finally {
       replacing = false;
     }

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -79,7 +79,7 @@ const BUDGETS: Record<string, number> = {
   'src/renderer/lib/app/note-ops.ts': 687,
   'src/renderer/lib/editor/formatting.ts': 671,
   'src/main/sources/tables.ts': 665,
-  'src/renderer/lib/components/FindInNotesDialog.svelte': 634,
+  'src/renderer/lib/components/FindInNotesDialog.svelte': 639,
   'src/preload/preload.ts': 614,
   'src/main/ipc/register-conversation-drafts.ts': 601,
 };

--- a/tests/main/ipc/register-notebase.test.ts
+++ b/tests/main/ipc/register-notebase.test.ts
@@ -283,10 +283,25 @@ describe('register-notebase — the #1631 project guard', () => {
     expect(h.getOnboardingDismissed).not.toHaveBeenCalled();
   });
 
-  // NOT pinned here, deliberately: NOTEBASE_FILE_EXISTS returns `false` with no
-  // project, conflating "no project" with "no such file" — the boolean overload
-  // CLAUDE.md's #1631 migration backlog already lists. Asserting it would bless
-  // it; its with-project delegation is covered below instead.
+  it('NOTEBASE_REPLACE_IN_NOTES throws rather than reporting a successful no-op', () => {
+    // It used to answer `{ changedPaths: [], replacedCount: 0 }`, so the
+    // find/replace dialog said "Replaced 0 matches" for a call that never ran
+    // (#1862). This is a WRITE: "nothing matched" and "there was nothing to
+    // search" are different facts, and only one of them is a success.
+    openProject = null;
+    expect(() => call(Channels.NOTEBASE_REPLACE_IN_NOTES, { query: 'x', replacement: 'y', selections: [] }))
+      .toThrow('No project open');
+    expect(h.replaceInNotes).not.toHaveBeenCalled();
+  });
+
+  it('NOTEBASE_FILE_EXISTS throws instead of answering "no such file"', () => {
+    // `false` now means exactly one thing (#1862). It used to mean that OR "no
+    // project", so a caller checking before a write couldn't tell "safe to
+    // create" from "there is nowhere to create it".
+    openProject = null;
+    expect(() => call(Channels.NOTEBASE_FILE_EXISTS, 'a.md')).toThrow('No project open');
+    expect(h.fileExists).not.toHaveBeenCalled();
+  });
 });
 
 describe('register-notebase — reads', () => {


### PR DESCRIPTION
Closes #1862.

`NOTEBASE_REPLACE_IN_NOTES` hand-rolled its project guard and returned `{ changedPaths: [], replacedCount: 0 }` with no project open. That's a **write** answering "I replaced 0 occurrences" for a call that never ran — the find/replace dialog said *"Replaced 0 matches"* and the user had no way to tell nothing had been attempted.

It now uses `withRootPath`. The dialog also gained the `catch` it never had: without one the rejection would leave it silently not-spinning, which is a quieter version of the same lie.

### Three neighbours moved with it

The hand-rolled form is *why* the first one slipped through — writing `if (!rootPath) return X` by hand doesn't make you say whether `X` is an answer or an excuse.

| Handler | Now | Behaviour |
| --- | --- | --- |
| `NOTEBASE_LIST_FILES` | `withRootPathOr([])` | unchanged — an empty tree is what the sidebar renders as "no notes yet" |
| `NOTEBASE_SEARCH_IN_NOTES` | `withRootPathOr([])` | unchanged — no results reads the same as "nothing matched" |
| `NOTEBASE_FILE_EXISTS` | `withRootPath` | **changed** — `false` used to mean "no such file" *or* "no project" |

On `FILE_EXISTS`: a caller checking before a write couldn't distinguish "safe to create" from "there is nowhere to create it". I checked all three callers individually — `template-ops.ts:86` and `project-ops.ts:129` are both inside a try/catch with `notebase.meta` already guaranteed, and `image-upload.ts:87` already had `.catch(() => false)`. This clears the last entry on CLAUDE.md's boolean-overload row apart from proposals `APPROVE`/`REJECT`.

### The bit worth reading

**The file-size ratchet from #1854 fired on this change** — its first catch, on unrelated work, four PRs after it landed:

```
File-size budget exceeded — the count went UP.
  + src/renderer/lib/components/FindInNotesDialog.svelte: 634 → 639 (+5)
```

Which is exactly the intended behaviour, and the right answer is the one its own message suggests: a five-line catch block doesn't justify extracting a seam from a 634-line dialog, so the budget is raised deliberately in the same commit. The value is that raising it was a decision I had to make in a diff rather than drift I'd never have noticed.

Tests: the two new no-project assertions replace the comment the #1861 author left explaining why `FILE_EXISTS` was deliberately *not* pinned — the behaviour it declined to bless is now gone.

`pnpm lint` clean; full suite 6,255 passing (611 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy