### PR TITLE
fix(renderer): classify runCell as the mutation it is (#1837)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,7 +38,7 @@ const DATAFLOW_MUTATION_METHODS =
   // settings: clipper / tools / bibliography / csl / sites / skills / compute
   'setEnabled|regenerateSecret|setSettings|setStyle|generate|importStyle|importLocale|' +
   'removeStyle|removeLocale|login|logout|setMenuConfig|setPythonSettings|restartPythonKernel|' +
-  'interruptPythonKernel|saveCellOutput|grantConsent|revokeConsent|' +
+  'interruptPythonKernel|saveCellOutput|grantConsent|revokeConsent|runCell|' +
   // publish / proposals / graph / refactor actions
   'runExport|toGit|upsertTarget|removeTarget|approve|reject|expire|runInspections|' +
   'setInspectionSettings|' +

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -145,10 +145,12 @@
      * Run-cell handler (#373). When supplied, replaces the direct
      * `api.compute.runCell` call. App.svelte injects a trust-gated
      * variant that prompts on first Python execution per thoughtbase.
-     * Keeping it pluggable lets headless / test contexts run cells
-     * without going through the dialog flow.
+     * Required, and pluggable on purpose: a headless or test context supplies
+     * its own runner rather than the component reaching for the IPC. The
+     * default it used to fall back to skipped the renderer's consent gate
+     * (main re-checks, so it was never unsafe — just wrong about who decides).
      */
-    onRunCell?: (
+    onRunCell: (
       language: string,
       code: string,
       notePath: string,
@@ -500,11 +502,11 @@
       }),
       bookmarkGutterExtension(),
       computeCellsExtension({
-        runCell: (language, code) => (
-          onRunCell
-            ? onRunCell(language, code, filePath)
-            : api.compute.runCell(language, code, filePath)
-        ),
+        // Always the injected runner — never `api.compute.runCell` directly
+        // (#1837). Running a cell writes an audit record to the project and
+        // leaves state in a shared kernel, so it's a mutation, and the caller
+        // that owns the consent gate should be the one to make it.
+        runCell: (language, code) => onRunCell(language, code, filePath),
         runAllRef,
       }),
       footnotePreview(),

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -60,7 +60,7 @@ const BUDGETS: Record<string, number> = {
   'src/renderer/lib/components/SourcesPanel.svelte': 1297,
   'src/renderer/lib/ipc/client.ts': 1241,
   'src/renderer/lib/stores/conversations.svelte.ts': 1212,
-  'src/renderer/lib/components/Editor.svelte': 1206,
+  'src/renderer/lib/components/Editor.svelte': 1208,
   'src/renderer/lib/stores/editor.svelte.ts': 1183,
   'src/main/graph/queries.ts': 1178,
   'src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte': 1156,

--- a/tests/renderer/dataflow-rule-coverage.test.ts
+++ b/tests/renderer/dataflow-rule-coverage.test.ts
@@ -58,10 +58,12 @@ const READ_ALLOWLIST = new Set<string>([
   'instances', 'noteProperties', 'smartMembers',
   // sources reads
   'getExcerptNoteFolder', 'getIngestSettings', 'hasPdf', 'listAll', 'queueMembers', 'readPdf',
-  // settings-ish reads + compute probes/execution (persist step saveCellOutput is denylisted)
+  // settings-ish reads + compute probes. `runCell` was here until #1837: it
+  // writes an audit record to the project and leaves state in a shared kernel,
+  // so it is a mutation, not a probe — it's on the denylist now.
   'getState', 'getKeyStorage', 'getSettings', 'getStyle', 'listStyles',
   'listUserLocales', 'listUserStyles', 'getPythonSettings', 'listConsent',
-  'browsePython', 'probePython', 'runCell',
+  'browsePython', 'probePython',
   // publish reads
   'checkGitHub', 'checkS3', 'listExporters', 'listTargets', 'resolvePlan',
   // embeddings + tools reads


### PR DESCRIPTION
Closes #1837 — what's actually left of it.

The review claimed the data-flow denylist "fails open" and that `api.compute.runCell` slipped past unnoticed. **That was wrong**, and I said so on the issue at the time: `dataflow-rule-coverage.test.ts` (#1626) forces every `api.*` method used in a component to be classified, and `runCell` *was* classified — as a read, in `READ_ALLOWLIST`, with a comment calling it "compute probes/execution".

The classification was the real defect, and it's all that remained.

### Why it's a mutation

Running a cell writes an audit record to the project (`register-compute.ts:36` → `recordExecution`) and leaves variables in a shared kernel that later cells see. By the rule's own words — *"anything that writes thoughtbase / graph / source / settings state"* — that's a mutation. Its persist step `saveCellOutput` was already denylisted, which made the split look principled when it was a line drawn one call too late.

### The call site

`Editor.svelte` used the injected `onRunCell` when present and fell back to `api.compute.runCell` when absent. That fallback skipped the renderer's **consent gate** (`runCellWithTrust`). Never unsafe — main re-checks consent at its enforcement boundary (#1411/#1412) — but wrong about who decides.

`onRunCell` is now **required**, which is what its own docstring already wanted: *"keeping it pluggable lets headless / test contexts run cells without going through the dialog flow."* A test context injects a runner; the component doesn't reach for the IPC. Editor has exactly one instantiation and it already passes the prop, so nothing else changed.

Verified by putting the direct call back:

```
509:38  error  Renderer data-flow rule (#1086): components must not call
               mutating/subscribing `api.*` methods directly…
```

### And again

The file-size ratchet fired on Editor's two extra lines — third catch in three PRs. Budget raised deliberately, per its own instruction.

`pnpm lint` clean; full suite 6,253 passing (611 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy