### PR TITLE
fix(queries): refuse a Thoughtbase-scoped save with no project, don't demote it (#1877)

### DIFF
--- a/src/main/saved-queries.ts
+++ b/src/main/saved-queries.ts
@@ -166,7 +166,17 @@ export function saveQuery(
   language: QueryLanguage,
   group: string | null = null,
 ): SavedQuery {
-  const dir = scope === 'project' && rootPath
+  // Refuse rather than quietly demote (#1877). Falling back to the global
+  // directory here wrote the file somewhere the user didn't ask for AND
+  // returned `scope: 'project'` below, so the list showed it under Thoughtbase
+  // scope while the file followed them into every other thoughtbase.
+  // `moveQueryScope` already refuses the identical condition; these two should
+  // not disagree about what's possible.
+  if (scope === 'project' && !rootPath) {
+    throw new Error('Cannot save to Thoughtbase scope: no project open.');
+  }
+
+  const dir = rootPath && scope === 'project'
     ? projectQueriesDir(rootPath)
     : globalQueriesDir();
 

--- a/tests/main/saved-queries.test.ts
+++ b/tests/main/saved-queries.test.ts
@@ -181,9 +181,30 @@ describe('saved-queries integration (#313/#314/#315)', () => {
     expect(fs.existsSync(q.filePath)).toBe(true);
   });
 
-  it('saveQuery falls back to global dir when project is null', () => {
-    const q = saveQuery(null, 'project', 'P', '', 'SELECT 1', 'sparql');
+  it('saveQuery refuses Thoughtbase scope when no project is open (#1877)', () => {
+    // This used to fall back to the global directory AND return
+    // `scope: 'project'`, so the caller was told the file was somewhere it
+    // wasn't — and it then followed the user into every other thoughtbase.
+    // `moveQueryScope` refuses the identical condition; these two should not
+    // disagree about what's possible.
+    expect(() => saveQuery(null, 'project', 'P', '', 'SELECT 1', 'sparql'))
+      .toThrow(/no project open/i);
+  });
+
+  it('saveQuery still writes global-scope queries with no project open', () => {
+    // The refusal is about the SCOPE, not about having a project: a global
+    // query is a legitimate thing to save from a project-less window.
+    const q = saveQuery(null, 'global', 'G', '', 'SELECT 1', 'sparql');
     expect(q.filePath.startsWith(userDataDir.value)).toBe(true);
+    expect(q.scope).toBe('global');
+  });
+
+  it('saveQuery reports the scope the file actually landed in', () => {
+    // The half of the bug the old test missed: it asserted the directory but
+    // never that the returned `scope` agreed with it.
+    const q = saveQuery(projectRoot, 'project', 'P2', '', 'SELECT 1', 'sparql');
+    expect(q.scope).toBe('project');
+    expect(q.filePath.startsWith(projectRoot)).toBe(true);
   });
 
   it('saveQuery preserves @group on disk', () => {


### PR DESCRIPTION
Closes #1877.

`saveQuery` fell back to the global directory when asked for project scope with no project open — and then returned `scope: 'project'` alongside the global path. The saved-query list showed it under Thoughtbase scope while the file sat in `~/.minerva/queries/`, following the user into every other thoughtbase.

`moveQueryScope` already refuses the identical condition. **Two functions on the same store disagreeing about whether project scope is possible** is the actual defect; the misfiling is what that disagreement produced. It now throws, with the same wording.

The guard is in the domain function rather than the handler on purpose: `QUERIES_SAVE` can't be `withRootPath`, because a *global*-scope save from a project-less window is a legitimate thing to do. Only the scope is refused, not the call.

### Why it survived

The old behaviour had a test:

```ts
it('saveQuery falls back to global dir when project is null', () => {
  const q = saveQuery(null, 'project', 'P', '', 'SELECT 1', 'sparql');
  expect(q.filePath.startsWith(userDataDir.value)).toBe(true);
});
```

It asserted the directory and never that the returned `scope` agreed with it — so it pinned half of a two-part lie, and made the whole thing look deliberate. Its replacement covers the refusal, the still-legal global save, and the `scope`/`filePath` agreement that nothing was checking.

`pnpm lint` clean; full suite 6,283 passing (612 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy