### PR TITLE
test(ipc): batches A and B — merged into their base branches, never into main (#1840)

### DIFF
--- a/tests/architecture/ipc-registrar-coverage.test.ts
+++ b/tests/architecture/ipc-registrar-coverage.test.ts
@@ -49,12 +49,15 @@ const IPC_DIR = path.join(ROOT, 'src', 'main', 'ipc');
  * This list may only SHRINK. Deleting an entry because you wrote its test is
  * the intended way to change this file; adding one is not.
  */
-const KNOWN_UNTESTED: readonly string[] = [
-  'register-compute',      // 119 lines
-  'register-tools',        // 108 lines
-  'register-types',        //  78 lines
-  'register-queries',      //  63 lines
-];
+/**
+ * Registrars with no direct test. **Empty** — every `register-*.ts` is now
+ * exercised by a file under `tests/main/ipc/` (#1840, batches a/b/c).
+ *
+ * Keep it that way: this list is the pre-existing backlog and may only shrink,
+ * so a new registrar without a test fails the check above rather than landing
+ * here. There is nothing left for it to hold.
+ */
+const KNOWN_UNTESTED: readonly string[] = [];
 
 /** Module names (no extension) of every `src/main/ipc/register-*.ts`. */
 function registrars(): string[] {

--- a/tests/architecture/ipc-registrar-coverage.test.ts
+++ b/tests/architecture/ipc-registrar-coverage.test.ts
@@ -50,9 +50,6 @@ const IPC_DIR = path.join(ROOT, 'src', 'main', 'ipc');
  * the intended way to change this file; adding one is not.
  */
 const KNOWN_UNTESTED: readonly string[] = [
-  'register-sources',      // 343 lines
-  'register-publish',      // 171 lines
-  'register-bibliography', // 144 lines
   'register-compute',      // 119 lines
   'register-tools',        // 108 lines
   'register-types',        //  78 lines

--- a/tests/architecture/ipc-registrar-coverage.test.ts
+++ b/tests/architecture/ipc-registrar-coverage.test.ts
@@ -57,12 +57,6 @@ const KNOWN_UNTESTED: readonly string[] = [
   'register-tools',        // 108 lines
   'register-types',        //  78 lines
   'register-queries',      //  63 lines
-  'register-app',          //  48 lines
-  'register-clipper',      //  40 lines
-  'register-views',        //  25 lines
-  'register-tags',         //  23 lines
-  'register-sites',        //  22 lines
-  'register-git',          //  17 lines
 ];
 
 /** Module names (no extension) of every `src/main/ipc/register-*.ts`. */

--- a/tests/main/ipc/register-bibliography.test.ts
+++ b/tests/main/ipc/register-bibliography.test.ts
@@ -1,0 +1,491 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-bibliography.ts` (#1840).
+ *
+ * Two jobs live in this registrar: choosing/importing CSL assets, and the one
+ * handler that writes a note (`BIBLIOGRAPHY_GENERATE`). It drives the real
+ * `registerBibliography()` with the write pipeline + CSL loaders mocked, and
+ * pins:
+ *
+ *   - the #1631 guard, including the deliberate exception: the style PICKER
+ *     answers with the bundled set when no project is open (the Settings
+ *     dialog can be opened before any thoughtbase is), while every write
+ *     throws;
+ *   - `BIBLIOGRAPHY_SET_STYLE` refuses an id that isn't in the merged
+ *     registry — including inherited `Object.prototype` keys, which is what
+ *     `hasOwnProperty.call` is there for;
+ *   - the import handlers validate the file's CONTENT (not just its
+ *     extension) before copying it into the project, and a cancelled picker
+ *     writes nothing;
+ *   - the remove handlers reject an id that could escape the CSL directory —
+ *     these two build a path by interpolation, so the regex IS the guard;
+ *   - `BIBLIOGRAPHY_GENERATE` writes through the history-aware pipeline under
+ *     a named cause, and doesn't write at all when nothing changed.
+ *
+ * The pure CSL helpers (`isValidCslStyle`, `deriveStyleId`, …) are kept real —
+ * stubbing them would make the validation tests assert their own mocks. Only
+ * the filesystem-reading loaders are replaced.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  win: { id: 1, isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
+  // electron / node
+  showOpenDialog: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+  unlink: vi.fn(),
+  // csl registry
+  getMergedStyles: vi.fn(),
+  loadUserStyles: vi.fn(),
+  loadUserLocales: vi.fn(),
+  // project config
+  getBibliographyStyleId: vi.fn(),
+  setBibliographyStyleId: vi.fn(),
+  // note write path
+  notebaseReadFile: vi.fn(),
+  generateBibliography: vi.fn(),
+  writeAndReindex: vi.fn(),
+  runWithHistorySource: vi.fn(<T>(_s: unknown, fn: () => Promise<T>) => fn()),
+  renderInlineCitations: vi.fn(),
+  // call-order log
+  order: [] as string[],
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+  dialog: { showOpenDialog: h.showOpenDialog },
+}));
+
+vi.mock('node:fs/promises', () => {
+  const api = { readFile: h.readFile, writeFile: h.writeFile, mkdir: h.mkdir, unlink: h.unlink };
+  return { default: api, ...api };
+});
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  rootPathFromEvent: () => openProject,
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+  withRootPathWin:
+    <A extends unknown[], R>(fn: (rootPath: string, win: unknown, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, h.win, ...args);
+      },
+  hooks: { HOOKS: true },
+}));
+
+// Partial mock: the fs-reading loaders are stubbed, the pure validators /
+// id-derivers / directory constants stay real.
+vi.mock('../../../src/main/publish/csl/user-assets', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/publish/csl/user-assets')>();
+  return {
+    ...actual,
+    getMergedStyles: h.getMergedStyles,
+    loadUserStyles: h.loadUserStyles,
+    loadUserLocales: h.loadUserLocales,
+  };
+});
+
+vi.mock('../../../src/main/notebase/fs', () => ({ readFile: h.notebaseReadFile }));
+vi.mock('../../../src/main/notebase/write-pipeline', () => ({ writeAndReindex: h.writeAndReindex }));
+vi.mock('../../../src/main/history', () => ({ runWithHistorySource: h.runWithHistorySource }));
+vi.mock('../../../src/main/bibliography/generate', () => ({ generateBibliography: h.generateBibliography }));
+vi.mock('../../../src/main/citations/render-inline', () => ({ renderInlineCitations: h.renderInlineCitations }));
+vi.mock('../../../src/main/project-config', () => ({
+  getBibliographyStyleId: h.getBibliographyStyleId,
+  setBibliographyStyleId: h.setBibliographyStyleId,
+}));
+
+import { registerBibliography } from '../../../src/main/ipc/register-bibliography';
+import { Channels } from '../../../src/shared/channels';
+import { DEFAULT_STYLE } from '../../../src/main/publish/csl/assets';
+import { USER_STYLES_DIR, USER_LOCALES_DIR } from '../../../src/main/publish/csl/user-assets';
+
+registerBibliography();
+
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!({}, ...args);
+const callAsync = (channel: string, ...args: unknown[]): Promise<unknown> =>
+  Promise.resolve(call(channel, ...args));
+
+/** A minimally-valid CSL style — the validator matches on the namespace. */
+const STYLE_XML = '<style xmlns="http://purl.org/net/xbiblio/csl"><info><title>House Style</title></info></style>';
+/** …and a locale. */
+const LOCALE_XML = '<locale xmlns="http://purl.org/net/xbiblio/csl" xml:lang="en-GB"/>';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  openProject = ROOT;
+  h.order.length = 0;
+  h.runWithHistorySource.mockImplementation(<T>(_s: unknown, fn: () => Promise<T>) => fn());
+  h.getMergedStyles.mockResolvedValue({
+    styles: { apa: '<x/>', ieee: '<x/>' },
+    labels: { apa: 'APA', ieee: 'IEEE' },
+    userIds: new Set<string>(),
+  });
+  h.loadUserStyles.mockResolvedValue([]);
+  h.loadUserLocales.mockResolvedValue([]);
+  // The fs writers are awaited (and `unlink` is `.catch`-ed), so they have to
+  // hand back promises rather than the `undefined` a reset mock returns.
+  h.mkdir.mockResolvedValue(undefined);
+  h.writeFile.mockResolvedValue(undefined);
+  h.unlink.mockResolvedValue(undefined);
+});
+
+describe('register-bibliography — the #1631 project guard', () => {
+  const throwers: [string, unknown[]][] = [
+    [Channels.BIBLIOGRAPHY_SET_STYLE, ['ieee']],
+    [Channels.BIBLIOGRAPHY_GENERATE, ['notes/a.md']],
+    [Channels.CSL_IMPORT_STYLE, []],
+    [Channels.CSL_IMPORT_LOCALE, []],
+    [Channels.CSL_REMOVE_STYLE, ['mine']],
+    [Channels.CSL_REMOVE_LOCALE, ['en-GB']],
+  ];
+
+  it.each(throwers)('%s throws with no project open', (channel, args) => {
+    openProject = null;
+    expect(() => call(channel, ...args)).toThrow('No project open');
+  });
+
+  it('nothing is written, imported or unlinked when there is no project', () => {
+    openProject = null;
+    for (const [channel, args] of throwers) {
+      try { call(channel, ...args); } catch { /* asserted above */ }
+    }
+    expect(h.setBibliographyStyleId).not.toHaveBeenCalled();
+    expect(h.writeAndReindex).not.toHaveBeenCalled();
+    expect(h.writeFile).not.toHaveBeenCalled();
+    expect(h.unlink).not.toHaveBeenCalled();
+    expect(h.showOpenDialog).not.toHaveBeenCalled();
+  });
+
+  // Each of these fallbacks is also the answer for a project that has simply
+  // configured nothing — a legitimate value, not an error in disguise.
+  const fallbacks: [string, unknown[], unknown][] = [
+    [Channels.BIBLIOGRAPHY_GET_STYLE, [], DEFAULT_STYLE],
+    [Channels.CSL_LIST_USER_STYLES, [], []],
+    [Channels.CSL_LIST_USER_LOCALES, [], []],
+    [Channels.CITATION_RENDER_INLINE, [[{ key: 'x' }]], { markers: [], bibliography: null, missing: [], styleId: DEFAULT_STYLE }],
+  ];
+
+  it.each(fallbacks)('%s answers with its empty value and no project', async (channel, args, expected) => {
+    openProject = null;
+    await expect(callAsync(channel, ...args)).resolves.toEqual(expected);
+    expect(h.loadUserStyles).not.toHaveBeenCalled();
+    expect(h.renderInlineCitations).not.toHaveBeenCalled();
+  });
+
+  it('CITATION_RENDER_INLINE\'s project-less answer is a fully-shaped response', async () => {
+    // A partial object would make the preview renderer read `undefined.length`
+    // — the fallback has to be a real empty answer, not a stub.
+    openProject = null;
+    const answer = await callAsync(Channels.CITATION_RENDER_INLINE, []) as Record<string, unknown>;
+    expect(Object.keys(answer).sort()).toEqual(['bibliography', 'markers', 'missing', 'styleId']);
+  });
+
+  it('BIBLIOGRAPHY_LIST_STYLES still fills the picker with no project open', async () => {
+    // The Settings dialog opens before a thoughtbase does in some flows; an
+    // empty style picker there would look like a broken install.
+    openProject = null;
+    await expect(callAsync(Channels.BIBLIOGRAPHY_LIST_STYLES)).resolves.toEqual([
+      { id: 'apa', label: 'APA', isUser: false },
+      { id: 'ieee', label: 'IEEE', isUser: false },
+    ]);
+    // Honest note: the project-less branch asks for the merged registry at
+    // rootPath `''`, so the user-style scan runs against a path relative to
+    // the process CWD rather than being skipped outright. Harmless today (the
+    // directory won't exist), pinned so a change is deliberate.
+    expect(h.getMergedStyles).toHaveBeenCalledWith('');
+  });
+});
+
+describe('register-bibliography — style selection', () => {
+  it('BIBLIOGRAPHY_LIST_STYLES marks which entries came from the project', async () => {
+    // The settings row only offers "remove" for user-imported styles, so this
+    // flag is what keeps a bundled style from looking deletable.
+    h.getMergedStyles.mockResolvedValue({
+      styles: { apa: '<x/>', 'house-style': '<x/>' },
+      labels: { apa: 'APA', 'house-style': 'House Style' },
+      userIds: new Set(['house-style']),
+    });
+
+    await expect(callAsync(Channels.BIBLIOGRAPHY_LIST_STYLES)).resolves.toEqual([
+      { id: 'apa', label: 'APA', isUser: false },
+      { id: 'house-style', label: 'House Style', isUser: true },
+    ]);
+    expect(h.getMergedStyles).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('BIBLIOGRAPHY_LIST_STYLES falls back to the id for a style with no title', async () => {
+    h.getMergedStyles.mockResolvedValue({ styles: { odd: '<x/>' }, labels: {}, userIds: new Set(['odd']) });
+    await expect(callAsync(Channels.BIBLIOGRAPHY_LIST_STYLES))
+      .resolves.toEqual([{ id: 'odd', label: 'odd', isUser: true }]);
+  });
+
+  it('BIBLIOGRAPHY_GET_STYLE returns the project\'s configured style', () => {
+    h.getBibliographyStyleId.mockReturnValue('ieee');
+    expect(call(Channels.BIBLIOGRAPHY_GET_STYLE)).toBe('ieee');
+    expect(h.getBibliographyStyleId).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('BIBLIOGRAPHY_GET_STYLE falls back to the default when the project never chose one', () => {
+    h.getBibliographyStyleId.mockReturnValue(null);
+    expect(call(Channels.BIBLIOGRAPHY_GET_STYLE)).toBe(DEFAULT_STYLE);
+  });
+
+  it('BIBLIOGRAPHY_SET_STYLE stores a style that exists in the merged registry', async () => {
+    await callAsync(Channels.BIBLIOGRAPHY_SET_STYLE, 'ieee');
+    expect(h.setBibliographyStyleId).toHaveBeenCalledWith(ROOT, 'ieee');
+  });
+
+  it('BIBLIOGRAPHY_SET_STYLE refuses an unknown id instead of storing a dud', async () => {
+    // Storing an id with no XML behind it would fail later, at export time,
+    // far from the setting that caused it.
+    await expect(callAsync(Channels.BIBLIOGRAPHY_SET_STYLE, 'chicago-note'))
+      .rejects.toThrow('Unknown CSL style: chicago-note');
+    expect(h.setBibliographyStyleId).not.toHaveBeenCalled();
+  });
+
+  it.each(['constructor', 'toString', '__proto__'])(
+    'BIBLIOGRAPHY_SET_STYLE refuses the inherited key %s', async (key) => {
+      // `hasOwnProperty.call` rather than `styleId in styles` — a plain `in`
+      // would accept every Object.prototype member as a valid style.
+      await expect(callAsync(Channels.BIBLIOGRAPHY_SET_STYLE, key))
+        .rejects.toThrow(`Unknown CSL style: ${key}`);
+      expect(h.setBibliographyStyleId).not.toHaveBeenCalled();
+    });
+});
+
+describe('register-bibliography — user CSL assets', () => {
+  it('CSL_LIST_USER_STYLES reports only what the settings row needs', async () => {
+    // Not the XML: the renderer never renders it, and these files are large.
+    h.loadUserStyles.mockResolvedValue([
+      { id: 'house', label: 'House Style', filePath: '/vault/.minerva/csl-styles/house.csl', xml: STYLE_XML },
+    ]);
+    await expect(callAsync(Channels.CSL_LIST_USER_STYLES)).resolves.toEqual([
+      { id: 'house', label: 'House Style', filePath: '/vault/.minerva/csl-styles/house.csl' },
+    ]);
+  });
+
+  it('CSL_LIST_USER_LOCALES reports only what the settings row needs', async () => {
+    h.loadUserLocales.mockResolvedValue([
+      { id: 'en-GB', filePath: '/vault/.minerva/csl-locales/en-GB.xml', xml: LOCALE_XML },
+    ]);
+    await expect(callAsync(Channels.CSL_LIST_USER_LOCALES)).resolves.toEqual([
+      { id: 'en-GB', filePath: '/vault/.minerva/csl-locales/en-GB.xml' },
+    ]);
+  });
+
+  it('CSL_IMPORT_STYLE copies the file into the project and names it from its <title>', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/House Style.csl'] });
+    h.readFile.mockResolvedValue(STYLE_XML);
+
+    await expect(callAsync(Channels.CSL_IMPORT_STYLE)).resolves.toEqual({
+      id: 'house-style',
+      label: 'House Style',
+      filePath: `${ROOT}/${USER_STYLES_DIR}/house-style.csl`,
+    });
+
+    // The import is a copy, not a reference: the picked file can be deleted
+    // or live on a volume that isn't mounted next time.
+    expect(h.mkdir).toHaveBeenCalledWith(`${ROOT}/${USER_STYLES_DIR}`, { recursive: true });
+    expect(h.writeFile).toHaveBeenCalledWith(`${ROOT}/${USER_STYLES_DIR}/house-style.csl`, STYLE_XML, 'utf-8');
+  });
+
+  it('CSL_IMPORT_STYLE falls back to the derived id when the style has no title', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/untitled.csl'] });
+    h.readFile.mockResolvedValue('<style xmlns="http://purl.org/net/xbiblio/csl"/>');
+    await expect(callAsync(Channels.CSL_IMPORT_STYLE))
+      .resolves.toEqual({ id: 'untitled', label: 'untitled', filePath: `${ROOT}/${USER_STYLES_DIR}/untitled.csl` });
+  });
+
+  it('CSL_IMPORT_STYLE rejects a file that is not CSL, whatever its extension says', async () => {
+    // The picker filters on `.csl`/`.xml`; only the content proves it's a
+    // style, and a non-style file would poison the picker with a broken entry.
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/notes.xml'] });
+    h.readFile.mockResolvedValue('<html><body>not csl</body></html>');
+
+    await expect(callAsync(Channels.CSL_IMPORT_STYLE)).rejects.toThrow('not a valid CSL style');
+    expect(h.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('CSL_IMPORT_STYLE rejects a filename that derives no usable id', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/++.csl'] });
+    h.readFile.mockResolvedValue(STYLE_XML);
+    await expect(callAsync(Channels.CSL_IMPORT_STYLE)).rejects.toThrow('Could not derive a style id');
+    expect(h.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('CSL_IMPORT_LOCALE copies the locale in, preserving its case', async () => {
+    // Locale ids are matched case-sensitively by citeproc ("en-GB", not
+    // "en-gb"), so unlike style ids these are not lowercased.
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/locales-en-GB.xml'] });
+    h.readFile.mockResolvedValue(LOCALE_XML);
+
+    await expect(callAsync(Channels.CSL_IMPORT_LOCALE)).resolves.toEqual({
+      id: 'en-GB',
+      filePath: `${ROOT}/${USER_LOCALES_DIR}/en-GB.xml`,
+    });
+    expect(h.writeFile).toHaveBeenCalledWith(`${ROOT}/${USER_LOCALES_DIR}/en-GB.xml`, LOCALE_XML, 'utf-8');
+  });
+
+  it('CSL_IMPORT_LOCALE rejects a file that is not a CSL locale', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/downloads/style.xml'] });
+    h.readFile.mockResolvedValue(STYLE_XML); // a style, not a locale
+    await expect(callAsync(Channels.CSL_IMPORT_LOCALE)).rejects.toThrow('not a valid CSL locale');
+    expect(h.writeFile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [Channels.CSL_IMPORT_STYLE, 'cancelled', { canceled: true, filePaths: [] }],
+    [Channels.CSL_IMPORT_STYLE, 'dismissed with no file', { canceled: false, filePaths: [] }],
+    [Channels.CSL_IMPORT_LOCALE, 'cancelled', { canceled: true, filePaths: [] }],
+    [Channels.CSL_IMPORT_LOCALE, 'dismissed with no file', { canceled: false, filePaths: [] }],
+  ])('%s imports nothing when the picker is %s', async (channel, _label, dialogResult) => {
+    h.showOpenDialog.mockResolvedValue(dialogResult);
+    await expect(callAsync(channel)).resolves.toBeNull();
+    expect(h.readFile).not.toHaveBeenCalled();
+    expect(h.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('CSL_REMOVE_STYLE deletes the imported file from the project', async () => {
+    await callAsync(Channels.CSL_REMOVE_STYLE, 'house-style');
+    expect(h.unlink).toHaveBeenCalledWith(`${ROOT}/${USER_STYLES_DIR}/house-style.csl`);
+  });
+
+  it('CSL_REMOVE_LOCALE deletes the imported locale from the project', async () => {
+    await callAsync(Channels.CSL_REMOVE_LOCALE, 'en-GB');
+    expect(h.unlink).toHaveBeenCalledWith(`${ROOT}/${USER_LOCALES_DIR}/en-GB.xml`);
+  });
+
+  it.each([
+    ['../../../etc/passwd'],
+    ['..'],
+    ['sub/dir'],
+    ['name with spaces'],
+    [''],
+  ])('CSL_REMOVE_STYLE refuses the id %j rather than joining it into a path', async (id) => {
+    // The target path is built by interpolation, so this regex is the whole
+    // traversal guard — no `assertSafePath` runs on this route.
+    await expect(callAsync(Channels.CSL_REMOVE_STYLE, id)).rejects.toThrow('Invalid style id.');
+    expect(h.unlink).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['../../../etc/passwd'],
+    ['..'],
+    ['sub/dir'],
+    [''],
+  ])('CSL_REMOVE_LOCALE refuses the id %j rather than joining it into a path', async (id) => {
+    await expect(callAsync(Channels.CSL_REMOVE_LOCALE, id)).rejects.toThrow('Invalid locale id.');
+    expect(h.unlink).not.toHaveBeenCalled();
+  });
+
+  it('removing a style that was already gone is not an error', async () => {
+    // Two settings windows, one file: the second remove is a no-op the user
+    // shouldn't see an error for.
+    h.unlink.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    await expect(callAsync(Channels.CSL_REMOVE_STYLE, 'house-style')).resolves.toBeUndefined();
+  });
+
+  it('a remove that failed for a REAL reason is swallowed too — a known #1631 outlier', async () => {
+    // Documented in CLAUDE.md's migration backlog ("CSL_REMOVE_STYLE /
+    // CSL_REMOVE_LOCALE (unlink swallows non-ENOENT)"): the bare
+    // `.catch(() => undefined)` also hides EACCES/EIO, so the settings row
+    // disappears while the file stays on disk and reappears on reload. Pinned
+    // as-is so the fix is a deliberate, visible change rather than a surprise.
+    h.unlink.mockRejectedValue(Object.assign(new Error('EACCES'), { code: 'EACCES' }));
+    await expect(callAsync(Channels.CSL_REMOVE_STYLE, 'house-style')).resolves.toBeUndefined();
+  });
+});
+
+describe('register-bibliography — CITATION_RENDER_INLINE', () => {
+  it('renders the requested references for the open project', async () => {
+    const refs = [{ key: 'smith2020', locator: '12' }];
+    h.renderInlineCitations.mockResolvedValue({ markers: ['(Smith 2020, 12)'], bibliography: '…', missing: [], styleId: 'apa' });
+    await expect(callAsync(Channels.CITATION_RENDER_INLINE, refs))
+      .resolves.toEqual({ markers: ['(Smith 2020, 12)'], bibliography: '…', missing: [], styleId: 'apa' });
+    expect(h.renderInlineCitations).toHaveBeenCalledWith(ROOT, refs);
+  });
+
+  it('treats a missing ref list as an empty one', async () => {
+    // The preview calls this on every keystroke; an undefined batch is a
+    // normal transient, not something to reject over.
+    h.renderInlineCitations.mockResolvedValue({ markers: [], bibliography: null, missing: [], styleId: 'apa' });
+    await callAsync(Channels.CITATION_RENDER_INLINE, undefined);
+    expect(h.renderInlineCitations).toHaveBeenCalledWith(ROOT, []);
+  });
+});
+
+describe('register-bibliography — BIBLIOGRAPHY_GENERATE', () => {
+  it('writes the regenerated note through the history-aware pipeline', async () => {
+    h.notebaseReadFile.mockResolvedValue('# Note\n\n[@smith2020]');
+    h.generateBibliography.mockResolvedValue({
+      changed: true, content: '# Note\n\n[@smith2020]\n\n## References\n…',
+      entriesCount: 1, missingIds: [], styleId: 'apa',
+    });
+
+    await expect(callAsync(Channels.BIBLIOGRAPHY_GENERATE, 'notes/a.md'))
+      .resolves.toEqual({ entriesCount: 1, missingIds: [], changed: true, styleId: 'apa' });
+
+    expect(h.generateBibliography).toHaveBeenCalledWith(ROOT, '# Note\n\n[@smith2020]');
+    // Named cause: a history timeline full of anonymous edits is unreadable.
+    expect(h.runWithHistorySource).toHaveBeenCalledWith(
+      { origin: 'edit', cause: 'Bibliography' },
+      expect.any(Function),
+    );
+    // Through the pipeline, not a bare fs write — graph, search and any open
+    // editor have to see the new text too.
+    expect(h.writeAndReindex).toHaveBeenCalledWith(
+      ROOT, 'notes/a.md', '# Note\n\n[@smith2020]\n\n## References\n…', { HOOKS: true },
+    );
+  });
+
+  it('writes nothing when the bibliography was already up to date', async () => {
+    // A no-op save would still stamp a history revision and re-index the note.
+    h.notebaseReadFile.mockResolvedValue('# Note');
+    h.generateBibliography.mockResolvedValue({ changed: false, content: '# Note', entriesCount: 0, missingIds: [], styleId: 'apa' });
+
+    await expect(callAsync(Channels.BIBLIOGRAPHY_GENERATE, 'notes/a.md'))
+      .resolves.toEqual({ entriesCount: 0, missingIds: [], changed: false, styleId: 'apa' });
+    expect(h.writeAndReindex).not.toHaveBeenCalled();
+    expect(h.runWithHistorySource).not.toHaveBeenCalled();
+  });
+
+  it('reports citation keys with no matching source instead of failing', async () => {
+    // Missing keys are a normal state of a draft, so the note is still
+    // rewritten and the gaps are reported for the UI to list.
+    h.notebaseReadFile.mockResolvedValue('# Note\n\n[@ghost]');
+    h.generateBibliography.mockResolvedValue({
+      changed: true, content: '# Note\n\n[@ghost]\n\n## References\n', entriesCount: 0,
+      missingIds: ['ghost'], styleId: 'ieee',
+    });
+
+    await expect(callAsync(Channels.BIBLIOGRAPHY_GENERATE, 'notes/a.md'))
+      .resolves.toEqual({ entriesCount: 0, missingIds: ['ghost'], changed: true, styleId: 'ieee' });
+    expect(h.writeAndReindex).toHaveBeenCalled();
+  });
+
+  it('lets a read failure reject rather than generating over an empty note', async () => {
+    h.notebaseReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    await expect(callAsync(Channels.BIBLIOGRAPHY_GENERATE, 'notes/gone.md')).rejects.toThrow('ENOENT');
+    expect(h.generateBibliography).not.toHaveBeenCalled();
+    expect(h.writeAndReindex).not.toHaveBeenCalled();
+  });
+});

--- a/tests/main/ipc/register-compute.test.ts
+++ b/tests/main/ipc/register-compute.test.ts
@@ -1,0 +1,478 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-compute.ts` (#1840).
+ *
+ * Compute is where a renderer (or an LLM-authored proposal) asks main to
+ * execute arbitrary code, so the handlers here carry two contracts worth
+ * pinning rather than one:
+ *
+ *   - the #1631 project guard — `COMPUTE_RUN_CELL` / `COMPUTE_GRANT_CONSENT` /
+ *     `COMPUTE_SAVE_CELL_OUTPUT` THROW with no project open, while the
+ *     `withRootPathOr` handlers answer a value that genuinely means what it
+ *     says (`'none'` = not consented, `{ ok: false, reason: 'no-kernel' }` =
+ *     there is no kernel) rather than a disguised error;
+ *   - the #1411/#1412 enforcement boundary — `COMPUTE_RUN_CELL` refuses a cell
+ *     the user never consented to *even when the caller skipped the prompt*,
+ *     and refusing means no execution at all.
+ *
+ * The consent store is the REAL one (`compute/consent.ts`, pointed at a temp
+ * `userData`), because "the guard fires" is only worth asserting against the
+ * real content-addressed hashing — a mocked guard would pass while the actual
+ * boundary rotted. The executor, kernel, audit log and settings store are
+ * mocked; they're what the handlers delegate to, not what they promise.
+ *
+ * Also pinned: the three discriminated `{ ok, … }` unions CLAUDE.md rule 3
+ * names (`CellResult`, `PythonProbeResult`, `InterruptResult`) RESOLVE on their
+ * failure arm. A caller branching on `ok` must never also have to catch.
+ */
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => {
+  return {
+    // Where the REAL consent store lives. Filled in below — `vi.hoisted` runs
+    // before the `node:fs` import exists, and `app.getPath` is only ever called
+    // from inside a handler, so a mutable holder is enough.
+    userData: { dir: '' },
+    handlers: new Map<string, Handler>(),
+    win: { id: 1 },
+    // electron
+    showOpenDialog: vi.fn(),
+    showItemInFolder: vi.fn(),
+    // compute/registry
+    runCell: vi.fn(),
+    registeredLanguages: vi.fn(),
+    // compute/audit
+    recordExecution: vi.fn(),
+    auditLogPath: vi.fn(),
+    // compute/python-kernel
+    restartKernel: vi.fn(),
+    interruptKernel: vi.fn(),
+    // compute/python-settings
+    getPythonSettings: vi.fn(),
+    setPythonSettings: vi.fn(),
+    probePythonInterpreter: vi.fn(),
+    resolvePythonInterpreter: vi.fn(),
+    // compute/save-cell-output
+    saveCellOutput: vi.fn(),
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+  dialog: { showOpenDialog: h.showOpenDialog },
+  shell: { showItemInFolder: h.showItemInFolder },
+  // The REAL consent store reads this to find `compute-consent.json`.
+  app: { getPath: () => h.userData.dir },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  winFromEvent: () => h.win,
+  rootPathFromEvent: () => openProject,
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+}));
+
+vi.mock('../../../src/main/compute/registry', () => ({
+  runCell: h.runCell,
+  registeredLanguages: h.registeredLanguages,
+}));
+vi.mock('../../../src/main/compute/audit', () => ({
+  recordExecution: h.recordExecution,
+  auditLogPath: h.auditLogPath,
+}));
+vi.mock('../../../src/main/compute/python-kernel', () => ({
+  restartKernel: h.restartKernel,
+  interruptKernel: h.interruptKernel,
+}));
+vi.mock('../../../src/main/compute/python-settings', () => ({
+  getPythonSettings: h.getPythonSettings,
+  setPythonSettings: h.setPythonSettings,
+  probePythonInterpreter: h.probePythonInterpreter,
+  resolvePythonInterpreter: h.resolvePythonInterpreter,
+}));
+vi.mock('../../../src/main/compute/save-cell-output', () => ({ saveCellOutput: h.saveCellOutput }));
+// register-compute re-exports the propose_compute helpers, which reach the
+// graph on import. Nothing here calls them; the stub just keeps the graph out.
+vi.mock('../../../src/main/graph/index', () => ({}));
+
+import { registerCompute } from '../../../src/main/ipc/register-compute';
+import { cellHash } from '../../../src/main/compute/consent';
+import { Channels } from '../../../src/shared/channels';
+
+registerCompute();
+h.userData.dir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-compute-'));
+
+const call = (channel: string, ...args: unknown[]) => h.handlers.get(channel)!({}, ...args);
+/** `call` wrapped so a SYNCHRONOUS throw (the `withRootPath` guard fires before
+ *  the async body runs) is assertable with the same `rejects` matcher. */
+const callAsync = async (channel: string, ...args: unknown[]) => call(channel, ...args);
+
+const consentFile = () => path.join(h.userData.dir, 'compute-consent.json');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  openProject = ROOT;
+  // A machine that has never trusted anything — the state every assertion
+  // about the guard has to start from.
+  fs.rmSync(consentFile(), { force: true });
+  h.auditLogPath.mockReturnValue(path.join(h.userData.dir, 'audit', 'compute-audit.jsonl'));
+});
+
+afterAll(() => { fs.rmSync(h.userData.dir, { recursive: true, force: true }); });
+
+const OK_RESULT = { ok: true, output: { type: 'text', value: '42' } };
+
+describe('COMPUTE_RUN_CELL — the consent enforcement boundary (#1411/#1412)', () => {
+  it('refuses code the user never consented to, and executes nothing', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+
+    const result = await call(Channels.COMPUTE_RUN_CELL, 'python', 'import os; os.system("rm -rf ~")');
+
+    // The refusal is a normal CellResult, not a rejection — the renderer
+    // renders it in the output block like any other failed cell.
+    expect(result).toEqual({ ok: false, error: expect.stringContaining('has not been approved to run') });
+    // The point of the boundary: reaching the IPC without prompting buys nothing.
+    expect(h.runCell).not.toHaveBeenCalled();
+  });
+
+  it('runs the cell once that exact code is consented', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+
+    await expect(callAsync(Channels.COMPUTE_RUN_CELL, 'python', 'print(1)')).resolves.toEqual(OK_RESULT);
+    expect(h.runCell).toHaveBeenCalledWith('python', 'print(1)', { rootPath: ROOT });
+  });
+
+  it('consent is content-addressed — editing a single character re-refuses', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+
+    // This is the whole reason consent is keyed on a code hash: an approved
+    // cell must not become a licence to run whatever replaces it.
+    const result = await call(Channels.COMPUTE_RUN_CELL, 'python', 'print(2)');
+
+    expect(result).toEqual({ ok: false, error: expect.any(String) });
+    expect(h.runCell).not.toHaveBeenCalled();
+  });
+
+  it('blanket project trust lets an unseen cell run', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'anything', 'project');
+
+    await expect(callAsync(Channels.COMPUTE_RUN_CELL, 'python', 'never seen before')).resolves.toEqual(OK_RESULT);
+  });
+
+  it("blanket trust is per-thoughtbase — it doesn't spill to another project", async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'x', 'project');
+
+    openProject = '/other-vault';
+    const result = await call(Channels.COMPUTE_RUN_CELL, 'python', 'x');
+
+    expect(result).toEqual({ ok: false, error: expect.any(String) });
+    expect(h.runCell).not.toHaveBeenCalled();
+  });
+
+  it('throws with no project open, rather than running against an unknown root', async () => {
+    openProject = null;
+    await expect(callAsync(Channels.COMPUTE_RUN_CELL, 'python', 'print(1)')).rejects.toThrow(/No project open/);
+    expect(h.runCell).not.toHaveBeenCalled();
+  });
+
+  it('audits the run, keyed to the consent decision that permitted it', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+
+    await call(Channels.COMPUTE_RUN_CELL, 'python', 'print(1)', 'notes/a.md');
+
+    expect(h.runCell).toHaveBeenCalledWith('python', 'print(1)', { rootPath: ROOT, notePath: 'notes/a.md' });
+    expect(h.recordExecution).toHaveBeenCalledWith({
+      project: ROOT,
+      language: 'python',
+      code: 'print(1)',
+      // `editor` distinguishes a human-reviewed run from the LLM
+      // propose_compute path, which is the higher-risk one the trail cares about.
+      provenance: 'editor',
+      notePath: 'notes/a.md',
+      result: OK_RESULT,
+    });
+  });
+
+  it('omits notePath entirely when the cell has no note (not `notePath: undefined`)', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'sql', 'SELECT 1', 'cell');
+
+    await call(Channels.COMPUTE_RUN_CELL, 'sql', 'SELECT 1');
+
+    expect(h.runCell.mock.calls[0]?.[2]).not.toHaveProperty('notePath');
+    expect(h.recordExecution.mock.calls[0]?.[0]).not.toHaveProperty('notePath');
+  });
+
+  it("a failed cell RESOLVES its `{ ok: false }` arm and is still audited", async () => {
+    const failure = { ok: false, error: 'NameError: x is not defined' };
+    h.runCell.mockResolvedValue(failure);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'x', 'cell');
+
+    // A cell that errors is a normal input, not a bug — CLAUDE.md rule 3.
+    await expect(callAsync(Channels.COMPUTE_RUN_CELL, 'python', 'x')).resolves.toEqual(failure);
+    // A failure is the *most* interesting thing to have on the trail.
+    expect(h.recordExecution).toHaveBeenCalledWith(expect.objectContaining({ result: failure }));
+  });
+
+  it('propagates an executor crash (a thrown error is not a cell result)', async () => {
+    h.runCell.mockRejectedValue(new Error('kernel died'));
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'boom', 'cell');
+
+    await expect(callAsync(Channels.COMPUTE_RUN_CELL, 'python', 'boom')).rejects.toThrow(/kernel died/);
+    expect(h.recordExecution).not.toHaveBeenCalled();
+  });
+});
+
+describe('COMPUTE_CONSENT_STATUS / GRANT / LIST / REVOKE', () => {
+  it('reports none → cell → blanket as consent is granted', () => {
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'print(1)')).toBe('none');
+
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'print(1)')).toBe('cell');
+
+    // An eyes-on-code'd cell keeps reporting `cell` under blanket trust, so the
+    // conversation path can still tell "reviewed" from "merely trusted".
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'other', 'project');
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'print(1)')).toBe('cell');
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'unseen')).toBe('blanket');
+  });
+
+  it("with no project open answers 'none' — the fallback that FORCES a prompt", () => {
+    openProject = null;
+    // `withRootPathOr('none', …)`: the fallback is the conservative end of the
+    // scale, so a missing project can never be read as trust.
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'print(1)')).toBe('none');
+  });
+
+  it('anything other than the literal "project" scope grants only this cell', () => {
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'everything');
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'print(1)')).toBe('cell');
+    // No blanket trust leaked in from the unrecognised scope.
+    expect(call(Channels.COMPUTE_CONSENT_STATUS, 'python', 'something else')).toBe('none');
+  });
+
+  it('GRANT throws with no project — trust cannot be recorded against nothing', () => {
+    openProject = null;
+    expect(() => call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'project')).toThrow(/No project open/);
+    expect(fs.existsSync(consentFile())).toBe(false);
+  });
+
+  it('LIST and REVOKE are machine-scoped — they work with no project open', () => {
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'x', 'project');
+
+    // Settings → Compute has to show (and undo) trust for thoughtbases that
+    // aren't the open one, so these deliberately aren't `withRootPath`.
+    openProject = null;
+    expect(call(Channels.COMPUTE_LIST_CONSENT)).toEqual([
+      { rootPath: ROOT, blanket: true, cellCount: 1 },
+    ]);
+
+    call(Channels.COMPUTE_REVOKE_CONSENT, ROOT);
+    expect(call(Channels.COMPUTE_LIST_CONSENT)).toEqual([]);
+  });
+
+  it('a revoked thoughtbase prompts again on its next run', async () => {
+    h.runCell.mockResolvedValue(OK_RESULT);
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'cell');
+    call(Channels.COMPUTE_REVOKE_CONSENT, ROOT);
+
+    const result = await call(Channels.COMPUTE_RUN_CELL, 'python', 'print(1)');
+    expect(result).toEqual({ ok: false, error: expect.any(String) });
+    expect(h.runCell).not.toHaveBeenCalled();
+  });
+
+  it('revoking a thoughtbase that was never trusted is a no-op, not an error', () => {
+    expect(() => call(Channels.COMPUTE_REVOKE_CONSENT, '/never-seen')).not.toThrow();
+  });
+
+  it('hashes are stored, not the code itself', () => {
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'API_KEY = "hunter2"', 'cell');
+    const stored = fs.readFileSync(consentFile(), 'utf-8');
+    // The consent store sits in userData forever; it must not become a copy of
+    // every cell the user has ever run.
+    expect(stored).not.toContain('hunter2');
+    expect(stored).toContain(cellHash('python', 'API_KEY = "hunter2"'));
+  });
+});
+
+describe('python kernel handlers', () => {
+  it('COMPUTE_RESTART_PYTHON_KERNEL restarts the open project\'s kernel', async () => {
+    await call(Channels.COMPUTE_RESTART_PYTHON_KERNEL);
+    expect(h.restartKernel).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('COMPUTE_RESTART_PYTHON_KERNEL is a no-op with no project (there is no kernel)', async () => {
+    openProject = null;
+    await expect(callAsync(Channels.COMPUTE_RESTART_PYTHON_KERNEL)).resolves.toBeUndefined();
+    expect(h.restartKernel).not.toHaveBeenCalled();
+  });
+
+  it('COMPUTE_INTERRUPT_PYTHON passes the kernel\'s result through, both arms', async () => {
+    h.interruptKernel.mockReturnValue({ ok: true });
+    await expect(callAsync(Channels.COMPUTE_INTERRUPT_PYTHON)).resolves.toEqual({ ok: true });
+
+    // The failure arm RESOLVES; a renderer branching on `ok` never also catches.
+    h.interruptKernel.mockReturnValue({ ok: false, reason: 'unsupported-platform' });
+    await expect(callAsync(Channels.COMPUTE_INTERRUPT_PYTHON))
+      .resolves.toEqual({ ok: false, reason: 'unsupported-platform' });
+  });
+
+  it('COMPUTE_INTERRUPT_PYTHON with no project answers the same "no-kernel" a real interrupt would', async () => {
+    openProject = null;
+    // `withRootPathOr({ ok: false, reason: 'no-kernel' }, …)` is legitimate
+    // under #1631 rule 2: with no project there IS no kernel, so the fallback
+    // means exactly what a genuine miss means — it isn't "error" in disguise.
+    await expect(callAsync(Channels.COMPUTE_INTERRUPT_PYTHON))
+      .resolves.toEqual({ ok: false, reason: 'no-kernel' });
+    expect(h.interruptKernel).not.toHaveBeenCalled();
+  });
+});
+
+describe('python settings handlers', () => {
+  it('COMPUTE_GET_PYTHON_SETTINGS reads the per-machine settings', async () => {
+    h.getPythonSettings.mockResolvedValue({ pythonPath: '/usr/bin/python3', allowNetwork: true });
+    await expect(callAsync(Channels.COMPUTE_GET_PYTHON_SETTINGS))
+      .resolves.toEqual({ pythonPath: '/usr/bin/python3', allowNetwork: true });
+  });
+
+  it('COMPUTE_SET_PYTHON_SETTINGS stores what it was given', async () => {
+    await call(Channels.COMPUTE_SET_PYTHON_SETTINGS, { pythonPath: '/opt/py', allowNetwork: true });
+    expect(h.setPythonSettings).toHaveBeenCalledWith({ pythonPath: '/opt/py', allowNetwork: true });
+  });
+
+  it('COMPUTE_SET_PYTHON_SETTINGS coerces a malformed payload to the safe defaults', async () => {
+    // `allowNetwork` gates outbound network access from user code, so anything
+    // that isn't literally `true` has to land on `false`.
+    await call(Channels.COMPUTE_SET_PYTHON_SETTINGS, { pythonPath: 42, allowNetwork: 'yes' });
+    expect(h.setPythonSettings).toHaveBeenCalledWith({ pythonPath: '', allowNetwork: false });
+  });
+
+  it('COMPUTE_SET_PYTHON_SETTINGS survives a missing payload', async () => {
+    await call(Channels.COMPUTE_SET_PYTHON_SETTINGS, undefined);
+    expect(h.setPythonSettings).toHaveBeenCalledWith({ pythonPath: '', allowNetwork: false });
+  });
+
+  it('COMPUTE_PROBE_PYTHON probes the candidate the caller named', async () => {
+    h.probePythonInterpreter.mockResolvedValue({ ok: true, path: '/opt/py', version: 'Python 3.12.0' });
+    await expect(callAsync(Channels.COMPUTE_PROBE_PYTHON, '/opt/py'))
+      .resolves.toEqual({ ok: true, path: '/opt/py', version: 'Python 3.12.0' });
+    expect(h.resolvePythonInterpreter).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, '', '   '])('COMPUTE_PROBE_PYTHON probes the ACTIVE interpreter for %j', async (candidate) => {
+    // An empty box in Settings means "whatever we'd pick right now", which is
+    // the resolver's answer — not a literal empty path.
+    h.resolvePythonInterpreter.mockResolvedValue('/usr/bin/python3');
+    h.probePythonInterpreter.mockResolvedValue({ ok: true, path: '/usr/bin/python3' });
+
+    await call(Channels.COMPUTE_PROBE_PYTHON, candidate);
+    expect(h.probePythonInterpreter).toHaveBeenCalledWith('/usr/bin/python3');
+  });
+
+  it('COMPUTE_PROBE_PYTHON RESOLVES a failed probe rather than rejecting', async () => {
+    h.probePythonInterpreter.mockResolvedValue({ ok: false, path: '/nope', error: 'ENOENT' });
+    // A bad interpreter path is a normal thing to type; Settings renders it inline.
+    await expect(callAsync(Channels.COMPUTE_PROBE_PYTHON, '/nope'))
+      .resolves.toEqual({ ok: false, path: '/nope', error: 'ENOENT' });
+  });
+
+  it('COMPUTE_BROWSE_PYTHON returns the picked interpreter', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/opt/homebrew/bin/python3'] });
+    await expect(callAsync(Channels.COMPUTE_BROWSE_PYTHON)).resolves.toBe('/opt/homebrew/bin/python3');
+    expect(h.showOpenDialog).toHaveBeenCalledWith(h.win, expect.objectContaining({ properties: expect.any(Array) }));
+  });
+
+  it.each([
+    ['cancelled', { canceled: true, filePaths: [] }],
+    ['dismissed with an empty selection', { canceled: false, filePaths: [] }],
+  ])('COMPUTE_BROWSE_PYTHON returns null when the picker is %s', async (_label, dialogResult) => {
+    // `null` here has exactly one meaning — the user didn't pick (#1631 rule 5).
+    h.showOpenDialog.mockResolvedValue(dialogResult);
+    await expect(callAsync(Channels.COMPUTE_BROWSE_PYTHON)).resolves.toBeNull();
+  });
+});
+
+describe('COMPUTE_REVEAL_AUDIT_LOG', () => {
+  it('creates the log before revealing it, so a machine that never ran a cell still works', () => {
+    const logPath = path.join(h.userData.dir, 'fresh', 'compute-audit.jsonl');
+    h.auditLogPath.mockReturnValue(logPath);
+
+    call(Channels.COMPUTE_REVEAL_AUDIT_LOG);
+
+    expect(fs.existsSync(logPath)).toBe(true);
+    expect(h.showItemInFolder).toHaveBeenCalledWith(logPath);
+  });
+
+  it('leaves an existing log untouched', () => {
+    const logPath = path.join(h.userData.dir, 'existing', 'compute-audit.jsonl');
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.writeFileSync(logPath, '{"at":"2026-01-01T00:00:00Z"}\n', 'utf-8');
+    h.auditLogPath.mockReturnValue(logPath);
+
+    call(Channels.COMPUTE_REVEAL_AUDIT_LOG);
+
+    expect(fs.readFileSync(logPath, 'utf-8')).toBe('{"at":"2026-01-01T00:00:00Z"}\n');
+  });
+
+  it('still reveals when the log cannot be created', () => {
+    // A blocked parent (here: a file where a directory should be) is a reveal
+    // that shows nothing useful — but it must not reject the IPC.
+    const blocker = path.join(h.userData.dir, 'blocked');
+    fs.writeFileSync(blocker, 'not a directory', 'utf-8');
+    h.auditLogPath.mockReturnValue(path.join(blocker, 'compute-audit.jsonl'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => call(Channels.COMPUTE_REVEAL_AUDIT_LOG)).not.toThrow();
+    expect(h.showItemInFolder).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('the remaining delegations', () => {
+  it('COMPUTE_LANGUAGES lists the registered executors, project or not', () => {
+    h.registeredLanguages.mockReturnValue(['python', 'sql', 'sparql']);
+    expect(call(Channels.COMPUTE_LANGUAGES)).toEqual(['python', 'sql', 'sparql']);
+
+    // Which languages CAN run is a property of the build, not of the project.
+    openProject = null;
+    expect(call(Channels.COMPUTE_LANGUAGES)).toEqual(['python', 'sql', 'sparql']);
+  });
+
+  it('COMPUTE_SAVE_CELL_OUTPUT writes through to the open project', async () => {
+    h.saveCellOutput.mockResolvedValue({ kind: 'written', path: 'data/out.csv' });
+    const input = { format: 'csv', notePath: 'notes/a.md', cellId: 'c1' };
+
+    await expect(callAsync(Channels.COMPUTE_SAVE_CELL_OUTPUT, input))
+      .resolves.toEqual({ kind: 'written', path: 'data/out.csv' });
+    expect(h.saveCellOutput).toHaveBeenCalledWith(ROOT, input);
+  });
+
+  it('COMPUTE_SAVE_CELL_OUTPUT throws with no project rather than writing somewhere', async () => {
+    openProject = null;
+    await expect(callAsync(Channels.COMPUTE_SAVE_CELL_OUTPUT, {})).rejects.toThrow(/No project open/);
+    expect(h.saveCellOutput).not.toHaveBeenCalled();
+  });
+});

--- a/tests/main/ipc/register-publish.test.ts
+++ b/tests/main/ipc/register-publish.test.ts
@@ -1,0 +1,502 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-publish.ts` (#1840).
+ *
+ * Export + publish is the one path that writes files OUTSIDE the thoughtbase,
+ * so what this registrar does with its arguments matters more than usual. It
+ * drives the real `registerPublish()` with the publish engine mocked and pins:
+ *
+ *   - the #1631 guard: every project-scoped handler THROWS with no project,
+ *     while the two connection checks (S3 / GitHub) and the exporter listing
+ *     deliberately work without one — they don't read the thoughtbase;
+ *   - `PUBLISH_RESOLVE_PLAN` strips `content`/`frontmatter` off every input
+ *     before it crosses IPC (the preview needs paths and kinds, not the text
+ *     of every file in the project) and only forwards the options the caller
+ *     actually set;
+ *   - `PUBLISH_RUN_EXPORT` opens the destination picker only when the renderer
+ *     didn't already choose one, and a cancelled picker means `null` and
+ *     nothing written — `null`'s ONE documented meaning here (#1631 rule 5);
+ *   - `PUBLISH_TO_GIT` is a sanctioned `{ ok, … }` union (CLAUDE.md rule 3):
+ *     auth / network / non-fast-forward come back as `{ ok: false, error }`
+ *     carrying the raw git message rather than a stringified rejection.
+ *
+ * `withRootPath*` are re-implemented in the helpers mock with the real
+ * semantics (helpers.ts drags in electron + graph/search/vectors, so it can't
+ * be imported here); what's under test is WHICH wrapper each handler picked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  win: { id: 1, isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
+  // electron
+  showOpenDialog: vi.fn(),
+  getVersion: vi.fn(() => '1.2.3'),
+  // publish engine
+  listExporters: vi.fn(),
+  getExporter: vi.fn(),
+  resolvePlan: vi.fn(),
+  runExport: vi.fn(),
+  publishTarget: vi.fn(),
+  checkS3Connection: vi.fn(),
+  checkGitHubToken: vi.fn(),
+  // csl
+  buildCitationAudit: vi.fn(),
+  getMergedStyles: vi.fn(),
+  getMergedLocales: vi.fn(),
+  // project config
+  getPublishTargets: vi.fn(),
+  upsertPublishTarget: vi.fn(),
+  removePublishTarget: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+  dialog: { showOpenDialog: h.showOpenDialog },
+  app: { getVersion: h.getVersion },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathWin:
+    <A extends unknown[], R>(fn: (rootPath: string, win: unknown, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, h.win, ...args);
+      },
+}));
+
+// The publish barrel re-exports the whole engine; only what the registrar
+// reaches for is stubbed, plus the real EXPORT_GROUPS table (it's a constant —
+// stubbing it would make the group-metadata assertion tautological).
+vi.mock('../../../src/main/publish', async () => {
+  const { EXPORT_GROUPS } = await import('../../../src/main/publish/types');
+  return {
+    EXPORT_GROUPS,
+    listExporters: h.listExporters,
+    getExporter: h.getExporter,
+    resolvePlan: h.resolvePlan,
+    runExport: h.runExport,
+    publishTarget: h.publishTarget,
+    checkS3Connection: h.checkS3Connection,
+  };
+});
+vi.mock('../../../src/main/publish/csl/audit', () => ({ buildCitationAudit: h.buildCitationAudit }));
+vi.mock('../../../src/main/publish/csl/user-assets', () => ({
+  getMergedStyles: h.getMergedStyles,
+  getMergedLocales: h.getMergedLocales,
+}));
+vi.mock('../../../src/main/git/publish-git', () => ({ checkGitHubToken: h.checkGitHubToken }));
+vi.mock('../../../src/main/project-config', () => ({
+  getPublishTargets: h.getPublishTargets,
+  upsertPublishTarget: h.upsertPublishTarget,
+  removePublishTarget: h.removePublishTarget,
+}));
+
+import { registerPublish } from '../../../src/main/ipc/register-publish';
+import { Channels } from '../../../src/shared/channels';
+import { EXPORT_GROUPS } from '../../../src/main/publish/types';
+import { DEFAULT_STYLE } from '../../../src/main/publish/csl/assets';
+
+registerPublish();
+
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!({}, ...args);
+const callAsync = (channel: string, ...args: unknown[]): Promise<unknown> =>
+  Promise.resolve(call(channel, ...args));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  openProject = ROOT;
+  h.getVersion.mockReturnValue('1.2.3');
+  h.listExporters.mockReturnValue([]);
+  h.getMergedStyles.mockResolvedValue({ styles: { apa: '<xml/>' }, labels: { apa: 'APA' }, userIds: new Set() });
+  h.getMergedLocales.mockResolvedValue({ locales: { 'en-US': '<xml/>' }, userIds: new Set() });
+  h.buildCitationAudit.mockReturnValue({ bySource: [], missing: [] });
+  h.getPublishTargets.mockReturnValue([]);
+});
+
+describe('register-publish — the #1631 project guard', () => {
+  const throwers: [string, unknown[]][] = [
+    [Channels.PUBLISH_RESOLVE_PLAN, [{ kind: 'project' }]],
+    [Channels.PUBLISH_RUN_EXPORT, [{ exporterId: 'markdown', input: { kind: 'project' } }]],
+    [Channels.PUBLISH_LIST_TARGETS, []],
+    [Channels.PUBLISH_UPSERT_TARGET, [{ id: 't1', label: 'Site', exporter: 'site', kind: 'git' }]],
+    [Channels.PUBLISH_REMOVE_TARGET, ['t1']],
+    [Channels.PUBLISH_TO_GIT, ['t1']],
+  ];
+
+  it.each(throwers)('%s throws with no project open', (channel, args) => {
+    openProject = null;
+    expect(() => call(channel, ...args)).toThrow('No project open');
+  });
+
+  it('nothing is exported, published or saved when there is no project', () => {
+    openProject = null;
+    for (const [channel, args] of throwers) {
+      try { call(channel, ...args); } catch { /* asserted above */ }
+    }
+    expect(h.runExport).not.toHaveBeenCalled();
+    expect(h.publishTarget).not.toHaveBeenCalled();
+    expect(h.upsertPublishTarget).not.toHaveBeenCalled();
+    expect(h.removePublishTarget).not.toHaveBeenCalled();
+    expect(h.showOpenDialog).not.toHaveBeenCalled();
+  });
+
+  it('PUBLISH_TO_GIT throws rather than reporting { ok: false } for a missing project', () => {
+    // The union is for EXPECTED publish outcomes (auth, network, rejected
+    // push). "There is no thoughtbase to publish" is not one of them, and
+    // folding it in would put a nonsense message in the dialog.
+    openProject = null;
+    expect(() => call(Channels.PUBLISH_TO_GIT, 't1')).toThrow('No project open');
+  });
+
+  it('PUBLISH_LIST_EXPORTERS answers without a project — the registry is static', () => {
+    openProject = null;
+    h.listExporters.mockReturnValue([]);
+    expect(call(Channels.PUBLISH_LIST_EXPORTERS)).toEqual([]);
+  });
+
+  it.each([
+    [Channels.PUBLISH_CHECK_S3, [{ bucket: 'b' }], 'checkS3Connection'],
+    [Channels.PUBLISH_CHECK_GITHUB, [{ token: 'ghp_x' }], 'checkGitHubToken'],
+  ] as const)('%s runs without a project — it only tests credentials', async (channel, args, fn) => {
+    openProject = null;
+    h[fn].mockResolvedValue({ ok: true });
+    await expect(callAsync(channel, ...args)).resolves.toEqual({ ok: true });
+  });
+});
+
+describe('register-publish — PUBLISH_LIST_EXPORTERS', () => {
+  it('carries the format-first menu metadata for each exporter', () => {
+    h.listExporters.mockReturnValue([
+      { id: 'markdown', label: 'Markdown (verbatim)', group: 'markdown', variantLabel: 'Verbatim', variantOrder: 1, acceptedKinds: ['single-note', 'folder', 'project', 'tree'] },
+    ]);
+
+    expect(call(Channels.PUBLISH_LIST_EXPORTERS)).toEqual([{
+      id: 'markdown',
+      label: 'Markdown (verbatim)',
+      acceptedKinds: ['single-note', 'folder', 'project', 'tree'],
+      group: EXPORT_GROUPS.markdown,
+      variantLabel: 'Verbatim',
+      variantOrder: 1,
+    }]);
+  });
+
+  it('defaults an exporter that declared no kinds to the non-tree scopes', () => {
+    // `tree` is opt-in: only exporters that know how to walk a wiki-link
+    // closure should offer it, so the default must NOT include it.
+    h.listExporters.mockReturnValue([{ id: 'pdf', label: 'PDF', group: 'pdf' }]);
+
+    const [listed] = call(Channels.PUBLISH_LIST_EXPORTERS) as { acceptedKinds: string[]; variantOrder: number }[];
+    expect(listed?.acceptedKinds).toEqual(['single-note', 'folder', 'project']);
+    expect(listed?.acceptedKinds).not.toContain('tree');
+    // An undeclared variant sorts first rather than becoming NaN/undefined in
+    // the dialog's sort.
+    expect(listed?.variantOrder).toBe(0);
+  });
+
+  it('drops the exporter function itself — only serialisable metadata crosses IPC', () => {
+    h.listExporters.mockReturnValue([
+      { id: 'html', label: 'HTML', group: 'html', run: () => { throw new Error('never'); } },
+    ]);
+    const [listed] = call(Channels.PUBLISH_LIST_EXPORTERS) as Record<string, unknown>[];
+    expect(listed).not.toHaveProperty('run');
+    expect(Object.keys(listed ?? {}).sort())
+      .toEqual(['acceptedKinds', 'group', 'id', 'label', 'variantLabel', 'variantOrder']);
+  });
+});
+
+describe('register-publish — PUBLISH_RESOLVE_PLAN', () => {
+  const plan = (over: Record<string, unknown> = {}) => ({
+    inputs: [
+      { relativePath: 'a.md', kind: 'note', title: 'A', content: '# A\n\nlots of text', frontmatter: { tags: ['x'] } },
+    ],
+    excluded: [{ relativePath: 'draft.md', reason: 'excluded-by-frontmatter' }],
+    ...over,
+  });
+
+  it('strips file bodies out of the preview payload', async () => {
+    // Sending every file's text over IPC to render a list of paths is pure
+    // waste on a project-scoped export.
+    h.resolvePlan.mockResolvedValue(plan());
+    h.getExporter.mockReturnValue({ id: 'markdown', label: 'Markdown' });
+
+    const result = await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }, { exporterId: 'markdown' }) as {
+      inputs: Record<string, unknown>[]; excluded: unknown[]; exporterId: string; exporterLabel: string;
+    };
+
+    expect(result.inputs).toEqual([{ relativePath: 'a.md', kind: 'note', title: 'A', overridden: false }]);
+    expect(result.excluded).toEqual([{ relativePath: 'draft.md', reason: 'excluded-by-frontmatter' }]);
+    expect(result.exporterId).toBe('markdown');
+    expect(result.exporterLabel).toBe('Markdown');
+  });
+
+  it('keeps an explicit include/exclude override visible in the preview', async () => {
+    h.resolvePlan.mockResolvedValue(plan({
+      inputs: [{ relativePath: 'a.md', kind: 'note', title: 'A', content: 'x', overridden: true }],
+    }));
+    const result = await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }) as { inputs: { overridden: boolean }[] };
+    expect(result.inputs[0]?.overridden).toBe(true);
+  });
+
+  it('forwards only the options the caller actually set', async () => {
+    // Passing `undefined` through would override a resolved default with
+    // nothing — `exactOptionalPropertyTypes` is on for a reason.
+    h.resolvePlan.mockResolvedValue(plan());
+    await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }, { exporterId: 'markdown', citationStyle: 'ieee' });
+    expect(h.resolvePlan).toHaveBeenCalledWith(ROOT, { kind: 'project' }, { citationStyle: 'ieee' });
+  });
+
+  it('passes no options at all when the caller gave none', async () => {
+    h.resolvePlan.mockResolvedValue(plan());
+    await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'single-note', relativePath: 'a.md' });
+    expect(h.resolvePlan).toHaveBeenCalledWith(ROOT, { kind: 'single-note', relativePath: 'a.md' }, {});
+  });
+
+  it('forwards the force-include/exclude lists the preview checkboxes produce', async () => {
+    h.resolvePlan.mockResolvedValue(plan());
+    await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }, {
+      linkPolicy: 'rewrite', forceInclude: ['draft.md'], forceExclude: ['a.md'],
+    });
+    expect(h.resolvePlan).toHaveBeenCalledWith(ROOT, { kind: 'project' }, {
+      linkPolicy: 'rewrite', forceInclude: ['draft.md'], forceExclude: ['a.md'],
+    });
+  });
+
+  it('reports an empty citation audit and the default style when the plan has no citations', async () => {
+    h.resolvePlan.mockResolvedValue(plan());
+
+    const result = await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }) as {
+      citations: { styleId: string; localeId: string; bySource: unknown[]; missing: unknown[] };
+      exporterId: string; exporterLabel: string;
+    };
+
+    // No citations in the plan means no audit to run at all…
+    expect(h.buildCitationAudit).not.toHaveBeenCalled();
+    expect(result.citations.bySource).toEqual([]);
+    expect(result.citations.missing).toEqual([]);
+    // …and the picker still needs a style selected, so it falls back.
+    expect(result.citations.styleId).toBe(DEFAULT_STYLE);
+    expect(result.citations.localeId).toBe('en-US');
+    // No exporterId asked for → empty strings, not undefined: the dialog binds
+    // these straight into its header.
+    expect(result.exporterId).toBe('');
+    expect(result.exporterLabel).toBe('');
+    expect(h.getExporter).not.toHaveBeenCalled();
+  });
+
+  it('audits the citations against the plan inputs when there are some', async () => {
+    h.resolvePlan.mockResolvedValue(plan({ citations: { styleId: 'ieee', localeId: 'en-GB' } }));
+    h.buildCitationAudit.mockReturnValue({ bySource: [{ sourceId: 's1', count: 2 }], missing: [{ key: 'nope' }] });
+
+    const result = await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }) as {
+      citations: { styleId: string; localeId: string; bySource: unknown[]; missing: unknown[] };
+    };
+
+    // The audit reads the FULL inputs (with content) — that's the only place
+    // the citation keys live, and it's also why they can be stripped after.
+    expect(h.buildCitationAudit).toHaveBeenCalledWith(
+      [expect.objectContaining({ relativePath: 'a.md', content: '# A\n\nlots of text' })],
+      { styleId: 'ieee', localeId: 'en-GB' },
+    );
+    expect(result.citations.styleId).toBe('ieee');
+    expect(result.citations.localeId).toBe('en-GB');
+    expect(result.citations.missing).toEqual([{ key: 'nope' }]);
+  });
+
+  it('offers the project-scoped style registry — bundled plus user-imported', async () => {
+    // #302: the picker has to reflect whatever the user dropped into the
+    // project, without a second roundtrip.
+    h.resolvePlan.mockResolvedValue(plan());
+    h.getMergedStyles.mockResolvedValue({
+      styles: { apa: '<x/>', 'my-house-style': '<x/>' },
+      labels: { apa: 'APA' },
+      userIds: new Set(['my-house-style']),
+    });
+    h.getMergedLocales.mockResolvedValue({ locales: { 'en-US': '<x/>', 'de-DE': '<x/>' }, userIds: new Set() });
+
+    const result = await callAsync(Channels.PUBLISH_RESOLVE_PLAN, { kind: 'project' }) as {
+      citations: { availableStyles: { id: string; label: string }[]; availableLocales: { id: string; label: string }[] };
+    };
+
+    expect(h.getMergedStyles).toHaveBeenCalledWith(ROOT);
+    expect(result.citations.availableStyles).toEqual([
+      { id: 'apa', label: 'APA' },
+      // A user style with no <title> falls back to its id rather than
+      // rendering a blank row in the picker.
+      { id: 'my-house-style', label: 'my-house-style' },
+    ]);
+    expect(result.citations.availableLocales).toEqual([
+      { id: 'en-US', label: 'en-US' },
+      { id: 'de-DE', label: 'de-DE' },
+    ]);
+  });
+});
+
+describe('register-publish — PUBLISH_RUN_EXPORT', () => {
+  it('exports straight to a destination the renderer already chose', async () => {
+    h.runExport.mockResolvedValue({ files: 3, outputDir: '/out' });
+
+    await expect(callAsync(Channels.PUBLISH_RUN_EXPORT, { exporterId: 'markdown', input: { kind: 'project' }, outputDir: '/out' }))
+      .resolves.toEqual({ files: 3, outputDir: '/out' });
+
+    expect(h.showOpenDialog).not.toHaveBeenCalled();
+    expect(h.runExport).toHaveBeenCalledWith(ROOT, { exporterId: 'markdown', input: { kind: 'project' }, outputDir: '/out' });
+  });
+
+  it('asks for a destination, parented to the invoking window, when none was given', async () => {
+    // Parenting matters: an unparented picker floats as a sheet the user can
+    // lose behind the main window.
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/picked'] });
+    h.runExport.mockResolvedValue({ files: 1 });
+
+    await callAsync(Channels.PUBLISH_RUN_EXPORT, { exporterId: 'markdown', input: { kind: 'project' } });
+
+    expect(h.showOpenDialog).toHaveBeenCalledWith(h.win, expect.objectContaining({
+      properties: ['openDirectory', 'createDirectory'],
+    }));
+    expect(h.runExport).toHaveBeenCalledWith(ROOT, { exporterId: 'markdown', input: { kind: 'project' }, outputDir: '/picked' });
+  });
+
+  it.each([
+    ['cancelled', { canceled: true, filePaths: [] }],
+    ['dismissed with no directory', { canceled: false, filePaths: [] }],
+  ])('writes nothing when the picker is %s', async (_label, dialogResult) => {
+    // `null` here means exactly one thing — the user backed out (#1631 rule 5).
+    h.showOpenDialog.mockResolvedValue(dialogResult);
+    await expect(callAsync(Channels.PUBLISH_RUN_EXPORT, { exporterId: 'markdown', input: { kind: 'project' } }))
+      .resolves.toBeNull();
+    expect(h.runExport).not.toHaveBeenCalled();
+  });
+
+  it('lets an export failure reject rather than dressing it up as a result', async () => {
+    h.runExport.mockRejectedValue(new Error('EACCES /out'));
+    await expect(callAsync(Channels.PUBLISH_RUN_EXPORT, { exporterId: 'markdown', input: { kind: 'project' }, outputDir: '/out' }))
+      .rejects.toThrow('EACCES /out');
+  });
+});
+
+describe('register-publish — publish targets', () => {
+  it('PUBLISH_LIST_TARGETS reads the project config', () => {
+    h.getPublishTargets.mockReturnValue([{ id: 't1', label: 'Site', exporter: 'site', kind: 'git' }]);
+    expect(call(Channels.PUBLISH_LIST_TARGETS)).toEqual([{ id: 't1', label: 'Site', exporter: 'site', kind: 'git' }]);
+    expect(h.getPublishTargets).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('PUBLISH_UPSERT_TARGET answers with the list AFTER the save', () => {
+    // The settings UI rebinds from this return value, so it has to be the
+    // post-write state — re-reading rather than echoing the argument is what
+    // makes a secret-stripping / normalising store visible to the caller.
+    const target = { id: 't1', label: 'Site', exporter: 'site', kind: 'git' as const };
+    const stored = [{ ...target, token: undefined }];
+    h.upsertPublishTarget.mockImplementation(() => { h.getPublishTargets.mockReturnValue(stored); });
+
+    expect(call(Channels.PUBLISH_UPSERT_TARGET, target)).toEqual(stored);
+    expect(h.upsertPublishTarget).toHaveBeenCalledWith(ROOT, target);
+  });
+
+  it('PUBLISH_REMOVE_TARGET answers with the list AFTER the removal', () => {
+    h.getPublishTargets.mockReturnValue([{ id: 't2', label: 'Other', exporter: 'site', kind: 'git' }]);
+    expect(call(Channels.PUBLISH_REMOVE_TARGET, 't1'))
+      .toEqual([{ id: 't2', label: 'Other', exporter: 'site', kind: 'git' }]);
+    expect(h.removePublishTarget).toHaveBeenCalledWith(ROOT, 't1');
+  });
+});
+
+describe('register-publish — PUBLISH_TO_GIT', () => {
+  it('reports success with the transport result', async () => {
+    h.publishTarget.mockResolvedValue({ commit: 'abc123', pushed: true });
+    await expect(callAsync(Channels.PUBLISH_TO_GIT, 't1'))
+      .resolves.toEqual({ ok: true, result: { commit: 'abc123', pushed: true } });
+  });
+
+  it('stamps the app version and defaults to a real push', async () => {
+    h.publishTarget.mockResolvedValue({});
+    await callAsync(Channels.PUBLISH_TO_GIT, 't1');
+    // The version goes into the commit message, so a published site can be
+    // traced back to the build that produced it.
+    expect(h.publishTarget).toHaveBeenCalledWith(ROOT, 't1', { dryRun: false, version: '1.2.3' });
+  });
+
+  it('passes dryRun through for the preview, and createRepo only when asked', async () => {
+    h.publishTarget.mockResolvedValue({});
+    await callAsync(Channels.PUBLISH_TO_GIT, 't1', { dryRun: true, createRepo: { private: true } });
+    expect(h.publishTarget).toHaveBeenCalledWith(ROOT, 't1', {
+      dryRun: true, version: '1.2.3', createRepo: { private: true },
+    });
+  });
+
+  it('turns an auth / network / rejected-push failure into { ok: false } with the raw message', async () => {
+    // A sanctioned discriminated union (CLAUDE.md #1631 rule 3): the dialog
+    // shows git's own words verbatim, which is what makes "non-fast-forward"
+    // actionable. Honest caveat — the catch is unconditional, so a programming
+    // error inside the transport also arrives as `{ ok: false }` rather than
+    // surfacing as a crash.
+    h.publishTarget.mockRejectedValue(new Error('failed to push some refs (non-fast-forward)'));
+    await expect(callAsync(Channels.PUBLISH_TO_GIT, 't1'))
+      .resolves.toEqual({ ok: false, error: 'failed to push some refs (non-fast-forward)' });
+  });
+
+  it('stringifies a non-Error rejection rather than showing "[object Object]"', async () => {
+    h.publishTarget.mockRejectedValue('git exited with code 128');
+    await expect(callAsync(Channels.PUBLISH_TO_GIT, 't1'))
+      .resolves.toEqual({ ok: false, error: 'git exited with code 128' });
+  });
+});
+
+describe('register-publish — connection checks', () => {
+  it('PUBLISH_CHECK_S3 builds a throwaway target from the unsaved form', async () => {
+    // Validating BEFORE saving is the point — the user shouldn't have to
+    // persist a broken target to find out it's broken.
+    h.checkS3Connection.mockResolvedValue({ ok: true });
+
+    await callAsync(Channels.PUBLISH_CHECK_S3, {
+      bucket: 'notes', endpoint: 'https://s3.example', region: 'eu-west-1',
+      accessKeyId: 'AK', secretAccessKey: 'SK',
+    });
+
+    expect(h.checkS3Connection).toHaveBeenCalledWith(
+      { id: 'check', label: 'check', exporter: '', kind: 's3', bucket: 'notes', endpoint: 'https://s3.example', region: 'eu-west-1' },
+      { accessKeyId: 'AK', secretAccessKey: 'SK' },
+    );
+  });
+
+  it('PUBLISH_CHECK_S3 omits the optional fields the form left blank', async () => {
+    // Sending `endpoint: undefined` would override the SDK's own default.
+    h.checkS3Connection.mockResolvedValue({ ok: false, error: 'NoSuchBucket' });
+
+    await expect(callAsync(Channels.PUBLISH_CHECK_S3, { bucket: 'notes' }))
+      .resolves.toEqual({ ok: false, error: 'NoSuchBucket' });
+    expect(h.checkS3Connection).toHaveBeenCalledWith(
+      { id: 'check', label: 'check', exporter: '', kind: 's3', bucket: 'notes' },
+      {},
+    );
+  });
+
+  it('PUBLISH_CHECK_GITHUB tests the gh CLI / env fallback for a blank token', async () => {
+    // Matches what the push itself would resolve, so "check" and "publish"
+    // can't disagree about which credential is in play.
+    h.checkGitHubToken.mockResolvedValue({ ok: true, login: 'octocat' });
+    await callAsync(Channels.PUBLISH_CHECK_GITHUB, {});
+    expect(h.checkGitHubToken).toHaveBeenCalledWith(undefined);
+  });
+
+  it('PUBLISH_CHECK_GITHUB tests the typed token when one was entered', async () => {
+    h.checkGitHubToken.mockResolvedValue({ ok: false, error: 'Bad credentials' });
+    await expect(callAsync(Channels.PUBLISH_CHECK_GITHUB, { token: 'ghp_x' }))
+      .resolves.toEqual({ ok: false, error: 'Bad credentials' });
+    expect(h.checkGitHubToken).toHaveBeenCalledWith('ghp_x');
+  });
+});

--- a/tests/main/ipc/register-queries.test.ts
+++ b/tests/main/ipc/register-queries.test.ts
@@ -1,0 +1,265 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-queries.ts` (#1840).
+ *
+ * Saved queries are the one family in the IPC layer that is deliberately NOT
+ * project-scoped: a query can live in the thoughtbase (`project` scope) or on
+ * the machine (`global` scope), and the global ones have to be listable,
+ * renamable and reorderable with no project open at all. That's why these
+ * handlers reach for `rootPathFromEvent` directly instead of `withRootPath*` —
+ * `rootPath` is an *input* to the scope decision, not a precondition. This
+ * file pins that reading, and the two consequences that fall out of it:
+ *
+ *   - with no project open, `QUERIES_LIST` still answers the global queries,
+ *     and every non-scoped mutation still works;
+ *   - `QUERIES_MOVE` into project scope with no project open THROWS rather
+ *     than quietly landing the query somewhere else (#1631 rule 1).
+ *
+ * Plus the bookkeeping the native menu depends on: every mutation rebuilds the
+ * Query menu, and only after the store agreed the change happened. `SEARCH_QUERY`
+ * is the one `withRootPathOr` handler here — an empty result list is what a
+ * search with nothing to search returns, so the fallback is a legitimate value.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => {
+  /** Call-order log — the menu rebuild must follow the store mutation. */
+  const order: string[] = [];
+  return {
+    handlers: new Map<string, Handler>(),
+    order,
+    /** Wrap a store fn so its call lands in the order log before its result. */
+    logged: (name: string, fn: (...a: unknown[]) => unknown) =>
+      (...a: unknown[]) => { order.push(name); return fn(...a); },
+    listSavedQueries: vi.fn(),
+    saveQuery: vi.fn(),
+    deleteQuery: vi.fn(),
+    renameQuery: vi.fn(),
+    moveQueryScope: vi.fn(),
+    setQueryGroup: vi.fn(),
+    setQueryOrder: vi.fn(),
+    rebuildMenu: vi.fn(),
+    search: vi.fn(),
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  rootPathFromEvent: () => openProject,
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+}));
+
+vi.mock('../../../src/main/saved-queries', () => ({
+  listSavedQueries: h.listSavedQueries,
+  saveQuery: h.logged('saveQuery', h.saveQuery),
+  deleteQuery: h.logged('deleteQuery', h.deleteQuery),
+  renameQuery: h.logged('renameQuery', h.renameQuery),
+  moveQueryScope: h.logged('moveQueryScope', h.moveQueryScope),
+  setQueryGroup: h.logged('setQueryGroup', h.setQueryGroup),
+  setQueryOrder: h.logged('setQueryOrder', h.setQueryOrder),
+}));
+vi.mock('../../../src/main/menu', () => ({
+  rebuildMenu: (...a: unknown[]) => { h.order.push('rebuildMenu'); return h.rebuildMenu(...a); },
+}));
+vi.mock('../../../src/main/search/index', () => ({ search: h.search }));
+vi.mock('../../../src/main/project-context-types', () => ({
+  projectContext: (rootPath: string) => ({ rootPath }),
+}));
+
+import { registerQueries } from '../../../src/main/ipc/register-queries';
+import { Channels } from '../../../src/shared/channels';
+
+registerQueries();
+
+const call = (channel: string, ...args: unknown[]) => h.handlers.get(channel)!({}, ...args);
+
+const GLOBAL_QUERY = {
+  id: 'orphans', name: 'Orphans', description: '', query: 'SELECT *', language: 'sparql',
+  scope: 'global', filePath: '/home/u/.minerva/queries/orphans.sparql', group: null, order: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.order.length = 0;
+  openProject = ROOT;
+});
+
+describe('QUERIES_LIST', () => {
+  it('lists project + global queries when a thoughtbase is open', () => {
+    h.listSavedQueries.mockReturnValue([GLOBAL_QUERY]);
+    expect(call(Channels.QUERIES_LIST)).toEqual([GLOBAL_QUERY]);
+    expect(h.listSavedQueries).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('still answers the global queries with no project open', () => {
+    // `rootPath` is an input to the scope decision here, not a precondition:
+    // the store takes `string | null` and simply skips the project directory.
+    // A `withRootPath` guard would have hidden the user's machine-wide queries
+    // whenever they closed a thoughtbase.
+    openProject = null;
+    h.listSavedQueries.mockReturnValue([GLOBAL_QUERY]);
+
+    expect(call(Channels.QUERIES_LIST)).toEqual([GLOBAL_QUERY]);
+    expect(h.listSavedQueries).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('QUERIES_SAVE', () => {
+  it('saves, then rebuilds the Query menu', () => {
+    h.saveQuery.mockReturnValue(GLOBAL_QUERY);
+
+    const result = call(Channels.QUERIES_SAVE, 'project', 'Orphans', 'Notes nobody links to', 'SELECT *', 'sparql', 'Health');
+
+    expect(result).toEqual(GLOBAL_QUERY);
+    expect(h.saveQuery).toHaveBeenCalledWith(ROOT, 'project', 'Orphans', 'Notes nobody links to', 'SELECT *', 'sparql', 'Health');
+    // Rebuilding first would put an entry on the menu for a file that might
+    // not have been written.
+    expect(h.order).toEqual(['saveQuery', 'rebuildMenu']);
+  });
+
+  it('recognises exactly one language besides SPARQL', () => {
+    h.saveQuery.mockReturnValue(GLOBAL_QUERY);
+
+    call(Channels.QUERIES_SAVE, 'global', 'Rows', '', 'SELECT 1', 'sql');
+    expect(h.saveQuery).toHaveBeenLastCalledWith(ROOT, 'global', 'Rows', '', 'SELECT 1', 'sql', null);
+
+    // Anything unrecognised lands on SPARQL rather than reaching the store as a
+    // language it has no file extension for.
+    call(Channels.QUERIES_SAVE, 'global', 'Rows', '', 'SELECT 1', 'duckdb');
+    expect(h.saveQuery).toHaveBeenLastCalledWith(ROOT, 'global', 'Rows', '', 'SELECT 1', 'sparql', null);
+  });
+
+  it('defaults the group to null when the caller omits it', () => {
+    h.saveQuery.mockReturnValue(GLOBAL_QUERY);
+    call(Channels.QUERIES_SAVE, 'global', 'Rows', '', 'SELECT 1', 'sparql');
+    // `null` = ungrouped, and it has to be explicit: `undefined` would serialize
+    // an `@group` line reading "undefined".
+    expect(h.saveQuery).toHaveBeenCalledWith(ROOT, 'global', 'Rows', '', 'SELECT 1', 'sparql', null);
+  });
+
+  it('leaves the menu alone when the save failed', () => {
+    h.saveQuery.mockImplementation(() => { throw new Error('EACCES: permission denied'); });
+    expect(() => call(Channels.QUERIES_SAVE, 'global', 'Rows', '', 'SELECT 1', 'sparql')).toThrow(/EACCES/);
+    expect(h.rebuildMenu).not.toHaveBeenCalled();
+  });
+});
+
+describe('the file-addressed mutations work with or without a project', () => {
+  it('QUERIES_DELETE removes the query and rebuilds the menu', () => {
+    call(Channels.QUERIES_DELETE, GLOBAL_QUERY.filePath);
+    expect(h.deleteQuery).toHaveBeenCalledWith(GLOBAL_QUERY.filePath);
+    expect(h.order).toEqual(['deleteQuery', 'rebuildMenu']);
+  });
+
+  it('QUERIES_RENAME returns the new path and rebuilds the menu', () => {
+    h.renameQuery.mockReturnValue('/home/u/.minerva/queries/lonely-notes.sparql');
+
+    const result = call(Channels.QUERIES_RENAME, GLOBAL_QUERY.filePath, 'Lonely notes');
+
+    expect(result).toBe('/home/u/.minerva/queries/lonely-notes.sparql');
+    expect(h.order).toEqual(['renameQuery', 'rebuildMenu']);
+  });
+
+  it('QUERIES_RENAME propagates a failed rename and leaves the menu alone', () => {
+    h.renameQuery.mockImplementation(() => { throw new Error('ENOENT: no such file'); });
+    expect(() => call(Channels.QUERIES_RENAME, '/gone.sparql', 'New')).toThrow(/ENOENT/);
+    expect(h.rebuildMenu).not.toHaveBeenCalled();
+  });
+
+  it('QUERIES_SET_GROUP sets a group and clears it with null', () => {
+    call(Channels.QUERIES_SET_GROUP, GLOBAL_QUERY.filePath, 'Health');
+    expect(h.setQueryGroup).toHaveBeenCalledWith(GLOBAL_QUERY.filePath, 'Health');
+
+    call(Channels.QUERIES_SET_GROUP, GLOBAL_QUERY.filePath, null);
+    expect(h.setQueryGroup).toHaveBeenLastCalledWith(GLOBAL_QUERY.filePath, null);
+    expect(h.rebuildMenu).toHaveBeenCalledTimes(2);
+  });
+
+  it('QUERIES_SET_ORDER writes the whole ordering in one call', () => {
+    const entries = [{ filePath: '/a.sparql', order: 0 }, { filePath: '/b.sparql', order: null }];
+    call(Channels.QUERIES_SET_ORDER, entries);
+    expect(h.setQueryOrder).toHaveBeenCalledWith(entries);
+    expect(h.order).toEqual(['setQueryOrder', 'rebuildMenu']);
+  });
+
+  it.each([
+    [Channels.QUERIES_DELETE, ['/g.sparql']],
+    [Channels.QUERIES_SET_GROUP, ['/g.sparql', 'Health']],
+    [Channels.QUERIES_SET_ORDER, [[]]],
+  ])('%s still works on a global query with no project open', (channel, args) => {
+    openProject = null;
+    expect(() => call(channel, ...args)).not.toThrow();
+    expect(h.rebuildMenu).toHaveBeenCalled();
+  });
+});
+
+describe('QUERIES_MOVE', () => {
+  it('hands the open project to the store as the destination root', () => {
+    h.moveQueryScope.mockReturnValue('/vault/.minerva/queries/orphans.sparql');
+
+    const result = call(Channels.QUERIES_MOVE, GLOBAL_QUERY.filePath, 'project');
+
+    expect(result).toBe('/vault/.minerva/queries/orphans.sparql');
+    expect(h.moveQueryScope).toHaveBeenCalledWith(GLOBAL_QUERY.filePath, 'project', ROOT);
+    expect(h.order).toEqual(['moveQueryScope', 'rebuildMenu']);
+  });
+
+  it('moves a project query out to global scope', () => {
+    h.moveQueryScope.mockReturnValue('/home/u/.minerva/queries/orphans.sparql');
+    call(Channels.QUERIES_MOVE, '/vault/.minerva/queries/orphans.sparql', 'global');
+    expect(h.moveQueryScope).toHaveBeenCalledWith('/vault/.minerva/queries/orphans.sparql', 'global', ROOT);
+  });
+
+  it('throws when asked to move into a thoughtbase that is not open', () => {
+    // The store refuses this rather than silently writing to the global dir, and
+    // the handler lets the throw reach the renderer (#1631 rule 1) instead of
+    // reporting a path the query isn't at.
+    openProject = null;
+    h.moveQueryScope.mockImplementation(() => { throw new Error('Cannot move to Thoughtbase scope: no project open.'); });
+
+    expect(() => call(Channels.QUERIES_MOVE, GLOBAL_QUERY.filePath, 'project')).toThrow(/no project open/i);
+    expect(h.moveQueryScope).toHaveBeenCalledWith(GLOBAL_QUERY.filePath, 'project', null);
+    expect(h.rebuildMenu).not.toHaveBeenCalled();
+  });
+});
+
+describe('SEARCH_QUERY', () => {
+  it('searches the open project\'s index', async () => {
+    const hits = [{ path: 'notes/paxos.md', title: 'Paxos', excerpt: '…consensus…' }];
+    h.search.mockResolvedValue(hits);
+
+    await expect(call(Channels.SEARCH_QUERY, 'consensus')).resolves.toEqual(hits);
+    expect(h.search).toHaveBeenCalledWith({ rootPath: ROOT }, 'consensus');
+  });
+
+  it('answers an empty result list with no project open', async () => {
+    openProject = null;
+    // `withRootPathOr([], …)`: "no notes matched" is what a search over nothing
+    // means, so the fallback reads the same as a genuine miss — the results
+    // pane shows "no results", not an error.
+    await expect(call(Channels.SEARCH_QUERY, 'consensus')).resolves.toEqual([]);
+    expect(h.search).not.toHaveBeenCalled();
+  });
+
+  it('is the same empty answer a project with no matches gives', async () => {
+    h.search.mockResolvedValue([]);
+    const noMatches = await call(Channels.SEARCH_QUERY, 'zzzz');
+
+    openProject = null;
+    const noProject = await call(Channels.SEARCH_QUERY, 'zzzz');
+
+    expect(noProject).toEqual(noMatches);
+  });
+});

--- a/tests/main/ipc/register-small.test.ts
+++ b/tests/main/ipc/register-small.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Direct handler tests for the six smallest IPC registrars (#1840).
+ *
+ * `tags`, `sites`, `git`, `views`, `clipper` and `app` are each under 50 lines
+ * and were all in `KNOWN_UNTESTED`. They share a file because they share a
+ * harness and none of them justifies its own: what's interesting about them is
+ * mostly the project-scoping decision each handler makes, which is exactly what
+ * CLAUDE.md's #1631 rules are about and exactly what nothing was checking.
+ *
+ * Each `describe` drives the real `register*()` with its domain module mocked,
+ * and the project-scoping helpers reproduced (not stubbed away) so a handler
+ * that swaps `withRootPath` for `withRootPathOr` — or drops the guard — fails
+ * here rather than shipping.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+/** What `rootPathFromEvent` reports; `null` models "no project open". */
+let openProject: string | null = ROOT;
+
+const { handlers, listeners, h } = vi.hoisted(() => ({
+  handlers: new Map<string, (event: unknown, ...args: unknown[]) => unknown>(),
+  listeners: new Map<string, (event: unknown, ...args: unknown[]) => unknown>(),
+  h: {
+    // graph (tags)
+    listTags: vi.fn(), notesByTag: vi.fn(), notesByTagPrefix: vi.fn(),
+    sourcesByTag: vi.fn(), allTags: vi.fn(),
+    // privileged sites
+    listSites: vi.fn(), addSite: vi.fn(), removeSite: vi.fn(),
+    logoutSite: vi.fn(), openLoginWindow: vi.fn(),
+    // git
+    getStatus: vi.fn(), commitAll: vi.fn(),
+    // saved views
+    listSavedViews: vi.fn(), saveView: vi.fn(), deleteView: vi.fn(),
+    renameView: vi.fn(), setViewOrder: vi.fn(),
+    // clipper
+    getClipperConfig: vi.fn(), setClipperEnabled: vi.fn(), regenerateClipperSecret: vi.fn(),
+    getClipperInfo: vi.fn(), applyClipperConfigChange: vi.fn(),
+    // menu (app)
+    getMenuShortcuts: vi.fn(), setMenuThemeMode: vi.fn(), setMenuEditorState: vi.fn(),
+    fromWebContents: vi.fn(),
+  },
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: Handler) => { handlers.set(channel, fn); },
+    on: (channel: string, fn: Handler) => { listeners.set(channel, fn); },
+  },
+  app: { getName: () => 'Minerva', getVersion: () => '2.0.0-test' },
+  BrowserWindow: { fromWebContents: (...a: unknown[]) => h.fromWebContents(...a) },
+}));
+
+// The real project-scoping semantics, not a stub: `withRootPath` throws with no
+// project, `withRootPathOr` answers its fallback. A registrar that picks the
+// wrong one is the bug class these tests exist to catch.
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  rootPathFromEvent: () => openProject,
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+}));
+
+vi.mock('../../../src/main/graph/index', () => ({
+  listTags: h.listTags, notesByTag: h.notesByTag, notesByTagPrefix: h.notesByTagPrefix,
+  sourcesByTag: h.sourcesByTag, allTags: h.allTags,
+}));
+vi.mock('../../../src/main/project-context-types', () => ({
+  projectContext: (rootPath: string) => ({ rootPath }),
+}));
+vi.mock('../../../src/main/privileged-sites', () => ({
+  listSites: h.listSites, addSite: h.addSite, removeSite: h.removeSite,
+  logoutSite: h.logoutSite, openLoginWindow: h.openLoginWindow,
+}));
+vi.mock('../../../src/main/git/index', () => ({ getStatus: h.getStatus, commitAll: h.commitAll }));
+vi.mock('../../../src/main/saved-views', () => ({
+  listSavedViews: h.listSavedViews, saveView: h.saveView, deleteView: h.deleteView,
+  renameView: h.renameView, setViewOrder: h.setViewOrder,
+}));
+vi.mock('../../../src/main/clipper/clipper-config', () => ({
+  getClipperConfig: h.getClipperConfig,
+  setClipperEnabled: h.setClipperEnabled,
+  regenerateClipperSecret: h.regenerateClipperSecret,
+}));
+vi.mock('../../../src/main/clipper/lifecycle', () => ({ getClipperInfo: h.getClipperInfo }));
+vi.mock('../../../src/main/window-manager', () => ({ applyClipperConfigChange: h.applyClipperConfigChange }));
+vi.mock('../../../src/main/menu', () => ({
+  getMenuShortcuts: h.getMenuShortcuts,
+  setMenuThemeMode: h.setMenuThemeMode,
+  setMenuEditorState: h.setMenuEditorState,
+}));
+
+import { Channels } from '../../../src/shared/channels';
+import { registerTags } from '../../../src/main/ipc/register-tags';
+import { registerSites } from '../../../src/main/ipc/register-sites';
+import { registerGit } from '../../../src/main/ipc/register-git';
+import { registerViews } from '../../../src/main/ipc/register-views';
+import { registerClipper } from '../../../src/main/ipc/register-clipper';
+import { registerApp } from '../../../src/main/ipc/register-app';
+
+registerTags();
+registerSites();
+registerGit();
+registerViews();
+registerClipper();
+registerApp();
+
+const call = (channel: string, ...args: unknown[]) => handlers.get(channel)!({}, ...args);
+const send = (channel: string, event: unknown, ...args: unknown[]) => listeners.get(channel)!(event, ...args);
+
+beforeEach(() => {
+  openProject = ROOT;
+  vi.clearAllMocks();
+});
+
+describe('register-tags (#1840)', () => {
+  const cases: Array<[string, unknown[], keyof typeof h]> = [
+    [Channels.TAGS_LIST, [], 'listTags'],
+    [Channels.TAGS_NOTES_BY_TAG, ['x'], 'notesByTag'],
+    [Channels.TAGS_NOTES_BY_TAG_PREFIX, ['x/'], 'notesByTagPrefix'],
+    [Channels.TAGS_SOURCES_BY_TAG, ['x'], 'sourcesByTag'],
+    [Channels.TAGS_ALL_NAMES, [], 'allTags'],
+  ];
+
+  it.each(cases)('%s answers with an empty list and no graph read when no project is open', (channel, args, fn) => {
+    // Every handler here is `withRootPathOr([])`, and that is the right call:
+    // "no project" and "a project with no tags" both render as an empty panel,
+    // so the fallback isn't an error wearing a value's clothes (#1631 rule 2).
+    openProject = null;
+    expect(call(channel, ...args)).toEqual([]);
+    expect(h[fn]).not.toHaveBeenCalled();
+  });
+
+  it('scopes each read to the open project', () => {
+    h.listTags.mockReturnValue([{ tag: 'a', noteCount: 1, sourceCount: 0 }]);
+    expect(call(Channels.TAGS_LIST)).toEqual([{ tag: 'a', noteCount: 1, sourceCount: 0 }]);
+    expect(h.listTags).toHaveBeenCalledWith({ rootPath: ROOT });
+
+    call(Channels.TAGS_NOTES_BY_TAG_PREFIX, 'area/');
+    expect(h.notesByTagPrefix).toHaveBeenCalledWith({ rootPath: ROOT }, 'area/');
+  });
+});
+
+describe('register-sites (#1840)', () => {
+  it('needs no project — privileged logins are per-machine', () => {
+    // Deliberately unscoped: these persist to userData, not to a thoughtbase.
+    openProject = null;
+    h.listSites.mockReturnValue([{ id: 's1', domain: 'example.com' }]);
+    expect(call(Channels.SITES_LIST)).toEqual([{ id: 's1', domain: 'example.com' }]);
+  });
+
+  it('passes the domain and optional label through to the store', () => {
+    call(Channels.SITES_ADD, 'example.com', 'Example');
+    expect(h.addSite).toHaveBeenCalledWith('example.com', 'Example');
+    call(Channels.SITES_ADD, 'bare.com');
+    expect(h.addSite).toHaveBeenLastCalledWith('bare.com', undefined);
+  });
+
+  it('delegates remove and logout by id', () => {
+    call(Channels.SITES_REMOVE, 's1');
+    expect(h.removeSite).toHaveBeenCalledWith('s1');
+    call(Channels.SITES_LOGOUT, 's1');
+    expect(h.logoutSite).toHaveBeenCalledWith('s1');
+  });
+
+  it('awaits the login window and resolves with nothing', async () => {
+    h.openLoginWindow.mockResolvedValue('ignored');
+    await expect(call(Channels.SITES_LOGIN, 's1')).resolves.toBeUndefined();
+    expect(h.openLoginWindow).toHaveBeenCalledWith('s1');
+  });
+});
+
+describe('register-git (#1840)', () => {
+  it('reports "not a repo" rather than throwing when no project is open', () => {
+    // A legitimate project-less answer: with nothing open there is nothing
+    // under version control, which is what the status bar renders anyway.
+    openProject = null;
+    // The fallback is a plain value while the success path is a promise — the
+    // handler's own type says `GitStatus | Promise<GitStatus>`. Electron wraps
+    // either at the IPC boundary; a direct call sees the difference.
+    expect(call(Channels.GIT_STATUS)).toEqual({ isRepo: false, branch: null, files: [] });
+    expect(h.getStatus).not.toHaveBeenCalled();
+  });
+
+  it('delegates status to the git module for the open project', async () => {
+    h.getStatus.mockResolvedValue({ isRepo: true, branch: 'main', files: [] });
+    await expect(call(Channels.GIT_STATUS)).resolves.toMatchObject({ branch: 'main' });
+    expect(h.getStatus).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('throws on commit with no project — a write, not a query', () => {
+    openProject = null;
+    expect(() => call(Channels.GIT_COMMIT, 'msg')).toThrow('No project open');
+    expect(h.commitAll).not.toHaveBeenCalled();
+  });
+
+  it('returns the sha of the commit it made', async () => {
+    h.commitAll.mockResolvedValue('abc1234');
+    // NOTE: `success: true` is hardcoded — any real failure throws out of
+    // `commitAll` before this returns. It's on CLAUDE.md's #1631 backlog as
+    // vestigial, so this pins the sha and the delegation, not the flag's
+    // meaning, which would be blessing it.
+    await expect(call(Channels.GIT_COMMIT, 'msg')).resolves.toMatchObject({ sha: 'abc1234' });
+    expect(h.commitAll).toHaveBeenCalledWith(ROOT, 'msg');
+  });
+});
+
+describe('register-views (#1840)', () => {
+  it('hands the store a null root when no project is open', () => {
+    // Deliberate (see the module docstring): saved views exist in a global
+    // scope too, so the store decides what a project-less list means. The
+    // registrar's job is only to report the truth about the window.
+    openProject = null;
+    h.listSavedViews.mockReturnValue([]);
+    expect(call(Channels.VIEWS_LIST)).toEqual([]);
+    expect(h.listSavedViews).toHaveBeenCalledWith(null);
+  });
+
+  it('scopes list and save to the open project', () => {
+    call(Channels.VIEWS_LIST);
+    expect(h.listSavedViews).toHaveBeenCalledWith(ROOT);
+    const input = { typeId: 't', name: 'v' };
+    call(Channels.VIEWS_SAVE, 'project', input);
+    expect(h.saveView).toHaveBeenCalledWith(ROOT, 'project', input);
+  });
+
+  it('addresses delete, rename and reorder by file path, not by project', () => {
+    // These take an absolute path the caller already has, so they work the
+    // same with or without a project open.
+    openProject = null;
+    call(Channels.VIEWS_DELETE, '/p/v.md');
+    call(Channels.VIEWS_RENAME, '/p/v.md', 'new');
+    call(Channels.VIEWS_SET_ORDER, [{ filePath: '/p/v.md', order: 1 }]);
+    expect(h.deleteView).toHaveBeenCalledWith('/p/v.md');
+    expect(h.renameView).toHaveBeenCalledWith('/p/v.md', 'new');
+    expect(h.setViewOrder).toHaveBeenCalledWith([{ filePath: '/p/v.md', order: 1 }]);
+  });
+});
+
+describe('register-clipper (#1840)', () => {
+  beforeEach(() => {
+    h.getClipperConfig.mockResolvedValue({ enabled: true, secret: 'sec' });
+    h.getClipperInfo.mockReturnValue({ port: 4321 });
+  });
+
+  it('reports a pairing code only when the server is actually running', async () => {
+    await expect(call(Channels.CLIPPER_GET_STATE)).resolves.toMatchObject({
+      enabled: true, running: true, port: 4321,
+    });
+    const running = await call(Channels.CLIPPER_GET_STATE) as { pairingCode: string | null };
+    expect(running.pairingCode).toBeTruthy();
+
+    // Enabled in config but not listening: a code the browser can't reach
+    // would be worse than none, so it's null.
+    h.getClipperInfo.mockReturnValue(null);
+    await expect(call(Channels.CLIPPER_GET_STATE)).resolves.toMatchObject({
+      running: false, port: null, pairingCode: null,
+    });
+  });
+
+  it('withholds the pairing code when there is no secret yet', async () => {
+    h.getClipperConfig.mockResolvedValue({ enabled: true, secret: '' });
+    await expect(call(Channels.CLIPPER_GET_STATE)).resolves.toMatchObject({ pairingCode: null });
+  });
+
+  it('applies the lifecycle change before reporting the new state', async () => {
+    const order: string[] = [];
+    h.setClipperEnabled.mockImplementation(async () => { order.push('persist'); });
+    h.applyClipperConfigChange.mockImplementation(async () => { order.push('apply'); });
+    h.getClipperConfig.mockImplementation(async () => { order.push('read'); return { enabled: true, secret: 's' }; });
+
+    await call(Channels.CLIPPER_SET_ENABLED, true);
+
+    // Reading state before starting/stopping the server would report the old
+    // `running` value — the flip the user just asked for, missing.
+    expect(order).toEqual(['persist', 'apply', 'read']);
+  });
+
+  it('rotates the secret, restarts, and answers with the fresh state', async () => {
+    await call(Channels.CLIPPER_REGENERATE_SECRET);
+    expect(h.regenerateClipperSecret).toHaveBeenCalled();
+    expect(h.applyClipperConfigChange).toHaveBeenCalled();
+    expect(h.getClipperConfig).toHaveBeenCalled();
+  });
+});
+
+describe('register-app (#1840)', () => {
+  it('reports build metadata, falling back when the build-time defines are absent', () => {
+    // `__APP_COMMIT__` / `__BUILD_DATE__` are injected by vite's `define`; in a
+    // test (and in `pnpm dev`) they don't exist, and the About dialog should
+    // say "unknown" rather than crashing on a ReferenceError.
+    const info = call(Channels.APP_GET_INFO) as Record<string, string>;
+    expect(info).toMatchObject({ name: 'Minerva', version: '2.0.0-test', commit: 'unknown', buildDate: 'unknown' });
+    expect(info.node).toBe(process.versions.node);
+  });
+
+  it('exposes the menu shortcut reference', () => {
+    h.getMenuShortcuts.mockReturnValue([{ label: 'Save', accelerator: 'CmdOrCtrl+S' }]);
+    expect(call(Channels.APP_GET_SHORTCUTS)).toEqual([{ label: 'Save', accelerator: 'CmdOrCtrl+S' }]);
+  });
+
+  it('records the theme the renderer reports, for the native View menu', () => {
+    send(Channels.MENU_REPORT_THEME, {}, 'dark');
+    expect(h.setMenuThemeMode).toHaveBeenCalledWith('dark');
+  });
+
+  it('scopes reported editor state to the reporting window', () => {
+    h.fromWebContents.mockReturnValue({ id: 7 });
+    send(Channels.MENU_REPORT_EDITOR_STATE, { sender: 'wc' }, { hasNote: true });
+    expect(h.setMenuEditorState).toHaveBeenCalledWith(7, { hasNote: true });
+  });
+
+  it('ignores state from a window that has already gone', () => {
+    // The report can arrive after the window closed; a null lookup must not
+    // become `setMenuEditorState(undefined, …)` on some other window's menu.
+    h.fromWebContents.mockReturnValue(null);
+    send(Channels.MENU_REPORT_EDITOR_STATE, { sender: 'wc' }, { hasNote: true });
+    expect(h.setMenuEditorState).not.toHaveBeenCalled();
+  });
+});

--- a/tests/main/ipc/register-sources.test.ts
+++ b/tests/main/ipc/register-sources.test.ts
@@ -1,0 +1,739 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-sources.ts` (#1840).
+ *
+ * At 343 lines this was the largest remaining untested registrar, and the one
+ * with the most repetition: a dozen source mutations that all have to
+ * `persistIndexes` and then broadcast `SOURCES_CHANGED` to a window that may
+ * already have closed. Copy-paste is exactly where one of those steps goes
+ * missing, so the repeated contract is asserted for every handler via a table
+ * rather than trusted to review.
+ *
+ * Beyond that it pins the parts with real logic:
+ *
+ *   - the #1631 project guard on every handler — throw vs each fallback's own
+ *     legitimate empty value;
+ *   - a closed window is never sent to: `isDestroyed()` is checked AFTER the
+ *     await, which is the only reason that check exists at all;
+ *   - `SOURCES_MERGE` carries a `MergeSourcesError`'s structured `code` across
+ *     the IPC boundary (a plain rethrow loses it and the UI can no longer tell
+ *     "you picked the same source twice" from a crash) while any other error
+ *     passes through untouched;
+ *   - ingest fetches through the privileged-sites wrapper, not bare `fetch`,
+ *     and honours the user's `importUpstreamTags` setting;
+ *   - a cancelled file picker imports nothing;
+ *   - the reading-queue / smart-collection membership filters short-circuit
+ *     instead of listing every source in the thoughtbase to intersect against
+ *     an empty set.
+ *
+ * `withRootPath*` are re-implemented in the helpers mock with the real
+ * semantics (helpers.ts drags in electron + graph/search/vectors, so it can't
+ * be imported here). Their own contract is covered by
+ * tests/main/ipc/registration.test.ts; what matters here is WHICH wrapper each
+ * handler picked — throw vs fallback — which is exactly what #1631 governs.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => {
+  /** Stands in for the real `MergeSourcesError` so the `instanceof` holds. */
+  class FakeMergeSourcesError extends Error {
+    constructor(message: string, public readonly code: string) {
+      super(message);
+      this.name = 'MergeSourcesError';
+    }
+  }
+  return {
+    handlers: new Map<string, Handler>(),
+    win: { id: 1, isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } },
+    MergeSourcesError: FakeMergeSourcesError,
+    // electron / node
+    showOpenDialog: vi.fn(),
+    stat: vi.fn(),
+    // ingest
+    privilegedFetch: vi.fn(),
+    ingestUrl: vi.fn(),
+    ingestIdentifier: vi.fn(),
+    ingestSmart: vi.fn(),
+    ingestFile: vi.fn(),
+    finishPdfOcrIngest: vi.fn(),
+    readOriginalPdf: vi.fn(),
+    getIngestSettings: vi.fn(),
+    saveIngestSettings: vi.fn(),
+    // source mutations
+    deleteSource: vi.fn(),
+    mergeSources: vi.fn(),
+    setSourceReadStatus: vi.fn(),
+    setSourceReadDueBy: vi.fn(),
+    setSourceTitle: vi.fn(),
+    addSourceTag: vi.fn(),
+    removeSourceTag: vi.fn(),
+    stripUpstreamTags: vi.fn(),
+    createExcerpt: vi.fn(),
+    // references / stubs
+    mineSourceReferences: vi.fn(),
+    createReferenceStubs: vi.fn(),
+    resolveStub: vi.fn(),
+    applyStubResolution: vi.fn(),
+    // imports
+    importBibtex: vi.fn(),
+    importZoteroRdf: vi.fn(),
+    // graph
+    listAllSources: vi.fn(),
+    getReadingQueueSourceIds: vi.fn(),
+    sourcesByTag: vi.fn(),
+    sourcesByReadStatus: vi.fn(),
+    // collections
+    loadCollections: vi.fn(),
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    addSourceToCollection: vi.fn(),
+    removeSourceFromCollection: vi.fn(),
+    createSmartCollection: vi.fn(),
+    renameSmartCollection: vi.fn(),
+    deleteSmartCollection: vi.fn(),
+    updateSmartCollectionPredicate: vi.fn(),
+    resolveSmartMembers: vi.fn(),
+    // project config
+    getExcerptNoteFolder: vi.fn(),
+    setExcerptNoteFolder: vi.fn(),
+    // helpers
+    reindexFile: vi.fn(),
+    persistIndexes: vi.fn(),
+    // call-order log — ordering is load-bearing in the ingest/OCR handlers
+    order: [] as string[],
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+  dialog: { showOpenDialog: h.showOpenDialog },
+  BrowserWindow: class {},
+}));
+
+vi.mock('node:fs/promises', () => ({ default: { stat: h.stat }, stat: h.stat }));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+  withRootPathWin:
+    <A extends unknown[], R>(fn: (rootPath: string, win: unknown, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, h.win, ...args);
+      },
+  reindexFile: h.reindexFile,
+  persistIndexes: h.persistIndexes,
+}));
+
+vi.mock('../../../src/main/privileged-sites', () => ({ privilegedFetch: h.privilegedFetch }));
+vi.mock('../../../src/main/sources/ingest', () => ({ ingestUrl: h.ingestUrl }));
+vi.mock('../../../src/main/sources/ingest-identifier', () => ({ ingestIdentifier: h.ingestIdentifier }));
+vi.mock('../../../src/main/sources/ingest-smart', () => ({ ingestSmart: h.ingestSmart }));
+vi.mock('../../../src/main/sources/ingest-file', () => ({ ingestFile: h.ingestFile }));
+vi.mock('../../../src/main/sources/ingest-pdf', () => ({
+  finishPdfOcrIngest: h.finishPdfOcrIngest,
+  readOriginalPdf: h.readOriginalPdf,
+}));
+vi.mock('../../../src/main/sources/ingest-settings', () => ({
+  getIngestSettings: h.getIngestSettings,
+  saveIngestSettings: h.saveIngestSettings,
+}));
+vi.mock('../../../src/main/sources/delete-source', () => ({ deleteSource: h.deleteSource }));
+vi.mock('../../../src/main/sources/merge-sources', () => ({
+  mergeSources: h.mergeSources,
+  MergeSourcesError: h.MergeSourcesError,
+}));
+vi.mock('../../../src/main/sources/read-status', () => ({
+  setSourceReadStatus: h.setSourceReadStatus,
+  setSourceReadDueBy: h.setSourceReadDueBy,
+}));
+vi.mock('../../../src/main/sources/source-meta-write', () => ({
+  setSourceTitle: h.setSourceTitle,
+  addSourceTag: h.addSourceTag,
+  removeSourceTag: h.removeSourceTag,
+}));
+vi.mock('../../../src/main/sources/strip-upstream-tags', () => ({ stripUpstreamTags: h.stripUpstreamTags }));
+vi.mock('../../../src/main/sources/mine-references', () => ({ mineSourceReferences: h.mineSourceReferences }));
+vi.mock('../../../src/main/sources/create-reference-stubs', () => ({ createReferenceStubs: h.createReferenceStubs }));
+vi.mock('../../../src/main/sources/resolve-stub', () => ({
+  resolveStub: h.resolveStub,
+  applyStubResolution: h.applyStubResolution,
+}));
+vi.mock('../../../src/main/sources/import-bibtex', () => ({ importBibtex: h.importBibtex }));
+vi.mock('../../../src/main/sources/import-zotero-rdf', () => ({ importZoteroRdf: h.importZoteroRdf }));
+vi.mock('../../../src/main/sources/create-excerpt', () => ({ createExcerpt: h.createExcerpt }));
+vi.mock('../../../src/main/sources/collections', () => ({
+  loadCollections: h.loadCollections,
+  createCollection: h.createCollection,
+  renameCollection: h.renameCollection,
+  deleteCollection: h.deleteCollection,
+  addSourceToCollection: h.addSourceToCollection,
+  removeSourceFromCollection: h.removeSourceFromCollection,
+  createSmartCollection: h.createSmartCollection,
+  renameSmartCollection: h.renameSmartCollection,
+  deleteSmartCollection: h.deleteSmartCollection,
+  updateSmartCollectionPredicate: h.updateSmartCollectionPredicate,
+  resolveSmartMembers: h.resolveSmartMembers,
+}));
+vi.mock('../../../src/main/graph/index', () => ({
+  listAllSources: h.listAllSources,
+  getReadingQueueSourceIds: h.getReadingQueueSourceIds,
+  sourcesByTag: h.sourcesByTag,
+  sourcesByReadStatus: h.sourcesByReadStatus,
+}));
+vi.mock('../../../src/main/project-config', () => ({
+  getExcerptNoteFolder: h.getExcerptNoteFolder,
+  setExcerptNoteFolder: h.setExcerptNoteFolder,
+}));
+
+import { registerSources } from '../../../src/main/ipc/register-sources';
+import { Channels } from '../../../src/shared/channels';
+
+registerSources();
+
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!({}, ...args);
+/** Await a handler's answer whether it replied synchronously or with a promise. */
+const callAsync = (channel: string, ...args: unknown[]): Promise<unknown> =>
+  Promise.resolve(call(channel, ...args));
+/** Every channel the handler broadcast to the project's window, in order. */
+const sent = (): unknown[] => h.win.webContents.send.mock.calls.map((c) => c[0]);
+/** The ProjectContext the registrar builds from the root path. */
+const CTX = { rootPath: ROOT, _brand: 'ProjectContext' };
+
+beforeEach(() => {
+  // reset (not just clear): several tests install ordering/progress
+  // `mockImplementation`s that must not leak into the next one.
+  vi.resetAllMocks();
+  openProject = ROOT;
+  h.order.length = 0;
+  h.win.isDestroyed.mockReturnValue(false);
+  h.getIngestSettings.mockResolvedValue({ importUpstreamTags: true });
+  h.listAllSources.mockReturnValue([]);
+  h.loadCollections.mockResolvedValue({ collections: [], smartCollections: [] });
+});
+
+describe('register-sources — the #1631 project guard', () => {
+  // Every source mutation and every single-source read. An empty answer here
+  // would be a claim about a thoughtbase that isn't open.
+  const throwers: [string, unknown[]][] = [
+    [Channels.SOURCES_INGEST_URL, ['https://example.org/a']],
+    [Channels.SOURCES_INGEST_IDENTIFIER, ['10.1234/x']],
+    [Channels.SOURCES_INGEST_SMART, ['some input']],
+    [Channels.SOURCES_INGEST_FILE, []],
+    [Channels.SOURCES_MINE_REFERENCES, ['s1']],
+    [Channels.SOURCES_CREATE_REFERENCE_STUBS, [{ sourceId: 's1', refs: [] }]],
+    [Channels.SOURCES_RESOLVE_STUB, ['s1']],
+    [Channels.SOURCES_APPLY_STUB_RESOLUTION, [{ sourceId: 's1', doi: '10.1/x' }]],
+    [Channels.SOURCES_IMPORT_BIBTEX, []],
+    [Channels.SOURCES_IMPORT_ZOTERO_RDF, []],
+    [Channels.SOURCES_READ_PDF, ['s1']],
+    [Channels.SOURCES_FINISH_PDF_OCR, ['s1', ['page one']]],
+    [Channels.SOURCES_DELETE, ['s1']],
+    [Channels.SOURCES_MERGE, [{ srcId: 'a', destId: 'b' }]],
+    [Channels.SOURCES_SET_READ_STATUS, [{ sourceId: 's1', status: 'read' }]],
+    [Channels.SOURCES_SET_READ_DUE_BY, [{ sourceId: 's1', dueBy: null }]],
+    [Channels.SOURCES_SET_TITLE, [{ sourceId: 's1', title: 'T' }]],
+    [Channels.SOURCES_ADD_TAG, [{ sourceId: 's1', tag: 't' }]],
+    [Channels.SOURCES_REMOVE_TAG, [{ sourceId: 's1', tag: 't' }]],
+    [Channels.SOURCES_STRIP_UPSTREAM_TAGS, ['s1']],
+    [Channels.SOURCES_CREATE_EXCERPT, [{ sourceId: 's1', citedText: 'x' }]],
+    [Channels.EXCERPT_SET_NOTE_FOLDER, ['Notes']],
+    [Channels.COLLECTIONS_CREATE, [{ name: 'C' }]],
+    [Channels.COLLECTIONS_RENAME, [{ id: 'c1', name: 'C' }]],
+    [Channels.COLLECTIONS_DELETE, ['c1']],
+    [Channels.COLLECTIONS_ADD_SOURCE, [{ collectionId: 'c1', sourceId: 's1' }]],
+    [Channels.COLLECTIONS_REMOVE_SOURCE, [{ collectionId: 'c1', sourceId: 's1' }]],
+    [Channels.COLLECTIONS_CREATE_SMART, [{ name: 'C', predicate: { kind: 'tags', allOf: [] } }]],
+    [Channels.COLLECTIONS_RENAME_SMART, [{ id: 'c1', name: 'C' }]],
+    [Channels.COLLECTIONS_DELETE_SMART, ['c1']],
+    [Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, [{ id: 'c1', predicate: { kind: 'tags', allOf: [] } }]],
+  ];
+
+  it.each(throwers)('%s throws with no project open', (channel, args) => {
+    openProject = null;
+    expect(() => call(channel, ...args)).toThrow('No project open');
+  });
+
+  it('nothing is ingested, written or deleted when there is no project', () => {
+    openProject = null;
+    for (const [channel, args] of throwers) {
+      try { call(channel, ...args); } catch { /* asserted above */ }
+    }
+    expect(h.ingestUrl).not.toHaveBeenCalled();
+    expect(h.ingestFile).not.toHaveBeenCalled();
+    expect(h.deleteSource).not.toHaveBeenCalled();
+    expect(h.mergeSources).not.toHaveBeenCalled();
+    expect(h.createCollection).not.toHaveBeenCalled();
+    expect(h.setExcerptNoteFolder).not.toHaveBeenCalled();
+    // Not even a file picker: a cancelled-looking dialog with nowhere to put
+    // the result is worse than the throw.
+    expect(h.showOpenDialog).not.toHaveBeenCalled();
+  });
+
+  // Each of these fallbacks is also what the surface shows for a thoughtbase
+  // that simply has nothing yet — a legitimate value per #1631 rule 2, not an
+  // error signal wearing a value's clothes.
+  const fallbacks: [string, unknown[], unknown][] = [
+    [Channels.SOURCES_LIST_ALL, [], []],
+    [Channels.SOURCES_QUEUE_MEMBERS, ['unread'], []],
+    [Channels.EXCERPT_GET_NOTE_FOLDER, [], ''],
+    [Channels.COLLECTIONS_LIST, [], { collections: [] }],
+    [Channels.COLLECTIONS_SMART_MEMBERS, ['c1'], []],
+  ];
+
+  it.each(fallbacks)('%s answers with its empty value and reaches no domain module', async (channel, args, expected) => {
+    openProject = null;
+    await expect(callAsync(channel, ...args)).resolves.toEqual(expected);
+    expect(h.listAllSources).not.toHaveBeenCalled();
+    expect(h.loadCollections).not.toHaveBeenCalled();
+    expect(h.getExcerptNoteFolder).not.toHaveBeenCalled();
+  });
+
+  it('COLLECTIONS_LIST\'s project-less answer is shaped like a real empty file', async () => {
+    // The fallback omits `smartCollections` where `loadCollections` normalises
+    // it to `[]`. That is only safe because the type marks it optional and the
+    // panel reads `data.smartCollections ?? []` — pinned here so a caller that
+    // starts trusting the field notices the two shapes differ.
+    openProject = null;
+    const projectless = await callAsync(Channels.COLLECTIONS_LIST);
+    expect(projectless).toEqual({ collections: [] });
+    expect((projectless as { smartCollections?: unknown[] }).smartCollections).toBeUndefined();
+  });
+
+  it('SOURCES_HAS_PDF answers false with no project — the same false as "no PDF kept"', () => {
+    // Honest note: this `false` is overloaded (no project / no original.pdf /
+    // an unreadable one), the same shape as the NOTEBASE_FILE_EXISTS boolean
+    // on the #1631 backlog. Pinned as-is; it is not this test's job to change
+    // the contract.
+    openProject = null;
+    expect(call(Channels.SOURCES_HAS_PDF, 's1')).toBe(false);
+    expect(h.stat).not.toHaveBeenCalled();
+  });
+
+  it('INGEST_GET_SETTINGS and INGEST_SET_SETTINGS work with no project — they are per-machine', async () => {
+    openProject = null;
+    h.getIngestSettings.mockResolvedValue({ importUpstreamTags: false });
+    await expect(callAsync(Channels.INGEST_GET_SETTINGS)).resolves.toEqual({ importUpstreamTags: false });
+    await callAsync(Channels.INGEST_SET_SETTINGS, { importUpstreamTags: true });
+    expect(h.saveIngestSettings).toHaveBeenCalledWith({ importUpstreamTags: true });
+  });
+});
+
+describe('register-sources — mutations persist their indexes and announce themselves', () => {
+  // Eleven near-identical handlers. Each must persist the indexes AND tell the
+  // window; a step missing from one of them is invisible on review.
+  const mutations: [string, unknown[], () => void][] = [
+    [Channels.SOURCES_DELETE, ['s1'], () => { h.deleteSource.mockResolvedValue({ removed: 1 }); }],
+    [Channels.SOURCES_MERGE, [{ srcId: 'a', destId: 'b' }], () => { h.mergeSources.mockResolvedValue({ moved: 2 }); }],
+    [Channels.SOURCES_SET_READ_STATUS, [{ sourceId: 's1', status: 'read' }], () => {}],
+    [Channels.SOURCES_SET_READ_DUE_BY, [{ sourceId: 's1', dueBy: '2026-01-01' }], () => {}],
+    [Channels.SOURCES_SET_TITLE, [{ sourceId: 's1', title: 'T' }], () => {}],
+    [Channels.SOURCES_ADD_TAG, [{ sourceId: 's1', tag: 't' }], () => {}],
+    [Channels.SOURCES_REMOVE_TAG, [{ sourceId: 's1', tag: 't' }], () => {}],
+    [Channels.SOURCES_STRIP_UPSTREAM_TAGS, ['s1'], () => { h.stripUpstreamTags.mockResolvedValue({ removed: 3 }); }],
+    [Channels.SOURCES_FINISH_PDF_OCR, ['s1', ['p1']], () => {}],
+    [Channels.SOURCES_CREATE_REFERENCE_STUBS, [{ sourceId: 's1', refs: [] }], () => { h.createReferenceStubs.mockResolvedValue({ created: [] }); }],
+    [Channels.SOURCES_APPLY_STUB_RESOLUTION, [{ sourceId: 's1', doi: '10.1/x' }], () => { h.applyStubResolution.mockResolvedValue(true); }],
+  ];
+
+  it.each(mutations)('%s persists the indexes and tells the window', async (channel, args, arrange) => {
+    arrange();
+    await callAsync(channel, ...args);
+    expect(h.persistIndexes).toHaveBeenCalledWith(ROOT);
+    expect(sent()).toContain(Channels.SOURCES_CHANGED);
+  });
+
+  it.each(mutations)('%s sends nothing to a window that closed mid-write', async (channel, args, arrange) => {
+    // `isDestroyed()` is checked after the await precisely because the user can
+    // close the window while the write is in flight; sending then throws.
+    arrange();
+    h.win.isDestroyed.mockReturnValue(true);
+    await callAsync(channel, ...args);
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('SOURCES_DELETE also refreshes the excerpt panels — its excerpts went with it', async () => {
+    h.deleteSource.mockResolvedValue({ removed: 1 });
+    await expect(callAsync(Channels.SOURCES_DELETE, 's1')).resolves.toEqual({ removed: 1 });
+    expect(h.deleteSource).toHaveBeenCalledWith(ROOT, 's1');
+    expect(sent()).toEqual([Channels.SOURCES_CHANGED, Channels.EXCERPTS_CHANGED]);
+  });
+
+  it('SOURCES_MERGE also refreshes the excerpt panels — they changed source', async () => {
+    h.mergeSources.mockResolvedValue({ moved: 2 });
+    await expect(callAsync(Channels.SOURCES_MERGE, { srcId: 'a', destId: 'b' })).resolves.toEqual({ moved: 2 });
+    expect(h.mergeSources).toHaveBeenCalledWith(ROOT, 'a', 'b');
+    expect(sent()).toEqual([Channels.SOURCES_CHANGED, Channels.EXCERPTS_CHANGED]);
+  });
+
+  it('the other mutations leave the excerpt panels alone', async () => {
+    await callAsync(Channels.SOURCES_SET_TITLE, { sourceId: 's1', title: 'T' });
+    expect(sent()).toEqual([Channels.SOURCES_CHANGED]);
+  });
+
+  it('SOURCES_SET_READ_STATUS forwards a null status as "clear the status"', async () => {
+    await callAsync(Channels.SOURCES_SET_READ_STATUS, { sourceId: 's1', status: null });
+    expect(h.setSourceReadStatus).toHaveBeenCalledWith(ROOT, 's1', null);
+  });
+
+  it('SOURCES_SET_READ_DUE_BY forwards a null date as "clear the due date"', async () => {
+    await callAsync(Channels.SOURCES_SET_READ_DUE_BY, { sourceId: 's1', dueBy: null });
+    expect(h.setSourceReadDueBy).toHaveBeenCalledWith(ROOT, 's1', null);
+  });
+
+  it.each([
+    [Channels.SOURCES_ADD_TAG, 'addSourceTag'],
+    [Channels.SOURCES_REMOVE_TAG, 'removeSourceTag'],
+  ] as const)('%s applies the tag change to the source', async (channel, fn) => {
+    await callAsync(channel, { sourceId: 's1', tag: 'ml' });
+    expect(h[fn]).toHaveBeenCalledWith(ROOT, 's1', 'ml');
+  });
+
+  it('SOURCES_FINISH_PDF_OCR reindexes the source meta before persisting, so the OCR text is searchable', async () => {
+    h.finishPdfOcrIngest.mockImplementation(async () => { h.order.push('ocr'); });
+    h.reindexFile.mockImplementation(async () => { h.order.push('reindex'); });
+    h.persistIndexes.mockImplementation(async () => { h.order.push('persist'); });
+
+    await callAsync(Channels.SOURCES_FINISH_PDF_OCR, 's1', ['page one', 'page two']);
+
+    expect(h.finishPdfOcrIngest).toHaveBeenCalledWith(ROOT, 's1', ['page one', 'page two']);
+    expect(h.reindexFile).toHaveBeenCalledWith(ROOT, '.minerva/sources/s1/meta.ttl');
+    // Rewrite → reindex → persist. Persisting first would snapshot the index
+    // as it was before the OCR text landed in it.
+    expect(h.order).toEqual(['ocr', 'reindex', 'persist']);
+  });
+
+  it('a failed mutation announces nothing', async () => {
+    h.setSourceTitle.mockRejectedValue(new Error('EACCES'));
+    await expect(callAsync(Channels.SOURCES_SET_TITLE, { sourceId: 's1', title: 'T' })).rejects.toThrow('EACCES');
+    expect(h.persistIndexes).not.toHaveBeenCalled();
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-sources — SOURCES_MERGE error translation', () => {
+  it('carries the structured code across the IPC boundary', async () => {
+    // Without this the renderer sees a bare message and can't tell an expected
+    // "you picked the same source twice" from an actual crash.
+    h.mergeSources.mockRejectedValue(new h.MergeSourcesError('cannot merge a source into itself', 'same-source'));
+
+    const err = await callAsync(Channels.SOURCES_MERGE, { srcId: 'a', destId: 'a' })
+      .then(() => null, (e: unknown) => e as Error & { code?: string });
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err?.message).toBe('cannot merge a source into itself');
+    expect(err?.code).toBe('same-source');
+  });
+
+  it('does not persist or announce a merge that failed', async () => {
+    h.mergeSources.mockRejectedValue(new h.MergeSourcesError('no such source', 'not-found'));
+    await expect(callAsync(Channels.SOURCES_MERGE, { srcId: 'a', destId: 'b' })).rejects.toThrow('no such source');
+    expect(h.persistIndexes).not.toHaveBeenCalled();
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('lets a genuine crash through untouched', async () => {
+    // Only MergeSourcesError is translated. Wrapping everything would dress a
+    // real bug up as an expected outcome — and lose the original stack.
+    const boom = new Error('EIO');
+    h.mergeSources.mockRejectedValue(boom);
+    await expect(callAsync(Channels.SOURCES_MERGE, { srcId: 'a', destId: 'b' })).rejects.toBe(boom);
+  });
+});
+
+describe('register-sources — ingest', () => {
+  it.each([
+    [Channels.SOURCES_INGEST_URL, 'https://example.org/a', 'ingestUrl'],
+    [Channels.SOURCES_INGEST_IDENTIFIER, '10.1234/abc', 'ingestIdentifier'],
+    [Channels.SOURCES_INGEST_SMART, 'anything at all', 'ingestSmart'],
+  ] as const)('%s fetches through the privileged wrapper and honours the tag preference', async (channel, input, fn) => {
+    // A bare `fetch` would bypass the per-site credential/header handling, and
+    // a hardcoded tag flag would ignore the user's ingest setting.
+    h.getIngestSettings.mockResolvedValue({ importUpstreamTags: false });
+    h[fn].mockResolvedValue({ sourceId: 's9' });
+
+    await expect(callAsync(channel, input)).resolves.toEqual({ sourceId: 's9' });
+    expect(h[fn]).toHaveBeenCalledWith(ROOT, input, {
+      fetchImpl: h.privilegedFetch,
+      importUpstreamTags: false,
+    });
+  });
+
+  it('SOURCES_INGEST_FILE reindexes the new source so it appears in the sidebar', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/tmp/paper.pdf'] });
+    h.ingestFile.mockResolvedValue({ sourceId: 'src-42' });
+
+    await expect(callAsync(Channels.SOURCES_INGEST_FILE)).resolves.toEqual({ sourceId: 'src-42' });
+
+    expect(h.ingestFile).toHaveBeenCalledWith(ROOT, '/tmp/paper.pdf');
+    expect(h.reindexFile).toHaveBeenCalledWith(ROOT, '.minerva/sources/src-42/meta.ttl');
+    expect(h.persistIndexes).toHaveBeenCalledWith(ROOT);
+  });
+
+  it.each([
+    ['cancelled', { canceled: true, filePaths: [] }],
+    ['dismissed with no path', { canceled: false, filePaths: [] }],
+  ])('SOURCES_INGEST_FILE imports nothing when the picker is %s', async (_label, dialogResult) => {
+    h.showOpenDialog.mockResolvedValue(dialogResult);
+    await expect(callAsync(Channels.SOURCES_INGEST_FILE)).resolves.toBeNull();
+    expect(h.ingestFile).not.toHaveBeenCalled();
+    expect(h.persistIndexes).not.toHaveBeenCalled();
+  });
+
+  it('SOURCES_RESOLVE_STUB looks the reference up through the privileged fetcher', async () => {
+    h.resolveStub.mockResolvedValue({ doi: '10.1/x' });
+    await expect(callAsync(Channels.SOURCES_RESOLVE_STUB, 's1')).resolves.toEqual({ doi: '10.1/x' });
+    expect(h.resolveStub).toHaveBeenCalledWith(ROOT, 's1', { fetchImpl: h.privilegedFetch });
+  });
+
+  it('SOURCES_APPLY_STUB_RESOLUTION reports whether the stub was actually filled in', async () => {
+    h.applyStubResolution.mockResolvedValue(false);
+    await expect(callAsync(Channels.SOURCES_APPLY_STUB_RESOLUTION, { sourceId: 's1', doi: '10.1/x' }))
+      .resolves.toEqual({ ok: false });
+    expect(h.applyStubResolution).toHaveBeenCalledWith(ROOT, 's1', '10.1/x', { fetchImpl: h.privilegedFetch });
+  });
+
+  it('SOURCES_MINE_REFERENCES returns the parsed references', async () => {
+    h.mineSourceReferences.mockResolvedValue([{ title: 'A paper' }]);
+    await expect(callAsync(Channels.SOURCES_MINE_REFERENCES, 's1')).resolves.toEqual([{ title: 'A paper' }]);
+    expect(h.mineSourceReferences).toHaveBeenCalledWith(ROOT, 's1');
+  });
+
+  it('SOURCES_CREATE_REFERENCE_STUBS passes the parsed refs straight through', async () => {
+    const refs = [{ title: 'A paper', doi: '10.1/x' }];
+    h.createReferenceStubs.mockResolvedValue({ created: ['stub-1'] });
+    await expect(callAsync(Channels.SOURCES_CREATE_REFERENCE_STUBS, { sourceId: 's1', refs }))
+      .resolves.toEqual({ created: ['stub-1'] });
+    expect(h.createReferenceStubs).toHaveBeenCalledWith(ROOT, 's1', refs);
+  });
+
+  it('SOURCES_READ_PDF hands the original bytes back for the renderer OCR worker', async () => {
+    h.readOriginalPdf.mockResolvedValue(new Uint8Array([37, 80]));
+    await expect(callAsync(Channels.SOURCES_READ_PDF, 's1')).resolves.toEqual(new Uint8Array([37, 80]));
+    expect(h.readOriginalPdf).toHaveBeenCalledWith(ROOT, 's1');
+  });
+
+  it('SOURCES_HAS_PDF reports true when the original was kept', async () => {
+    h.stat.mockResolvedValue({});
+    await expect(callAsync(Channels.SOURCES_HAS_PDF, 's1')).resolves.toBe(true);
+    expect(h.stat).toHaveBeenCalledWith('/vault/.minerva/sources/s1/original.pdf');
+  });
+
+  it('SOURCES_HAS_PDF reports false for a source ingested without one', async () => {
+    h.stat.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    await expect(callAsync(Channels.SOURCES_HAS_PDF, 's1')).resolves.toBe(false);
+  });
+});
+
+describe('register-sources — bibliography imports', () => {
+  it.each([
+    [Channels.SOURCES_IMPORT_BIBTEX, 'importBibtex', Channels.SOURCES_IMPORT_BIBTEX_PROGRESS],
+    [Channels.SOURCES_IMPORT_ZOTERO_RDF, 'importZoteroRdf', Channels.SOURCES_IMPORT_ZOTERO_RDF_PROGRESS],
+  ] as const)('%s streams progress to the window while it runs', async (channel, fn, progressChannel) => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/tmp/refs.bib'] });
+    h[fn].mockImplementation(async (_root: string, _file: string, opts: { onProgress: (p: unknown) => void }) => {
+      opts.onProgress({ done: 1, total: 2 });
+      opts.onProgress({ done: 2, total: 2 });
+      return { imported: 2 };
+    });
+
+    await expect(callAsync(channel)).resolves.toEqual({ imported: 2 });
+    expect(h[fn]).toHaveBeenCalledWith(ROOT, '/tmp/refs.bib', { onProgress: expect.any(Function) });
+    // A long import has to move a progress bar, not freeze the dialog.
+    expect(h.win.webContents.send.mock.calls).toEqual([
+      [progressChannel, { done: 1, total: 2 }],
+      [progressChannel, { done: 2, total: 2 }],
+    ]);
+  });
+
+  it.each([
+    [Channels.SOURCES_IMPORT_BIBTEX, 'importBibtex', { canceled: true, filePaths: [] }],
+    [Channels.SOURCES_IMPORT_BIBTEX, 'importBibtex', { canceled: false, filePaths: [] }],
+    [Channels.SOURCES_IMPORT_ZOTERO_RDF, 'importZoteroRdf', { canceled: true, filePaths: [] }],
+    [Channels.SOURCES_IMPORT_ZOTERO_RDF, 'importZoteroRdf', { canceled: false, filePaths: [] }],
+  ] as const)('%s imports nothing when the picker gives back no file', async (channel, fn, dialogResult) => {
+    h.showOpenDialog.mockResolvedValue(dialogResult);
+    await expect(callAsync(channel)).resolves.toBeNull();
+    expect(h[fn]).not.toHaveBeenCalled();
+  });
+
+  it('a progress tick after the window closed is dropped, not sent', async () => {
+    h.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['/tmp/refs.bib'] });
+    h.importBibtex.mockImplementation(async (_root: string, _file: string, opts: { onProgress: (p: unknown) => void }) => {
+      h.win.isDestroyed.mockReturnValue(true);
+      opts.onProgress({ done: 1, total: 2 });
+      return { imported: 1 };
+    });
+    await expect(callAsync(Channels.SOURCES_IMPORT_BIBTEX)).resolves.toEqual({ imported: 1 });
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-sources — reading queue and smart collections', () => {
+  it('SOURCES_QUEUE_MEMBERS returns only the sources in the requested view', () => {
+    h.getReadingQueueSourceIds.mockReturnValue(['s1', 's3']);
+    h.listAllSources.mockReturnValue([{ sourceId: 's1' }, { sourceId: 's2' }, { sourceId: 's3' }]);
+
+    expect(call(Channels.SOURCES_QUEUE_MEMBERS, 'unread')).toEqual([{ sourceId: 's1' }, { sourceId: 's3' }]);
+    expect(h.getReadingQueueSourceIds).toHaveBeenCalledWith(CTX, 'unread');
+  });
+
+  it('SOURCES_QUEUE_MEMBERS skips listing every source when the queue is empty', () => {
+    // Intersecting the whole library against nothing is pure waste on a large
+    // thoughtbase, and the answer is [] either way.
+    h.getReadingQueueSourceIds.mockReturnValue([]);
+    expect(call(Channels.SOURCES_QUEUE_MEMBERS, 'unread')).toEqual([]);
+    expect(h.listAllSources).not.toHaveBeenCalled();
+  });
+
+  it('SOURCES_LIST_ALL reads the graph for the open project', () => {
+    h.listAllSources.mockReturnValue([{ sourceId: 's1' }]);
+    expect(call(Channels.SOURCES_LIST_ALL)).toEqual([{ sourceId: 's1' }]);
+    expect(h.listAllSources).toHaveBeenCalledWith(CTX);
+  });
+
+  it('COLLECTIONS_SMART_MEMBERS resolves membership through the graph', async () => {
+    h.loadCollections.mockResolvedValue({
+      collections: [],
+      smartCollections: [{ id: 'sc1', predicate: { kind: 'tags', allOf: ['ml'] } }],
+    });
+    h.resolveSmartMembers.mockReturnValue(new Set(['s2']));
+    h.listAllSources.mockReturnValue([{ sourceId: 's1' }, { sourceId: 's2' }]);
+
+    await expect(callAsync(Channels.COLLECTIONS_SMART_MEMBERS, 'sc1')).resolves.toEqual([{ sourceId: 's2' }]);
+    expect(h.resolveSmartMembers).toHaveBeenCalledWith(
+      { kind: 'tags', allOf: ['ml'] },
+      { sourcesByTag: expect.any(Function), sourcesByReadStatus: expect.any(Function) },
+    );
+  });
+
+  it('the lookups it hands the resolver read from the graph, not a local cache', async () => {
+    // The graph is the source of truth for hasTag edges, so smart-collection
+    // membership matches what the tag panel shows.
+    h.loadCollections.mockResolvedValue({
+      collections: [], smartCollections: [{ id: 'sc1', predicate: { kind: 'tags', allOf: ['ml'] } }],
+    });
+    h.resolveSmartMembers.mockImplementation((_p: unknown, lookups: {
+      sourcesByTag: (t: string) => unknown; sourcesByReadStatus: (s: string) => unknown;
+    }) => {
+      lookups.sourcesByTag('ml');
+      lookups.sourcesByReadStatus('unread');
+      return new Set<string>();
+    });
+
+    await callAsync(Channels.COLLECTIONS_SMART_MEMBERS, 'sc1');
+
+    expect(h.sourcesByTag).toHaveBeenCalledWith(CTX, 'ml');
+    expect(h.sourcesByReadStatus).toHaveBeenCalledWith(CTX, 'unread');
+  });
+
+  it('COLLECTIONS_SMART_MEMBERS returns nothing for an id that no longer exists', async () => {
+    h.loadCollections.mockResolvedValue({ collections: [], smartCollections: [] });
+    await expect(callAsync(Channels.COLLECTIONS_SMART_MEMBERS, 'gone')).resolves.toEqual([]);
+    expect(h.resolveSmartMembers).not.toHaveBeenCalled();
+  });
+
+  it('COLLECTIONS_SMART_MEMBERS skips listing every source when nothing matched', async () => {
+    h.loadCollections.mockResolvedValue({
+      collections: [], smartCollections: [{ id: 'sc1', predicate: { kind: 'tags', allOf: ['nope'] } }],
+    });
+    h.resolveSmartMembers.mockReturnValue(new Set());
+    await expect(callAsync(Channels.COLLECTIONS_SMART_MEMBERS, 'sc1')).resolves.toEqual([]);
+    expect(h.listAllSources).not.toHaveBeenCalled();
+  });
+});
+
+describe('register-sources — collections', () => {
+  const collectionMutations: [string, unknown[], () => void][] = [
+    [Channels.COLLECTIONS_CREATE, [{ name: 'C' }], () => { h.createCollection.mockResolvedValue({ id: 'c1' }); }],
+    [Channels.COLLECTIONS_RENAME, [{ id: 'c1', name: 'C2' }], () => {}],
+    [Channels.COLLECTIONS_DELETE, ['c1'], () => {}],
+    [Channels.COLLECTIONS_ADD_SOURCE, [{ collectionId: 'c1', sourceId: 's1' }], () => {}],
+    [Channels.COLLECTIONS_REMOVE_SOURCE, [{ collectionId: 'c1', sourceId: 's1' }], () => {}],
+    [Channels.COLLECTIONS_CREATE_SMART, [{ name: 'S', predicate: { kind: 'tags', allOf: [] } }], () => { h.createSmartCollection.mockResolvedValue({ id: 'sc1' }); }],
+    [Channels.COLLECTIONS_RENAME_SMART, [{ id: 'sc1', name: 'S2' }], () => {}],
+    [Channels.COLLECTIONS_DELETE_SMART, ['sc1'], () => {}],
+    [Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, [{ id: 'sc1', predicate: { kind: 'tags', allOf: ['x'] } }], () => {}],
+  ];
+
+  it.each(collectionMutations)('%s tells the sidebar the collections changed', async (channel, args, arrange) => {
+    arrange();
+    await callAsync(channel, ...args);
+    expect(sent()).toEqual([Channels.COLLECTIONS_CHANGED]);
+  });
+
+  it.each(collectionMutations)('%s sends nothing to a window that closed mid-write', async (channel, args, arrange) => {
+    arrange();
+    h.win.isDestroyed.mockReturnValue(true);
+    await callAsync(channel, ...args);
+    expect(h.win.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('collection edits do not touch the source indexes', async () => {
+    // Collections live in their own JSON file, not the graph — persisting the
+    // search/graph indexes on every rename would be wasted IO.
+    await callAsync(Channels.COLLECTIONS_RENAME, { id: 'c1', name: 'C2' });
+    expect(h.renameCollection).toHaveBeenCalledWith(ROOT, 'c1', 'C2');
+    expect(h.persistIndexes).not.toHaveBeenCalled();
+  });
+
+  it('COLLECTIONS_CREATE forwards the parent so nesting works', async () => {
+    h.createCollection.mockResolvedValue({ id: 'c2' });
+    await expect(callAsync(Channels.COLLECTIONS_CREATE, { name: 'Child', parent: 'c1' }))
+      .resolves.toEqual({ id: 'c2' });
+    expect(h.createCollection).toHaveBeenCalledWith(ROOT, { name: 'Child', parent: 'c1' });
+  });
+
+  it('COLLECTIONS_LIST returns the stored file for the open project', async () => {
+    h.loadCollections.mockResolvedValue({ collections: [{ id: 'c1' }], smartCollections: [] });
+    await expect(callAsync(Channels.COLLECTIONS_LIST))
+      .resolves.toEqual({ collections: [{ id: 'c1' }], smartCollections: [] });
+    expect(h.loadCollections).toHaveBeenCalledWith(ROOT);
+  });
+
+  it.each([
+    [Channels.COLLECTIONS_ADD_SOURCE, 'addSourceToCollection'],
+    [Channels.COLLECTIONS_REMOVE_SOURCE, 'removeSourceFromCollection'],
+  ] as const)('%s moves the membership on the named collection', async (channel, fn) => {
+    await callAsync(channel, { collectionId: 'c1', sourceId: 's1' });
+    expect(h[fn]).toHaveBeenCalledWith(ROOT, 'c1', 's1');
+  });
+});
+
+describe('register-sources — excerpts', () => {
+  it('SOURCES_CREATE_EXCERPT passes the anchor through unchanged', async () => {
+    // The anchor fields are what re-locates a quote in the source later; a
+    // handler that dropped `pageRange`/`locationText` would silently produce
+    // unanchored excerpts.
+    const params = { sourceId: 's1', citedText: 'a quote', page: 12, pageRange: '12-13', locationText: 'ch. 2' };
+    h.createExcerpt.mockResolvedValue({ excerptId: 'ex1' });
+    await expect(callAsync(Channels.SOURCES_CREATE_EXCERPT, params)).resolves.toEqual({ excerptId: 'ex1' });
+    expect(h.createExcerpt).toHaveBeenCalledWith(ROOT, params);
+  });
+
+  it('EXCERPT_GET_NOTE_FOLDER reports the configured default', () => {
+    h.getExcerptNoteFolder.mockReturnValue('Notes/Excerpts');
+    expect(call(Channels.EXCERPT_GET_NOTE_FOLDER)).toBe('Notes/Excerpts');
+    expect(h.getExcerptNoteFolder).toHaveBeenCalledWith(ROOT);
+  });
+
+  it('EXCERPT_SET_NOTE_FOLDER stores the new default', () => {
+    call(Channels.EXCERPT_SET_NOTE_FOLDER, 'Notes/Excerpts');
+    expect(h.setExcerptNoteFolder).toHaveBeenCalledWith(ROOT, 'Notes/Excerpts');
+  });
+});

--- a/tests/main/ipc/register-tools.test.ts
+++ b/tests/main/ipc/register-tools.test.ts
@@ -1,0 +1,400 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-tools.ts` (#1840).
+ *
+ * This registrar is the renderer's whole door onto skills and the LLM: it runs
+ * a skill, streams its output back, cancels it, serves the skill catalog, and
+ * owns the model/provider settings. What it promises, and what's pinned here:
+ *
+ *   - **cancellation is per-window and self-cleaning.** One `AbortController`
+ *     per window id, handed to `executeTool` and dropped in a `finally` — so a
+ *     Cancel in window 2 can't abort window 1's run, and a Cancel that arrives
+ *     after a run finished (or crashed) is a no-op rather than a stale abort.
+ *   - **prompt bodies never cross IPC.** CLAUDE.md's skills section: "the
+ *     renderer never sees prompt bodies". `SKILLS_LIST` therefore goes through
+ *     the REAL `toSkillInfo`, and the test feeds it a skill whose body and
+ *     firstMessage are recognisable strings so a leak is visible.
+ *   - **`errors[]` is a per-item catalog, not a failure channel** (#1631
+ *     rule 4): an unparseable skill file is reported *alongside* the skills
+ *     that did load, and the call still succeeds.
+ *   - **opening Settings never prompts the keychain** — `TOOL_GET_SETTINGS`
+ *     reads the display view, never the decrypting `getSettings()`.
+ *
+ * Nothing here is `withRootPath`: skills, models and API keys are per-machine,
+ * not per-thoughtbase, so every handler works with no project open. The
+ * catalog/executor/settings modules behind them are mocked; `broadcast` is real
+ * so the TOOL_STREAM channel and payload are genuinely exercised.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SkillDef, MenuConfig } from '../../../src/shared/skills/types';
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => {
+  const makeWin = (id: number) => ({ id, isDestroyed: () => false, webContents: { send: vi.fn() } });
+  const win = makeWin(1);
+  return {
+    handlers: new Map<string, Handler>(),
+    win,
+    otherWin: makeWin(2),
+    /** Which window the next `call()` appears to come from. */
+    current: { win },
+    // tools/executor
+    executeTool: vi.fn(),
+    prepareConversationTool: vi.fn(),
+    // skills
+    getSkillCatalog: vi.fn(),
+    reloadAndRegisterSkills: vi.fn(),
+    reapplyMenuConfig: vi.fn(),
+    pickAndImportSkill: vi.fn(),
+    removeUserSkill: vi.fn(),
+    revealSkillsFolder: vi.fn(),
+    getMenuConfig: vi.fn(),
+    saveMenuConfig: vi.fn(),
+    rebuildMenu: vi.fn(),
+    // llm
+    getSettings: vi.fn(),
+    getSettingsForDisplay: vi.fn(),
+    saveSettings: vi.fn(),
+    getApiKeyStorage: vi.fn(),
+    checkConnection: vi.fn(),
+    /** Call-order log — remove/import must re-register BEFORE rebuilding the menu. */
+    order: [] as string[],
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({ winFromEvent: () => h.current.win }));
+
+vi.mock('../../../src/main/menu', () => ({
+  rebuildMenu: (...a: unknown[]) => { h.order.push('rebuildMenu'); return h.rebuildMenu(...a); },
+}));
+vi.mock('../../../src/main/tools/executor', () => ({
+  executeTool: h.executeTool,
+  prepareConversationTool: h.prepareConversationTool,
+}));
+vi.mock('../../../src/main/skills/loader', () => ({ getSkillCatalog: h.getSkillCatalog }));
+vi.mock('../../../src/main/skills/register', () => ({
+  reloadAndRegisterSkills: (...a: unknown[]) => { h.order.push('reload'); return h.reloadAndRegisterSkills(...a); },
+  reapplyMenuConfig: h.reapplyMenuConfig,
+}));
+vi.mock('../../../src/main/skills/manage', () => ({
+  pickAndImportSkill: h.pickAndImportSkill,
+  removeUserSkill: (...a: unknown[]) => { h.order.push('remove'); return h.removeUserSkill(...a); },
+  revealSkillsFolder: h.revealSkillsFolder,
+}));
+vi.mock('../../../src/main/skills/menu-config-store', () => ({
+  getMenuConfig: h.getMenuConfig,
+  saveMenuConfig: h.saveMenuConfig,
+}));
+vi.mock('../../../src/main/llm/settings', () => ({
+  getSettings: h.getSettings,
+  getSettingsForDisplay: h.getSettingsForDisplay,
+  saveSettings: h.saveSettings,
+  getApiKeyStorage: h.getApiKeyStorage,
+}));
+vi.mock('../../../src/main/llm/validate', () => ({ checkConnection: h.checkConnection }));
+
+import { registerTools } from '../../../src/main/ipc/register-tools';
+import { Channels } from '../../../src/shared/channels';
+
+registerTools();
+
+const call = (channel: string, ...args: unknown[]) => h.handlers.get(channel)!({}, ...args);
+
+const EMPTY_CONFIG: MenuConfig = { skills: {}, order: { Learning: [], Research: [], Analysis: [] } };
+
+/** A fully-populated skill, so the body/firstMessage leak check has something
+ *  unmistakable to look for. */
+const SKILL: SkillDef = {
+  id: 'stock.socratic',
+  name: 'Socratic Dialogue',
+  description: 'Question the note',
+  longDescription: 'Longer blurb',
+  menu: 'Learning',
+  scope: 'note',
+  outputMode: 'openConversation',
+  context: [],
+  parameters: [],
+  tools: ['propose_claims'],
+  web: false,
+  requiresSelection: false,
+  firstMessage: 'FIRST-MESSAGE-TEMPLATE-{{title}}',
+  body: 'SYSTEM-PROMPT-BODY-{{note.content}}',
+  source: 'stock',
+  filePath: './stock/socratic.md',
+};
+
+const REQUEST = { toolId: 'stock.socratic', context: { fullNoteTitle: 'Paxos' } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.order.length = 0;
+  h.current.win = h.win;
+  h.getMenuConfig.mockReturnValue(EMPTY_CONFIG);
+});
+
+describe('TOOL_EXECUTE / TOOL_CANCEL', () => {
+  /** Start a run and hand back the arguments `executeTool` was given, with the
+   *  run still in flight so it can be cancelled. */
+  function startRun(): {
+    settle: (v: unknown) => void;
+    fail: (e: unknown) => void;
+    args: () => { onChunk: (s: string) => void; signal: AbortSignal };
+    done: Promise<unknown>;
+  } {
+    let settle!: (v: unknown) => void;
+    let fail!: (e: unknown) => void;
+    let captured!: { onChunk: (s: string) => void; signal: AbortSignal };
+    h.executeTool.mockImplementation((_req: unknown, onChunk: (s: string) => void, signal: AbortSignal) => {
+      captured = { onChunk, signal };
+      return new Promise((resolve, reject) => { settle = resolve; fail = reject; });
+    });
+    const done = call(Channels.TOOL_EXECUTE, REQUEST) as Promise<unknown>;
+    return { settle, fail, args: () => captured, done };
+  }
+
+  it('runs the requested tool and returns its result', async () => {
+    h.executeTool.mockResolvedValue({ toolId: 'stock.socratic', output: 'text' });
+    await expect(call(Channels.TOOL_EXECUTE, REQUEST)).resolves.toEqual({ toolId: 'stock.socratic', output: 'text' });
+    expect(h.executeTool).toHaveBeenCalledWith(REQUEST, expect.any(Function), expect.any(AbortSignal));
+  });
+
+  it('streams each chunk to the window that asked for the run', async () => {
+    const run = startRun();
+    run.args().onChunk('partial ');
+    run.args().onChunk('output');
+    run.settle({ output: 'partial output' });
+    await run.done;
+
+    expect(h.win.webContents.send.mock.calls).toEqual([
+      [Channels.TOOL_STREAM, 'partial '],
+      [Channels.TOOL_STREAM, 'output'],
+    ]);
+  });
+
+  it('drops chunks for a window the user already closed', async () => {
+    // A skill can keep streaming for a while after its window goes away;
+    // sending to destroyed webContents throws, which would surface as a
+    // rejected TOOL_EXECUTE for a run that actually succeeded.
+    const closed = { id: 9, isDestroyed: () => true, webContents: { send: vi.fn() } };
+    h.current.win = closed;
+    const run = startRun();
+    run.args().onChunk('into the void');
+    run.settle({ output: '' });
+    await run.done;
+
+    expect(closed.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('TOOL_CANCEL aborts the run in flight', async () => {
+    const run = startRun();
+    expect(run.args().signal.aborted).toBe(false);
+
+    call(Channels.TOOL_CANCEL);
+
+    expect(run.args().signal.aborted).toBe(true);
+    run.settle({ output: '' });
+    await run.done;
+  });
+
+  it('cancels only the asking window\'s run', async () => {
+    const run = startRun();
+
+    // A second window pressing Cancel must not kill this window's skill.
+    h.current.win = h.otherWin;
+    call(Channels.TOOL_CANCEL);
+
+    expect(run.args().signal.aborted).toBe(false);
+    run.settle({ output: '' });
+    await run.done;
+  });
+
+  it('TOOL_CANCEL with nothing running is a no-op', () => {
+    expect(() => call(Channels.TOOL_CANCEL)).not.toThrow();
+  });
+
+  it('forgets the controller once the run finishes, so a late Cancel is inert', async () => {
+    const first = startRun();
+    first.settle({ output: 'done' });
+    await first.done;
+
+    call(Channels.TOOL_CANCEL); // late click on a finished run
+
+    const second = startRun();
+    // A stale controller left in the map would have aborted this one at birth.
+    expect(second.args().signal.aborted).toBe(false);
+    second.settle({ output: '' });
+    await second.done;
+  });
+
+  it('forgets the controller when the run THROWS, and surfaces the error', async () => {
+    const failed = startRun();
+    failed.fail(new Error('Unknown tool: nope'));
+    await expect(failed.done).rejects.toThrow(/Unknown tool/);
+
+    const next = startRun();
+    expect(next.args().signal.aborted).toBe(false);
+    next.settle({ output: '' });
+    await next.done;
+  });
+
+  it('TOOL_PREPARE_CONVERSATION delegates to the conversation payload builder', () => {
+    h.prepareConversationTool.mockReturnValue({ prompt: 'system', model: 'claude-opus-5' });
+    expect(call(Channels.TOOL_PREPARE_CONVERSATION, REQUEST)).toEqual({ prompt: 'system', model: 'claude-opus-5' });
+    expect(h.prepareConversationTool).toHaveBeenCalledWith(REQUEST);
+  });
+});
+
+describe('SKILLS_LIST', () => {
+  it('sends serializable metadata and the menu config', async () => {
+    h.getSkillCatalog.mockResolvedValue({ skills: [SKILL], errors: [] });
+
+    const result = await call(Channels.SKILLS_LIST) as { skills: Array<Record<string, unknown>>; config: MenuConfig };
+
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0]).toMatchObject({ id: 'stock.socratic', name: 'Socratic Dialogue', menu: 'Learning', source: 'stock' });
+    expect(result.config).toEqual(EMPTY_CONFIG);
+  });
+
+  it('never ships the prompt body or firstMessage to the renderer', async () => {
+    h.getSkillCatalog.mockResolvedValue({ skills: [SKILL], errors: [] });
+
+    const result = await call(Channels.SKILLS_LIST);
+
+    // CLAUDE.md: templates are rendered in main at prepare/execute time; the
+    // renderer gets metadata only. A field added to SkillDef and mirrored into
+    // SkillInfo by accident would show up right here.
+    expect(JSON.stringify(result)).not.toContain('SYSTEM-PROMPT-BODY');
+    expect(JSON.stringify(result)).not.toContain('FIRST-MESSAGE-TEMPLATE');
+    expect((result as { skills: Array<Record<string, unknown>> }).skills[0]).not.toHaveProperty('body');
+    expect((result as { skills: Array<Record<string, unknown>> }).skills[0]).not.toHaveProperty('filePath');
+  });
+
+  it('reports an unloadable skill alongside the ones that loaded (#1631 rule 4)', async () => {
+    const broken = { source: 'user' as const, filePath: '/u/bad.md', label: 'bad.md', message: 'missing `menu:`' };
+    h.getSkillCatalog.mockResolvedValue({ skills: [SKILL], errors: [broken] });
+
+    // A per-item catalog is not a failure channel: the call succeeds, and the
+    // good skill is still usable.
+    const result = await call(Channels.SKILLS_LIST) as { skills: unknown[]; errors: unknown[] };
+    expect(result.skills).toHaveLength(1);
+    expect(result.errors).toEqual([broken]);
+  });
+});
+
+describe('skill management', () => {
+  it('SKILLS_RELOAD re-scans, rebuilds the native menu, and returns the fresh catalog', async () => {
+    h.reloadAndRegisterSkills.mockResolvedValue({ skills: [SKILL], errors: [] });
+
+    const result = await call(Channels.SKILLS_RELOAD) as { skills: unknown[] };
+
+    expect(result.skills).toHaveLength(1);
+    // The menu is rebuilt from the NEW registry, so it must come second.
+    expect(h.order).toEqual(['reload', 'rebuildMenu']);
+  });
+
+  it('SKILLS_MENU_CONFIG_SET persists, re-syncs the registry, and returns what was STORED', async () => {
+    const asked: MenuConfig = {
+      skills: { 'stock.socratic': { enabled: false, menu: 'Research' } },
+      order: { Learning: [], Research: ['stock.socratic'], Analysis: [] },
+    };
+    // Normalisation can drop junk, so the caller must render the saved config
+    // rather than the one it optimistically sent.
+    const stored: MenuConfig = { ...asked, skills: {} };
+    h.saveMenuConfig.mockResolvedValue(stored);
+    h.getSkillCatalog.mockResolvedValue({ skills: [SKILL], errors: [] });
+
+    await expect(call(Channels.SKILLS_MENU_CONFIG_SET, asked)).resolves.toEqual(stored);
+    expect(h.saveMenuConfig).toHaveBeenCalledWith(asked);
+    expect(h.reapplyMenuConfig).toHaveBeenCalledWith({ skills: [SKILL], errors: [] });
+    expect(h.rebuildMenu).toHaveBeenCalled();
+  });
+
+  it('SKILLS_IMPORT registers and re-menus the imported skill', async () => {
+    const imported = { id: 'user.mine', name: 'Mine', filePath: '/u/mine.md' };
+    h.pickAndImportSkill.mockResolvedValue(imported);
+    h.reloadAndRegisterSkills.mockResolvedValue({ skills: [], errors: [] });
+
+    await expect(call(Channels.SKILLS_IMPORT)).resolves.toEqual(imported);
+    expect(h.pickAndImportSkill).toHaveBeenCalledWith(h.win);
+    expect(h.order).toEqual(['reload', 'rebuildMenu']);
+  });
+
+  it('SKILLS_IMPORT does no work when the picker is cancelled', async () => {
+    // `null` here means exactly one thing — the user closed the picker (#1631
+    // rule 5) — so nothing should be reloaded or rebuilt.
+    h.pickAndImportSkill.mockResolvedValue(null);
+
+    await expect(call(Channels.SKILLS_IMPORT)).resolves.toBeNull();
+    expect(h.order).toEqual([]);
+  });
+
+  it('SKILLS_REMOVE deletes the file, then re-registers, then rebuilds', async () => {
+    h.reloadAndRegisterSkills.mockResolvedValue({ skills: [], errors: [] });
+
+    await call(Channels.SKILLS_REMOVE, 'user.mine');
+
+    expect(h.removeUserSkill).toHaveBeenCalledWith('user.mine');
+    // Rebuilding before the re-scan would leave the deleted skill on the menu.
+    expect(h.order).toEqual(['remove', 'reload', 'rebuildMenu']);
+  });
+
+  it('SKILLS_REMOVE propagates a failed delete instead of reporting success', async () => {
+    h.removeUserSkill.mockRejectedValue(new Error('Cannot remove a stock skill'));
+    await expect(call(Channels.SKILLS_REMOVE, 'stock.socratic')).rejects.toThrow(/stock skill/);
+    expect(h.rebuildMenu).not.toHaveBeenCalled();
+  });
+
+  it('SKILLS_REVEAL opens the user skills folder', async () => {
+    await call(Channels.SKILLS_REVEAL);
+    expect(h.revealSkillsFolder).toHaveBeenCalled();
+  });
+});
+
+describe('LLM settings handlers', () => {
+  it('TOOL_GET_SETTINGS reads the display view, never the decrypting one', async () => {
+    h.getSettingsForDisplay.mockResolvedValue({ model: 'claude-opus-5', hasApiKey: true });
+
+    await expect(call(Channels.TOOL_GET_SETTINGS)).resolves.toEqual({ model: 'claude-opus-5', hasApiKey: true });
+    // Opening Settings must not raise a keychain prompt, which `getSettings()`
+    // would — that's the whole reason the display read exists.
+    expect(h.getSettings).not.toHaveBeenCalled();
+  });
+
+  it('TOOL_SET_SETTINGS writes the update through', async () => {
+    const update = { model: 'claude-sonnet-5', apiKey: 'sk-new' };
+    await call(Channels.TOOL_SET_SETTINGS, update);
+    expect(h.saveSettings).toHaveBeenCalledWith(update);
+  });
+
+  it('TOOL_SET_SETTINGS surfaces a failed save', async () => {
+    h.saveSettings.mockRejectedValue(new Error('keychain denied'));
+    await expect(call(Channels.TOOL_SET_SETTINGS, {})).rejects.toThrow(/keychain denied/);
+  });
+
+  it('TOOL_GET_KEY_STORAGE reports where the key is kept', async () => {
+    h.getApiKeyStorage.mockResolvedValue('keychain');
+    await expect(call(Channels.TOOL_GET_KEY_STORAGE)).resolves.toBe('keychain');
+  });
+
+  it('TOOL_CHECK_CONNECTION passes the unsaved key and baseURL through', async () => {
+    h.checkConnection.mockResolvedValue({ ok: true });
+    await expect(call(Channels.TOOL_CHECK_CONNECTION, 'openai', 'sk-typed', 'http://localhost:1234'))
+      .resolves.toEqual({ ok: true });
+    expect(h.checkConnection).toHaveBeenCalledWith('openai', 'sk-typed', 'http://localhost:1234');
+  });
+
+  it('TOOL_CHECK_CONNECTION RESOLVES a failed check rather than rejecting', async () => {
+    // A wrong key is the expected outcome the button exists to discover, so it
+    // comes back on the union's failure arm (#1631 rule 3), not as a rejection.
+    h.checkConnection.mockResolvedValue({ ok: false, error: '401 invalid x-api-key' });
+    await expect(call(Channels.TOOL_CHECK_CONNECTION, 'anthropic'))
+      .resolves.toEqual({ ok: false, error: '401 invalid x-api-key' });
+    expect(h.checkConnection).toHaveBeenCalledWith('anthropic', undefined, undefined);
+  });
+});

--- a/tests/main/ipc/register-types.test.ts
+++ b/tests/main/ipc/register-types.test.ts
@@ -1,0 +1,292 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process coverage for `register-types.ts` (#1840).
+ *
+ * This registrar is the clearest example in the tree of #1631's two-wrapper
+ * split, so that's what it's pinned on:
+ *
+ *   - the four READS (`TYPES_LIST`, `TYPES_NOTE_PROPERTIES`, `TYPES_INSTANCES`,
+ *     `TYPES_NOTE_TYPE_MAP`) use `withRootPathOr`, and each fallback is a
+ *     legitimate value — the SAME shape the domain returns when a project is
+ *     open and genuinely has nothing. Every one of them is asserted against
+ *     that real empty answer rather than against a hand-written literal, so a
+ *     fallback that drifted into meaning "error" (a `null`, an `{ error }`, a
+ *     differently-shaped stub) would fail here.
+ *   - the four WRITES (`TYPES_SAVE`, `TYPES_DELETE`, `TYPES_DELETE_SAFELY`,
+ *     `TYPES_RENAME`) use `withRootPath`: they throw with no project open and
+ *     touch nothing, because there is no such thing as saving a type into no
+ *     thoughtbase.
+ *
+ * Also pinned: `errors[]` is a per-item catalog (#1631 rule 4) — a malformed
+ * type file is reported next to the types that loaded, and the call succeeds;
+ * the graph's type catalog is reloaded AFTER a write, and not at all if the
+ * write failed; and `toTypeInfo` (the real one) keeps `filePath` off the wire.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TypeDef } from '../../../src/shared/objects/type-def';
+
+const ROOT = '/vault';
+/** What `rootPathFromEvent` reports; null models "no project open". */
+let openProject: string | null = ROOT;
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  // types/*
+  loadTypeCatalog: vi.fn(),
+  saveType: vi.fn(),
+  deleteType: vi.fn(),
+  deleteTypeSafely: vi.fn(),
+  renameType: vi.fn(),
+  // graph/*
+  getNoteTypedProperties: vi.fn(),
+  getTypeInstances: vi.fn(),
+  getNoteTypeMap: vi.fn(),
+  reloadTypeCatalog: vi.fn(),
+  /** Call-order log — the catalog reload has to follow the write. */
+  order: [] as string[],
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: Handler) => { h.handlers.set(channel, fn); } },
+}));
+
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  rootPathFromEvent: () => openProject,
+  withRootPath:
+    <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => {
+        if (!openProject) throw new Error('No project open');
+        return fn(openProject, ...args);
+      },
+  withRootPathOr:
+    <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
+      (_e: unknown, ...args: A): R => (openProject ? fn(openProject, ...args) : fallback),
+}));
+
+vi.mock('../../../src/main/types/loader', () => ({ loadTypeCatalog: h.loadTypeCatalog }));
+vi.mock('../../../src/main/types/write', () => ({
+  saveType: (...a: unknown[]) => { h.order.push('saveType'); return h.saveType(...a); },
+  deleteType: (...a: unknown[]) => { h.order.push('deleteType'); return h.deleteType(...a); },
+}));
+vi.mock('../../../src/main/types/migrate', () => ({
+  deleteTypeSafely: h.deleteTypeSafely,
+  renameType: h.renameType,
+}));
+vi.mock('../../../src/main/graph/index', () => ({
+  getNoteTypedProperties: h.getNoteTypedProperties,
+  getTypeInstances: h.getTypeInstances,
+  getNoteTypeMap: h.getNoteTypeMap,
+  reloadTypeCatalog: (...a: unknown[]) => { h.order.push('reloadTypeCatalog'); return h.reloadTypeCatalog(...a); },
+}));
+vi.mock('../../../src/main/project-context-types', () => ({
+  projectContext: (rootPath: string) => ({ rootPath }),
+}));
+
+import { registerTypes } from '../../../src/main/ipc/register-types';
+import { Channels } from '../../../src/shared/channels';
+
+registerTypes();
+
+const call = (channel: string, ...args: unknown[]) => h.handlers.get(channel)!({}, ...args);
+/** `call` wrapped so a SYNCHRONOUS throw (the `withRootPath` guard fires before
+ *  the async body runs) is assertable with the same `rejects` matcher. */
+const callAsync = async (channel: string, ...args: unknown[]) => call(channel, ...args);
+
+const BOOK: TypeDef = {
+  id: 'book',
+  label: 'Book',
+  classLocalName: 'Book',
+  properties: [{ name: 'author', type: 'text' }],
+  template: '## Notes\n',
+  source: 'stock',
+  filePath: '/vault/.minerva/types/book.md',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.order.length = 0;
+  openProject = ROOT;
+});
+
+describe('the reads answer an empty project and no project identically', () => {
+  it('TYPES_LIST: an empty catalog is the same `{ types: [], errors: [] }` either way', async () => {
+    h.loadTypeCatalog.mockResolvedValue({ types: [], errors: [] });
+    const withProject = await call(Channels.TYPES_LIST);
+
+    openProject = null;
+    const withoutProject = await call(Channels.TYPES_LIST);
+
+    // The fallback isn't a disguised error — it's the answer a project with no
+    // types gives, so the picker renders "nothing yet" in both cases.
+    expect(withoutProject).toEqual(withProject);
+    expect(withoutProject).toEqual({ types: [], errors: [] });
+    expect(h.loadTypeCatalog).toHaveBeenCalledTimes(1); // never reached without a project
+  });
+
+  it('TYPES_NOTE_PROPERTIES: an untyped note and no project both answer `{ type: null, properties: [] }`', async () => {
+    h.getNoteTypedProperties.mockReturnValue({ type: null, properties: [] });
+    const untyped = await call(Channels.TYPES_NOTE_PROPERTIES, 'notes/a.md');
+
+    openProject = null;
+    const noProject = await call(Channels.TYPES_NOTE_PROPERTIES, 'notes/a.md');
+
+    expect(noProject).toEqual(untyped);
+    expect(h.getNoteTypedProperties).toHaveBeenCalledTimes(1);
+  });
+
+  it('TYPES_INSTANCES: an unused type and no project both answer `{ type: null, instances: [] }`', async () => {
+    h.getTypeInstances.mockReturnValue({ type: null, instances: [] });
+    const unused = await call(Channels.TYPES_INSTANCES, 'book');
+
+    openProject = null;
+    const noProject = await call(Channels.TYPES_INSTANCES, 'book');
+
+    expect(noProject).toEqual(unused);
+    expect(h.getTypeInstances).toHaveBeenCalledTimes(1);
+  });
+
+  it('TYPES_NOTE_TYPE_MAP: "nothing is typed yet" and no project are both `{}`', async () => {
+    h.getNoteTypeMap.mockReturnValue({});
+    const nothingTyped = await call(Channels.TYPES_NOTE_TYPE_MAP);
+
+    openProject = null;
+    const noProject = await call(Channels.TYPES_NOTE_TYPE_MAP);
+
+    expect(noProject).toEqual(nothingTyped);
+    expect(h.getNoteTypeMap).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the reads with a project open', () => {
+  it('TYPES_LIST serializes the catalog without the on-disk path', async () => {
+    h.loadTypeCatalog.mockResolvedValue({ types: [BOOK], errors: [] });
+
+    const result = await call(Channels.TYPES_LIST) as { types: Array<Record<string, unknown>> };
+
+    expect(h.loadTypeCatalog).toHaveBeenCalledWith(ROOT);
+    // The template body DOES cross (it's a note scaffold, not an LLM prompt) —
+    // the picker instantiates from it without a round-trip.
+    expect(result.types[0]).toMatchObject({ id: 'book', label: 'Book', template: '## Notes\n' });
+    expect(result.types[0]).not.toHaveProperty('filePath');
+  });
+
+  it('TYPES_LIST reports a broken type file alongside the ones that loaded (#1631 rule 4)', async () => {
+    const broken = { source: 'user', filePath: '/vault/.minerva/types/bad.md', label: 'bad.md', message: 'no `label:`' };
+    h.loadTypeCatalog.mockResolvedValue({ types: [BOOK], errors: [broken] });
+
+    const result = await call(Channels.TYPES_LIST) as { types: unknown[]; errors: unknown[] };
+
+    // The call succeeded; `errors` describes the items, it isn't the outcome.
+    expect(result.types).toHaveLength(1);
+    expect(result.errors).toEqual([broken]);
+  });
+
+  it('TYPES_LIST rethrows a genuine load failure instead of answering an empty catalog', async () => {
+    h.loadTypeCatalog.mockRejectedValue(new Error('EACCES: permission denied'));
+    // `{ types: [], errors: [] }` here would tell the picker every type had been
+    // deleted — the fallback means "none", never "couldn't look".
+    await expect(callAsync(Channels.TYPES_LIST)).rejects.toThrow(/EACCES/);
+  });
+
+  it('TYPES_NOTE_PROPERTIES projects the note over the indexed graph', async () => {
+    const props = { type: 'book', properties: [{ name: 'author', type: 'text', value: 'Lamport' }] };
+    h.getNoteTypedProperties.mockReturnValue(props);
+
+    await expect(callAsync(Channels.TYPES_NOTE_PROPERTIES, 'notes/paxos.md')).resolves.toEqual(props);
+    expect(h.getNoteTypedProperties).toHaveBeenCalledWith({ rootPath: ROOT }, 'notes/paxos.md');
+  });
+
+  it('TYPES_INSTANCES lists every note of a type', async () => {
+    const instances = { type: 'book', instances: [{ path: 'notes/paxos.md', values: {} }] };
+    h.getTypeInstances.mockReturnValue(instances);
+
+    await expect(callAsync(Channels.TYPES_INSTANCES, 'book')).resolves.toEqual(instances);
+    expect(h.getTypeInstances).toHaveBeenCalledWith({ rootPath: ROOT }, 'book');
+  });
+
+  it('TYPES_NOTE_TYPE_MAP keys the note rows by type', async () => {
+    h.getNoteTypeMap.mockReturnValue({ 'notes/paxos.md': 'book' });
+    await expect(callAsync(Channels.TYPES_NOTE_TYPE_MAP)).resolves.toEqual({ 'notes/paxos.md': 'book' });
+    expect(h.getNoteTypeMap).toHaveBeenCalledWith({ rootPath: ROOT });
+  });
+});
+
+describe('the writes', () => {
+  it('TYPES_SAVE writes the file, THEN reloads the graph catalog', async () => {
+    h.saveType.mockResolvedValue({ id: 'book', filePath: '/vault/.minerva/types/book.md' });
+
+    await expect(callAsync(Channels.TYPES_SAVE, { label: 'Book', properties: [] }))
+      .resolves.toEqual({ id: 'book', filePath: '/vault/.minerva/types/book.md' });
+
+    expect(h.saveType).toHaveBeenCalledWith(ROOT, { label: 'Book', properties: [] });
+    // Reloading first would re-read the catalog without the new type, leaving
+    // it unusable for promotion/indexing until the next reload.
+    expect(h.order).toEqual(['saveType', 'reloadTypeCatalog']);
+    expect(h.reloadTypeCatalog).toHaveBeenCalledWith({ rootPath: ROOT });
+  });
+
+  it('TYPES_SAVE does not reload the catalog when the write failed', async () => {
+    h.saveType.mockRejectedValue(new Error('EROFS: read-only file system'));
+    await expect(callAsync(Channels.TYPES_SAVE, { label: 'Book' })).rejects.toThrow(/EROFS/);
+    expect(h.reloadTypeCatalog).not.toHaveBeenCalled();
+  });
+
+  it('TYPES_DELETE removes the file, THEN reloads the catalog', async () => {
+    await call(Channels.TYPES_DELETE, 'book');
+    expect(h.deleteType).toHaveBeenCalledWith(ROOT, 'book');
+    expect(h.order).toEqual(['deleteType', 'reloadTypeCatalog']);
+  });
+
+  it('TYPES_DELETE_SAFELY reports what it cleared and what it could not (#1588)', async () => {
+    const outcome = { cleared: ['notes/a.md'], failed: [{ path: 'notes/b.md', error: 'EACCES' }] };
+    h.deleteTypeSafely.mockResolvedValue(outcome);
+
+    // A per-note outcome catalog: the delete succeeded, and the caller can see
+    // which instances were left behind.
+    await expect(callAsync(Channels.TYPES_DELETE_SAFELY, 'book', true)).resolves.toEqual(outcome);
+    expect(h.deleteTypeSafely).toHaveBeenCalledWith(ROOT, 'book', true);
+  });
+
+  it('TYPES_DELETE_SAFELY passes `clearInstances: false` through unchanged', async () => {
+    h.deleteTypeSafely.mockResolvedValue({ cleared: [], failed: [] });
+    await call(Channels.TYPES_DELETE_SAFELY, 'book', false);
+    // Leaving instances typed vs clearing them is the user's explicit choice;
+    // the handler must not helpfully default it.
+    expect(h.deleteTypeSafely).toHaveBeenCalledWith(ROOT, 'book', false);
+  });
+
+  it('TYPES_RENAME migrates every instance to the new id', async () => {
+    const outcome = { newId: 'monograph', migrated: ['notes/a.md'], failed: [] };
+    h.renameType.mockResolvedValue(outcome);
+
+    await expect(callAsync(Channels.TYPES_RENAME, 'book', 'Monograph')).resolves.toEqual(outcome);
+    expect(h.renameType).toHaveBeenCalledWith(ROOT, 'book', 'Monograph');
+  });
+
+  it.each([
+    [Channels.TYPES_SAVE, [{ label: 'Book' }]],
+    [Channels.TYPES_DELETE, ['book']],
+    [Channels.TYPES_DELETE_SAFELY, ['book', true]],
+    [Channels.TYPES_RENAME, ['book', 'Monograph']],
+  ])('%s throws with no project open', async (channel, args) => {
+    openProject = null;
+    await expect(callAsync(channel, ...args)).rejects.toThrow(/No project open/);
+  });
+
+  it('none of the writes touched disk or the graph with no project open', async () => {
+    openProject = null;
+    await expect(callAsync(Channels.TYPES_SAVE, {})).rejects.toThrow();
+    await expect(callAsync(Channels.TYPES_DELETE, 'book')).rejects.toThrow();
+    await expect(callAsync(Channels.TYPES_DELETE_SAFELY, 'book', true)).rejects.toThrow();
+    await expect(callAsync(Channels.TYPES_RENAME, 'book', 'Monograph')).rejects.toThrow();
+
+    expect(h.saveType).not.toHaveBeenCalled();
+    expect(h.deleteType).not.toHaveBeenCalled();
+    expect(h.deleteTypeSafely).not.toHaveBeenCalled();
+    expect(h.renameType).not.toHaveBeenCalled();
+    expect(h.reloadTypeCatalog).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -131,21 +131,22 @@ export default defineConfig({
           branches: 66,
         },
         // IPC registrars — channel→module glue that was entirely unfenced
-        // (QA C1 / #1612), then covered registrar by registrar. #1840 added
-        // direct handler tests for the three biggest untested ones —
-        // register-notebase (the write path), register-graph, register-links —
-        // taking the layer from ~33 L / 18.7 F / 30.7 S / 14.3 B to ~50.5 L /
-        // 38.1 F / 48.2 S / 31.6 B. The branch floor especially matters: this
-        // is the layer that owns `withRootPath` vs `withRootPathOr` semantics,
-        // so the #1631 no-project/not-found conflations can now regress into a
-        // test failure instead of passing silently. Floors sit ~10 points below
-        // measured so a refactor won't flap. Still a BACKSTOP, not a target —
-        // 16 registrars remain without a direct test; ratchet up as they land.
+        // (QA C1 / #1612), then covered registrar by registrar until #1840
+        // finished the job: all 24 now have a direct handler test, and
+        // `tests/architecture/ipc-registrar-coverage.test.ts` keeps it that way
+        // (a new registrar without one fails). That took the layer from ~33 L /
+        // 18.7 F / 30.7 S / 14.3 B to ~75.8 L / 76.5 F / 74.7 S / 61.7 B.
+        //
+        // The branch floor is the one that earns its keep: this layer owns the
+        // `withRootPath` vs `withRootPathOr` decision, so a #1631 no-project
+        // conflation now regresses into a test failure instead of passing in
+        // silence. Floors sit ~10 points below measured so a refactor won't
+        // flap. No longer a backstop — a real gate.
         'src/main/ipc/**': {
-          lines: 40,
-          functions: 28,
-          statements: 38,
-          branches: 21,
+          lines: 65,
+          functions: 66,
+          statements: 64,
+          branches: 51,
         },
         // Neglected top-level main modules — previously unfenced (#1100 / QA
         // H1). These sit at `src/main/*.ts` (no directory of their own), so


### PR DESCRIPTION
Closes #1840. **This is a recovery PR, not new work.**

### What happened

#1876, #1879 and #1880 were stacked: each targeted its predecessor's branch rather than `main`. #1876 merged to main correctly. Then #1879 merged into `test/ipc-registrars-batch-c` and #1880 into `test/ipc-registrars-batch-a` — both of which had already served their purpose and were no longer heading anywhere. GitHub shows all three as MERGED, and two of them merged into dead ends.

So `main` has batch C's six small registrars and **none** of batch A's or B's:

```
$ ls tests/main/ipc/    # on main, before this PR
register-bookmarks  register-conversation  register-graph  register-history
register-links      register-notebase      register-shell  register-small
```

No sources, publish, bibliography, compute, tools, types or queries — 325 tests and the coverage-floor raise, all sitting on branches. `KNOWN_UNTESTED` on main still lists seven registrars that do have tests, just not ones main can see.

That's the second time this session that work reported as merged wasn't on main (#1858 lost two commits the same way). Stacked PRs are the common factor, and I should have verified `main` rather than the PR state both times.

### What this contains

Nothing new — `origin/test/ipc-registrars-batch-b` merged onto current main, which carries A's and B's commits with it:

| | Tests |
| --- | --- |
| `register-sources` / `publish` / `bibliography` (batch A) | 219 |
| `register-compute` / `tools` / `types` / `queries` (batch B) | 106 |
| `vitest.config.mts` floor raise | — |

One conflict, in `KNOWN_UNTESTED` — resolved to the empty list, which is correct now that all 24 registrars have tests.

Re-verified on the merged tree rather than trusting the branches:

- `pnpm lint` clean
- full suite **6,606 passing** (619 files)
- `pnpm coverage` passes: `src/main/ipc/**` at **75.8 L / 76.5 F / 74.7 S / 61.7 B** against the new 65/66/64/51 floors

The PR bodies of #1879 and #1880 describe the tests and their findings; nothing about the content has changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy