### PR TITLE
test(ipc): compute/tools/types/queries, and the backlog hits zero (#1840)

### DIFF
--- a/tests/architecture/ipc-registrar-coverage.test.ts
+++ b/tests/architecture/ipc-registrar-coverage.test.ts
@@ -49,12 +49,15 @@ const IPC_DIR = path.join(ROOT, 'src', 'main', 'ipc');
  * This list may only SHRINK. Deleting an entry because you wrote its test is
  * the intended way to change this file; adding one is not.
  */
-const KNOWN_UNTESTED: readonly string[] = [
-  'register-compute',      // 119 lines
-  'register-tools',        // 108 lines
-  'register-types',        //  78 lines
-  'register-queries',      //  63 lines
-];
+/**
+ * Registrars with no direct test. **Empty** — every `register-*.ts` is now
+ * exercised by a file under `tests/main/ipc/` (#1840, batches a/b/c).
+ *
+ * Keep it that way: this list is the pre-existing backlog and may only shrink,
+ * so a new registrar without a test fails the check above rather than landing
+ * here. There is nothing left for it to hold.
+ */
+const KNOWN_UNTESTED: readonly string[] = [];
 
 /** Module names (no extension) of every `src/main/ipc/register-*.ts`. */
 function registrars(): string[] {

--- a/tests/main/ipc/register-compute.test.ts
+++ b/tests/main/ipc/register-compute.test.ts
@@ -1,0 +1,478 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-compute.ts` (#1840).
+ *
+ * Compute is where a renderer (or an LLM-authored proposal) asks main to
+ * execute arbitrary code, so the handlers here carry two contracts worth
+ * pinning rather than one:
+ *
+ *   - the #1631 project guard — `COMPUTE_RUN_CELL` / `COMPUTE_GRANT_CONSENT` /
+ *     `COMPUTE_SAVE_CELL_OUTPUT` THROW with no project open, while the
+ *     `withRootPathOr` handlers answer a value that genuinely means what it
+ *     says (`'none'` = not consented, `{ ok: false, reason: 'no-kernel' }` =
+ *     there is no kernel) rather than a disguised error;
+ *   - the #1411/#1412 enforcement boundary — `COMPUTE_RUN_CELL` refuses a cell
+ *     the user never consented to *even when the caller skipped the prompt*,
+ *     and refusing means no execution at all.
+ *
+ * The consent store is the REAL one (`compute/consent.ts`, pointed at a temp
+ * `userData`), because "the guard fires" is only worth asserting against the
+ * real content-addressed hashing — a mocked guard would pass while the actual
+ * boundary rotted. The executor, kernel, audit log and settings store are
+ * mocked; they're what the handlers delegate to, not what they promise.
+ *
+ * Also pinned: the three discriminated `{ ok, … }` unions CLAUDE.md rule 3
+ * names (`CellResult`, `PythonProbeResult`, `InterruptResult`) RESOLVE on their
+ * failure arm. A caller branching on `ok` must never also have to catch.
+ */
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => {
+  return {
+    // Where the REAL consent store lives. Filled in below — `vi.hoisted` runs
+    // before the `node:fs` import exists, and `app.getPath` is only ever called
+    // from inside a handler, so a mutable holder is enough.
+    userData: { dir: '' },
+    handlers: new Map<string, Handler>(),
+    win: { id: 1 },
+    // electron
+    showOpenDialog: vi.fn(),
+    showItemInFolder: vi.fn(),
+    // compute/registry
+    runCell: vi.fn(),
+    registeredLanguages: vi.fn(),
+    // compute/audit
+    recordExecution: vi.fn(),
+    auditLogPath: vi.fn(),
+    // compute/python-kernel
+    restartKernel: vi.fn(),
+    interruptKernel: vi.fn(),
+    // compute/python-settings
+    getPythonSettings: vi.fn(),
+    setPythonSettings: vi.fn(),
+    probePythonInterpreter: vi.fn(),
+    resolvePythonInterpreter: vi.fn(),
+    // compute/save-cell-output
+    saveCellOutput: vi.fn(),
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+  dialog: { showOpenDialog: h.showOpenDialog },
+  shell: { showItemInFolder: h.showItemInFolder },
+  // The REAL consent store reads this to find `compute-consent.json`.
+  app: { getPath: () => h.userData.dir },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  winFromEvent: () => h.win,
+  rootPathFromEvent: () => openProject,
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+}));
+
+vi.mock('../../../src/main/compute/registry', () => ({
+  runCell: h.runCell,
+  registeredLanguages: h.registeredLanguages,
+}));
+vi.mock('../../../src/main/compute/audit', () => ({
+  recordExecution: h.recordExecution,
+  auditLogPath: h.auditLogPath,
+}));
+vi.mock('../../../src/main/compute/python-kernel', () => ({
+  restartKernel: h.restartKernel,
+  interruptKernel: h.interruptKernel,
+}));
+vi.mock('../../../src/main/compute/python-settings', () => ({
+  getPythonSettings: h.getPythonSettings,
+  setPythonSettings: h.setPythonSettings,
+  probePythonInterpreter: h.probePythonInterpreter,
+  resolvePythonInterpreter: h.resolvePythonInterpreter,
+}));
+vi.mock('../../../src/main/compute/save-cell-output', () => ({ saveCellOutput: h.saveCellOutput }));
+// register-compute re-exports the propose_compute helpers, which reach the
+// graph on import. Nothing here calls them; the stub just keeps the graph out.
+vi.mock('../../../src/main/graph/index', () => ({}));
+
+import { registerCompute } from '../../../src/main/ipc/register-compute';
+import { cellHash } from '../../../src/main/compute/consent';
+import { Channels } from '../../../src/shared/channels';
+
+registerCompute();
+h.userData.dir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-compute-'));
+
+const call = (channel: string, ...args: unknown[]) => h.handlers.get(channel)!({}, ...args);
+/** `call` wrapped so a SYNCHRONOUS throw (the `withRootPath` guard fires before
+ *  the async body runs) is assertable with the same `rejects` matcher. */
+const callAsync = async (channel: string, ...args: unknown[]) => call(channel, ...args);
+
+const consentFile = () => path.join(h.userData.dir, 'compute-consent.json');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  openProject = ROOT;
+  // A machine that has never trusted anything — the state every assertion
+  // about the guard has to start from.
+  fs.rmSync(consentFile(), { force: true });
+  h.auditLogPath.mockReturnValue(path.join(h.userData.dir, 'audit', 'compute-audit.jsonl'));
+});
+
+afterAll(() => { fs.rmSync(h.userData.dir, { recursive: true, force: true }); });
+
+const OK_RESULT = { ok: true, output: { type: 'text', value: '42' } };
+
+describe('COMPUTE_RUN_CELL — the consent enforcement boundary (#1411/#1412)', () => {
+  it('refuses code the user never consented to, and executes nothing', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+
+    const result = await call(Channels.COMPUTE_RUN_CELL, 'python', 'import os; os.system("rm -rf ~")');
+
+    // The refusal is a normal CellResult, not a rejection — the renderer
+    // renders it in the output block like any other failed cell.
+    expect(result).toEqual({ ok: false, error: expect.stringContaining('has not been approved to run') });
+    // The point of the boundary: reaching the IPC without prompting buys nothing.
+    expect(h.runCell).not.toHaveBeenCalled();
+  });
+
+  it('runs the cell once that exact code is consented', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+
+    await expect(callAsync(Channels.COMPUTE_RUN_CELL, 'python', 'print(1)')).resolves.toEqual(OK_RESULT);
+    expect(h.runCell).toHaveBeenCalledWith('python', 'print(1)', { rootPath: ROOT });
+  });
+
+  it('consent is content-addressed — editing a single character re-refuses', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+
+    // This is the whole reason consent is keyed on a code hash: an approved
+    // cell must not become a licence to run whatever replaces it.
+    const result = await call(Channels.COMPUTE_RUN_CELL, 'python', 'print(2)');
+
+    expect(result).toEqual({ ok: false, error: expect.any(String) });
+    expect(h.runCell).not.toHaveBeenCalled();
+  });
+
+  it('blanket project trust lets an unseen cell run', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'anything', 'project');
+
+    await expect(callAsync(Channels.COMPUTE_RUN_CELL, 'python', 'never seen before')).resolves.toEqual(OK_RESULT);
+  });
+
+  it("blanket trust is per-thoughtbase — it doesn't spill to another project", async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'x', 'project');
+
+    openProject = '/other-vault';
+    const result = await call(Channels.COMPUTE_RUN_CELL, 'python', 'x');
+
+    expect(result).toEqual({ ok: false, error: expect.any(String) });
+    expect(h.runCell).not.toHaveBeenCalled();
+  });
+
+  it('throws with no project open, rather than running against an unknown root', async () => {
+    openProject = null;
+    await expect(callAsync(Channels.COMPUTE_RUN_CELL, 'python', 'print(1)')).rejects.toThrow(/No project open/);
+    expect(h.runCell).not.toHaveBeenCalled();
+  });
+
+  it('audits the run, keyed to the consent decision that permitted it', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+
+    await call(Channels.COMPUTE_RUN_CELL, 'python', 'print(1)', 'notes/a.md');
+
+    expect(h.runCell).toHaveBeenCalledWith('python', 'print(1)', { rootPath: ROOT, notePath: 'notes/a.md' });
+    expect(h.recordExecution).toHaveBeenCalledWith({
+      project: ROOT,
+      language: 'python',
+      code: 'print(1)',
+      // `editor` distinguishes a human-reviewed run from the LLM
+      // propose_compute path, which is the higher-risk one the trail cares about.
+      provenance: 'editor',
+      notePath: 'notes/a.md',
+      result: OK_RESULT,
+    });
+  });
+
+  it('omits notePath entirely when the cell has no note (not `notePath: undefined`)', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'sql', 'SELECT 1', 'cell');
+
+    await call(Channels.COMPUTE_RUN_CELL, 'sql', 'SELECT 1');
+
+    expect(h.runCell.mock.calls[0]?.[2]).not.toHaveProperty('notePath');
+    expect(h.recordExecution.mock.calls[0]?.[0]).not.toHaveProperty('notePath');
+  });
+
+  it("a failed cell RESOLVES its `{ ok: false }` arm and is still audited", async () => {
+    const failure = { ok: false, error: 'NameError: x is not defined' };
+    h.runCell.mockResolvedValue(failure);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'x', 'cell');
+
+    // A cell that errors is a normal input, not a bug — CLAUDE.md rule 3.
+    await expect(callAsync(Channels.COMPUTE_RUN_CELL, 'python', 'x')).resolves.toEqual(failure);
+    // A failure is the *most* interesting thing to have on the trail.
+    expect(h.recordExecution).toHaveBeenCalledWith(expect.objectContaining({ result: failure }));
+  });
+
+  it('propagates an executor crash (a thrown error is not a cell result)', async () => {
+    h.runCell.mockRejectedValue(new Error('kernel died'));
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'boom', 'cell');
+
+    await expect(callAsync(Channels.COMPUTE_RUN_CELL, 'python', 'boom')).rejects.toThrow(/kernel died/);
+    expect(h.recordExecution).not.toHaveBeenCalled();
+  });
+});
+
+describe('COMPUTE_CONSENT_STATUS / GRANT / LIST / REVOKE', () => {
+  it('reports none → cell → blanket as consent is granted', () => {
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'print(1)')).toBe('none');
+
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'print(1)')).toBe('cell');
+
+    // An eyes-on-code'd cell keeps reporting `cell` under blanket trust, so the
+    // conversation path can still tell "reviewed" from "merely trusted".
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'other', 'project');
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'print(1)')).toBe('cell');
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'unseen')).toBe('blanket');
+  });
+
+  it("with no project open answers 'none' — the fallback that FORCES a prompt", () => {
+    openProject = null;
+    // `withRootPathOr('none', …)`: the fallback is the conservative end of the
+    // scale, so a missing project can never be read as trust.
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'print(1)')).toBe('none');
+  });
+
+  it('anything other than the literal "project" scope grants only this cell', () => {
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'everything');
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'print(1)')).toBe('cell');
+    // No blanket trust leaked in from the unrecognised scope.
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'something else')).toBe('none');
+  });
+
+  it('GRANT throws with no project — trust cannot be recorded against nothing', () => {
+    openProject = null;
+    expect(() => call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'project')).toThrow(/No project open/);
+    expect(fs.existsSync(consentFile())).toBe(false);
+  });
+
+  it('LIST and REVOKE are machine-scoped — they work with no project open', () => {
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'x', 'project');
+
+    // Settings → Compute has to show (and undo) trust for thoughtbases that
+    // aren't the open one, so these deliberately aren't `withRootPath`.
+    openProject = null;
+    expect(call(Channels.COMPUTE_LIST_CONSENT)).toEqual([
+      { rootPath: ROOT, blanket: true, cellCount: 1 },
+    ]);
+
+    call(Channels.COMPUTE_REVOKE_CONSENT, ROOT);
+    expect(call(Channels.COMPUTE_LIST_CONSENT)).toEqual([]);
+  });
+
+  it('a revoked thoughtbase prompts again on its next run', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+    call(Channels.COMPUTE_REVOKE_CONSENT, ROOT);
+
+    const result = await call(Channels.COMPUTE_RUN_CELL, 'python', 'print(1)');
+    expect(result).toEqual({ ok: false, error: expect.any(String) });
+    expect(h.runCell).not.toHaveBeenCalled();
+  });
+
+  it('revoking a thoughtbase that was never trusted is a no-op, not an error', () => {
+    expect(() => call(Channels.COMPUTE_REVOKE_CONSENT, '/never-seen')).not.toThrow();
+  });
+
+  it('hashes are stored, not the code itself', () => {
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'API_KEY = "hunter2"', 'cell');
+    const stored = fs.readFileSync(consentFile(), 'utf-8');
+    // The consent store sits in userData forever; it must not become a copy of
+    // every cell the user has ever run.
+    expect(stored).not.toContain('hunter2');
+    expect(stored).toContain(cellHash('python', 'API_KEY = "hunter2"'));
+  });
+});
+
+describe('python kernel handlers', () => {
+  it('COMPUTE_RESTART_PYTHON_KERNEL restarts the open project\'s kernel', async () => {
+    await call(Channels.COMPUTE_RESTART_PYTHON_KERNEL);
+    expect(h.restartKernel).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('COMPUTE_RESTART_PYTHON_KERNEL is a no-op with no project (there is no kernel)', async () => {
+    openProject = null;
+    await expect(callAsync(Channels.COMPUTE_RESTART_PYTHON_KERNEL)).resolves.toBeUndefined();
+    expect(h.restartKernel).not.toHaveBeenCalled();
+  });
+
+  it('COMPUTE_INTERRUPT_PYTHON passes the kernel\'s result through, both arms', async () => {
+    h.interruptKernel.mockReturnValue({ ok: true });
+    await expect(callAsync(Channels.COMPUTE_INTERRUPT_PYTHON)).resolves.toEqual({ ok: true });
+
+    // The failure arm RESOLVES; a renderer branching on `ok` never also catches.
+    h.interruptKernel.mockReturnValue({ ok: false, reason: 'unsupported-platform' });
+    await expect(callAsync(Channels.COMPUTE_INTERRUPT_PYTHON))
+      .resolves.toEqual({ ok: false, reason: 'unsupported-platform' });
+  });
+
+  it('COMPUTE_INTERRUPT_PYTHON with no project answers the same "no-kernel" a real interrupt would', async () => {
+    openProject = null;
+    // `withRootPathOr({ ok: false, reason: 'no-kernel' }, …)` is legitimate
+    // under #1631 rule 2: with no project there IS no kernel, so the fallback
+    // means exactly what a genuine miss means — it isn't "error" in disguise.
+    await expect(callAsync(Channels.COMPUTE_INTERRUPT_PYTHON))
+      .resolves.toEqual({ ok: false, reason: 'no-kernel' });
+    expect(h.interruptKernel).not.toHaveBeenCalled();
+  });
+});
+
+describe('python settings handlers', () => {
+  it('COMPUTE_GET_PYTHON_SETTINGS reads the per-machine settings', async () => {
+    h.getPythonSettings.mockResolvedValue({ pythonPath: '/usr/bin/python3', allowNetwork: true });
+    await expect(callAsync(Channels.COMPUTE_GET_PYTHON_SETTINGS))
+      .resolves.toEqual({ pythonPath: '/usr/bin/python3', allowNetwork: true });
+  });
+
+  it('COMPUTE_SET_PYTHON_SETTINGS stores what it was given', async () => {
+    await call(Channels.COMPUTE_SET_PYTHON_SETTINGS, { pythonPath: '/opt/py', allowNetwork: true });
+    expect(h.setPythonSettings).toHaveBeenCalledWith({ pythonPath: '/opt/py', allowNetwork: true });
+  });
+
+  it('COMPUTE_SET_PYTHON_SETTINGS coerces a malformed payload to the safe defaults', async () => {
+    // `allowNetwork` gates outbound network access from user code, so anything
+    // that isn't literally `true` has to land on `false`.
+    await call(Channels.COMPUTE_SET_PYTHON_SETTINGS, { pythonPath: 42, allowNetwork: 'yes' });
+    expect(h.setPythonSettings).toHaveBeenCalledWith({ pythonPath: '', allowNetwork: false });
+  });
+
+  it('COMPUTE_SET_PYTHON_SETTINGS survives a missing payload', async () => {
+    await call(Channels.COMPUTE_SET_PYTHON_SETTINGS, undefined);
+    expect(h.setPythonSettings).toHaveBeenCalledWith({ pythonPath: '', allowNetwork: false });
+  });
+
+  it('COMPUTE_PROBE_PYTHON probes the candidate the caller named', async () => {
+    h.probePythonInterpreter.mockResolvedValue({ ok: true, path: '/opt/py', version: 'Python 3.12.0' });
+    await expect(callAsync(Channels.COMPUTE_PROBE_PYTHON, '/opt/py'))
+      .resolves.toEqual({ ok: true, path: '/opt/py', version: 'Python 3.12.0' });
+    expect(h.resolvePythonInterpreter).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, '', '   '])('COMPUTE_PROBE_PYTHON probes the ACTIVE interpreter for %j', async (candidate) => {
+    // An empty box in Settings means "whatever we'd pick right now", which is
+    // the resolver's answer — not a literal empty path.
+    h.resolvePythonInterpreter.mockResolvedValue('/usr/bin/python3');
+    h.probePythonInterpreter.mockResolvedValue({ ok: true, path: '/usr/bin/python3' });
+
+    await call(Channels.COMPUTE_PROBE_PYTHON, candidate);
+    expect(h.probePythonInterpreter).toHaveBeenCalledWith('/usr/bin/python3');
+  });
+
+  it('COMPUTE_PROBE_PYTHON RESOLVES a failed probe rather than rejecting', async () => {
+    h.probePythonInterpreter.mockResolvedValue({ ok: false, path: '/nope', error: 'ENOENT' });
+    // A bad interpreter path is a normal thing to type; Settings renders it inline.
+    await expect(callAsync(Channels.COMPUTE_PROBE_PYTHON, '/nope'))
+      .resolves.toEqual({ ok: false, path: '/nope', error: 'ENOENT' });
+  });
+
+  it('COMPUTE_BROWSE_PYTHON returns the picked interpreter', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/opt/homebrew/bin/python3'] });
+    await expect(callAsync(Channels.COMPUTE_BROWSE_PYTHON)).resolves.toBe('/opt/homebrew/bin/python3');
+    expect(h.showOpenDialog).toHaveBeenCalledWith(h.win, expect.objectContaining({ properties: expect.any(Array) }));
+  });
+
+  it.each([
+    ['cancelled', { canceled: true, filePaths: [] }],
+    ['dismissed with an empty selection', { canceled: false, filePaths: [] }],
+  ])('COMPUTE_BROWSE_PYTHON returns null when the picker is %s', async (_label, dialogResult) => {
+    // `null` here has exactly one meaning — the user didn't pick (#1631 rule 5).
+    h.showOpenDialog.mockResolvedValue(dialogResult);
+    await expect(callAsync(Channels.COMPUTE_BROWSE_PYTHON)).resolves.toBeNull();
+  });
+});
+
+describe('COMPUTE_REVEAL_AUDIT_LOG', () => {
+  it('creates the log before revealing it, so a machine that never ran a cell still works', () => {
+    const logPath = path.join(h.userData.dir, 'fresh', 'compute-audit.jsonl');
+    h.auditLogPath.mockReturnValue(logPath);
+
+    call(Channels.COMPUTE_REVEAL_AUDIT_LOG);
+
+    expect(fs.existsSync(logPath)).toBe(true);
+    expect(h.showItemInFolder).toHaveBeenCalledWith(logPath);
+  });
+
+  it('leaves an existing log untouched', () => {
+    const logPath = path.join(h.userData.dir, 'existing', 'compute-audit.jsonl');
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.writeFileSync(logPath, '{"at":"2026-01-01T00:00:00Z"}\n', 'utf-8');
+    h.auditLogPath.mockReturnValue(logPath);
+
+    call(Channels.COMPUTE_REVEAL_AUDIT_LOG);
+
+    expect(fs.readFileSync(logPath, 'utf-8')).toBe('{"at":"2026-01-01T00:00:00Z"}\n');
+  });
+
+  it('still reveals when the log cannot be created', () => {
+    // A blocked parent (here: a file where a directory should be) is a reveal
+    // that shows nothing useful — but it must not reject the IPC.
+    const blocker = path.join(h.userData.dir, 'blocked');
+    fs.writeFileSync(blocker, 'not a directory', 'utf-8');
+    h.auditLogPath.mockReturnValue(path.join(blocker, 'compute-audit.jsonl'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => call(Channels.COMPUTE_REVEAL_AUDIT_LOG)).not.toThrow();
+    expect(h.showItemInFolder).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('the remaining delegations', () => {
+  it('COMPUTE_LANGUAGES lists the registered executors, project or not', () => {
+    h.registeredLanguages.mockReturnValue(['python', 'sql', 'sparql']);
+    expect(call(Channels.COMPUTE_LANGUAGES)).toEqual(['python', 'sql', 'sparql']);
+
+    // Which languages CAN run is a property of the build, not of the project.
+    openProject = null;
+    expect(call(Channels.COMPUTE_LANGUAGES)).toEqual(['python', 'sql', 'sparql']);
+  });
+
+  it('COMPUTE_SAVE_CELL_OUTPUT writes through to the open project', async () => {
+    h.saveCellOutput.mockResolvedValue({ kind: 'written', path: 'data/out.csv' });
+    const input = { format: 'csv', notePath: 'notes/a.md', cellId: 'c1' };
+
+    await expect(callAsync(Channels.COMPUTE_SAVE_CELL_OUTPUT, input))
+      .resolves.toEqual({ kind: 'written', path: 'data/out.csv' });
+    expect(h.saveCellOutput).toHaveBeenCalledWith(ROOT, input);
+  });
+
+  it('COMPUTE_SAVE_CELL_OUTPUT throws with no project rather than writing somewhere', async () => {
+    openProject = null;
+    await expect(callAsync(Channels.COMPUTE_SAVE_CELL_OUTPUT, {})).rejects.toThrow(/No project open/);
+    expect(h.saveCellOutput).not.toHaveBeenCalled();
+  });
+});

--- a/tests/main/ipc/register-queries.test.ts
+++ b/tests/main/ipc/register-queries.test.ts
@@ -1,0 +1,265 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-queries.ts` (#1840).
+ *
+ * Saved queries are the one family in the IPC layer that is deliberately NOT
+ * project-scoped: a query can live in the thoughtbase (`project` scope) or on
+ * the machine (`global` scope), and the global ones have to be listable,
+ * renamable and reorderable with no project open at all. That's why these
+ * handlers reach for `rootPathFromEvent` directly instead of `withRootPath*` —
+ * `rootPath` is an *input* to the scope decision, not a precondition. This
+ * file pins that reading, and the two consequences that fall out of it:
+ *
+ *   - with no project open, `QUERIES_LIST` still answers the global queries,
+ *     and every non-scoped mutation still works;
+ *   - `QUERIES_MOVE` into project scope with no project open THROWS rather
+ *     than quietly landing the query somewhere else (#1631 rule 1).
+ *
+ * Plus the bookkeeping the native menu depends on: every mutation rebuilds the
+ * Query menu, and only after the store agreed the change happened. `SEARCH_QUERY`
+ * is the one `withRootPathOr` handler here — an empty result list is what a
+ * search with nothing to search returns, so the fallback is a legitimate value.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => {
+  /** Call-order log — the menu rebuild must follow the store mutation. */
+  const order: string[] = [];
+  return {
+    handlers: new Map<string, Handler>(),
+    order,
+    /** Wrap a store fn so its call lands in the order log before its result. */
+    logged: (name: string, fn: (...a: unknown[]) => unknown) =>
+      (...a: unknown[]) => { order.push(name); return fn(...a); },
+    listSavedQueries: vi.fn(),
+    saveQuery: vi.fn(),
+    deleteQuery: vi.fn(),
+    renameQuery: vi.fn(),
+    moveQueryScope: vi.fn(),
+    setQueryGroup: vi.fn(),
+    setQueryOrder: vi.fn(),
+    rebuildMenu: vi.fn(),
+    search: vi.fn(),
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  rootPathFromEvent: () => openProject,
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+}));
+
+vi.mock('../../../src/main/saved-queries', () => ({
+  listSavedQueries: h.listSavedQueries,
+  saveQuery: h.logged('saveQuery', h.saveQuery),
+  deleteQuery: h.logged('deleteQuery', h.deleteQuery),
+  renameQuery: h.logged('renameQuery', h.renameQuery),
+  moveQueryScope: h.logged('moveQueryScope', h.moveQueryScope),
+  setQueryGroup: h.logged('setQueryGroup', h.setQueryGroup),
+  setQueryOrder: h.logged('setQueryOrder', h.setQueryOrder),
+}));
+vi.mock('../../../src/main/menu', () => ({
+  rebuildMenu: (...a: unknown[]) => { h.order.push('rebuildMenu'); return h.rebuildMenu(...a); },
+}));
+vi.mock('../../../src/main/search/index', () => ({ search: h.search }));
+vi.mock('../../../src/main/project-context-types', () => ({
+  projectContext: (rootPath: string) => ({ rootPath }),
+}));
+
+import { registerQueries } from '../../../src/main/ipc/register-queries';
+import { Channels } from '../../../src/shared/channels';
+
+registerQueries();
+
+const call = (channel: string, ...args: unknown[]) => h.handlers.get(channel)!({}, ...args);
+
+const GLOBAL_QUERY = {
+  id: 'orphans', name: 'Orphans', description: '', query: 'SELECT *', language: 'sparql',
+  scope: 'global', filePath: '/home/u/.minerva/queries/orphans.sparql', group: null, order: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.order.length = 0;
+  openProject = ROOT;
+});
+
+describe('QUERIES_LIST', () => {
+  it('lists project + global queries when a thoughtbase is open', () => {
+    h.listSavedQueries.mockReturnValue([GLOBAL_QUERY]);
+    expect(call(Channels.QUERIES_LIST)).toEqual([GLOBAL_QUERY]);
+    expect(h.listSavedQueries).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('still answers the global queries with no project open', () => {
+    // `rootPath` is an input to the scope decision here, not a precondition:
+    // the store takes `string | null` and simply skips the project directory.
+    // A `withRootPath` guard would have hidden the user's machine-wide queries
+    // whenever they closed a thoughtbase.
+    openProject = null;
+    h.listSavedQueries.mockReturnValue([GLOBAL_QUERY]);
+
+    expect(call(Channels.QUERIES_LIST)).toEqual([GLOBAL_QUERY]);
+    expect(h.listSavedQueries).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('QUERIES_SAVE', () => {
+  it('saves, then rebuilds the Query menu', () => {
+    h.saveQuery.mockReturnValue(GLOBAL_QUERY);
+
+    const result = call(Channels.QUERIES_SAVE, 'project', 'Orphans', 'Notes nobody links to', 'SELECT *', 'sparql', 'Health');
+
+    expect(result).toEqual(GLOBAL_QUERY);
+    expect(h.saveQuery).toHaveBeenCalledWith(ROOT, 'project', 'Orphans', 'Notes nobody links to', 'SELECT *', 'sparql', 'Health');
+    // Rebuilding first would put an entry on the menu for a file that might
+    // not have been written.
+    expect(h.order).toEqual(['saveQuery', 'rebuildMenu']);
+  });
+
+  it('recognises exactly one language besides SPARQL', () => {
+    h.saveQuery.mockReturnValue(GLOBAL_QUERY);
+
+    call(Channels.QUERIES_SAVE, 'global', 'Rows', '', 'SELECT 1', 'sql');
+    expect(h.saveQuery).toHaveBeenLastCalledWith(ROOT, 'global', 'Rows', '', 'SELECT 1', 'sql', null);
+
+    // Anything unrecognised lands on SPARQL rather than reaching the store as a
+    // language it has no file extension for.
+    call(Channels.QUERIES_SAVE, 'global', 'Rows', '', 'SELECT 1', 'duckdb');
+    expect(h.saveQuery).toHaveBeenLastCalledWith(ROOT, 'global', 'Rows', '', 'SELECT 1', 'sparql', null);
+  });
+
+  it('defaults the group to null when the caller omits it', () => {
+    h.saveQuery.mockReturnValue(GLOBAL_QUERY);
+    call(Channels.QUERIES_SAVE, 'global', 'Rows', '', 'SELECT 1', 'sparql');
+    // `null` = ungrouped, and it has to be explicit: `undefined` would serialize
+    // an `@group` line reading "undefined".
+    expect(h.saveQuery).toHaveBeenCalledWith(ROOT, 'global', 'Rows', '', 'SELECT 1', 'sparql', null);
+  });
+
+  it('leaves the menu alone when the save failed', () => {
+    h.saveQuery.mockImplementation(() => { throw new Error('EACCES: permission denied'); });
+    expect(() => call(Channels.QUERIES_SAVE, 'global', 'Rows', '', 'SELECT 1', 'sparql')).toThrow(/EACCES/);
+    expect(h.rebuildMenu).not.toHaveBeenCalled();
+  });
+});
+
+describe('the file-addressed mutations work with or without a project', () => {
+  it('QUERIES_DELETE removes the query and rebuilds the menu', () => {
+    call(Channels.QUERIES_DELETE, GLOBAL_QUERY.filePath);
+    expect(h.deleteQuery).toHaveBeenCalledWith(GLOBAL_QUERY.filePath);
+    expect(h.order).toEqual(['deleteQuery', 'rebuildMenu']);
+  });
+
+  it('QUERIES_RENAME returns the new path and rebuilds the menu', () => {
+    h.renameQuery.mockReturnValue('/home/u/.minerva/queries/lonely-notes.sparql');
+
+    const result = call(Channels.QUERIES_RENAME, GLOBAL_QUERY.filePath, 'Lonely notes');
+
+    expect(result).toBe('/home/u/.minerva/queries/lonely-notes.sparql');
+    expect(h.order).toEqual(['renameQuery', 'rebuildMenu']);
+  });
+
+  it('QUERIES_RENAME propagates a failed rename and leaves the menu alone', () => {
+    h.renameQuery.mockImplementation(() => { throw new Error('ENOENT: no such file'); });
+    expect(() => call(Channels.QUERIES_RENAME, '/gone.sparql', 'New')).toThrow(/ENOENT/);
+    expect(h.rebuildMenu).not.toHaveBeenCalled();
+  });
+
+  it('QUERIES_SET_GROUP sets a group and clears it with null', () => {
+    call(Channels.QUERIES_SET_GROUP, GLOBAL_QUERY.filePath, 'Health');
+    expect(h.setQueryGroup).toHaveBeenCalledWith(GLOBAL_QUERY.filePath, 'Health');
+
+    call(Channels.QUERIES_SET_GROUP, GLOBAL_QUERY.filePath, null);
+    expect(h.setQueryGroup).toHaveBeenLastCalledWith(GLOBAL_QUERY.filePath, null);
+    expect(h.rebuildMenu).toHaveBeenCalledTimes(2);
+  });
+
+  it('QUERIES_SET_ORDER writes the whole ordering in one call', () => {
+    const entries = [{ filePath: '/a.sparql', order: 0 }, { filePath: '/b.sparql', order: null }];
+    call(Channels.QUERIES_SET_ORDER, entries);
+    expect(h.setQueryOrder).toHaveBeenCalledWith(entries);
+    expect(h.order).toEqual(['setQueryOrder', 'rebuildMenu']);
+  });
+
+  it.each([
+    [Channels.QUERIES_DELETE, ['/g.sparql']],
+    [Channels.QUERIES_SET_GROUP, ['/g.sparql', 'Health']],
+    [Channels.QUERIES_SET_ORDER, [[]]],
+  ])('%s still works on a global query with no project open', (channel, args) => {
+    openProject = null;
+    expect(() => call(channel, ...args)).not.toThrow();
+    expect(h.rebuildMenu).toHaveBeenCalled();
+  });
+});
+
+describe('QUERIES_MOVE', () => {
+  it('hands the open project to the store as the destination root', () => {
+    h.moveQueryScope.mockReturnValue('/vault/.minerva/queries/orphans.sparql');
+
+    const result = call(Channels.QUERIES_MOVE, GLOBAL_QUERY.filePath, 'project');
+
+    expect(result).toBe('/vault/.minerva/queries/orphans.sparql');
+    expect(h.moveQueryScope).toHaveBeenCalledWith(GLOBAL_QUERY.filePath, 'project', ROOT);
+    expect(h.order).toEqual(['moveQueryScope', 'rebuildMenu']);
+  });
+
+  it('moves a project query out to global scope', () => {
+    h.moveQueryScope.mockReturnValue('/home/u/.minerva/queries/orphans.sparql');
+    call(Channels.QUERIES_MOVE, '/vault/.minerva/queries/orphans.sparql', 'global');
+    expect(h.moveQueryScope).toHaveBeenCalledWith('/vault/.minerva/queries/orphans.sparql', 'global', ROOT);
+  });
+
+  it('throws when asked to move into a thoughtbase that is not open', () => {
+    // The store refuses this rather than silently writing to the global dir, and
+    // the handler lets the throw reach the renderer (#1631 rule 1) instead of
+    // reporting a path the query isn't at.
+    openProject = null;
+    h.moveQueryScope.mockImplementation(() => { throw new Error('Cannot move to Thoughtbase scope: no project open.'); });
+
+    expect(() => call(Channels.QUERIES_MOVE, GLOBAL_QUERY.filePath, 'project')).toThrow(/no project open/i);
+    expect(h.moveQueryScope).toHaveBeenCalledWith(GLOBAL_QUERY.filePath, 'project', null);
+    expect(h.rebuildMenu).not.toHaveBeenCalled();
+  });
+});
+
+describe('SEARCH_QUERY', () => {
+  it('searches the open project\'s index', async () => {
+    const hits = [{ path: 'notes/paxos.md', title: 'Paxos', excerpt: '…consensus…' }];
+    h.search.mockResolvedValue(hits);
+
+    await expect(call(Channels.SEARCH_QUERY, 'consensus')).resolves.toEqual(hits);
+    expect(h.search).toHaveBeenCalledWith({ rootPath: ROOT }, 'consensus');
+  });
+
+  it('answers an empty result list with no project open', async () => {
+    openProject = null;
+    // `withRootPathOr([], …)`: "no notes matched" is what a search over nothing
+    // means, so the fallback reads the same as a genuine miss — the results
+    // pane shows "no results", not an error.
+    await expect(call(Channels.SEARCH_QUERY, 'consensus')).resolves.toEqual([]);
+    expect(h.search).not.toHaveBeenCalled();
+  });
+
+  it('is the same empty answer a project with no matches gives', async () => {
+    h.search.mockResolvedValue([]);
+    const noMatches = await call(Channels.SEARCH_QUERY, 'zzzz');
+
+    openProject = null;
+    const noProject = await call(Channels.SEARCH_QUERY, 'zzzz');
+
+    expect(noProject).toEqual(noMatches);
+  });
+});

--- a/tests/main/ipc/register-tools.test.ts
+++ b/tests/main/ipc/register-tools.test.ts
@@ -1,0 +1,400 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-tools.ts` (#1840).
+ *
+ * This registrar is the renderer's whole door onto skills and the LLM: it runs
+ * a skill, streams its output back, cancels it, serves the skill catalog, and
+ * owns the model/provider settings. What it promises, and what's pinned here:
+ *
+ *   - **cancellation is per-window and self-cleaning.** One `AbortController`
+ *     per window id, handed to `executeTool` and dropped in a `finally` — so a
+ *     Cancel in window 2 can't abort window 1's run, and a Cancel that arrives
+ *     after a run finished (or crashed) is a no-op rather than a stale abort.
+ *   - **prompt bodies never cross IPC.** CLAUDE.md's skills section: "the
+ *     renderer never sees prompt bodies". `SKILLS_LIST` therefore goes through
+ *     the REAL `toSkillInfo`, and the test feeds it a skill whose body and
+ *     firstMessage are recognisable strings so a leak is visible.
+ *   - **`errors[]` is a per-item catalog, not a failure channel** (#1631
+ *     rule 4): an unparseable skill file is reported *alongside* the skills
+ *     that did load, and the call still succeeds.
+ *   - **opening Settings never prompts the keychain** — `TOOL_GET_SETTINGS`
+ *     reads the display view, never the decrypting `getSettings()`.
+ *
+ * Nothing here is `withRootPath`: skills, models and API keys are per-machine,
+ * not per-thoughtbase, so every handler works with no project open. The
+ * catalog/executor/settings modules behind them are mocked; `broadcast` is real
+ * so the TOOL_STREAM channel and payload are genuinely exercised.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SkillDef, MenuConfig } from '../../../src/shared/skills/types';
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => {
+  const makeWin = (id: number) => ({ id, isDestroyed: () => false, webContents: { send: vi.fn() } });
+  const win = makeWin(1);
+  return {
+    handlers: new Map<string, Handler>(),
+    win,
+    otherWin: makeWin(2),
+    /** Which window the next `call()` appears to come from. */
+    current: { win },
+    // tools/executor
+    executeTool: vi.fn(),
+    prepareConversationTool: vi.fn(),
+    // skills
+    getSkillCatalog: vi.fn(),
+    reloadAndRegisterSkills: vi.fn(),
+    reapplyMenuConfig: vi.fn(),
+    pickAndImportSkill: vi.fn(),
+    removeUserSkill: vi.fn(),
+    revealSkillsFolder: vi.fn(),
+    getMenuConfig: vi.fn(),
+    saveMenuConfig: vi.fn(),
+    rebuildMenu: vi.fn(),
+    // llm
+    getSettings: vi.fn(),
+    getSettingsForDisplay: vi.fn(),
+    saveSettings: vi.fn(),
+    getApiKeyStorage: vi.fn(),
+    checkConnection: vi.fn(),
+    /** Call-order log — remove/import must re-register BEFORE rebuilding the menu. */
+    order: [] as string[],
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({ winFromEvent: () => h.current.win }));
+
+vi.mock('../../../src/main/menu', () => ({
+  rebuildMenu: (...a: unknown[]) => { h.order.push('rebuildMenu'); return h.rebuildMenu(...a); },
+}));
+vi.mock('../../../src/main/tools/executor', () => ({
+  executeTool: h.executeTool,
+  prepareConversationTool: h.prepareConversationTool,
+}));
+vi.mock('../../../src/main/skills/loader', () => ({ getSkillCatalog: h.getSkillCatalog }));
+vi.mock('../../../src/main/skills/register', () => ({
+  reloadAndRegisterSkills: (...a: unknown[]) => { h.order.push('reload'); return h.reloadAndRegisterSkills(...a); },
+  reapplyMenuConfig: h.reapplyMenuConfig,
+}));
+vi.mock('../../../src/main/skills/manage', () => ({
+  pickAndImportSkill: h.pickAndImportSkill,
+  removeUserSkill: (...a: unknown[]) => { h.order.push('remove'); return h.removeUserSkill(...a); },
+  revealSkillsFolder: h.revealSkillsFolder,
+}));
+vi.mock('../../../src/main/skills/menu-config-store', () => ({
+  getMenuConfig: h.getMenuConfig,
+  saveMenuConfig: h.saveMenuConfig,
+}));
+vi.mock('../../../src/main/llm/settings', () => ({
+  getSettings: h.getSettings,
+  getSettingsForDisplay: h.getSettingsForDisplay,
+  saveSettings: h.saveSettings,
+  getApiKeyStorage: h.getApiKeyStorage,
+}));
+vi.mock('../../../src/main/llm/validate', () => ({ checkConnection: h.checkConnection }));
+
+import { registerTools } from '../../../src/main/ipc/register-tools';
+import { Channels } from '../../../src/shared/channels';
+
+registerTools();
+
+const call = (channel: string, ...args: unknown[]) => h.handlers.get(channel)!({}, ...args);
+
+const EMPTY_CONFIG: MenuConfig = { skills: {}, order: { Learning: [], Research: [], Analysis: [] } };
+
+/** A fully-populated skill, so the body/firstMessage leak check has something
+ *  unmistakable to look for. */
+const SKILL: SkillDef = {
+  id: 'stock.socratic',
+  name: 'Socratic Dialogue',
+  description: 'Question the note',
+  longDescription: 'Longer blurb',
+  menu: 'Learning',
+  scope: 'note',
+  outputMode: 'openConversation',
+  context: [],
+  parameters: [],
+  tools: ['propose_claims'],
+  web: false,
+  requiresSelection: false,
+  firstMessage: 'FIRST-MESSAGE-TEMPLATE-{{title}}',
+  body: 'SYSTEM-PROMPT-BODY-{{note.content}}',
+  source: 'stock',
+  filePath: './stock/socratic.md',
+};
+
+const REQUEST = { toolId: 'stock.socratic', context: { fullNoteTitle: 'Paxos' } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.order.length = 0;
+  h.current.win = h.win;
+  h.getMenuConfig.mockReturnValue(EMPTY_CONFIG);
+});
+
+describe('TOOL_EXECUTE / TOOL_CANCEL', () => {
+  /** Start a run and hand back the arguments `executeTool` was given, with the
+   *  run still in flight so it can be cancelled. */
+  function startRun(): {
+    settle: (v: unknown) => void;
+    fail: (e: unknown) => void;
+    args: () => { onChunk: (s: string) => void; signal: AbortSignal };
+    done: Promise<unknown>;
+  } {
+    let settle!: (v: unknown) => void;
+    let fail!: (e: unknown) => void;
+    let captured!: { onChunk: (s: string) => void; signal: AbortSignal };
+    h.executeTool.mockImplementation((_req: unknown, onChunk: (s: string) => void, signal: AbortSignal) => {
+      captured = { onChunk, signal };
+      return new Promise((resolve, reject) => { settle = resolve; fail = reject; });
+    });
+    const done = call(Channels.TOOL_EXECUTE, REQUEST) as Promise<unknown>;
+    return { settle, fail, args: () => captured, done };
+  }
+
+  it('runs the requested tool and returns its result', async () => {
+    h.executeTool.mockResolvedValue({ toolId: 'stock.socratic', output: 'text' });
+    await expect(call(Channels.TOOL_EXECUTE, REQUEST)).resolves.toEqual({ toolId: 'stock.socratic', output: 'text' });
+    expect(h.executeTool).toHaveBeenCalledWith(REQUEST, expect.any(Function), expect.any(AbortSignal));
+  });
+
+  it('streams each chunk to the window that asked for the run', async () => {
+    const run = startRun();
+    run.args().onChunk('partial ');
+    run.args().onChunk('output');
+    run.settle({ output: 'partial output' });
+    await run.done;
+
+    expect(h.win.webContents.send.mock.calls).toEqual([
+      [Channels.TOOL_STREAM, 'partial '],
+      [Channels.TOOL_STREAM, 'output'],
+    ]);
+  });
+
+  it('drops chunks for a window the user already closed', async () => {
+    // A skill can keep streaming for a while after its window goes away;
+    // sending to destroyed webContents throws, which would surface as a
+    // rejected TOOL_EXECUTE for a run that actually succeeded.
+    const closed = { id: 9, isDestroyed: () => true, webContents: { send: vi.fn() } };
+    h.current.win = closed;
+    const run = startRun();
+    run.args().onChunk('into the void');
+    run.settle({ output: '' });
+    await run.done;
+
+    expect(closed.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('TOOL_CANCEL aborts the run in flight', async () => {
+    const run = startRun();
+    expect(run.args().signal.aborted).toBe(false);
+
+    call(Channels.TOOL_CANCEL);
+
+    expect(run.args().signal.aborted).toBe(true);
+    run.settle({ output: '' });
+    await run.done;
+  });
+
+  it('cancels only the asking window\'s run', async () => {
+    const run = startRun();
+
+    // A second window pressing Cancel must not kill this window's skill.
+    h.current.win = h.otherWin;
+    call(Channels.TOOL_CANCEL);
+
+    expect(run.args().signal.aborted).toBe(false);
+    run.settle({ output: '' });
+    await run.done;
+  });
+
+  it('TOOL_CANCEL with nothing running is a no-op', () => {
+    expect(() => call(Channels.TOOL_CANCEL)).not.toThrow();
+  });
+
+  it('forgets the controller once the run finishes, so a late Cancel is inert', async () => {
+    const first = startRun();
+    first.settle({ output: 'done' });
+    await first.done;
+
+    call(Channels.TOOL_CANCEL); // late click on a finished run
+
+    const second = startRun();
+    // A stale controller left in the map would have aborted this one at birth.
+    expect(second.args().signal.aborted).toBe(false);
+    second.settle({ output: '' });
+    await second.done;
+  });
+
+  it('forgets the controller when the run THROWS, and surfaces the error', async () => {
+    const failed = startRun();
+    failed.fail(new Error('Unknown tool: nope'));
+    await expect(failed.done).rejects.toThrow(/Unknown tool/);
+
+    const next = startRun();
+    expect(next.args().signal.aborted).toBe(false);
+    next.settle({ output: '' });
+    await next.done;
+  });
+
+  it('TOOL_PREPARE_CONVERSATION delegates to the conversation payload builder', () => {
+    h.prepareConversationTool.mockReturnValue({ prompt: 'system', model: 'claude-opus-5' });
+    expect(call(Channels.TOOL_PREPARE_CONVERSATION, REQUEST)).toEqual({ prompt: 'system', model: 'claude-opus-5' });
+    expect(h.prepareConversationTool).toHaveBeenCalledWith(REQUEST);
+  });
+});
+
+describe('SKILLS_LIST', () => {
+  it('sends serializable metadata and the menu config', async () => {
+    h.getSkillCatalog.mockResolvedValue({ skills: [SKILL], errors: [] });
+
+    const result = await call(Channels.SKILLS_LIST) as { skills: Array<Record<string, unknown>>; config: MenuConfig };
+
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0]).toMatchObject({ id: 'stock.socratic', name: 'Socratic Dialogue', menu: 'Learning', source: 'stock' });
+    expect(result.config).toEqual(EMPTY_CONFIG);
+  });
+
+  it('never ships the prompt body or firstMessage to the renderer', async () => {
+    h.getSkillCatalog.mockResolvedValue({ skills: [SKILL], errors: [] });
+
+    const result = await call(Channels.SKILLS_LIST);
+
+    // CLAUDE.md: templates are rendered in main at prepare/execute time; the
+    // renderer gets metadata only. A field added to SkillDef and mirrored into
+    // SkillInfo by accident would show up right here.
+    expect(JSON.stringify(result)).not.toContain('SYSTEM-PROMPT-BODY');
+    expect(JSON.stringify(result)).not.toContain('FIRST-MESSAGE-TEMPLATE');
+    expect((result as { skills: Array<Record<string, unknown>> }).skills[0]).not.toHaveProperty('body');
+    expect((result as { skills: Array<Record<string, unknown>> }).skills[0]).not.toHaveProperty('filePath');
+  });
+
+  it('reports an unloadable skill alongside the ones that loaded (#1631 rule 4)', async () => {
+    const broken = { source: 'user' as const, filePath: '/u/bad.md', label: 'bad.md', message: 'missing `menu:`' };
+    h.getSkillCatalog.mockResolvedValue({ skills: [SKILL], errors: [broken] });
+
+    // A per-item catalog is not a failure channel: the call succeeds, and the
+    // good skill is still usable.
+    const result = await call(Channels.SKILLS_LIST) as { skills: unknown[]; errors: unknown[] };
+    expect(result.skills).toHaveLength(1);
+    expect(result.errors).toEqual([broken]);
+  });
+});
+
+describe('skill management', () => {
+  it('SKILLS_RELOAD re-scans, rebuilds the native menu, and returns the fresh catalog', async () => {
+    h.reloadAndRegisterSkills.mockResolvedValue({ skills: [SKILL], errors: [] });
+
+    const result = await call(Channels.SKILLS_RELOAD) as { skills: unknown[] };
+
+    expect(result.skills).toHaveLength(1);
+    // The menu is rebuilt from the NEW registry, so it must come second.
+    expect(h.order).toEqual(['reload', 'rebuildMenu']);
+  });
+
+  it('SKILLS_MENU_CONFIG_SET persists, re-syncs the registry, and returns what was STORED', async () => {
+    const asked: MenuConfig = {
+      skills: { 'stock.socratic': { enabled: false, menu: 'Research' } },
+      order: { Learning: [], Research: ['stock.socratic'], Analysis: [] },
+    };
+    // Normalisation can drop junk, so the caller must render the saved config
+    // rather than the one it optimistically sent.
+    const stored: MenuConfig = { ...asked, skills: {} };
+    h.saveMenuConfig.mockResolvedValue(stored);
+    h.getSkillCatalog.mockResolvedValue({ skills: [SKILL], errors: [] });
+
+    await expect(call(Channels.SKILLS_MENU_CONFIG_SET, asked)).resolves.toEqual(stored);
+    expect(h.saveMenuConfig).toHaveBeenCalledWith(asked);
+    expect(h.reapplyMenuConfig).toHaveBeenCalledWith({ skills: [SKILL], errors: [] });
+    expect(h.rebuildMenu).toHaveBeenCalled();
+  });
+
+  it('SKILLS_IMPORT registers and re-menus the imported skill', async () => {
+    const imported = { id: 'user.mine', name: 'Mine', filePath: '/u/mine.md' };
+    h.pickAndImportSkill.mockResolvedValue(imported);
+    h.reloadAndRegisterSkills.mockResolvedValue({ skills: [], errors: [] });
+
+    await expect(call(Channels.SKILLS_IMPORT)).resolves.toEqual(imported);
+    expect(h.pickAndImportSkill).toHaveBeenCalledWith(h.win);
+    expect(h.order).toEqual(['reload', 'rebuildMenu']);
+  });
+
+  it('SKILLS_IMPORT does no work when the picker is cancelled', async () => {
+    // `null` here means exactly one thing — the user closed the picker (#1631
+    // rule 5) — so nothing should be reloaded or rebuilt.
+    h.pickAndImportSkill.mockResolvedValue(null);
+
+    await expect(call(Channels.SKILLS_IMPORT)).resolves.toBeNull();
+    expect(h.order).toEqual([]);
+  });
+
+  it('SKILLS_REMOVE deletes the file, then re-registers, then rebuilds', async () => {
+    h.reloadAndRegisterSkills.mockResolvedValue({ skills: [], errors: [] });
+
+    await call(Channels.SKILLS_REMOVE, 'user.mine');
+
+    expect(h.removeUserSkill).toHaveBeenCalledWith('user.mine');
+    // Rebuilding before the re-scan would leave the deleted skill on the menu.
+    expect(h.order).toEqual(['remove', 'reload', 'rebuildMenu']);
+  });
+
+  it('SKILLS_REMOVE propagates a failed delete instead of reporting success', async () => {
+    h.removeUserSkill.mockRejectedValue(new Error('Cannot remove a stock skill'));
+    await expect(call(Channels.SKILLS_REMOVE, 'stock.socratic')).rejects.toThrow(/stock skill/);
+    expect(h.rebuildMenu).not.toHaveBeenCalled();
+  });
+
+  it('SKILLS_REVEAL opens the user skills folder', async () => {
+    await call(Channels.SKILLS_REVEAL);
+    expect(h.revealSkillsFolder).toHaveBeenCalled();
+  });
+});
+
+describe('LLM settings handlers', () => {
+  it('TOOL_GET_SETTINGS reads the display view, never the decrypting one', async () => {
+    h.getSettingsForDisplay.mockResolvedValue({ model: 'claude-opus-5', hasApiKey: true });
+
+    await expect(call(Channels.TOOL_GET_SETTINGS)).resolves.toEqual({ model: 'claude-opus-5', hasApiKey: true });
+    // Opening Settings must not raise a keychain prompt, which `getSettings()`
+    // would — that's the whole reason the display read exists.
+    expect(h.getSettings).not.toHaveBeenCalled();
+  });
+
+  it('TOOL_SET_SETTINGS writes the update through', async () => {
+    const update = { model: 'claude-sonnet-5', apiKey: 'sk-new' };
+    await call(Channels.TOOL_SET_SETTINGS, update);
+    expect(h.saveSettings).toHaveBeenCalledWith(update);
+  });
+
+  it('TOOL_SET_SETTINGS surfaces a failed save', async () => {
+    h.saveSettings.mockRejectedValue(new Error('keychain denied'));
+    await expect(call(Channels.TOOL_SET_SETTINGS, {})).rejects.toThrow(/keychain denied/);
+  });
+
+  it('TOOL_GET_KEY_STORAGE reports where the key is kept', async () => {
+    h.getApiKeyStorage.mockResolvedValue('keychain');
+    await expect(call(Channels.TOOL_GET_KEY_STORAGE)).resolves.toBe('keychain');
+  });
+
+  it('TOOL_CHECK_CONNECTION passes the unsaved key and baseURL through', async () => {
+    h.checkConnection.mockResolvedValue({ ok: true });
+    await expect(call(Channels.TOOL_CHECK_CONNECTION, 'openai', 'sk-typed', 'http://localhost:1234'))
+      .resolves.toEqual({ ok: true });
+    expect(h.checkConnection).toHaveBeenCalledWith('openai', 'sk-typed', 'http://localhost:1234');
+  });
+
+  it('TOOL_CHECK_CONNECTION RESOLVES a failed check rather than rejecting', async () => {
+    // A wrong key is the expected outcome the button exists to discover, so it
+    // comes back on the union's failure arm (#1631 rule 3), not as a rejection.
+    h.checkConnection.mockResolvedValue({ ok: false, error: '401 invalid x-api-key' });
+    await expect(call(Channels.TOOL_CHECK_CONNECTION, 'anthropic'))
+      .resolves.toEqual({ ok: false, error: '401 invalid x-api-key' });
+    expect(h.checkConnection).toHaveBeenCalledWith('anthropic', undefined, undefined);
+  });
+});

--- a/tests/main/ipc/register-types.test.ts
+++ b/tests/main/ipc/register-types.test.ts
@@ -1,0 +1,292 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-types.ts` (#1840).
+ *
+ * This registrar is the clearest example in the tree of #1631's two-wrapper
+ * split, so that's what it's pinned on:
+ *
+ *   - the four READS (`TYPES_LIST`, `TYPES_NOTE_PROPERTIES`, `TYPES_INSTANCES`,
+ *     `TYPES_NOTE_TYPE_MAP`) use `withRootPathOr`, and each fallback is a
+ *     legitimate value — the SAME shape the domain returns when a project is
+ *     open and genuinely has nothing. Every one of them is asserted against
+ *     that real empty answer rather than against a hand-written literal, so a
+ *     fallback that drifted into meaning "error" (a `null`, an `{ error }`, a
+ *     differently-shaped stub) would fail here.
+ *   - the four WRITES (`TYPES_SAVE`, `TYPES_DELETE`, `TYPES_DELETE_SAFELY`,
+ *     `TYPES_RENAME`) use `withRootPath`: they throw with no project open and
+ *     touch nothing, because there is no such thing as saving a type into no
+ *     thoughtbase.
+ *
+ * Also pinned: `errors[]` is a per-item catalog (#1631 rule 4) — a malformed
+ * type file is reported next to the types that loaded, and the call succeeds;
+ * the graph's type catalog is reloaded AFTER a write, and not at all if the
+ * write failed; and `toTypeInfo` (the real one) keeps `filePath` off the wire.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TypeDef } from '../../../src/shared/objects/type-def';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  // types/*
+  loadTypeCatalog: vi.fn(),
+  saveType: vi.fn(),
+  deleteType: vi.fn(),
+  deleteTypeSafely: vi.fn(),
+  renameType: vi.fn(),
+  // graph/*
+  getNoteTypedProperties: vi.fn(),
+  getTypeInstances: vi.fn(),
+  getNoteTypeMap: vi.fn(),
+  reloadTypeCatalog: vi.fn(),
+  /** Call-order log — the catalog reload has to follow the write. */
+  order: [] as string[],
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  rootPathFromEvent: () => openProject,
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+}));
+
+vi.mock('../../../src/main/types/loader', () => ({ loadTypeCatalog: h.loadTypeCatalog }));
+vi.mock('../../../src/main/types/write', () => ({
+  saveType: (...a: unknown[]) => { h.order.push('saveType'); return h.saveType(...a); },
+  deleteType: (...a: unknown[]) => { h.order.push('deleteType'); return h.deleteType(...a); },
+}));
+vi.mock('../../../src/main/types/migrate', () => ({
+  deleteTypeSafely: h.deleteTypeSafely,
+  renameType: h.renameType,
+}));
+vi.mock('../../../src/main/graph/index', () => ({
+  getNoteTypedProperties: h.getNoteTypedProperties,
+  getTypeInstances: h.getTypeInstances,
+  getNoteTypeMap: h.getNoteTypeMap,
+  reloadTypeCatalog: (...a: unknown[]) => { h.order.push('reloadTypeCatalog'); return h.reloadTypeCatalog(...a); },
+}));
+vi.mock('../../../src/main/project-context-types', () => ({
+  projectContext: (rootPath: string) => ({ rootPath }),
+}));
+
+import { registerTypes } from '../../../src/main/ipc/register-types';
+import { Channels } from '../../../src/shared/channels';
+
+registerTypes();
+
+const call = (channel: string, ...args: unknown[]) => h.handlers.get(channel)!({}, ...args);
+/** `call` wrapped so a SYNCHRONOUS throw (the `withRootPath` guard fires before
+ *  the async body runs) is assertable with the same `rejects` matcher. */
+const callAsync = async (channel: string, ...args: unknown[]) => call(channel, ...args);
+
+const BOOK: TypeDef = {
+  id: 'book',
+  label: 'Book',
+  classLocalName: 'Book',
+  properties: [{ name: 'author', type: 'text' }],
+  template: '## Notes\n',
+  source: 'stock',
+  filePath: '/vault/.minerva/types/book.md',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.order.length = 0;
+  openProject = ROOT;
+});
+
+describe('the reads answer an empty project and no project identically', () => {
+  it('TYPES_LIST: an empty catalog is the same `{ types: [], errors: [] }` either way', async () => {
+    h.loadTypeCatalog.mockResolvedValue({ types: [], errors: [] });
+    const withProject = await call(Channels.TYPES_LIST);
+
+    openProject = null;
+    const withoutProject = await call(Channels.TYPES_LIST);
+
+    // The fallback isn't a disguised error — it's the answer a project with no
+    // types gives, so the picker renders "nothing yet" in both cases.
+    expect(withoutProject).toEqual(withProject);
+    expect(withoutProject).toEqual({ types: [], errors: [] });
+    expect(h.loadTypeCatalog).toHaveBeenCalledTimes(1); // never reached without a project
+  });
+
+  it('TYPES_NOTE_PROPERTIES: an untyped note and no project both answer `{ type: null, properties: [] }`', async () => {
+    h.getNoteTypedProperties.mockReturnValue({ type: null, properties: [] });
+    const untyped = await call(Channels.TYPES_NOTE_PROPERTIES, 'notes/a.md');
+
+    openProject = null;
+    const noProject = await call(Channels.TYPES_NOTE_PROPERTIES, 'notes/a.md');
+
+    expect(noProject).toEqual(untyped);
+    expect(h.getNoteTypedProperties).toHaveBeenCalledTimes(1);
+  });
+
+  it('TYPES_INSTANCES: an unused type and no project both answer `{ type: null, instances: [] }`', async () => {
+    h.getTypeInstances.mockReturnValue({ type: null, instances: [] });
+    const unused = await call(Channels.TYPES_INSTANCES, 'book');
+
+    openProject = null;
+    const noProject = await call(Channels.TYPES_INSTANCES, 'book');
+
+    expect(noProject).toEqual(unused);
+    expect(h.getTypeInstances).toHaveBeenCalledTimes(1);
+  });
+
+  it('TYPES_NOTE_TYPE_MAP: "nothing is typed yet" and no project are both `{}`', async () => {
+    h.getNoteTypeMap.mockReturnValue({});
+    const nothingTyped = await call(Channels.TYPES_NOTE_TYPE_MAP);
+
+    openProject = null;
+    const noProject = await call(Channels.TYPES_NOTE_TYPE_MAP);
+
+    expect(noProject).toEqual(nothingTyped);
+    expect(h.getNoteTypeMap).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the reads with a project open', () => {
+  it('TYPES_LIST serializes the catalog without the on-disk path', async () => {
+    h.loadTypeCatalog.mockResolvedValue({ types: [BOOK], errors: [] });
+
+    const result = await call(Channels.TYPES_LIST) as { types: Array<Record<string, unknown>> };
+
+    expect(h.loadTypeCatalog).toHaveBeenCalledWith(ROOT);
+    // The template body DOES cross (it's a note scaffold, not an LLM prompt) —
+    // the picker instantiates from it without a round-trip.
+    expect(result.types[0]).toMatchObject({ id: 'book', label: 'Book', template: '## Notes\n' });
+    expect(result.types[0]).not.toHaveProperty('filePath');
+  });
+
+  it('TYPES_LIST reports a broken type file alongside the ones that loaded (#1631 rule 4)', async () => {
+    const broken = { source: 'user', filePath: '/vault/.minerva/types/bad.md', label: 'bad.md', message: 'no `label:`' };
+    h.loadTypeCatalog.mockResolvedValue({ types: [BOOK], errors: [broken] });
+
+    const result = await call(Channels.TYPES_LIST) as { types: unknown[]; errors: unknown[] };
+
+    // The call succeeded; `errors` describes the items, it isn't the outcome.
+    expect(result.types).toHaveLength(1);
+    expect(result.errors).toEqual([broken]);
+  });
+
+  it('TYPES_LIST rethrows a genuine load failure instead of answering an empty catalog', async () => {
+    h.loadTypeCatalog.mockRejectedValue(new Error('EACCES: permission denied'));
+    // `{ types: [], errors: [] }` here would tell the picker every type had been
+    // deleted — the fallback means "none", never "couldn't look".
+    await expect(callAsync(Channels.TYPES_LIST)).rejects.toThrow(/EACCES/);
+  });
+
+  it('TYPES_NOTE_PROPERTIES projects the note over the indexed graph', async () => {
+    const props = { type: 'book', properties: [{ name: 'author', type: 'text', value: 'Lamport' }] };
+    h.getNoteTypedProperties.mockReturnValue(props);
+
+    await expect(callAsync(Channels.TYPES_NOTE_PROPERTIES, 'notes/paxos.md')).resolves.toEqual(props);
+    expect(h.getNoteTypedProperties).toHaveBeenCalledWith({ rootPath: ROOT }, 'notes/paxos.md');
+  });
+
+  it('TYPES_INSTANCES lists every note of a type', async () => {
+    const instances = { type: 'book', instances: [{ path: 'notes/paxos.md', values: {} }] };
+    h.getTypeInstances.mockReturnValue(instances);
+
+    await expect(callAsync(Channels.TYPES_INSTANCES, 'book')).resolves.toEqual(instances);
+    expect(h.getTypeInstances).toHaveBeenCalledWith({ rootPath: ROOT }, 'book');
+  });
+
+  it('TYPES_NOTE_TYPE_MAP keys the note rows by type', async () => {
+    h.getNoteTypeMap.mockReturnValue({ 'notes/paxos.md': 'book' });
+    await expect(callAsync(Channels.TYPES_NOTE_TYPE_MAP)).resolves.toEqual({ 'notes/paxos.md': 'book' });
+    expect(h.getNoteTypeMap).toHaveBeenCalledWith({ rootPath: ROOT });
+  });
+});
+
+describe('the writes', () => {
+  it('TYPES_SAVE writes the file, THEN reloads the graph catalog', async () => {
+    h.saveType.mockResolvedValue({ id: 'book', filePath: '/vault/.minerva/types/book.md' });
+
+    await expect(callAsync(Channels.TYPES_SAVE, { label: 'Book', properties: [] }))
+      .resolves.toEqual({ id: 'book', filePath: '/vault/.minerva/types/book.md' });
+
+    expect(h.saveType).toHaveBeenCalledWith(ROOT, { label: 'Book', properties: [] });
+    // Reloading first would re-read the catalog without the new type, leaving
+    // it unusable for promotion/indexing until the next reload.
+    expect(h.order).toEqual(['saveType', 'reloadTypeCatalog']);
+    expect(h.reloadTypeCatalog).toHaveBeenCalledWith({ rootPath: ROOT });
+  });
+
+  it('TYPES_SAVE does not reload the catalog when the write failed', async () => {
+    h.saveType.mockRejectedValue(new Error('EROFS: read-only file system'));
+    await expect(callAsync(Channels.TYPES_SAVE, { label: 'Book' })).rejects.toThrow(/EROFS/);
+    expect(h.reloadTypeCatalog).not.toHaveBeenCalled();
+  });
+
+  it('TYPES_DELETE removes the file, THEN reloads the catalog', async () => {
+    await call(Channels.TYPES_DELETE, 'book');
+    expect(h.deleteType).toHaveBeenCalledWith(ROOT, 'book');
+    expect(h.order).toEqual(['deleteType', 'reloadTypeCatalog']);
+  });
+
+  it('TYPES_DELETE_SAFELY reports what it cleared and what it could not (#1588)', async () => {
+    const outcome = { cleared: ['notes/a.md'], failed: [{ path: 'notes/b.md', error: 'EACCES' }] };
+    h.deleteTypeSafely.mockResolvedValue(outcome);
+
+    // A per-note outcome catalog: the delete succeeded, and the caller can see
+    // which instances were left behind.
+    await expect(callAsync(Channels.TYPES_DELETE_SAFELY, 'book', true)).resolves.toEqual(outcome);
+    expect(h.deleteTypeSafely).toHaveBeenCalledWith(ROOT, 'book', true);
+  });
+
+  it('TYPES_DELETE_SAFELY passes `clearInstances: false` through unchanged', async () => {
+    h.deleteTypeSafely.mockResolvedValue({ cleared: [], failed: [] });
+    await call(Channels.TYPES_DELETE_SAFELY, 'book', false);
+    // Leaving instances typed vs clearing them is the user's explicit choice;
+    // the handler must not helpfully default it.
+    expect(h.deleteTypeSafely).toHaveBeenCalledWith(ROOT, 'book', false);
+  });
+
+  it('TYPES_RENAME migrates every instance to the new id', async () => {
+    const outcome = { newId: 'monograph', migrated: ['notes/a.md'], failed: [] };
+    h.renameType.mockResolvedValue(outcome);
+
+    await expect(callAsync(Channels.TYPES_RENAME, 'book', 'Monograph')).resolves.toEqual(outcome);
+    expect(h.renameType).toHaveBeenCalledWith(ROOT, 'book', 'Monograph');
+  });
+
+  it.each([
+    [Channels.TYPES_SAVE, [{ label: 'Book' }]],
+    [Channels.TYPES_DELETE, ['book']],
+    [Channels.TYPES_DELETE_SAFELY, ['book', true]],
+    [Channels.TYPES_RENAME, ['book', 'Monograph']],
+  ])('%s throws with no project open', async (channel, args) => {
+    openProject = null;
+    await expect(callAsync(channel, ...args)).rejects.toThrow(/No project open/);
+  });
+
+  it('none of the writes touched disk or the graph with no project open', async () => {
+    openProject = null;
+    await expect(callAsync(Channels.TYPES_SAVE, {})).rejects.toThrow();
+    await expect(callAsync(Channels.TYPES_DELETE, 'book')).rejects.toThrow();
+    await expect(callAsync(Channels.TYPES_DELETE_SAFELY, 'book', true)).rejects.toThrow();
+    await expect(callAsync(Channels.TYPES_RENAME, 'book', 'Monograph')).rejects.toThrow();
+
+    expect(h.saveType).not.toHaveBeenCalled();
+    expect(h.deleteType).not.toHaveBeenCalled();
+    expect(h.deleteTypeSafely).not.toHaveBeenCalled();
+    expect(h.renameType).not.toHaveBeenCalled();
+    expect(h.reloadTypeCatalog).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -131,21 +131,22 @@ export default defineConfig({
           branches: 66,
         },
         // IPC registrars — channel→module glue that was entirely unfenced
-        // (QA C1 / #1612), then covered registrar by registrar. #1840 added
-        // direct handler tests for the three biggest untested ones —
-        // register-notebase (the write path), register-graph, register-links —
-        // taking the layer from ~33 L / 18.7 F / 30.7 S / 14.3 B to ~50.5 L /
-        // 38.1 F / 48.2 S / 31.6 B. The branch floor especially matters: this
-        // is the layer that owns `withRootPath` vs `withRootPathOr` semantics,
-        // so the #1631 no-project/not-found conflations can now regress into a
-        // test failure instead of passing silently. Floors sit ~10 points below
-        // measured so a refactor won't flap. Still a BACKSTOP, not a target —
-        // 16 registrars remain without a direct test; ratchet up as they land.
+        // (QA C1 / #1612), then covered registrar by registrar until #1840
+        // finished the job: all 24 now have a direct handler test, and
+        // `tests/architecture/ipc-registrar-coverage.test.ts` keeps it that way
+        // (a new registrar without one fails). That took the layer from ~33 L /
+        // 18.7 F / 30.7 S / 14.3 B to ~75.8 L / 76.5 F / 74.7 S / 61.7 B.
+        //
+        // The branch floor is the one that earns its keep: this layer owns the
+        // `withRootPath` vs `withRootPathOr` decision, so a #1631 no-project
+        // conflation now regresses into a test failure instead of passing in
+        // silence. Floors sit ~10 points below measured so a refactor won't
+        // flap. No longer a backstop — a real gate.
         'src/main/ipc/**': {
-          lines: 40,
-          functions: 28,
-          statements: 38,
-          branches: 21,
+          lines: 65,
+          functions: 66,
+          statements: 64,
+          branches: 51,
         },
         // Neglected top-level main modules — previously unfenced (#1100 / QA
         // H1). These sit at `src/main/*.ts` (no directory of their own), so


### PR DESCRIPTION
Closes #1840. **106 tests**, and with them `KNOWN_UNTESTED` goes to zero — every one of the 24 IPC registrars now has a direct handler test.

**Stacked on #1879.** Merge order: #1876 → #1879 → this.

| Registrar | Lines | Tests |
| --- | --- | --- |
| `register-compute` | 119 | 40 |
| `register-tools` | 108 | 25 |
| `register-types` | 78 | 21 |
| `register-queries` | 63 | 20 |

The consent boundary is tested against the **real** `compute/consent.ts` (temp `userData`), not a mocked guard — so `COMPUTE_RUN_CELL` refusing unconsented code, content-addressing (one edited character re-refuses), blanket trust not crossing thoughtbases, revoke re-prompting, and "the store holds hashes, not your code" are genuinely exercised, with `runCell` asserted un-called on every refusal. All three `{ ok, … }` unions are asserted to **resolve** on their failure arm, per CLAUDE.md rule 3.

### The coverage floor, raised once

| `src/main/ipc/**` | at the start | now | new floor |
| --- | --- | --- | --- |
| lines | 32.96 | **75.82** | 65 |
| functions | 18.67 | **76.53** | 66 |
| statements | 30.74 | **74.70** | 64 |
| branches | **14.31** | **61.72** | 51 |

Measured once on the finished stack rather than three times against a moving number. The branch floor is the one that earns its keep: this layer owns the `withRootPath` vs `withRootPathOr` decision, and at 14% a #1631 no-project conflation could regress with nothing noticing. At 51% it can't — which was the argument for the floor when #1840 was filed, now true rather than aspirational.

### Findings — filed, not fixed

- **#1877 (bug)** — a project-scoped query saved with no project open is written to the *global* directory and reported back as `scope: 'project'`. `moveQueryScope` throws for the identical condition, so the two paths disagree. I verified both sites.
- **#1878** — `PythonProbeResult` is an in-band `error?`, not a discriminated union, so `{ ok: true, error: '…' }` type-checks. CLAUDE.md lists it beside `CellResult` and `InterruptResult` as a legitimate union; unlike those two it isn't one.

Two more, judged not worth issues but noted in comments: a *refused* cell leaves no audit record (arguably the most interesting entry the trail could hold — pinned as-is so changing it is a visible decision), and `SEARCH_QUERY`'s project-less fallback is one shared `Promise` instance created at registration time.

`pnpm lint` clean; full suite **6,606 passing** (619 files); `pnpm coverage` passes with the new floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy