### PR TITLE
refactor(compute): make PythonProbeResult a real discriminated union (#1878)

### DIFF
--- a/src/main/compute/python-settings.ts
+++ b/src/main/compute/python-settings.ts
@@ -19,6 +19,7 @@ import { spawn } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { loadConfigFile, asString, asRecord } from '../config/config-store';
+import type { PythonProbeResult } from '../../shared/compute/types';
 
 export interface PythonSettings {
   /**
@@ -37,15 +38,10 @@ export interface PythonSettings {
   allowNetwork: boolean;
 }
 
-export interface PythonProbeResult {
-  ok: boolean;
-  /** Resolved interpreter path (the input, normalised). */
-  path: string;
-  /** Version string from `python --version` (e.g. "Python 3.11.10"). */
-  version?: string;
-  /** Error message when `ok: false` — surfaced inline in the Settings UI. */
-  error?: string;
-}
+// The probe's result shape moved to `shared/compute/types` in #1878, where the
+// IPC contract and the settings panel can share one definition instead of
+// restating it. Re-exported so existing importers of this module still resolve.
+export type { PythonProbeResult } from '../../shared/compute/types';
 
 const DEFAULT_SETTINGS: PythonSettings = { pythonPath: '', allowNetwork: false };
 

--- a/src/renderer/lib/components/ComputeSettings.svelte
+++ b/src/renderer/lib/components/ComputeSettings.svelte
@@ -8,7 +8,7 @@
    */
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
-  import type { ComputeConsentSummary } from '../../../shared/compute/types';
+  import type { ComputeConsentSummary, PythonProbeResult } from '../../../shared/compute/types';
   import { getSettingsStore } from '../stores/settings.svelte';
 
   const settings = getSettingsStore();
@@ -38,7 +38,10 @@
   let pythonPathInput = $state('');
   /** What's saved to disk; used to detect dirty state. */
   let pythonPathSaved = $state('');
-  let pythonProbe = $state<{ ok: boolean; path: string; version?: string; error?: string } | null>(null);
+  // The shared union (#1878), not a restated shape: `{#if pythonProbe.ok}` now
+  // narrows, so the template reaches `version` and `error` on the arm that has
+  // them rather than on an optional the compiler couldn't vouch for.
+  let pythonProbe = $state<PythonProbeResult | null>(null);
   let pythonProbing = $state(false);
   /** Network egress toggle (#1413). Off by default; the kernel blocks non-local
    *  sockets unless this is on. Applied when the kernel next starts. */

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -269,8 +269,8 @@ export interface FilesApi {
   dropImport(targetFolder: string, localPaths: string[]): Promise<DropImportResult>;
 }
 
-export type { CellOutput, CellResult } from '../../../shared/compute/types';
-import type { CellResult, ComputeConsentSummary } from '../../../shared/compute/types';
+export type { CellOutput, CellResult, PythonProbeResult } from '../../../shared/compute/types';
+import type { CellResult, ComputeConsentSummary, PythonProbeResult } from '../../../shared/compute/types';
 
 export interface CitationAuditPayload {
   /** Resolved style id after fallback (e.g. 'apa'). */
@@ -503,12 +503,7 @@ export interface ComputeApi {
    * Probe a candidate interpreter — verify it runs + capture the
    * version string. Empty / omitted `candidate` probes the active
    * resolver pick (the Settings UI's "what's running" display). */
-  probePython(candidate?: string): Promise<{
-    ok: boolean;
-    path: string;
-    version?: string;
-    error?: string;
-  }>;
+  probePython(candidate?: string): Promise<PythonProbeResult>;
   /** Native file picker for selecting a Python interpreter; null on cancel. */
   browsePython(): Promise<string | null>;
   /**

--- a/src/shared/compute/types.ts
+++ b/src/shared/compute/types.ts
@@ -43,6 +43,32 @@ export type CellResult =
   | { ok: false; error: string };
 
 /**
+ * Outcome of probing a candidate Python interpreter (#1878).
+ *
+ * A discriminated union, like `CellResult` above and `InterruptResult` in the
+ * kernel — not `{ ok: boolean; version?; error? }`, which was the shape until
+ * #1878. That shape let `{ ok: true, error: '…' }` type-check and narrowed
+ * nothing on `if (result.ok)`, so every consumer re-checked `version` the
+ * compiler could have guaranteed.
+ *
+ * `path` is on both arms because the answer is always ABOUT an interpreter:
+ * the settings status line names the one it probed whether or not it ran.
+ *
+ * Lives here rather than in `main/compute/python-settings.ts` because the
+ * contract, the client and the settings panel all need it, and each was
+ * restating the shape inline — three copies free to drift.
+ *
+ * Like the other unions here, the CALL does not reject: a probe that couldn't
+ * run is an expected answer the settings status line renders, not a failure
+ * the caller has to catch.
+ */
+export type PythonProbeResult =
+  /** Ran, and reported a version — `version` is the raw `python --version` line. */
+  | { ok: true; path: string; version: string }
+  /** Didn't run, or didn't look like Python. `error` is user-facing. */
+  | { ok: false; path: string; error: string };
+
+/**
  * Wire format the Python kernel emits for last-expression results
  * (#243). Modelled on Jupyter's display-data MIME bundle so any future
  * frontend that already understands the shape can plug in. The

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -61,7 +61,7 @@ import type { InspectionSettings } from './inspections';
 import type { ClipperState } from './clipper-pairing';
 import type { Proposal } from './proposals';
 import type { HistorySettings, LabelNotesResult, RevisionMeta } from './history';
-import type { CellResult, CellOutput, ComputeConsentSummary } from './compute/types';
+import type { CellResult, CellOutput, ComputeConsentSummary, PythonProbeResult } from './compute/types';
 import type { AutoLinkSuggestion } from './refactor/auto-link';
 import type { AutoLinkInboundSuggestion } from './refactor/auto-link-inbound';
 import type { FormatSettings } from './formatter/engine';
@@ -372,7 +372,7 @@ export interface ChannelMap {
     | { ok: false; reason: 'no-kernel' | 'unsupported-platform' | 'signal-failed' };
   'compute:getPythonSettings': () => { pythonPath: string; allowNetwork: boolean };
   'compute:setPythonSettings': (settings: { pythonPath: string; allowNetwork: boolean }) => void;
-  'compute:probePython': (candidate?: string) => { ok: boolean; path: string; version?: string; error?: string };
+  'compute:probePython': (candidate?: string) => PythonProbeResult;
   'compute:browsePython': () => string | null;
   'compute:consentStatus': (language: string, code: string) => 'cell' | 'blanket' | 'none';
   'compute:grantConsent': (language: string, code: string, scope: 'cell' | 'project') => void;

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -58,7 +58,7 @@ const BUDGETS: Record<string, number> = {
   'src/renderer/lib/components/Preview.svelte': 1531,
   'src/renderer/lib/components/SourceDetail.svelte': 1329,
   'src/renderer/lib/components/SourcesPanel.svelte': 1297,
-  'src/renderer/lib/ipc/client.ts': 1241,
+  'src/renderer/lib/ipc/client.ts': 1236,
   'src/renderer/lib/stores/conversations.svelte.ts': 1212,
   'src/renderer/lib/components/Editor.svelte': 1208,
   'src/renderer/lib/stores/editor.svelte.ts': 1183,

--- a/tests/main/compute/python-settings.test.ts
+++ b/tests/main/compute/python-settings.test.ts
@@ -154,13 +154,16 @@ describe('probePythonInterpreter (#374)', () => {
 
   skipIfNoPython('returns ok + version for a real python on PATH', async () => {
     const r = await probePythonInterpreter('python3');
-    expect(r.ok).toBe(true);
+    // Narrowing, not optional-chaining: since #1878 the result is a
+    // discriminated union, so `version` is guaranteed on this arm rather than
+    // being a `string | undefined` every caller has to re-check.
+    if (!r.ok) throw new Error(`expected a successful probe, got: ${r.error}`);
     expect(r.version).toMatch(/^Python \d+\.\d+/);
   });
 
   it('returns an error result for an obviously-bogus path', async () => {
     const r = await probePythonInterpreter('/not/a/real/python');
-    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error(`expected a failed probe, got: ${r.version}`);
     expect(r.error).toBeTruthy();
     expect(r.path).toBe('/not/a/real/python');
   });


### PR DESCRIPTION
Closes #1878.

CLAUDE.md's rule 3 lists `PythonProbeResult` beside `CellResult` and `InterruptResult` as a legitimate `{ ok, … }` union. Unlike those two, it wasn't one:

```ts
// before — one shape, two optionals
interface PythonProbeResult { ok: boolean; path: string; version?: string; error?: string }

// after
type PythonProbeResult =
  | { ok: true;  path: string; version: string }
  | { ok: false; path: string; error: string };
```

`if (result.ok)` narrowed nothing, every consumer re-checked `version` the compiler could have guaranteed, and `{ ok: true, error: '…' }` type-checked. `path` stays on both arms because the answer is always *about* an interpreter — the status line names the one it probed whether or not it ran.

### It was written out four times

The interface in `python-settings.ts`, inline restatements in `ipc-contract.ts` and `client.ts`, and a fourth copy as the `$state` annotation in `ComputeSettings.svelte`. Four copies of a shape is how a shape drifts. There's one now, in `shared/compute/types.ts` next to its siblings, and `python-settings.ts` re-exports it so existing importers still resolve.

### The invariant is checkable, not just intended

Verified by adding `error` to the success arm:

```
error TS2353: Object literal may only specify known properties, and 'error'
does not exist in type '{ ok: true; path: string; version: string; }'.
```

### Both consumers got simpler

Which is the tell that the type was wrong rather than the callers. The settings template narrows on `{#if pythonProbe.ok}` instead of reaching for optionals, and the probe tests assert on the arm they mean:

```ts
if (!r.ok) throw new Error(`expected a successful probe, got: ${r.error}`);
expect(r.version).toMatch(/^Python \d+\.\d+/);
```

Those tests were reaching `r.version` on an un-narrowed result and passing only because `tsconfig.json` includes `src/**/*` and not `tests/` — worth knowing, since it means the test tree doesn't get this class of check.

No CLAUDE.md edit needed: rule 3 already described this as a union. The documentation was aspirational and the code has caught up.

The file-size ratchet fired **downward** for once — `client.ts` lost five lines to the shared type — and its budget is lowered to match, per its own instruction.

`pnpm lint` clean; full suite 6,608 passing (619 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy