### PR TITLE
test(ipc): direct handler tests for sources, publish, bibliography (#1840)

### DIFF
--- a/tests/architecture/ipc-registrar-coverage.test.ts
+++ b/tests/architecture/ipc-registrar-coverage.test.ts
@@ -50,9 +50,6 @@ const IPC_DIR = path.join(ROOT, 'src', 'main', 'ipc');
  * the intended way to change this file; adding one is not.
  */
 const KNOWN_UNTESTED: readonly string[] = [
-  'register-sources',      // 343 lines
-  'register-publish',      // 171 lines
-  'register-bibliography', // 144 lines
   'register-compute',      // 119 lines
   'register-tools',        // 108 lines
   'register-types',        //  78 lines

--- a/tests/main/ipc/register-bibliography.test.ts
+++ b/tests/main/ipc/register-bibliography.test.ts
@@ -1,0 +1,491 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-bibliography.ts` (#1840).
+ *
+ * Two jobs live in this registrar: choosing/importing CSL assets, and the one
+ * handler that writes a note (`BIBLIOGRAPHY_GENERATE`). It drives the real
+ * `registerBibliography()` with the write pipeline + CSL loaders mocked, and
+ * pins:
+ *
+ *   - the #1631 guard, including the deliberate exception: the style PICKER
+ *     answers with the bundled set when no project is open (the Settings
+ *     dialog can be opened before any thoughtbase is), while every write
+ *     throws;
+ *   - `BIBLIOGRAPHY_SET_STYLE` refuses an id that isn't in the merged
+ *     registry — including inherited `Object.prototype` keys, which is what
+ *     `hasOwnProperty.call` is there for;
+ *   - the import handlers validate the file's CONTENT (not just its
+ *     extension) before copying it into the project, and a cancelled picker
+ *     writes nothing;
+ *   - the remove handlers reject an id that could escape the CSL directory —
+ *     these two build a path by interpolation, so the regex IS the guard;
+ *   - `BIBLIOGRAPHY_GENERATE` writes through the history-aware pipeline under
+ *     a named cause, and doesn't write at all when nothing changed.
+ *
+ * The pure CSL helpers (`isValidCslStyle`, `deriveStyleId`, …) are kept real —
+ * stubbing them would make the validation tests assert their own mocks. Only
+ * the filesystem-reading loaders are replaced.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  win: { id: 1, isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
+  // electron / node
+  showOpenDialog: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+  unlink: vi.fn(),
+  // csl registry
+  getMergedStyles: vi.fn(),
+  loadUserStyles: vi.fn(),
+  loadUserLocales: vi.fn(),
+  // project config
+  getBibliographyStyleId: vi.fn(),
+  setBibliographyStyleId: vi.fn(),
+  // note write path
+  notebaseReadFile: vi.fn(),
+  generateBibliography: vi.fn(),
+  writeAndReindex: vi.fn(),
+  runWithHistorySource: vi.fn(<T>(_s: unknown, fn: () => Promise<T>) => fn()),
+  renderInlineCitations: vi.fn(),
+  // call-order log
+  order: [] as string[],
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+  dialog: { showOpenDialog: h.showOpenDialog },
+}));
+
+vi.mock('node:fs/promises', () => {
+  const api = { readFile: h.readFile, writeFile: h.writeFile, mkdir: h.mkdir, unlink: h.unlink };
+  return { default: api, ...api };
+});
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  rootPathFromEvent: () => openProject,
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+  withRootPathWin:
+    <A extends unknown[], R>(fn: (rootPath: string, win: unknown, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, h.win, ...args);
+      },
+  hooks: { HOOKS: true },
+}));
+
+// Partial mock: the fs-reading loaders are stubbed, the pure validators /
+// id-derivers / directory constants stay real.
+vi.mock('../../../src/main/publish/csl/user-assets', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/publish/csl/user-assets')>();
+  return {
+    ...actual,
+    getMergedStyles: h.getMergedStyles,
+    loadUserStyles: h.loadUserStyles,
+    loadUserLocales: h.loadUserLocales,
+  };
+});
+
+vi.mock('../../../src/main/notebase/fs', () => ({ readFile: h.notebaseReadFile }));
+vi.mock('../../../src/main/notebase/write-pipeline', () => ({ writeAndReindex: h.writeAndReindex }));
+vi.mock('../../../src/main/history', () => ({ runWithHistorySource: h.runWithHistorySource }));
+vi.mock('../../../src/main/bibliography/generate', () => ({ generateBibliography: h.generateBibliography }));
+vi.mock('../../../src/main/citations/render-inline', () => ({ renderInlineCitations: h.renderInlineCitations }));
+vi.mock('../../../src/main/project-config', () => ({
+  getBibliographyStyleId: h.getBibliographyStyleId,
+  setBibliographyStyleId: h.setBibliographyStyleId,
+}));
+
+import { registerBibliography } from '../../../src/main/ipc/register-bibliography';
+import { Channels } from '../../../src/shared/channels';
+import { DEFAULT_STYLE } from '../../../src/main/publish/csl/assets';
+import { USER_STYLES_DIR, USER_LOCALES_DIR } from '../../../src/main/publish/csl/user-assets';
+
+registerBibliography();
+
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!({}, ...args);
+const callAsync = (channel: string, ...args: unknown[]): Promise<unknown> =>
+  Promise.resolve(call(channel, ...args));
+
+/** A minimally-valid CSL style — the validator matches on the namespace. */
+const STYLE_XML = '<style xmlns="http://purl.org/net/xbiblio/csl"><info><title>House Style</title></info></style>';
+/** …and a locale. */
+const LOCALE_XML = '<locale xmlns="http://purl.org/net/xbiblio/csl" xml:lang="en-GB"/>';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  openProject = ROOT;
+  h.order.length = 0;
+  h.runWithHistorySource.mockImplementation(<T>(_s: unknown, fn: () => Promise<T>) => fn());
+  h.getMergedStyles.mockResolvedValue({
+    styles: { apa: '<x/>', ieee: '<x/>' },
+    labels: { apa: 'APA', ieee: 'IEEE' },
+    userIds: new Set<string>(),
+  });
+  h.loadUserStyles.mockResolvedValue([]);
+  h.loadUserLocales.mockResolvedValue([]);
+  // The fs writers are awaited (and `unlink` is `.catch`-ed), so they have to
+  // hand back promises rather than the `undefined` a reset mock returns.
+  h.mkdir.mockResolvedValue(undefined);
+  h.writeFile.mockResolvedValue(undefined);
+  h.unlink.mockResolvedValue(undefined);
+});
+
+describe('register-bibliography — the #1631 project guard', () => {
+  const throwers: [string, unknown[]][] = [
+    [Channels.BIBLIOGRAPHY_SET_STYLE, ['ieee']],
+    [Channels.BIBLIOGRAPHY_GENERATE, ['notes/a.md']],
+    [Channels.CSL_IMPORT_STYLE, []],
+    [Channels.CSL_IMPORT_LOCALE, []],
+    [Channels.CSL_REMOVE_STYLE, ['mine']],
+    [Channels.CSL_REMOVE_LOCALE, ['en-GB']],
+  ];
+
+  it.each(throwers)('%s throws with no project open', (channel, args) => {
+    openProject = null;
+    expect(() => call(channel, ...args)).toThrow('No project open');
+  });
+
+  it('nothing is written, imported or unlinked when there is no project', () => {
+    openProject = null;
+    for (const [channel, args] of throwers) {
+      try { call(channel, ...args); } catch { /* asserted above */ }
+    }
+    expect(h.setBibliographyStyleId).not.toHaveBeenCalled();
+    expect(h.writeAndReindex).not.toHaveBeenCalled();
+    expect(h.writeFile).not.toHaveBeenCalled();
+    expect(h.unlink).not.toHaveBeenCalled();
+    expect(h.showOpenDialog).not.toHaveBeenCalled();
+  });
+
+  // Each of these fallbacks is also the answer for a project that has simply
+  // configured nothing — a legitimate value, not an error in disguise.
+  const fallbacks: [string, unknown[], unknown][] = [
+    [Channels.BIBLIOGRAPHY_GET_STYLE, [], DEFAULT_STYLE],
+    [Channels.CSL_LIST_USER_STYLES, [], []],
+    [Channels.CSL_LIST_USER_LOCALES, [], []],
+    [Channels.CITATION_RENDER_INLINE, [[{ key: 'x' }]], { markers: [], bibliography: null, missing: [], styleId: DEFAULT_STYLE }],
+  ];
+
+  it.each(fallbacks)('%s answers with its empty value and no project', async (channel, args, expected) => {
+    openProject = null;
+    await expect(callAsync(channel, ...args)).resolves.toEqual(expected);
+    expect(h.loadUserStyles).not.toHaveBeenCalled();
+    expect(h.renderInlineCitations).not.toHaveBeenCalled();
+  });
+
+  it('CITATION_RENDER_INLINE\'s project-less answer is a fully-shaped response', async () => {
+    // A partial object would make the preview renderer read `undefined.length`
+    // — the fallback has to be a real empty answer, not a stub.
+    openProject = null;
+    const answer = await callAsync(Channels.CITATION_RENDER_INLINE, []) as Record<string, unknown>;
+    expect(Object.keys(answer).sort()).toEqual(['bibliography', 'markers', 'missing', 'styleId']);
+  });
+
+  it('BIBLIOGRAPHY_LIST_STYLES still fills the picker with no project open', async () => {
+    // The Settings dialog opens before a thoughtbase does in some flows; an
+    // empty style picker there would look like a broken install.
+    openProject = null;
+    await expect(callAsync(Channels.BIBLIOGRAPHY_LIST_STYLES)).resolves.toEqual([
+      { id: 'apa', label: 'APA', isUser: false },
+      { id: 'ieee', label: 'IEEE', isUser: false },
+    ]);
+    // Honest note: the project-less branch asks for the merged registry at
+    // rootPath `''`, so the user-style scan runs against a path relative to
+    // the process CWD rather than being skipped outright. Harmless today (the
+    // directory won't exist), pinned so a change is deliberate.
+    expect(h.getMergedStyles).toHaveBeenCalledWith('');
+  });
+});
+
+describe('register-bibliography — style selection', () => {
+  it('BIBLIOGRAPHY_LIST_STYLES marks which entries came from the project', async () => {
+    // The settings row only offers "remove" for user-imported styles, so this
+    // flag is what keeps a bundled style from looking deletable.
+    h.getMergedStyles.mockResolvedValue({
+      styles: { apa: '<x/>', 'house-style': '<x/>' },
+      labels: { apa: 'APA', 'house-style': 'House Style' },
+      userIds: new Set(['house-style']),
+    });
+
+    await expect(callAsync(Channels.BIBLIOGRAPHY_LIST_STYLES)).resolves.toEqual([
+      { id: 'apa', label: 'APA', isUser: false },
+      { id: 'house-style', label: 'House Style', isUser: true },
+    ]);
+    expect(h.getMergedStyles).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('BIBLIOGRAPHY_LIST_STYLES falls back to the id for a style with no title', async () => {
+    h.getMergedStyles.mockResolvedValue({ styles: { odd: '<x/>' }, labels: {}, userIds: new Set(['odd']) });
+    await expect(callAsync(Channels.BIBLIOGRAPHY_LIST_STYLES))
+      .resolves.toEqual([{ id: 'odd', label: 'odd', isUser: true }]);
+  });
+
+  it('BIBLIOGRAPHY_GET_STYLE returns the project\'s configured style', () => {
+    h.getBibliographyStyleId.mockReturnValue('ieee');
+    expect(call(Channels.BIBLIOGRAPHY_GET_STYLE)).toBe('ieee');
+    expect(h.getBibliographyStyleId).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('BIBLIOGRAPHY_GET_STYLE falls back to the default when the project never chose one', () => {
+    h.getBibliographyStyleId.mockReturnValue(null);
+    expect(call(Channels.BIBLIOGRAPHY_GET_STYLE)).toBe(DEFAULT_STYLE);
+  });
+
+  it('BIBLIOGRAPHY_SET_STYLE stores a style that exists in the merged registry', async () => {
+    await callAsync(Channels.BIBLIOGRAPHY_SET_STYLE, 'ieee');
+    expect(h.setBibliographyStyleId).toHaveBeenCalledWith(ROOT, 'ieee');
+  });
+
+  it('BIBLIOGRAPHY_SET_STYLE refuses an unknown id instead of storing a dud', async () => {
+    // Storing an id with no XML behind it would fail later, at export time,
+    // far from the setting that caused it.
+    await expect(callAsync(Channels.BIBLIOGRAPHY_SET_STYLE, 'chicago-note'))
+      .rejects.toThrow('Unknown CSL style: chicago-note');
+    expect(h.setBibliographyStyleId).not.toHaveBeenCalled();
+  });
+
+  it.each(['constructor', 'toString', '__proto__'])(
+    'BIBLIOGRAPHY_SET_STYLE refuses the inherited key %s', async (key) => {
+      // `hasOwnProperty.call` rather than `styleId in styles` — a plain `in`
+      // would accept every Object.prototype member as a valid style.
+      await expect(callAsync(Channels.BIBLIOGRAPHY_SET_STYLE, key))
+        .rejects.toThrow(`Unknown CSL style: ${key}`);
+      expect(h.setBibliographyStyleId).not.toHaveBeenCalled();
+    });
+});
+
+describe('register-bibliography — user CSL assets', () => {
+  it('CSL_LIST_USER_STYLES reports only what the settings row needs', async () => {
+    // Not the XML: the renderer never renders it, and these files are large.
+    h.loadUserStyles.mockResolvedValue([
+      { id: 'house', label: 'House Style', filePath: '/vault/.minerva/csl-styles/house.csl', xml: STYLE_XML },
+    ]);
+    await expect(callAsync(Channels.CSL_LIST_USER_STYLES)).resolves.toEqual([
+      { id: 'house', label: 'House Style', filePath: '/vault/.minerva/csl-styles/house.csl' },
+    ]);
+  });
+
+  it('CSL_LIST_USER_LOCALES reports only what the settings row needs', async () => {
+    h.loadUserLocales.mockResolvedValue([
+      { id: 'en-GB', filePath: '/vault/.minerva/csl-locales/en-GB.xml', xml: LOCALE_XML },
+    ]);
+    await expect(callAsync(Channels.CSL_LIST_USER_LOCALES)).resolves.toEqual([
+      { id: 'en-GB', filePath: '/vault/.minerva/csl-locales/en-GB.xml' },
+    ]);
+  });
+
+  it('CSL_IMPORT_STYLE copies the file into the project and names it from its <title>', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/House Style.csl'] });
+    h.readFile.mockResolvedValue(STYLE_XML);
+
+    await expect(callAsync(Channels.CSL_IMPORT_STYLE)).resolves.toEqual({
+      id: 'house-style',
+      label: 'House Style',
+      filePath: `${ROOT}/${USER_STYLES_DIR}/house-style.csl`,
+    });
+
+    // The import is a copy, not a reference: the picked file can be deleted
+    // or live on a volume that isn't mounted next time.
+    expect(h.mkdir).toHaveBeenCalledWith(`${ROOT}/${USER_STYLES_DIR}`, { recursive: true });
+    expect(h.writeFile).toHaveBeenCalledWith(`${ROOT}/${USER_STYLES_DIR}/house-style.csl`, STYLE_XML, 'utf-8');
+  });
+
+  it('CSL_IMPORT_STYLE falls back to the derived id when the style has no title', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/untitled.csl'] });
+    h.readFile.mockResolvedValue('<style xmlns="http://purl.org/net/xbiblio/csl"/>');
+    await expect(callAsync(Channels.CSL_IMPORT_STYLE))
+      .resolves.toEqual({ id: 'untitled', label: 'untitled', filePath: `${ROOT}/${USER_STYLES_DIR}/untitled.csl` });
+  });
+
+  it('CSL_IMPORT_STYLE rejects a file that is not CSL, whatever its extension says', async () => {
+    // The picker filters on `.csl`/`.xml`; only the content proves it's a
+    // style, and a non-style file would poison the picker with a broken entry.
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/notes.xml'] });
+    h.readFile.mockResolvedValue('<html><body>not csl</body></html>');
+
+    await expect(callAsync(Channels.CSL_IMPORT_STYLE)).rejects.toThrow('not a valid CSL style');
+    expect(h.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('CSL_IMPORT_STYLE rejects a filename that derives no usable id', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/++.csl'] });
+    h.readFile.mockResolvedValue(STYLE_XML);
+    await expect(callAsync(Channels.CSL_IMPORT_STYLE)).rejects.toThrow('Could not derive a style id');
+    expect(h.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('CSL_IMPORT_LOCALE copies the locale in, preserving its case', async () => {
+    // Locale ids are matched case-sensitively by citeproc ("en-GB", not
+    // "en-gb"), so unlike style ids these are not lowercased.
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/locales-en-GB.xml'] });
+    h.readFile.mockResolvedValue(LOCALE_XML);
+
+    await expect(callAsync(Channels.CSL_IMPORT_LOCALE)).resolves.toEqual({
+      id: 'en-GB',
+      filePath: `${ROOT}/${USER_LOCALES_DIR}/en-GB.xml`,
+    });
+    expect(h.writeFile).toHaveBeenCalledWith(`${ROOT}/${USER_LOCALES_DIR}/en-GB.xml`, LOCALE_XML, 'utf-8');
+  });
+
+  it('CSL_IMPORT_LOCALE rejects a file that is not a CSL locale', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/style.xml'] });
+    h.readFile.mockResolvedValue(STYLE_XML); // a style, not a locale
+    await expect(callAsync(Channels.CSL_IMPORT_LOCALE)).rejects.toThrow('not a valid CSL locale');
+    expect(h.writeFile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [Channels.CSL_IMPORT_STYLE, 'cancelled', { canceled: true, filePaths: [] }],
+    [Channels.CSL_IMPORT_STYLE, 'dismissed with no file', { canceled: false, filePaths: [] }],
+    [Channels.CSL_IMPORT_LOCALE, 'cancelled', { canceled: true, filePaths: [] }],
+    [Channels.CSL_IMPORT_LOCALE, 'dismissed with no file', { canceled: false, filePaths: [] }],
+  ])('%s imports nothing when the picker is %s', async (channel, _label, dialogResult) => {
+    h.showOpenDialog.mockResolvedValue(dialogResult);
+    await expect(callAsync(channel)).resolves.toBeNull();
+    expect(h.readFile).not.toHaveBeenCalled();
+    expect(h.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('CSL_REMOVE_STYLE deletes the imported file from the project', async () => {
+    await callAsync(Channels.CSL_REMOVE_STYLE, 'house-style');
+    expect(h.unlink).toHaveBeenCalledWith(`${ROOT}/${USER_STYLES_DIR}/house-style.csl`);
+  });
+
+  it('CSL_REMOVE_LOCALE deletes the imported locale from the project', async () => {
+    await callAsync(Channels.CSL_REMOVE_LOCALE, 'en-GB');
+    expect(h.unlink).toHaveBeenCalledWith(`${ROOT}/${USER_LOCALES_DIR}/en-GB.xml`);
+  });
+
+  it.each([
+    ['../../../etc/passwd'],
+    ['..'],
+    ['sub/dir'],
+    ['name with spaces'],
+    [''],
+  ])('CSL_REMOVE_STYLE refuses the id %j rather than joining it into a path', async (id) => {
+    // The target path is built by interpolation, so this regex is the whole
+    // traversal guard — no `assertSafePath` runs on this route.
+    await expect(callAsync(Channels.CSL_REMOVE_STYLE, id)).rejects.toThrow('Invalid style id.');
+    expect(h.unlink).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['../../../etc/passwd'],
+    ['..'],
+    ['sub/dir'],
+    [''],
+  ])('CSL_REMOVE_LOCALE refuses the id %j rather than joining it into a path', async (id) => {
+    await expect(callAsync(Channels.CSL_REMOVE_LOCALE, id)).rejects.toThrow('Invalid locale id.');
+    expect(h.unlink).not.toHaveBeenCalled();
+  });
+
+  it('removing a style that was already gone is not an error', async () => {
+    // Two settings windows, one file: the second remove is a no-op the user
+    // shouldn't see an error for.
+    h.unlink.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    await expect(callAsync(Channels.CSL_REMOVE_STYLE, 'house-style')).resolves.toBeUndefined();
+  });
+
+  it('a remove that failed for a REAL reason is swallowed too — a known #1631 outlier', async () => {
+    // Documented in CLAUDE.md's migration backlog ("CSL_REMOVE_STYLE /
+    // CSL_REMOVE_LOCALE (unlink swallows non-ENOENT)"): the bare
+    // `.catch(() => undefined)` also hides EACCES/EIO, so the settings row
+    // disappears while the file stays on disk and reappears on reload. Pinned
+    // as-is so the fix is a deliberate, visible change rather than a surprise.
+    h.unlink.mockRejectedValue(Object.assign(new Error('EACCES'), { code: 'EACCES' }));
+    await expect(callAsync(Channels.CSL_REMOVE_STYLE, 'house-style')).resolves.toBeUndefined();
+  });
+});
+
+describe('register-bibliography — CITATION_RENDER_INLINE', () => {
+  it('renders the requested references for the open project', async () => {
+    const refs = [{ key: 'smith2020', locator: '12' }];
+    h.renderInlineCitations.mockResolvedValue({ markers: ['(Smith 2020, 12)'], bibliography: '…', missing: [], styleId: 'apa' });
+    await expect(callAsync(Channels.CITATION_RENDER_INLINE, refs))
+      .resolves.toEqual({ markers: ['(Smith 2020, 12)'], bibliography: '…', missing: [], styleId: 'apa' });
+    expect(h.renderInlineCitations).toHaveBeenCalledWith(ROOT, refs);
+  });
+
+  it('treats a missing ref list as an empty one', async () => {
+    // The preview calls this on every keystroke; an undefined batch is a
+    // normal transient, not something to reject over.
+    h.renderInlineCitations.mockResolvedValue({ markers: [], bibliography: null, missing: [], styleId: 'apa' });
+    await callAsync(Channels.CITATION_RENDER_INLINE, undefined);
+    expect(h.renderInlineCitations).toHaveBeenCalledWith(ROOT, []);
+  });
+});
+
+describe('register-bibliography — BIBLIOGRAPHY_GENERATE', () => {
+  it('writes the regenerated note through the history-aware pipeline', async () => {
+    h.notebaseReadFile.mockResolvedValue('# Note\n\n[@smith2020]');
+    h.generateBibliography.mockResolvedValue({
+      changed: true, content: '# Note\n\n[@smith2020]\n\n## References\n…',
+      entriesCount: 1, missingIds: [], styleId: 'apa',
+    });
+
+    await expect(callAsync(Channels.BIBLIOGRAPHY_GENERATE, 'notes/a.md'))
+      .resolves.toEqual({ entriesCount: 1, missingIds: [], changed: true, styleId: 'apa' });
+
+    expect(h.generateBibliography).toHaveBeenCalledWith(ROOT, '# Note\n\n[@smith2020]');
+    // Named cause: a history timeline full of anonymous edits is unreadable.
+    expect(h.runWithHistorySource).toHaveBeenCalledWith(
+      { origin: 'edit', cause: 'Bibliography' },
+      expect.any(Function),
+    );
+    // Through the pipeline, not a bare fs write — graph, search and any open
+    // editor have to see the new text too.
+    expect(h.writeAndReindex).toHaveBeenCalledWith(
+      ROOT, 'notes/a.md', '# Note\n\n[@smith2020]\n\n## References\n…', { HOOKS: true },
+    );
+  });
+
+  it('writes nothing when the bibliography was already up to date', async () => {
+    // A no-op save would still stamp a history revision and re-index the note.
+    h.notebaseReadFile.mockResolvedValue('# Note');
+    h.generateBibliography.mockResolvedValue({ changed: false, content: '# Note', entriesCount: 0, missingIds: [], styleId: 'apa' });
+
+    await expect(callAsync(Channels.BIBLIOGRAPHY_GENERATE, 'notes/a.md'))
+      .resolves.toEqual({ entriesCount: 0, missingIds: [], changed: false, styleId: 'apa' });
+    expect(h.writeAndReindex).not.toHaveBeenCalled();
+    expect(h.runWithHistorySource).not.toHaveBeenCalled();
+  });
+
+  it('reports citation keys with no matching source instead of failing', async () => {
+    // Missing keys are a normal state of a draft, so the note is still
+    // rewritten and the gaps are reported for the UI to list.
+    h.notebaseReadFile.mockResolvedValue('# Note\n\n[@ghost]');
+    h.generateBibliography.mockResolvedValue({
+      changed: true, content: '# Note\n\n[@ghost]\n\n## References\n', entriesCount: 0,
+      missingIds: ['ghost'], styleId: 'ieee',
+    });
+
+    await expect(callAsync(Channels.BIBLIOGRAPHY_GENERATE, 'notes/a.md'))
+      .resolves.toEqual({ entriesCount: 0, missingIds: ['ghost'], changed: true, styleId: 'ieee' });
+    expect(h.writeAndReindex).toHaveBeenCalled();
+  });
+
+  it('lets a read failure reject rather than generating over an empty note', async () => {
+    h.notebaseReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    await expect(callAsync(Channels.BIBLIOGRAPHY_GENERATE, 'notes/gone.md')).rejects.toThrow('ENOENT');
+    expect(h.generateBibliography).not.toHaveBeenCalled();
+    expect(h.writeAndReindex).not.toHaveBeenCalled();
+  });
+});

--- a/tests/main/ipc/register-publish.test.ts
+++ b/tests/main/ipc/register-publish.test.ts
@@ -1,0 +1,502 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-publish.ts` (#1840).
+ *
+ * Export + publish is the one path that writes files OUTSIDE the thoughtbase,
+ * so what this registrar does with its arguments matters more than usual. It
+ * drives the real `registerPublish()` with the publish engine mocked and pins:
+ *
+ *   - the #1631 guard: every project-scoped handler THROWS with no project,
+ *     while the two connection checks (S3 / GitHub) and the exporter listing
+ *     deliberately work without one — they don't read the thoughtbase;
+ *   - `PUBLISH_RESOLVE_PLAN` strips `content`/`frontmatter` off every input
+ *     before it crosses IPC (the preview needs paths and kinds, not the text
+ *     of every file in the project) and only forwards the options the caller
+ *     actually set;
+ *   - `PUBLISH_RUN_EXPORT` opens the destination picker only when the renderer
+ *     didn't already choose one, and a cancelled picker means `null` and
+ *     nothing written — `null`'s ONE documented meaning here (#1631 rule 5);
+ *   - `PUBLISH_TO_GIT` is a sanctioned `{ ok, … }` union (CLAUDE.md rule 3):
+ *     auth / network / non-fast-forward come back as `{ ok: false, error }`
+ *     carrying the raw git message rather than a stringified rejection.
+ *
+ * `withRootPath*` are re-implemented in the helpers mock with the real
+ * semantics (helpers.ts drags in electron + graph/search/vectors, so it can't
+ * be imported here); what's under test is WHICH wrapper each handler picked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  win: { id: 1, isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
+  // electron
+  showOpenDialog: vi.fn(),
+  getVersion: vi.fn(() => '1.2.3'),
+  // publish engine
+  listExporters: vi.fn(),
+  getExporter: vi.fn(),
+  resolvePlan: vi.fn(),
+  runExport: vi.fn(),
+  publishTarget: vi.fn(),
+  checkS3Connection: vi.fn(),
+  checkGitHubToken: vi.fn(),
+  // csl
+  buildCitationAudit: vi.fn(),
+  getMergedStyles: vi.fn(),
+  getMergedLocales: vi.fn(),
+  // project config
+  getPublishTargets: vi.fn(),
+  upsertPublishTarget: vi.fn(),
+  removePublishTarget: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+  dialog: { showOpenDialog: h.showOpenDialog },
+  app: { getVersion: h.getVersion },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathWin:
+    <A extends unknown[], R>(fn: (rootPath: string, win: unknown, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, h.win, ...args);
+      },
+}));
+
+// The publish barrel re-exports the whole engine; only what the registrar
+// reaches for is stubbed, plus the real EXPORT_GROUPS table (it's a constant —
+// stubbing it would make the group-metadata assertion tautological).
+vi.mock('../../../src/main/publish', async () => {
+  const { EXPORT_GROUPS } = await import('../../../src/main/publish/types');
+  return {
+    EXPORT_GROUPS,
+    listExporters: h.listExporters,
+    getExporter: h.getExporter,
+    resolvePlan: h.resolvePlan,
+    runExport: h.runExport,
+    publishTarget: h.publishTarget,
+    checkS3Connection: h.checkS3Connection,
+  };
+});
+vi.mock('../../../src/main/publish/csl/audit', () => ({ buildCitationAudit: h.buildCitationAudit }));
+vi.mock('../../../src/main/publish/csl/user-assets', () => ({
+  getMergedStyles: h.getMergedStyles,
+  getMergedLocales: h.getMergedLocales,
+}));
+vi.mock('../../../src/main/git/publish-git', () => ({ checkGitHubToken: h.checkGitHubToken }));
+vi.mock('../../../src/main/project-config', () => ({
+  getPublishTargets: h.getPublishTargets,
+  upsertPublishTarget: h.upsertPublishTarget,
+  removePublishTarget: h.removePublishTarget,
+}));
+
+import { registerPublish } from '../../../src/main/ipc/register-publish';
+import { Channels } from '../../../src/shared/channels';
+import { EXPORT_GROUPS } from '../../../src/main/publish/types';
+import { DEFAULT_STYLE } from '../../../src/main/publish/csl/assets';
+
+registerPublish();
+
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!({}, ...args);
+const callAsync = (channel: string, ...args: unknown[]): Promise<unknown> =>
+  Promise.resolve(call(channel, ...args));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  openProject = ROOT;
+  h.getVersion.mockReturnValue('1.2.3');
+  h.listExporters.mockReturnValue([]);
+  h.getMergedStyles.mockResolvedValue({ styles: { apa: '<xml/>' }, labels: { apa: 'APA' }, userIds: new Set() });
+  h.getMergedLocales.mockResolvedValue({ locales: { 'en-US': '<xml/>' }, userIds: new Set() });
+  h.buildCitationAudit.mockReturnValue({ bySource: [], missing: [] });
+  h.getPublishTargets.mockReturnValue([]);
+});
+
+describe('register-publish — the #1631 project guard', () => {
+  const throwers: [string, unknown[]][] = [
+    [Channels.PUBLISH_RESOLVE_PLAN, [{ kind: 'project' }]],
+    [Channels.PUBLISH_RUN_EXPORT, [{ exporterId: 'markdown', input: { kind: 'project' } }]],
+    [Channels.PUBLISH_LIST_TARGETS, []],
+    [Channels.PUBLISH_UPSERT_TARGET, [{ id: 't1', label: 'Site', exporter: 'site', kind: 'git' }]],
+    [Channels.PUBLISH_REMOVE_TARGET, ['t1']],
+    [Channels.PUBLISH_TO_GIT, ['t1']],
+  ];
+
+  it.each(throwers)('%s throws with no project open', (channel, args) => {
+    openProject = null;
+    expect(() => call(channel, ...args)).toThrow('No project open');
+  });
+
+  it('nothing is exported, published or saved when there is no project', () => {
+    openProject = null;
+    for (const [channel, args] of throwers) {
+      try { call(channel, ...args); } catch { /* asserted above */ }
+    }
+    expect(h.runExport).not.toHaveBeenCalled();
+    expect(h.publishTarget).not.toHaveBeenCalled();
+    expect(h.upsertPublishTarget).not.toHaveBeenCalled();
+    expect(h.removePublishTarget).not.toHaveBeenCalled();
+    expect(h.showOpenDialog).not.toHaveBeenCalled();
+  });
+
+  it('PUBLISH_TO_GIT throws rather than reporting { ok: false } for a missing project', () => {
+    // The union is for EXPECTED publish outcomes (auth, network, rejected
+    // push). "There is no thoughtbase to publish" is not one of them, and
+    // folding it in would put a nonsense message in the dialog.
+    openProject = null;
+    expect(() => call(Channels.PUBLISH_TO_GIT, 't1')).toThrow('No project open');
+  });
+
+  it('PUBLISH_LIST_EXPORTERS answers without a project — the registry is static', () => {
+    openProject = null;
+    h.listExporters.mockReturnValue([]);
+    expect(call(Channels.PUBLISH_LIST_EXPORTERS)).toEqual([]);
+  });
+
+  it.each([
+    [Channels.PUBLISH_CHECK_S3, [{ bucket: 'b' }], 'checkS3Connection'],
+    [Channels.PUBLISH_CHECK_GITHUB, [{ token: 'ghp_x' }], 'checkGitHubToken'],
+  ] as const)('%s runs without a project — it only tests credentials', async (channel, args, fn) => {
+    openProject = null;
+    h[fn].mockResolvedValue({ ok: true });
+    await expect(callAsync(channel, ...args)).resolves.toEqual({ ok: true });
+  });
+});
+
+describe('register-publish — PUBLISH_LIST_EXPORTERS', () => {
+  it('carries the format-first menu metadata for each exporter', () => {
+    h.listExporters.mockReturnValue([
+      { id: 'markdown', label: 'Markdown (verbatim)', group: 'markdown', variantLabel: 'Verbatim', variantOrder: 1, acceptedKinds: ['single-note', 'folder', 'project', 'tree'] },
+    ]);
+
+    expect(call(Channels.PUBLISH_LIST_EXPORTERS)).toEqual([{
+      id: 'markdown',
+      label: 'Markdown (verbatim)',
+      acceptedKinds: ['single-note', 'folder', 'project', 'tree'],
+      group: EXPORT_GROUPS.markdown,
+      variantLabel: 'Verbatim',
+      variantOrder: 1,
+    }]);
+  });
+
+  it('defaults an exporter that declared no kinds to the non-tree scopes', () => {
+    // `tree` is opt-in: only exporters that know how to walk a wiki-link
+    // closure should offer it, so the default must NOT include it.
+    h.listExporters.mockReturnValue([{ id: 'pdf', label: 'PDF', group: 'pdf' }]);
+
+    const [listed] = call(Channels.PUBLISH_LIST_EXPORTERS) as { acceptedKinds: string[]; variantOrder: number }[];
+    expect(listed?.acceptedKinds).toEqual(['single-note', 'folder', 'project']);
+    expect(listed?.acceptedKinds).not.toContain('tree');
+    // An undeclared variant sorts first rather than becoming NaN/undefined in
+    // the dialog's sort.
+    expect(listed?.variantOrder).toBe(0);
+  });
+
+  it('drops the exporter function itself — only serialisable metadata crosses IPC', () => {
+    h.listExporters.mockReturnValue([
+      { id: 'html', label: 'HTML', group: 'html', run: () => { throw new Error('never'); } },
+    ]);
+    const [listed] = call(Channels.PUBLISH_LIST_EXPORTERS) as Record<string, unknown>[];
+    expect(listed).not.toHaveProperty('run');
+    expect(Object.keys(listed ?? {}).sort())
+      .toEqual(['acceptedKinds', 'group', 'id', 'label', 'variantLabel', 'variantOrder']);
+  });
+});
+
+describe('register-publish — PUBLISH_RESOLVE_PLAN', () => {
+  const plan = (over: Record<string, unknown> = {}) => ({
+    inputs: [
+      { relativePath: 'a.md', kind: 'note', title: 'A', content: '# A\n\nlots of text', frontmatter: { tags: ['x'] } },
+    ],
+    excluded: [{ relativePath: 'draft.md', reason: 'excluded-by-frontmatter' }],
+    ...over,
+  });
+
+  it('strips file bodies out of the preview payload', async () => {
+    // Sending every file's text over IPC to render a list of paths is pure
+    // waste on a project-scoped export.
+    h.resolvePlan.mockResolvedValue(plan());
+    h.getExporter.mockReturnValue({ id: 'markdown', label: 'Markdown' });
+
+    const result = await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }, { exporterId: 'markdown' }) as {
+      inputs: Record<string, unknown>[]; excluded: unknown[]; exporterId: string; exporterLabel: string;
+    };
+
+    expect(result.inputs).toEqual([{ relativePath: 'a.md', kind: 'note', title: 'A', overridden: false }]);
+    expect(result.excluded).toEqual([{ relativePath: 'draft.md', reason: 'excluded-by-frontmatter' }]);
+    expect(result.exporterId).toBe('markdown');
+    expect(result.exporterLabel).toBe('Markdown');
+  });
+
+  it('keeps an explicit include/exclude override visible in the preview', async () => {
+    h.resolvePlan.mockResolvedValue(plan({
+      inputs: [{ relativePath: 'a.md', kind: 'note', title: 'A', content: 'x', overridden: true }],
+    }));
+    const result = await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }) as { inputs: { overridden: boolean }[] };
+    expect(result.inputs[0]?.overridden).toBe(true);
+  });
+
+  it('forwards only the options the caller actually set', async () => {
+    // Passing `undefined` through would override a resolved default with
+    // nothing — `exactOptionalPropertyTypes` is on for a reason.
+    h.resolvePlan.mockResolvedValue(plan());
+    await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }, { exporterId: 'markdown', citationStyle: 'ieee' });
+    expect(h.resolvePlan).toHaveBeenCalledWith(ROOT, { kind: 'project' }, { citationStyle: 'ieee' });
+  });
+
+  it('passes no options at all when the caller gave none', async () => {
+    h.resolvePlan.mockResolvedValue(plan());
+    await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'single-note', relativePath: 'a.md' });
+    expect(h.resolvePlan).toHaveBeenCalledWith(ROOT, { kind: 'single-note', relativePath: 'a.md' }, {});
+  });
+
+  it('forwards the force-include/exclude lists the preview checkboxes produce', async () => {
+    h.resolvePlan.mockResolvedValue(plan());
+    await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }, {
+      linkPolicy: 'rewrite', forceInclude: ['draft.md'], forceExclude: ['a.md'],
+    });
+    expect(h.resolvePlan).toHaveBeenCalledWith(ROOT, { kind: 'project' }, {
+      linkPolicy: 'rewrite', forceInclude: ['draft.md'], forceExclude: ['a.md'],
+    });
+  });
+
+  it('reports an empty citation audit and the default style when the plan has no citations', async () => {
+    h.resolvePlan.mockResolvedValue(plan());
+
+    const result = await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }) as {
+      citations: { styleId: string; localeId: string; bySource: unknown[]; missing: unknown[] };
+      exporterId: string; exporterLabel: string;
+    };
+
+    // No citations in the plan means no audit to run at all…
+    expect(h.buildCitationAudit).not.toHaveBeenCalled();
+    expect(result.citations.bySource).toEqual([]);
+    expect(result.citations.missing).toEqual([]);
+    // …and the picker still needs a style selected, so it falls back.
+    expect(result.citations.styleId).toBe(DEFAULT_STYLE);
+    expect(result.citations.localeId).toBe('en-US');
+    // No exporterId asked for → empty strings, not undefined: the dialog binds
+    // these straight into its header.
+    expect(result.exporterId).toBe('');
+    expect(result.exporterLabel).toBe('');
+    expect(h.getExporter).not.toHaveBeenCalled();
+  });
+
+  it('audits the citations against the plan inputs when there are some', async () => {
+    h.resolvePlan.mockResolvedValue(plan({ citations: { styleId: 'ieee', localeId: 'en-GB' } }));
+    h.buildCitationAudit.mockReturnValue({ bySource: [{ sourceId: 's1', count: 2 }], missing: [{ key: 'nope' }] });
+
+    const result = await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }) as {
+      citations: { styleId: string; localeId: string; bySource: unknown[]; missing: unknown[] };
+    };
+
+    // The audit reads the FULL inputs (with content) — that's the only place
+    // the citation keys live, and it's also why they can be stripped after.
+    expect(h.buildCitationAudit).toHaveBeenCalledWith(
+      [expect.objectContaining({ relativePath: 'a.md', content: '# A\n\nlots of text' })],
+      { styleId: 'ieee', localeId: 'en-GB' },
+    );
+    expect(result.citations.styleId).toBe('ieee');
+    expect(result.citations.localeId).toBe('en-GB');
+    expect(result.citations.missing).toEqual([{ key: 'nope' }]);
+  });
+
+  it('offers the project-scoped style registry — bundled plus user-imported', async () => {
+    // #302: the picker has to reflect whatever the user dropped into the
+    // project, without a second roundtrip.
+    h.resolvePlan.mockResolvedValue(plan());
+    h.getMergedStyles.mockResolvedValue({
+      styles: { apa: '<x/>', 'my-house-style': '<x/>' },
+      labels: { apa: 'APA' },
+      userIds: new Set(['my-house-style']),
+    });
+    h.getMergedLocales.mockResolvedValue({ locales: { 'en-US': '<x/>', 'de-DE': '<x/>' }, userIds: new Set() });
+
+    const result = await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }) as {
+      citations: { availableStyles: { id: string; label: string }[]; availableLocales: { id: string; label: string }[] };
+    };
+
+    expect(h.getMergedStyles).toHaveBeenCalledWith(ROOT);
+    expect(result.citations.availableStyles).toEqual([
+      { id: 'apa', label: 'APA' },
+      // A user style with no <title> falls back to its id rather than
+      // rendering a blank row in the picker.
+      { id: 'my-house-style', label: 'my-house-style' },
+    ]);
+    expect(result.citations.availableLocales).toEqual([
+      { id: 'en-US', label: 'en-US' },
+      { id: 'de-DE', label: 'de-DE' },
+    ]);
+  });
+});
+
+describe('register-publish — PUBLISH_RUN_EXPORT', () => {
+  it('exports straight to a destination the renderer already chose', async () => {
+    h.runExport.mockResolvedValue({ files: 3, outputDir: '/out' });
+
+    await expect(callAsync(Channels.PUBLISH_RUN_EXPORT, { exporterId: 'markdown', input: { kind: 'project' }, outputDir: '/out' }))
+      .resolves.toEqual({ files: 3, outputDir: '/out' });
+
+    expect(h.showOpenDialog).not.toHaveBeenCalled();
+    expect(h.runExport).toHaveBeenCalledWith(ROOT, { exporterId: 'markdown', input: { kind: 'project' }, outputDir: '/out' });
+  });
+
+  it('asks for a destination, parented to the invoking window, when none was given', async () => {
+    // Parenting matters: an unparented picker floats as a sheet the user can
+    // lose behind the main window.
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/picked'] });
+    h.runExport.mockResolvedValue({ files: 1 });
+
+    await callAsync(Channels.PUBLISH_RUN_EXPORT, { exporterId: 'markdown', input: { kind: 'project' } });
+
+    expect(h.showOpenDialog).toHaveBeenCalledWith(h.win, expect.objectContaining({
+      properties: ['openDirectory', 'createDirectory'],
+    }));
+    expect(h.runExport).toHaveBeenCalledWith(ROOT, { exporterId: 'markdown', input: { kind: 'project' }, outputDir: '/picked' });
+  });
+
+  it.each([
+    ['cancelled', { canceled: true, filePaths: [] }],
+    ['dismissed with no directory', { canceled: false, filePaths: [] }],
+  ])('writes nothing when the picker is %s', async (_label, dialogResult) => {
+    // `null` here means exactly one thing — the user backed out (#1631 rule 5).
+    h.showOpenDialog.mockResolvedValue(dialogResult);
+    await expect(callAsync(Channels.PUBLISH_RUN_EXPORT, { exporterId: 'markdown', input: { kind: 'project' } }))
+      .resolves.toBeNull();
+    expect(h.runExport).not.toHaveBeenCalled();
+  });
+
+  it('lets an export failure reject rather than dressing it up as a result', async () => {
+    h.runExport.mockRejectedValue(new Error('EACCES /out'));
+    await expect(callAsync(Channels.PUBLISH_RUN_EXPORT, { exporterId: 'markdown', input: { kind: 'project' }, outputDir: '/out' }))
+      .rejects.toThrow('EACCES /out');
+  });
+});
+
+describe('register-publish — publish targets', () => {
+  it('PUBLISH_LIST_TARGETS reads the project config', () => {
+    h.getPublishTargets.mockReturnValue([{ id: 't1', label: 'Site', exporter: 'site', kind: 'git' }]);
+    expect(call(Channels.PUBLISH_LIST_TARGETS)).toEqual([{ id: 't1', label: 'Site', exporter: 'site', kind: 'git' }]);
+    expect(h.getPublishTargets).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('PUBLISH_UPSERT_TARGET answers with the list AFTER the save', () => {
+    // The settings UI rebinds from this return value, so it has to be the
+    // post-write state — re-reading rather than echoing the argument is what
+    // makes a secret-stripping / normalising store visible to the caller.
+    const target = { id: 't1', label: 'Site', exporter: 'site', kind: 'git' as const };
+    const stored = [{ ...target, token: undefined }];
+    h.upsertPublishTarget.mockImplementation(() => { h.getPublishTargets.mockReturnValue(stored); });
+
+    expect(call(Channels.PUBLISH_UPSERT_TARGET, target)).toEqual(stored);
+    expect(h.upsertPublishTarget).toHaveBeenCalledWith(ROOT, target);
+  });
+
+  it('PUBLISH_REMOVE_TARGET answers with the list AFTER the removal', () => {
+    h.getPublishTargets.mockReturnValue([{ id: 't2', label: 'Other', exporter: 'site', kind: 'git' }]);
+    expect(call(Channels.PUBLISH_REMOVE_TARGET, 't1'))
+      .toEqual([{ id: 't2', label: 'Other', exporter: 'site', kind: 'git' }]);
+    expect(h.removePublishTarget).toHaveBeenCalledWith(ROOT, 't1');
+  });
+});
+
+describe('register-publish — PUBLISH_TO_GIT', () => {
+  it('reports success with the transport result', async () => {
+    h.publishTarget.mockResolvedValue({ commit: 'abc123', pushed: true });
+    await expect(callAsync(Channels.PUBLISH_TO_GIT, 't1'))
+      .resolves.toEqual({ ok: true, result: { commit: 'abc123', pushed: true } });
+  });
+
+  it('stamps the app version and defaults to a real push', async () => {
+    h.publishTarget.mockResolvedValue({});
+    await callAsync(Channels.PUBLISH_TO_GIT, 't1');
+    // The version goes into the commit message, so a published site can be
+    // traced back to the build that produced it.
+    expect(h.publishTarget).toHaveBeenCalledWith(ROOT, 't1', { dryRun: false, version: '1.2.3' });
+  });
+
+  it('passes dryRun through for the preview, and createRepo only when asked', async () => {
+    h.publishTarget.mockResolvedValue({});
+    await callAsync(Channels.PUBLISH_TO_GIT, 't1', { dryRun: true, createRepo: { private: true } });
+    expect(h.publishTarget).toHaveBeenCalledWith(ROOT, 't1', {
+      dryRun: true, version: '1.2.3', createRepo: { private: true },
+    });
+  });
+
+  it('turns an auth / network / rejected-push failure into { ok: false } with the raw message', async () => {
+    // A sanctioned discriminated union (CLAUDE.md #1631 rule 3): the dialog
+    // shows git's own words verbatim, which is what makes "non-fast-forward"
+    // actionable. Honest caveat — the catch is unconditional, so a programming
+    // error inside the transport also arrives as `{ ok: false }` rather than
+    // surfacing as a crash.
+    h.publishTarget.mockRejectedValue(new Error('failed to push some refs (non-fast-forward)'));
+    await expect(callAsync(Channels.PUBLISH_TO_GIT, 't1'))
+      .resolves.toEqual({ ok: false, error: 'failed to push some refs (non-fast-forward)' });
+  });
+
+  it('stringifies a non-Error rejection rather than showing "[object Object]"', async () => {
+    h.publishTarget.mockRejectedValue('git exited with code 128');
+    await expect(callAsync(Channels.PUBLISH_TO_GIT, 't1'))
+      .resolves.toEqual({ ok: false, error: 'git exited with code 128' });
+  });
+});
+
+describe('register-publish — connection checks', () => {
+  it('PUBLISH_CHECK_S3 builds a throwaway target from the unsaved form', async () => {
+    // Validating BEFORE saving is the point — the user shouldn't have to
+    // persist a broken target to find out it's broken.
+    h.checkS3Connection.mockResolvedValue({ ok: true });
+
+    await callAsync(Channels.PUBLISH_CHECK_S3, {
+      bucket: 'notes', endpoint: 'https://s3.example', region: 'eu-west-1',
+      accessKeyId: 'AK', secretAccessKey: 'SK',
+    });
+
+    expect(h.checkS3Connection).toHaveBeenCalledWith(
+      { id: 'check', label: 'check', exporter: '', kind: 's3', bucket: 'notes', endpoint: 'https://s3.example', region: 'eu-west-1' },
+      { accessKeyId: 'AK', secretAccessKey: 'SK' },
+    );
+  });
+
+  it('PUBLISH_CHECK_S3 omits the optional fields the form left blank', async () => {
+    // Sending `endpoint: undefined` would override the SDK's own default.
+    h.checkS3Connection.mockResolvedValue({ ok: false, error: 'NoSuchBucket' });
+
+    await expect(callAsync(Channels.PUBLISH_CHECK_S3, { bucket: 'notes' }))
+      .resolves.toEqual({ ok: false, error: 'NoSuchBucket' });
+    expect(h.checkS3Connection).toHaveBeenCalledWith(
+      { id: 'check', label: 'check', exporter: '', kind: 's3', bucket: 'notes' },
+      {},
+    );
+  });
+
+  it('PUBLISH_CHECK_GITHUB tests the gh CLI / env fallback for a blank token', async () => {
+    // Matches what the push itself would resolve, so "check" and "publish"
+    // can't disagree about which credential is in play.
+    h.checkGitHubToken.mockResolvedValue({ ok: true, login: 'octocat' });
+    await callAsync(Channels.PUBLISH_CHECK_GITHUB, {});
+    expect(h.checkGitHubToken).toHaveBeenCalledWith(undefined);
+  });
+
+  it('PUBLISH_CHECK_GITHUB tests the typed token when one was entered', async () => {
+    h.checkGitHubToken.mockResolvedValue({ ok: false, error: 'Bad credentials' });
+    await expect(callAsync(Channels.PUBLISH_CHECK_GITHUB, { token: 'ghp_x' }))
+      .resolves.toEqual({ ok: false, error: 'Bad credentials' });
+    expect(h.checkGitHubToken).toHaveBeenCalledWith('ghp_x');
+  });
+});

--- a/tests/main/ipc/register-sources.test.ts
+++ b/tests/main/ipc/register-sources.test.ts
@@ -1,0 +1,739 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-sources.ts` (#1840).
+ *
+ * At 343 lines this was the largest remaining untested registrar, and the one
+ * with the most repetition: a dozen source mutations that all have to
+ * `persistIndexes` and then broadcast `SOURCES_CHANGED` to a window that may
+ * already have closed. Copy-paste is exactly where one of those steps goes
+ * missing, so the repeated contract is asserted for every handler via a table
+ * rather than trusted to review.
+ *
+ * Beyond that it pins the parts with real logic:
+ *
+ *   - the #1631 project guard on every handler — throw vs each fallback's own
+ *     legitimate empty value;
+ *   - a closed window is never sent to: `isDestroyed()` is checked AFTER the
+ *     await, which is the only reason that check exists at all;
+ *   - `SOURCES_MERGE` carries a `MergeSourcesError`'s structured `code` across
+ *     the IPC boundary (a plain rethrow loses it and the UI can no longer tell
+ *     "you picked the same source twice" from a crash) while any other error
+ *     passes through untouched;
+ *   - ingest fetches through the privileged-sites wrapper, not bare `fetch`,
+ *     and honours the user's `importUpstreamTags` setting;
+ *   - a cancelled file picker imports nothing;
+ *   - the reading-queue / smart-collection membership filters short-circuit
+ *     instead of listing every source in the thoughtbase to intersect against
+ *     an empty set.
+ *
+ * `withRootPath*` are re-implemented in the helpers mock with the real
+ * semantics (helpers.ts drags in electron + graph/search/vectors, so it can't
+ * be imported here). Their own contract is covered by
+ * tests/main/ipc/registration.test.ts; what matters here is WHICH wrapper each
+ * handler picked — throw vs fallback — which is exactly what #1631 governs.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => {
+  /** Stands in for the real `MergeSourcesError` so the `instanceof` holds. */
+  class FakeMergeSourcesError extends Error {
+    constructor(message: string, public readonly code: string) {
+      super(message);
+      this.name = 'MergeSourcesError';
+    }
+  }
+  return {
+    handlers: new Map<string, Handler>(),
+    win: { id: 1, isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
+    MergeSourcesError: FakeMergeSourcesError,
+    // electron / node
+    showOpenDialog: vi.fn(),
+    stat: vi.fn(),
+    // ingest
+    privilegedFetch: vi.fn(),
+    ingestUrl: vi.fn(),
+    ingestIdentifier: vi.fn(),
+    ingestSmart: vi.fn(),
+    ingestFile: vi.fn(),
+    finishPdfOcrIngest: vi.fn(),
+    readOriginalPdf: vi.fn(),
+    getIngestSettings: vi.fn(),
+    saveIngestSettings: vi.fn(),
+    // source mutations
+    deleteSource: vi.fn(),
+    mergeSources: vi.fn(),
+    setSourceReadStatus: vi.fn(),
+    setSourceReadDueBy: vi.fn(),
+    setSourceTitle: vi.fn(),
+    addSourceTag: vi.fn(),
+    removeSourceTag: vi.fn(),
+    stripUpstreamTags: vi.fn(),
+    createExcerpt: vi.fn(),
+    // references / stubs
+    mineSourceReferences: vi.fn(),
+    createReferenceStubs: vi.fn(),
+    resolveStub: vi.fn(),
+    applyStubResolution: vi.fn(),
+    // imports
+    importBibtex: vi.fn(),
+    importZoteroRdf: vi.fn(),
+    // graph
+    listAllSources: vi.fn(),
+    getReadingQueueSourceIds: vi.fn(),
+    sourcesByTag: vi.fn(),
+    sourcesByReadStatus: vi.fn(),
+    // collections
+    loadCollections: vi.fn(),
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    addSourceToCollection: vi.fn(),
+    removeSourceFromCollection: vi.fn(),
+    createSmartCollection: vi.fn(),
+    renameSmartCollection: vi.fn(),
+    deleteSmartCollection: vi.fn(),
+    updateSmartCollectionPredicate: vi.fn(),
+    resolveSmartMembers: vi.fn(),
+    // project config
+    getExcerptNoteFolder: vi.fn(),
+    setExcerptNoteFolder: vi.fn(),
+    // helpers
+    reindexFile: vi.fn(),
+    persistIndexes: vi.fn(),
+    // call-order log — ordering is load-bearing in the ingest/OCR handlers
+    order: [] as string[],
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+  dialog: { showOpenDialog: h.showOpenDialog },
+  BrowserWindow: class {},
+}));
+
+vi.mock('node:fs/promises', () => ({ default: { stat: h.stat }, stat: h.stat }));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+  withRootPathWin:
+    <A extends unknown[], R>(fn: (rootPath: string, win: unknown, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, h.win, ...args);
+      },
+  reindexFile: h.reindexFile,
+  persistIndexes: h.persistIndexes,
+}));
+
+vi.mock('../../../src/main/privileged-sites', () => ({ privilegedFetch: h.privilegedFetch }));
+vi.mock('../../../src/main/sources/ingest', () => ({ ingestUrl: h.ingestUrl }));
+vi.mock('../../../src/main/sources/ingest-identifier', () => ({ ingestIdentifier: h.ingestIdentifier }));
+vi.mock('../../../src/main/sources/ingest-smart', () => ({ ingestSmart: h.ingestSmart }));
+vi.mock('../../../src/main/sources/ingest-file', () => ({ ingestFile: h.ingestFile }));
+vi.mock('../../../src/main/sources/ingest-pdf', () => ({
+  finishPdfOcrIngest: h.finishPdfOcrIngest,
+  readOriginalPdf: h.readOriginalPdf,
+}));
+vi.mock('../../../src/main/sources/ingest-settings', () => ({
+  getIngestSettings: h.getIngestSettings,
+  saveIngestSettings: h.saveIngestSettings,
+}));
+vi.mock('../../../src/main/sources/delete-source', () => ({ deleteSource: h.deleteSource }));
+vi.mock('../../../src/main/sources/merge-sources', () => ({
+  mergeSources: h.mergeSources,
+  MergeSourcesError: h.MergeSourcesError,
+}));
+vi.mock('../../../src/main/sources/read-status', () => ({
+  setSourceReadStatus: h.setSourceReadStatus,
+  setSourceReadDueBy: h.setSourceReadDueBy,
+}));
+vi.mock('../../../src/main/sources/source-meta-write', () => ({
+  setSourceTitle: h.setSourceTitle,
+  addSourceTag: h.addSourceTag,
+  removeSourceTag: h.removeSourceTag,
+}));
+vi.mock('../../../src/main/sources/strip-upstream-tags', () => ({ stripUpstreamTags: h.stripUpstreamTags }));
+vi.mock('../../../src/main/sources/mine-references', () => ({ mineSourceReferences: h.mineSourceReferences }));
+vi.mock('../../../src/main/sources/create-reference-stubs', () => ({ createReferenceStubs: h.createReferenceStubs }));
+vi.mock('../../../src/main/sources/resolve-stub', () => ({
+  resolveStub: h.resolveStub,
+  applyStubResolution: h.applyStubResolution,
+}));
+vi.mock('../../../src/main/sources/import-bibtex', () => ({ importBibtex: h.importBibtex }));
+vi.mock('../../../src/main/sources/import-zotero-rdf', () => ({ importZoteroRdf: h.importZoteroRdf }));
+vi.mock('../../../src/main/sources/create-excerpt', () => ({ createExcerpt: h.createExcerpt }));
+vi.mock('../../../src/main/sources/collections', () => ({
+  loadCollections: h.loadCollections,
+  createCollection: h.createCollection,
+  renameCollection: h.renameCollection,
+  deleteCollection: h.deleteCollection,
+  addSourceToCollection: h.addSourceToCollection,
+  removeSourceFromCollection: h.removeSourceFromCollection,
+  createSmartCollection: h.createSmartCollection,
+  renameSmartCollection: h.renameSmartCollection,
+  deleteSmartCollection: h.deleteSmartCollection,
+  updateSmartCollectionPredicate: h.updateSmartCollectionPredicate,
+  resolveSmartMembers: h.resolveSmartMembers,
+}));
+vi.mock('../../../src/main/graph/index', () => ({
+  listAllSources: h.listAllSources,
+  getReadingQueueSourceIds: h.getReadingQueueSourceIds,
+  sourcesByTag: h.sourcesByTag,
+  sourcesByReadStatus: h.sourcesByReadStatus,
+}));
+vi.mock('../../../src/main/project-config', () => ({
+  getExcerptNoteFolder: h.getExcerptNoteFolder,
+  setExcerptNoteFolder: h.setExcerptNoteFolder,
+}));
+
+import { registerSources } from '../../../src/main/ipc/register-sources';
+import { Channels } from '../../../src/shared/channels';
+
+registerSources();
+
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!({}, ...args);
+/** Await a handler's answer whether it replied synchronously or with a promise. */
+const callAsync = (channel: string, ...args: unknown[]): Promise<unknown> =>
+  Promise.resolve(call(channel, ...args));
+/** Every channel the handler broadcast to the project's window, in order. */
+const sent = (): unknown[] => h.win.webContents.send.mock.calls.map((c) => c[0]);
+/** The ProjectContext the registrar builds from the root path. */
+const CTX = { rootPath: ROOT, _brand: 'ProjectContext' };
+
+beforeEach(() => {
+  // reset (not just clear): several tests install ordering/progress
+  // `mockImplementation`s that must not leak into the next one.
+  vi.resetAllMocks();
+  openProject = ROOT;
+  h.order.length = 0;
+  h.win.isDestroyed.mockReturnValue(false);
+  h.getIngestSettings.mockResolvedValue({ importUpstreamTags: true });
+  h.listAllSources.mockReturnValue([]);
+  h.loadCollections.mockResolvedValue({ collections: [], smartCollections: [] });
+});
+
+describe('register-sources — the #1631 project guard', () => {
+  // Every source mutation and every single-source read. An empty answer here
+  // would be a claim about a thoughtbase that isn't open.
+  const throwers: [string, unknown[]][] = [
+    [Channels.SOURCES_INGEST_URL, ['https://example.org/a']],
+    [Channels.SOURCES_INGEST_IDENTIFIER, ['10.1234/x']],
+    [Channels.SOURCES_INGEST_SMART, ['some input']],
+    [Channels.SOURCES_INGEST_FILE, []],
+    [Channels.SOURCES_MINE_REFERENCES, ['s1']],
+    [Channels.SOURCES_CREATE_REFERENCE_STUBS, [{ sourceId: 's1', refs: [] }]],
+    [Channels.SOURCES_RESOLVE_STUB, ['s1']],
+    [Channels.SOURCES_APPLY_STUB_RESOLUTION, [{ sourceId: 's1', doi: '10.1/x' }]],
+    [Channels.SOURCES_IMPORT_BIBTEX, []],
+    [Channels.SOURCES_IMPORT_ZOTERO_RDF, []],
+    [Channels.SOURCES_READ_PDF, ['s1']],
+    [Channels.SOURCES_FINISH_PDF_OCR, ['s1', ['page one']]],
+    [Channels.SOURCES_DELETE, ['s1']],
+    [Channels.SOURCES_MERGE, [{ srcId: 'a', destId: 'b' }]],
+    [Channels.SOURCES_SET_READ_STATUS, [{ sourceId: 's1', status: 'read' }]],
+    [Channels.SOURCES_SET_READ_DUE_BY, [{ sourceId: 's1', dueBy: null }]],
+    [Channels.SOURCES_SET_TITLE, [{ sourceId: 's1', title: 'T' }]],
+    [Channels.SOURCES_ADD_TAG, [{ sourceId: 's1', tag: 't' }]],
+    [Channels.SOURCES_REMOVE_TAG, [{ sourceId: 's1', tag: 't' }]],
+    [Channels.SOURCES_STRIP_UPSTREAM_TAGS, ['s1']],
+    [Channels.SOURCES_CREATE_EXCERPT, [{ sourceId: 's1', citedText: 'x' }]],
+    [Channels.EXCERPT_SET_NOTE_FOLDER, ['Notes']],
+    [Channels.COLLECTIONS_CREATE, [{ name: 'C' }]],
+    [Channels.COLLECTIONS_RENAME, [{ id: 'c1', name: 'C' }]],
+    [Channels.COLLECTIONS_DELETE, ['c1']],
+    [Channels.COLLECTIONS_ADD_SOURCE, [{ collectionId: 'c1', sourceId: 's1' }]],
+    [Channels.COLLECTIONS_REMOVE_SOURCE, [{ collectionId: 'c1', sourceId: 's1' }]],
+    [Channels.COLLECTIONS_CREATE_SMART, [{ name: 'C', predicate: { kind: 'tags', allOf: [] } }]],
+    [Channels.COLLECTIONS_RENAME_SMART, [{ id: 'c1', name: 'C' }]],
+    [Channels.COLLECTIONS_DELETE_SMART, ['c1']],
+    [Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, [{ id: 'c1', predicate: { kind: 'tags', allOf: [] } }]],
+  ];
+
+  it.each(throwers)('%s throws with no project open', (channel, args) => {
+    openProject = null;
+    expect(() => call(channel, ...args)).toThrow('No project open');
+  });
+
+  it('nothing is ingested, written or deleted when there is no project', () => {
+    openProject = null;
+    for (const [channel, args] of throwers) {
+      try { call(channel, ...args); } catch { /* asserted above */ }
+    }
+    expect(h.ingestUrl).not.toHaveBeenCalled();
+    expect(h.ingestFile).not.toHaveBeenCalled();
+    expect(h.deleteSource).not.toHaveBeenCalled();
+    expect(h.mergeSources).not.toHaveBeenCalled();
+    expect(h.createCollection).not.toHaveBeenCalled();
+    expect(h.setExcerptNoteFolder).not.toHaveBeenCalled();
+    // Not even a file picker: a cancelled-looking dialog with nowhere to put
+    // the result is worse than the throw.
+    expect(h.showOpenDialog).not.toHaveBeenCalled();
+  });
+
+  // Each of these fallbacks is also what the surface shows for a thoughtbase
+  // that simply has nothing yet — a legitimate value per #1631 rule 2, not an
+  // error signal wearing a value's clothes.
+  const fallbacks: [string, unknown[], unknown][] = [
+    [Channels.SOURCES_LIST_ALL, [], []],
+    [Channels.SOURCES_QUEUE_MEMBERS, ['unread'], []],
+    [Channels.EXCERPT_GET_NOTE_FOLDER, [], ''],
+    [Channels.COLLECTIONS_LIST, [], { collections: [] }],
+    [Channels.COLLECTIONS_SMART_MEMBERS, ['c1'], []],
+  ];
+
+  it.each(fallbacks)('%s answers with its empty value and reaches no domain module', async (channel, args, expected) => {
+    openProject = null;
+    await expect(callAsync(channel, ...args)).resolves.toEqual(expected);
+    expect(h.listAllSources).not.toHaveBeenCalled();
+    expect(h.loadCollections).not.toHaveBeenCalled();
+    expect(h.getExcerptNoteFolder).not.toHaveBeenCalled();
+  });
+
+  it('COLLECTIONS_LIST\'s project-less answer is shaped like a real empty file', async () => {
+    // The fallback omits `smartCollections` where `loadCollections` normalises
+    // it to `[]`. That is only safe because the type marks it optional and the
+    // panel reads `data.smartCollections ?? []` — pinned here so a caller that
+    // starts trusting the field notices the two shapes differ.
+    openProject = null;
+    const projectless = await callAsync(Channels.COLLECTIONS_LIST);
+    expect(projectless).toEqual({ collections: [] });
+    expect((projectless as { smartCollections?: unknown[] }).smartCollections).toBeUndefined();
+  });
+
+  it('SOURCES_HAS_PDF answers false with no project — the same false as "no PDF kept"', () => {
+    // Honest note: this `false` is overloaded (no project / no original.pdf /
+    // an unreadable one), the same shape as the NOTEBASE_FILE_EXISTS boolean
+    // on the #1631 backlog. Pinned as-is; it is not this test's job to change
+    // the contract.
+    openProject = null;
+    expect(call(Channels.SOURCES_HAS_PDF, 's1')).toBe(false);
+    expect(h.stat).not.toHaveBeenCalled();
+  });
+
+  it('INGEST_GET_SETTINGS and INGEST_SET_SETTINGS work with no project — they are per-machine', async () => {
+    openProject = null;
+    h.getIngestSettings.mockResolvedValue({ importUpstreamTags: false });
+    await expect(callAsync(Channels.INGEST_GET_SETTINGS)).resolves.toEqual({ importUpstreamTags: false });
+    await callAsync(Channels.INGEST_SET_SETTINGS, { importUpstreamTags: true });
+    expect(h.saveIngestSettings).toHaveBeenCalledWith({ importUpstreamTags: true });
+  });
+});
+
+describe('register-sources — mutations persist their indexes and announce themselves', () => {
+  // Eleven near-identical handlers. Each must persist the indexes AND tell the
+  // window; a step missing from one of them is invisible on review.
+  const mutations: [string, unknown[], () => void][] = [
+    [Channels.SOURCES_DELETE, ['s1'], () => { h.deleteSource.mockResolvedValue({ removed: 1 }); }],
+    [Channels.SOURCES_MERGE, [{ srcId: 'a', destId: 'b' }], () => { h.mergeSources.mockResolvedValue({ moved: 2 }); }],
+    [Channels.SOURCES_SET_READ_STATUS, [{ sourceId: 's1', status: 'read' }], () => {}],
+    [Channels.SOURCES_SET_READ_DUE_BY, [{ sourceId: 's1', dueBy: '2026-01-01' }], () => {}],
+    [Channels.SOURCES_SET_TITLE, [{ sourceId: 's1', title: 'T' }], () => {}],
+    [Channels.SOURCES_ADD_TAG, [{ sourceId: 's1', tag: 't' }], () => {}],
+    [Channels.SOURCES_REMOVE_TAG, [{ sourceId: 's1', tag: 't' }], () => {}],
+    [Channels.SOURCES_STRIP_UPSTREAM_TAGS, ['s1'], () => { h.stripUpstreamTags.mockResolvedValue({ removed: 3 }); }],
+    [Channels.SOURCES_FINISH_PDF_OCR, ['s1', ['p1']], () => {}],
+    [Channels.SOURCES_CREATE_REFERENCE_STUBS, [{ sourceId: 's1', refs: [] }], () => { h.createReferenceStubs.mockResolvedValue({ created: [] }); }],
+    [Channels.SOURCES_APPLY_STUB_RESOLUTION, [{ sourceId: 's1', doi: '10.1/x' }], () => { h.applyStubResolution.mockResolvedValue(true); }],
+  ];
+
+  it.each(mutations)('%s persists the indexes and tells the window', async (channel, args, arrange) => {
+    arrange();
+    await callAsync(channel, ...args);
+    expect(h.persistIndexes).toHaveBeenCalledWith(ROOT);
+    expect(sent()).toContain(Channels.SOURCES_CHANGED);
+  });
+
+  it.each(mutations)('%s sends nothing to a window that closed mid-write', async (channel, args, arrange) => {
+    // `isDestroyed()` is checked after the await precisely because the user can
+    // close the window while the write is in flight; sending then throws.
+    arrange();
+    h.win.isDestroyed.mockReturnValue(true);
+    await callAsync(channel, ...args);
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('SOURCES_DELETE also refreshes the excerpt panels — its excerpts went with it', async () => {
+    h.deleteSource.mockResolvedValue({ removed: 1 });
+    await expect(callAsync(Channels.SOURCES_DELETE, 's1')).resolves.toEqual({ removed: 1 });
+    expect(h.deleteSource).toHaveBeenCalledWith(ROOT, 's1');
+    expect(sent()).toEqual([Channels.SOURCES_CHANGED, Channels.EXCERPTS_CHANGED]);
+  });
+
+  it('SOURCES_MERGE also refreshes the excerpt panels — they changed source', async () => {
+    h.mergeSources.mockResolvedValue({ moved: 2 });
+    await expect(callAsync(Channels.SOURCES_MERGE, { srcId: 'a', destId: 'b' })).resolves.toEqual({ moved: 2 });
+    expect(h.mergeSources).toHaveBeenCalledWith(ROOT, 'a', 'b');
+    expect(sent()).toEqual([Channels.SOURCES_CHANGED, Channels.EXCERPTS_CHANGED]);
+  });
+
+  it('the other mutations leave the excerpt panels alone', async () => {
+    await callAsync(Channels.SOURCES_SET_TITLE, { sourceId: 's1', title: 'T' });
+    expect(sent()).toEqual([Channels.SOURCES_CHANGED]);
+  });
+
+  it('SOURCES_SET_READ_STATUS forwards a null status as "clear the status"', async () => {
+    await callAsync(Channels.SOURCES_SET_READ_STATUS, { sourceId: 's1', status: null });
+    expect(h.setSourceReadStatus).toHaveBeenCalledWith(ROOT, 's1', null);
+  });
+
+  it('SOURCES_SET_READ_DUE_BY forwards a null date as "clear the due date"', async () => {
+    await callAsync(Channels.SOURCES_SET_READ_DUE_BY, { sourceId: 's1', dueBy: null });
+    expect(h.setSourceReadDueBy).toHaveBeenCalledWith(ROOT, 's1', null);
+  });
+
+  it.each([
+    [Channels.SOURCES_ADD_TAG, 'addSourceTag'],
+    [Channels.SOURCES_REMOVE_TAG, 'removeSourceTag'],
+  ] as const)('%s applies the tag change to the source', async (channel, fn) => {
+    await callAsync(channel, { sourceId: 's1', tag: 'ml' });
+    expect(h[fn]).toHaveBeenCalledWith(ROOT, 's1', 'ml');
+  });
+
+  it('SOURCES_FINISH_PDF_OCR reindexes the source meta before persisting, so the OCR text is searchable', async () => {
+    h.finishPdfOcrIngest.mockImplementation(async () => { h.order.push('ocr'); });
+    h.reindexFile.mockImplementation(async () => { h.order.push('reindex'); });
+    h.persistIndexes.mockImplementation(async () => { h.order.push('persist'); });
+
+    await callAsync(Channels.SOURCES_FINISH_PDF_OCR, 's1', ['page one', 'page two']);
+
+    expect(h.finishPdfOcrIngest).toHaveBeenCalledWith(ROOT, 's1', ['page one', 'page two']);
+    expect(h.reindexFile).toHaveBeenCalledWith(ROOT, '.minerva/sources/s1/meta.ttl');
+    // Rewrite → reindex → persist. Persisting first would snapshot the index
+    // as it was before the OCR text landed in it.
+    expect(h.order).toEqual(['ocr', 'reindex', 'persist']);
+  });
+
+  it('a failed mutation announces nothing', async () => {
+    h.setSourceTitle.mockRejectedValue(new Error('EACCES'));
+    await expect(callAsync(Channels.SOURCES_SET_TITLE, { sourceId: 's1', title: 'T' })).rejects.toThrow('EACCES');
+    expect(h.persistIndexes).not.toHaveBeenCalled();
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-sources — SOURCES_MERGE error translation', () => {
+  it('carries the structured code across the IPC boundary', async () => {
+    // Without this the renderer sees a bare message and can't tell an expected
+    // "you picked the same source twice" from an actual crash.
+    h.mergeSources.mockRejectedValue(new h.MergeSourcesError('cannot merge a source into itself', 'same-source'));
+
+    const err = await callAsync(Channels.SOURCES_MERGE, { srcId: 'a', destId: 'a' })
+      .then(() => null, (e: unknown) => e as Error & { code?: string });
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err?.message).toBe('cannot merge a source into itself');
+    expect(err?.code).toBe('same-source');
+  });
+
+  it('does not persist or announce a merge that failed', async () => {
+    h.mergeSources.mockRejectedValue(new h.MergeSourcesError('no such source', 'not-found'));
+    await expect(callAsync(Channels.SOURCES_MERGE, { srcId: 'a', destId: 'b' })).rejects.toThrow('no such source');
+    expect(h.persistIndexes).not.toHaveBeenCalled();
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('lets a genuine crash through untouched', async () => {
+    // Only MergeSourcesError is translated. Wrapping everything would dress a
+    // real bug up as an expected outcome — and lose the original stack.
+    const boom = new Error('EIO');
+    h.mergeSources.mockRejectedValue(boom);
+    await expect(callAsync(Channels.SOURCES_MERGE, { srcId: 'a', destId: 'b' })).rejects.toBe(boom);
+  });
+});
+
+describe('register-sources — ingest', () => {
+  it.each([
+    [Channels.SOURCES_INGEST_URL, 'https://example.org/a', 'ingestUrl'],
+    [Channels.SOURCES_INGEST_IDENTIFIER, '10.1234/abc', 'ingestIdentifier'],
+    [Channels.SOURCES_INGEST_SMART, 'anything at all', 'ingestSmart'],
+  ] as const)('%s fetches through the privileged wrapper and honours the tag preference', async (channel, input, fn) => {
+    // A bare `fetch` would bypass the per-site credential/header handling, and
+    // a hardcoded tag flag would ignore the user's ingest setting.
+    h.getIngestSettings.mockResolvedValue({ importUpstreamTags: false });
+    h[fn].mockResolvedValue({ sourceId: 's9' });
+
+    await expect(callAsync(channel, input)).resolves.toEqual({ sourceId: 's9' });
+    expect(h[fn]).toHaveBeenCalledWith(ROOT, input, {
+      fetchImpl: h.privilegedFetch,
+      importUpstreamTags: false,
+    });
+  });
+
+  it('SOURCES_INGEST_FILE reindexes the new source so it appears in the sidebar', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/tmp/paper.pdf'] });
+    h.ingestFile.mockResolvedValue({ sourceId: 'src-42' });
+
+    await expect(callAsync(Channels.SOURCES_INGEST_FILE)).resolves.toEqual({ sourceId: 'src-42' });
+
+    expect(h.ingestFile).toHaveBeenCalledWith(ROOT, '/tmp/paper.pdf');
+    expect(h.reindexFile).toHaveBeenCalledWith(ROOT, '.minerva/sources/src-42/meta.ttl');
+    expect(h.persistIndexes).toHaveBeenCalledWith(ROOT);
+  });
+
+  it.each([
+    ['cancelled', { canceled: true, filePaths: [] }],
+    ['dismissed with no path', { canceled: false, filePaths: [] }],
+  ])('SOURCES_INGEST_FILE imports nothing when the picker is %s', async (_label, dialogResult) => {
+    h.showOpenDialog.mockResolvedValue(dialogResult);
+    await expect(callAsync(Channels.SOURCES_INGEST_FILE)).resolves.toBeNull();
+    expect(h.ingestFile).not.toHaveBeenCalled();
+    expect(h.persistIndexes).not.toHaveBeenCalled();
+  });
+
+  it('SOURCES_RESOLVE_STUB looks the reference up through the privileged fetcher', async () => {
+    h.resolveStub.mockResolvedValue({ doi: '10.1/x' });
+    await expect(callAsync(Channels.SOURCES_RESOLVE_STUB, 's1')).resolves.toEqual({ doi: '10.1/x' });
+    expect(h.resolveStub).toHaveBeenCalledWith(ROOT, 's1', { fetchImpl: h.privilegedFetch });
+  });
+
+  it('SOURCES_APPLY_STUB_RESOLUTION reports whether the stub was actually filled in', async () => {
+    h.applyStubResolution.mockResolvedValue(false);
+    await expect(callAsync(Channels.SOURCES_APPLY_STUB_RESOLUTION, { sourceId: 's1', doi: '10.1/x' }))
+      .resolves.toEqual({ ok: false });
+    expect(h.applyStubResolution).toHaveBeenCalledWith(ROOT, 's1', '10.1/x', { fetchImpl: h.privilegedFetch });
+  });
+
+  it('SOURCES_MINE_REFERENCES returns the parsed references', async () => {
+    h.mineSourceReferences.mockResolvedValue([{ title: 'A paper' }]);
+    await expect(callAsync(Channels.SOURCES_MINE_REFERENCES, 's1')).resolves.toEqual([{ title: 'A paper' }]);
+    expect(h.mineSourceReferences).toHaveBeenCalledWith(ROOT, 's1');
+  });
+
+  it('SOURCES_CREATE_REFERENCE_STUBS passes the parsed refs straight through', async () => {
+    const refs = [{ title: 'A paper', doi: '10.1/x' }];
+    h.createReferenceStubs.mockResolvedValue({ created: ['stub-1'] });
+    await expect(callAsync(Channels.SOURCES_CREATE_REFERENCE_STUBS, { sourceId: 's1', refs }))
+      .resolves.toEqual({ created: ['stub-1'] });
+    expect(h.createReferenceStubs).toHaveBeenCalledWith(ROOT, 's1', refs);
+  });
+
+  it('SOURCES_READ_PDF hands the original bytes back for the renderer OCR worker', async () => {
+    h.readOriginalPdf.mockResolvedValue(new Uint8Array([37, 80]));
+    await expect(callAsync(Channels.SOURCES_READ_PDF, 's1')).resolves.toEqual(new Uint8Array([37, 80]));
+    expect(h.readOriginalPdf).toHaveBeenCalledWith(ROOT, 's1');
+  });
+
+  it('SOURCES_HAS_PDF reports true when the original was kept', async () => {
+    h.stat.mockResolvedValue({});
+    await expect(callAsync(Channels.SOURCES_HAS_PDF, 's1')).resolves.toBe(true);
+    expect(h.stat).toHaveBeenCalledWith('/vault/.minerva/sources/s1/original.pdf');
+  });
+
+  it('SOURCES_HAS_PDF reports false for a source ingested without one', async () => {
+    h.stat.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    await expect(callAsync(Channels.SOURCES_HAS_PDF, 's1')).resolves.toBe(false);
+  });
+});
+
+describe('register-sources — bibliography imports', () => {
+  it.each([
+    [Channels.SOURCES_IMPORT_BIBTEX, 'importBibtex', Channels.SOURCES_IMPORT_BIBTEX_PROGRESS],
+    [Channels.SOURCES_IMPORT_ZOTERO_RDF, 'importZoteroRdf', Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS],
+  ] as const)('%s streams progress to the window while it runs', async (channel, fn, progressChannel) => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/tmp/refs.bib'] });
+    h[fn].mockImplementation(async (_root: string, _file: string, opts: { onProgress: (p: unknown) => void }) => {
+      opts.onProgress({ done: 1, total: 2 });
+      opts.onProgress({ done: 2, total: 2 });
+      return { imported: 2 };
+    });
+
+    await expect(callAsync(channel)).resolves.toEqual({ imported: 2 });
+    expect(h[fn]).toHaveBeenCalledWith(ROOT, '/tmp/refs.bib', { onProgress: expect.any(Function) });
+    // A long import has to move a progress bar, not freeze the dialog.
+    expect(h.win.webContents.send.mock.calls).toEqual([
+      [progressChannel, { done: 1, total: 2 }],
+      [progressChannel, { done: 2, total: 2 }],
+    ]);
+  });
+
+  it.each([
+    [Channels.SOURCES_IMPORT_BIBTEX, 'importBibtex', { canceled: true, filePaths: [] }],
+    [Channels.SOURCES_IMPORT_BIBTEX, 'importBibtex', { canceled: false, filePaths: [] }],
+    [Channels.SOURCES_IMPORT_ZOTERO_RDF, 'importZoteroRdf', { canceled: true, filePaths: [] }],
+    [Channels.SOURCES_IMPORT_ZOTERO_RDF, 'importZoteroRdf', { canceled: false, filePaths: [] }],
+  ] as const)('%s imports nothing when the picker gives back no file', async (channel, fn, dialogResult) => {
+    h.showOpenDialog.mockResolvedValue(dialogResult);
+    await expect(callAsync(channel)).resolves.toBeNull();
+    expect(h[fn]).not.toHaveBeenCalled();
+  });
+
+  it('a progress tick after the window closed is dropped, not sent', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/tmp/refs.bib'] });
+    h.importBibtex.mockImplementation(async (_root: string, _file: string, opts: { onProgress: (p: unknown) => void }) => {
+      h.win.isDestroyed.mockReturnValue(true);
+      opts.onProgress({ done: 1, total: 2 });
+      return { imported: 1 };
+    });
+    await expect(callAsync(Channels.SOURCES_IMPORT_BIBTEX)).resolves.toEqual({ imported: 1 });
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-sources — reading queue and smart collections', () => {
+  it('SOURCES_QUEUE_MEMBERS returns only the sources in the requested view', () => {
+    h.getReadingQueueSourceIds.mockReturnValue(['s1', 's3']);
+    h.listAllSources.mockReturnValue([{ sourceId: 's1' }, { sourceId: 's2' }, { sourceId: 's3' }]);
+
+    expect(call(Channels.SOURCES_QUEUE_MEMBERS, 'unread')).toEqual([{ sourceId: 's1' }, { sourceId: 's3' }]);
+    expect(h.getReadingQueueSourceIds).toHaveBeenCalledWith(CTX, 'unread');
+  });
+
+  it('SOURCES_QUEUE_MEMBERS skips listing every source when the queue is empty', () => {
+    // Intersecting the whole library against nothing is pure waste on a large
+    // thoughtbase, and the answer is [] either way.
+    h.getReadingQueueSourceIds.mockReturnValue([]);
+    expect(call(Channels.SOURCES_QUEUE_MEMBERS, 'unread')).toEqual([]);
+    expect(h.listAllSources).not.toHaveBeenCalled();
+  });
+
+  it('SOURCES_LIST_ALL reads the graph for the open project', () => {
+    h.listAllSources.mockReturnValue([{ sourceId: 's1' }]);
+    expect(call(Channels.SOURCES_LIST_ALL)).toEqual([{ sourceId: 's1' }]);
+    expect(h.listAllSources).toHaveBeenCalledWith(CTX);
+  });
+
+  it('COLLECTIONS_SMART_MEMBERS resolves membership through the graph', async () => {
+    h.loadCollections.mockResolvedValue({
+      collections: [],
+      smartCollections: [{ id: 'sc1', predicate: { kind: 'tags', allOf: ['ml'] } }],
+    });
+    h.resolveSmartMembers.mockReturnValue(new Set(['s2']));
+    h.listAllSources.mockReturnValue([{ sourceId: 's1' }, { sourceId: 's2' }]);
+
+    await expect(callAsync(Channels.COLLECTIONS_SMART_MEMBERS, 'sc1')).resolves.toEqual([{ sourceId: 's2' }]);
+    expect(h.resolveSmartMembers).toHaveBeenCalledWith(
+      { kind: 'tags', allOf: ['ml'] },
+      { sourcesByTag: expect.any(Function), sourcesByReadStatus: expect.any(Function) },
+    );
+  });
+
+  it('the lookups it hands the resolver read from the graph, not a local cache', async () => {
+    // The graph is the source of truth for hasTag edges, so smart-collection
+    // membership matches what the tag panel shows.
+    h.loadCollections.mockResolvedValue({
+      collections: [], smartCollections: [{ id: 'sc1', predicate: { kind: 'tags', allOf: ['ml'] } }],
+    });
+    h.resolveSmartMembers.mockImplementation((_p: unknown, lookups: {
+      sourcesByTag: (t: string) => unknown; sourcesByReadStatus: (s: string) => unknown;
+    }) => {
+      lookups.sourcesByTag('ml');
+      lookups.sourcesByReadStatus('unread');
+      return new Set<string>();
+    });
+
+    await callAsync(Channels.COLLECTIONS_SMART_MEMBERS, 'sc1');
+
+    expect(h.sourcesByTag).toHaveBeenCalledWith(CTX, 'ml');
+    expect(h.sourcesByReadStatus).toHaveBeenCalledWith(CTX, 'unread');
+  });
+
+  it('COLLECTIONS_SMART_MEMBERS returns nothing for an id that no longer exists', async () => {
+    h.loadCollections.mockResolvedValue({ collections: [], smartCollections: [] });
+    await expect(callAsync(Channels.COLLECTIONS_SMART_MEMBERS, 'gone')).resolves.toEqual([]);
+    expect(h.resolveSmartMembers).not.toHaveBeenCalled();
+  });
+
+  it('COLLECTIONS_SMART_MEMBERS skips listing every source when nothing matched', async () => {
+    h.loadCollections.mockResolvedValue({
+      collections: [], smartCollections: [{ id: 'sc1', predicate: { kind: 'tags', allOf: ['nope'] } }],
+    });
+    h.resolveSmartMembers.mockReturnValue(new Set());
+    await expect(callAsync(Channels.COLLECTIONS_SMART_MEMBERS, 'sc1')).resolves.toEqual([]);
+    expect(h.listAllSources).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-sources — collections', () => {
+  const collectionMutations: [string, unknown[], () => void][] = [
+    [Channels.COLLECTIONS_CREATE, [{ name: 'C' }], () => { h.createCollection.mockResolvedValue({ id: 'c1' }); }],
+    [Channels.COLLECTIONS_RENAME, [{ id: 'c1', name: 'C2' }], () => {}],
+    [Channels.COLLECTIONS_DELETE, ['c1'], () => {}],
+    [Channels.COLLECTIONS_ADD_SOURCE, [{ collectionId: 'c1', sourceId: 's1' }], () => {}],
+    [Channels.COLLECTIONS_REMOVE_SOURCE, [{ collectionId: 'c1', sourceId: 's1' }], () => {}],
+    [Channels.COLLECTIONS_CREATE_SMART, [{ name: 'S', predicate: { kind: 'tags', allOf: [] } }], () => { h.createSmartCollection.mockResolvedValue({ id: 'sc1' }); }],
+    [Channels.COLLECTIONS_RENAME_SMART, [{ id: 'sc1', name: 'S2' }], () => {}],
+    [Channels.COLLECTIONS_DELETE_SMART, ['sc1'], () => {}],
+    [Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, [{ id: 'sc1', predicate: { kind: 'tags', allOf: ['x'] } }], () => {}],
+  ];
+
+  it.each(collectionMutations)('%s tells the sidebar the collections changed', async (channel, args, arrange) => {
+    arrange();
+    await callAsync(channel, ...args);
+    expect(sent()).toEqual([Channels.COLLECTIONS_CHANGED]);
+  });
+
+  it.each(collectionMutations)('%s sends nothing to a window that closed mid-write', async (channel, args, arrange) => {
+    arrange();
+    h.win.isDestroyed.mockReturnValue(true);
+    await callAsync(channel, ...args);
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('collection edits do not touch the source indexes', async () => {
+    // Collections live in their own JSON file, not the graph — persisting the
+    // search/graph indexes on every rename would be wasted IO.
+    await callAsync(Channels.COLLECTIONS_RENAME, { id: 'c1', name: 'C2' });
+    expect(h.renameCollection).toHaveBeenCalledWith(ROOT, 'c1', 'C2');
+    expect(h.persistIndexes).not.toHaveBeenCalled();
+  });
+
+  it('COLLECTIONS_CREATE forwards the parent so nesting works', async () => {
+    h.createCollection.mockResolvedValue({ id: 'c2' });
+    await expect(callAsync(Channels.COLLECTIONS_CREATE, { name: 'Child', parent: 'c1' }))
+      .resolves.toEqual({ id: 'c2' });
+    expect(h.createCollection).toHaveBeenCalledWith(ROOT, { name: 'Child', parent: 'c1' });
+  });
+
+  it('COLLECTIONS_LIST returns the stored file for the open project', async () => {
+    h.loadCollections.mockResolvedValue({ collections: [{ id: 'c1' }], smartCollections: [] });
+    await expect(callAsync(Channels.COLLECTIONS_LIST))
+      .resolves.toEqual({ collections: [{ id: 'c1' }], smartCollections: [] });
+    expect(h.loadCollections).toHaveBeenCalledWith(ROOT);
+  });
+
+  it.each([
+    [Channels.COLLECTIONS_ADD_SOURCE, 'addSourceToCollection'],
+    [Channels.COLLECTIONS_REMOVE_SOURCE, 'removeSourceFromCollection'],
+  ] as const)('%s moves the membership on the named collection', async (channel, fn) => {
+    await callAsync(channel, { collectionId: 'c1', sourceId: 's1' });
+    expect(h[fn]).toHaveBeenCalledWith(ROOT, 'c1', 's1');
+  });
+});
+
+describe('register-sources — excerpts', () => {
+  it('SOURCES_CREATE_EXCERPT passes the anchor through unchanged', async () => {
+    // The anchor fields are what re-locates a quote in the source later; a
+    // handler that dropped `pageRange`/`locationText` would silently produce
+    // unanchored excerpts.
+    const params = { sourceId: 's1', citedText: 'a quote', page: 12, pageRange: '12-13', locationText: 'ch. 2' };
+    h.createExcerpt.mockResolvedValue({ excerptId: 'ex1' });
+    await expect(callAsync(Channels.SOURCES_CREATE_EXCERPT, params)).resolves.toEqual({ excerptId: 'ex1' });
+    expect(h.createExcerpt).toHaveBeenCalledWith(ROOT, params);
+  });
+
+  it('EXCERPT_GET_NOTE_FOLDER reports the configured default', () => {
+    h.getExcerptNoteFolder.mockReturnValue('Notes/Excerpts');
+    expect(call(Channels.EXCERPT_GET_NOTE_FOLDER)).toBe('Notes/Excerpts');
+    expect(h.getExcerptNoteFolder).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('EXCERPT_SET_NOTE_FOLDER stores the new default', () => {
+    call(Channels.EXCERPT_SET_NOTE_FOLDER, 'Notes/Excerpts');
+    expect(h.setExcerptNoteFolder).toHaveBeenCalledWith(ROOT, 'Notes/Excerpts');
+  });
+});


### PR DESCRIPTION
Part of #1840. The three largest untested registrars — **219 tests**.

**Stacked on #1876** (the six small ones). Merge order: #1876 → this → the compute/tools/types/queries PR. GitHub retargets each as its base lands.

| Registrar | Lines | Tests |
| --- | --- | --- |
| `register-sources` | 343 | 127 |
| `register-publish` | 171 | 39 |
| `register-bibliography` | 144 | 53 |

### Mutation-checked, not just green

The author didn't stop at "the tests pass" — each suite was verified by deliberately breaking the registrar and confirming targeted failures: dropped the `EXCERPTS_CHANGED` broadcast, swapped `withRootPathOr`→`withRootPath`, removed the merge-error `code`, stopped stripping plan `content`, ignored a picker cancel, `hasOwnProperty`→`in`, dropped the CSL id regex, always-write on unchanged. 3 / 5 / 11 failures respectively, then restored. I re-ran all 219 myself in the worktree.

### Findings — tested as-is, not fixed

1. **`register-sources.ts:156` — `SOURCES_HAS_PDF`'s overloaded `false`.** `withRootPathOr(false, …)` plus `catch { return false }` means one `false` covers *no project*, *no `original.pdf`*, and *unreadable file*. Same shape as the `NOTEBASE_FILE_EXISTS` overload #1862 just cleared — and this one isn't on CLAUDE.md's backlog. I verified it; filing separately.
2. **`register-bibliography.ts:117,122` — `CSL_REMOVE_STYLE` / `CSL_REMOVE_LOCALE` swallow non-ENOENT**, so the settings row vanishes while the file survives and reappears on reload. Already on the backlog; both the benign ENOENT case and the swallowed-EACCES case are pinned and labelled.
3. **`register-bibliography.ts:36` — `BIBLIOGRAPHY_LIST_STYLES` calls `getMergedStyles('')` with no project**, so the user-style scan runs against `.minerva/csl-styles` relative to the process CWD rather than being skipped. Harmless today; a `getBundledStyles()` seam would be honest.
4. **`register-publish.ts:132` — `PUBLISH_TO_GIT`'s catch is unconditional**, so a programming error inside the transport arrives as `{ ok: false, error: "…is not a function" }` in the publish dialog rather than surfacing as a crash. Not a violation of rule 3 — just its cost, noted in a comment.

One thing checked and cleared: `CREATE_REFERENCE_STUBS` / `APPLY_STUB_RESOLUTION` don't call `reindexFile`, unlike their siblings. That looked like an omission until the author traced it — they index via `graph.indexSource` themselves. No bug, nothing to assert at the registrar boundary.

`pnpm lint` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy