### PR TITLE
fix(sources): hasPdf's false means one thing now (#1881)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,9 @@ can't quietly grow while nobody re-reads it:
   `GRAPH_EXCERPT_SOURCE`, `PROPOSAL_DETAIL`, `TEMPLATES_GET` and
   `CONVERSATION_LOAD` are all `withRootPath` now, #1841.)*
 - boolean overloads: proposals `APPROVE` / `REJECT` (`false` = no-project ↔
-  failed). *(`NOTEBASE_FILE_EXISTS` cleared in #1862.)*
+  failed). *(`NOTEBASE_FILE_EXISTS` cleared in #1862, `SOURCES_HAS_PDF` in
+  #1881 — both were never listed here; the shape is worth grepping for rather
+  than trusting this list to be complete.)*
 - in-band `error?` → union: `GRAPH_QUERY` (`{ results, columns, error? }` should
   match the `TABLES_QUERY` `{ ok:false; error }` shape).
 - swallows: `LINKS_CITATIONS_FOR_NOTE` (`.catch(()=>'')`), `CSL_REMOVE_STYLE` /

--- a/src/main/ipc/register-sources.ts
+++ b/src/main/ipc/register-sources.ts
@@ -153,12 +153,20 @@ export function registerSources(): void {
     return await readOriginalPdf(rootPath, sourceId);
   }));
 
-  handle(Channels.SOURCES_HAS_PDF, withRootPathOr<[string], boolean | Promise<boolean>>(false, async (rootPath, sourceId: string) => {
+  // `false` means exactly one thing: this source was ingested without keeping
+  // its original PDF (#1881). It used to mean that OR "no project open" OR "the
+  // file is there but unreadable", so a PDF the user can see on disk showed no
+  // "Open original" button and gave no clue why. There is no meaningful
+  // project-less answer to "does this source have a PDF" — nothing can be
+  // asking about a source outside an open thoughtbase — so this is
+  // `withRootPath`, and only ENOENT is caught.
+  handle(Channels.SOURCES_HAS_PDF, withRootPath(async (rootPath, sourceId: string) => {
     try {
       await fs.stat(path.join(rootPath, '.minerva', 'sources', sourceId, 'original.pdf'));
       return true;
-    } catch {
-      return false;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      throw err;
     }
   }));
 

--- a/src/renderer/lib/app/nav-view.ts
+++ b/src/renderer/lib/app/nav-view.ts
@@ -130,7 +130,12 @@ export function createNavView(ctx: NavViewCtx) {
     // jumping to an excerpt is a markdown-view affordance until the
     // PDF viewer's highlight click-to-navigate is wired up. (#100)
     if (!highlightExcerptId && getPreferredSourceView(sourceId) === 'pdf') {
-      void api.sources.hasPdf(sourceId).then((ok) => {
+      // A failed check is not "no PDF" — but the honest fallback for routing is
+      // still the text view, so log and take it (#1881).
+      void api.sources.hasPdf(sourceId).catch((err: unknown) => {
+        console.error('[sources] could not check for an original PDF:', err);
+        return false;
+      }).then((ok) => {
         if (ok) {
           editor.openPdf(sourceId);
           nav.record({ type: 'source', sourceId });

--- a/src/renderer/lib/components/SourceDetail.svelte
+++ b/src/renderer/lib/components/SourceDetail.svelte
@@ -128,7 +128,15 @@
   let hasPdf = $state(false);
 
   $effect(() => {
-    void api.sources.hasPdf(sourceId).then((r) => { hasPdf = r; });
+    // `false` now means only "ingested without a PDF" (#1881); a genuine read
+    // failure rejects. Offering "Open original PDF" for a file we couldn't
+    // stat would just fail later, so treat it as absent — but say so.
+    void api.sources.hasPdf(sourceId)
+      .catch((err: unknown) => {
+        console.error('[sources] could not check for an original PDF:', err);
+        return false;
+      })
+      .then((r) => { hasPdf = r; });
   });
 
   async function handleRename() {

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -1104,6 +1104,9 @@ export interface SourcesApi {
   readPdf(sourceId: string): Promise<Uint8Array>;
   /** True iff `.minerva/sources/<id>/original.pdf` exists. Used by the
    *  source detail UI to decide whether to show the PDF affordance. */
+  /** Whether this source kept its original PDF. `false` means exactly that —
+   *  ingested without one (#1881); a failed check rejects rather than reading
+   *  as "no PDF". */
   hasPdf(sourceId: string): Promise<boolean>;
   /** Per-project default folder for excerpt-derived notes (#101).
    *  Returns '' = project root. */

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -56,9 +56,9 @@ const THRESHOLD = 600;
 const BUDGETS: Record<string, number> = {
   'src/renderer/App.svelte': 2080,
   'src/renderer/lib/components/Preview.svelte': 1531,
-  'src/renderer/lib/components/SourceDetail.svelte': 1329,
+  'src/renderer/lib/components/SourceDetail.svelte': 1337,
   'src/renderer/lib/components/SourcesPanel.svelte': 1297,
-  'src/renderer/lib/ipc/client.ts': 1236,
+  'src/renderer/lib/ipc/client.ts': 1239,
   'src/renderer/lib/stores/conversations.svelte.ts': 1212,
   'src/renderer/lib/components/Editor.svelte': 1208,
   'src/renderer/lib/stores/editor.svelte.ts': 1183,

--- a/tests/architecture/pattern-ratchets.test.ts
+++ b/tests/architecture/pattern-ratchets.test.ts
@@ -136,7 +136,6 @@ const SWALLOW_BASELINE: Record<string, number> = {
   'src/main/graph/indexers/source.ts': 1,
   'src/main/graph/parser.ts': 1,
   'src/main/images/remote-image-cache.ts': 2,
-  'src/main/ipc/register-sources.ts': 1,
   'src/main/llm/conversation.ts': 2,
   'src/main/llm/provider/openai.ts': 1,
   'src/main/llm/settings.ts': 1,

--- a/tests/main/ipc/register-sources.test.ts
+++ b/tests/main/ipc/register-sources.test.ts
@@ -315,13 +315,13 @@ describe('register-sources — the #1631 project guard', () => {
     expect((projectless as { smartCollections?: unknown[] }).smartCollections).toBeUndefined();
   });
 
-  it('SOURCES_HAS_PDF answers false with no project — the same false as "no PDF kept"', () => {
-    // Honest note: this `false` is overloaded (no project / no original.pdf /
-    // an unreadable one), the same shape as the NOTEBASE_FILE_EXISTS boolean
-    // on the #1631 backlog. Pinned as-is; it is not this test's job to change
-    // the contract.
+  it('SOURCES_HAS_PDF throws with no project rather than answering "no PDF" (#1881)', () => {
+    // Its `false` used to cover three facts — no project, no original.pdf, an
+    // unreadable one — the same overload #1862 cleared from
+    // NOTEBASE_FILE_EXISTS. Nothing can be asking about a source outside an
+    // open thoughtbase, so there is no honest project-less answer here.
     openProject = null;
-    expect(call(Channels.SOURCES_HAS_PDF, 's1')).toBe(false);
+    expect(() => call(Channels.SOURCES_HAS_PDF, 's1')).toThrow('No project open');
     expect(h.stat).not.toHaveBeenCalled();
   });
 
@@ -532,6 +532,13 @@ describe('register-sources — ingest', () => {
     h.stat.mockResolvedValue({});
     await expect(callAsync(Channels.SOURCES_HAS_PDF, 's1')).resolves.toBe(true);
     expect(h.stat).toHaveBeenCalledWith('/vault/.minerva/sources/s1/original.pdf');
+  });
+
+  it('SOURCES_HAS_PDF surfaces an unreadable file instead of calling it absent (#1881)', async () => {
+    // The distinction the old blanket catch erased: a PDF that is there but
+    // can't be stat'd is a problem to report, not a source without a PDF.
+    h.stat.mockRejectedValue(Object.assign(new Error('EACCES'), { code: 'EACCES' }));
+    await expect(callAsync(Channels.SOURCES_HAS_PDF, 's1')).rejects.toThrow('EACCES');
   });
 
   it('SOURCES_HAS_PDF reports false for a source ingested without one', async () => {


### PR DESCRIPTION
Closes #1881.

`SOURCES_HAS_PDF` answered `false` for three different facts:

| | before | after |
| --- | --- | --- |
| no project open | `false` | throws |
| ingested without a PDF | `false` | `false` |
| PDF present but unreadable | `false` | throws |

Two overloads stacked — a `withRootPathOr(false, …)` fallback and a blanket `catch` — so a PDF the user can *see on disk* showed no "Open original PDF" button and gave no clue why.

Only ENOENT returns `false` now. And the handler is `withRootPath`, because there's no honest project-less answer to "does this source have a PDF" — nothing can be asking about a source outside an open thoughtbase.

### The callers

Both were `void api.sources.hasPdf(id).then(…)` with no `.catch`, so a rejecting handler would have produced unhandled rejections. Both gained one. They still fall back to "no PDF" — offering to open a file we couldn't stat would just fail later — but they **log**, so the difference between "no PDF" and "something is wrong with this PDF" reaches somewhere a person can see it. Same posture as the formatter settings in #1841: the contract is honest, the UI degrades gracefully, and the failure isn't silent.

### Both ratchets fired, in opposite directions

```
Swallowed errors (catch → empty value): the count went DOWN — nice.
  − src/main/ipc/register-sources.ts: 1 → 0

File-size budget exceeded — the count went UP.
  + src/renderer/lib/components/SourceDetail.svelte: 1329 → 1337 (+8)
  + src/renderer/lib/ipc/client.ts: 1236 → 1239 (+3)
```

`register-sources` leaves the swallow list entirely; two files grew by the catch blocks and a doc comment. Baselines updated per each check's own instruction. Nice to see the down-direction land on a real fix rather than a refactor.

### A note on the backlog

Neither this nor `NOTEBASE_FILE_EXISTS` (cleared in #1862) was ever *on* CLAUDE.md's boolean-overload row. Both were found by reading code — one while writing registrar tests, one while fixing its neighbour. I've added that observation to the row itself: the shape is worth grepping for rather than trusting a hand-kept list to be complete. #1848's ratchet does exactly this for swallows; a boolean-overload ratchet would be harder (there's no syntactic tell), which is probably why the list exists at all.

`pnpm lint` clean; full suite 6,609 passing (619 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy