### PR TITLE
refactor(graph): the last three query families — queries.ts is a facade (#1838)

### DIFF
--- a/src/main/graph/queries.ts
+++ b/src/main/graph/queries.ts
@@ -1,27 +1,24 @@
 /**
- * Graph read / query layer (#671, increment 2).
+ * Graph read/query layer — a facade (#671, split by family in #1838).
  *
- * Pure read functions over the per-project `GraphState`: alias / frontmatter
- * lookups, SPARQL execution, tag / source / link / citation queries. None of
- * these mutate the store or go through the LLM write guard.
+ * Every query lives in `./queries/<family>.ts`; this file exists so that
+ * `graph/index` and the ~40 call sites that `import … from './queries'` don't
+ * have to know which family a function belongs to. It carries no logic of its
+ * own.
  *
- * Imports its foundations from `./state` (never from `./index`, to keep the
- * package acyclic). `./index` re-exports this module's public surface so
- * external `import * as graph from './graph/index'` callers are unchanged.
+ * The families, and what makes each one a family:
+ *   - `tags`       — questions keyed by tag
+ *   - `sources`    — questions about a source (detail, reading queue, citations)
+ *   - `links`      — note-to-note edges, both directions
+ *   - `references` — what points at a source / excerpt / anchor
+ *   - `notes`      — a note's own identity: aliases, frontmatter keys, headings
+ *   - `sparql`     — the engine surface: prefixes, completion schema, queryGraph
+ *
+ * The split is by QUESTION, not by table: `sources.ts` owns `listAllSources`
+ * because it calls `collectSourceMetadata`, even though it sat among the tag
+ * queries for years. Where a function goes is decided by what it needs, which
+ * is why each extraction was checked in both directions before it moved.
  */
-
-import * as $rdf from 'rdflib';
-import type { ProjectContext } from '../project-context-types';
-import { LINK_TYPES } from '../../shared/link-types';
-import { stripNoteExt } from '../../shared/note-extensions';
-import {
-  type GraphState, type HeadingSnapshot,
-  getState, getEngine, ensureN3Cache,
-  MINERVA, RDF, THOUGHT,
-  STANDARD_PREFIXES,
-  noteUri, sourceUri, excerptUri,
-  linkPredicate,
-} from './state';
 
 // Tag queries live in `./queries/tags` (#1838). Re-exported here so
 // `graph/index` and every `import … from './queries'` caller is unchanged —
@@ -60,318 +57,31 @@ export {
   findExternalInboundLinks,
 } from './queries/links';
 
-// ── Alias / frontmatter lookups ─────────────────────────────────────────────
+// Note-identity lookups live in `./queries/notes` (#1838).
+export {
+  getAliasMap,
+  aliasesForNote,
+  getAliasEntries,
+  getAllFrontmatterKeys,
+  noteUriFor,
+  headingsFor,
+} from './queries/notes';
+export type { AliasEntry } from './queries/notes';
 
-/**
- * Snapshot of the live alias map (#469). Returns alias → relativePath
- * pairs as a plain object; the renderer uses it for wiki-link
- * navigation and (eventually) autocomplete. Keys are lower-cased.
- */
-export function getAliasMap(ctx: ProjectContext): Record<string, string> {
-  const state = getState(ctx);
-  if (!state) return {};
-  const out: Record<string, string> = {};
-  for (const [k, v] of state.aliasMap) out[k] = v;
-  return out;
-}
+// Reference lookups live in `./queries/references` (#1838).
+export {
+  findNotesCitingSource,
+  findNotesQuotingExcerpt,
+  termNotePaths,
+  allNotePaths,
+  findNotesLinkingToAnchor,
+  findNotesLinkingToAnchorImpl,
+} from './queries/references';
 
-/**
- * Entries form of the alias map, preserving original casing (#492).
- * `getAliasMap` lowercases everything for case-insensitive resolution;
- * the wiki-link autocomplete needs the original casing so picking a
- * suggested alias inserts `[[JFK]]` rather than `[[jfk]]`.
- *
- * Same conflict policy as `rebuildAliasMap`:
- *   - Alphabetical-first-writer wins on alias collisions.
- *   - Aliases that lowercase-collide with a real note's path stem or
- *     basename are dropped.
- */
-export interface AliasEntry {
-  alias: string;
-  relativePath: string;
-}
-/** The frontmatter aliases declared by a single note (#1074) — for pointing the
- *  unlinked-mentions embeddings query at an object's title + aliases. */
-export function aliasesForNote(ctx: ProjectContext, relativePath: string): string[] {
-  const state = getState(ctx);
-  return state?.aliasesPerNote.get(relativePath) ?? [];
-}
-
-export function getAliasEntries(ctx: ProjectContext): AliasEntry[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  const claimed = new Set<string>(); // lowercase aliases already taken
-  // Drop any alias whose lowercase form collides with a real note's
-  // canonical name — matches rebuildAliasMap's second pass.
-  const canonicals = new Set<string>();
-  for (const path of state.indexedNotePaths) {
-    const stem = stripNoteExt(path).toLowerCase();
-    canonicals.add(stem);
-    const basename = stem.split('/').pop() ?? '';
-    if (basename) canonicals.add(basename);
-  }
-  const out: AliasEntry[] = [];
-  const paths = [...state.aliasesPerNote.keys()].sort();
-  for (const path of paths) {
-    const aliases = state.aliasesPerNote.get(path) ?? [];
-    for (const alias of aliases) {
-      const key = alias.toLowerCase();
-      if (canonicals.has(key)) continue;
-      if (claimed.has(key)) continue;
-      claimed.add(key);
-      out.push({ alias, relativePath: path });
-    }
-  }
-  return out;
-}
-
-/**
- * Deduped, alphabetically-sorted list of every frontmatter key
- * currently in use across the project. Powers the Properties panel's
- * Add-Property autocomplete (#488). Empty when the project has no
- * graph state yet.
- */
-export function getAllFrontmatterKeys(ctx: ProjectContext): string[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  const seen = new Set<string>();
-  for (const keys of state.frontmatterKeysPerNote.values()) {
-    for (const k of keys) seen.add(k);
-  }
-  return [...seen].sort((a, b) => a.localeCompare(b));
-}
-
-/**
- * The IRI Minerva uses to identify the note at `relativePath` in the
- * graph for project `ctx`. Exposed so callers outside graph/index.ts
- * (notably the conversation module, which writes thought:contextNote
- * triples) can write a real IRI instead of stuffing a relative path
- * into an angle-bracket slot. Returns null when the project has no
- * graph state yet — caller should treat that as "no triple to write".
- */
-export function noteUriFor(ctx: ProjectContext, relativePath: string): string | null {
-  const state = getState(ctx);
-  if (!state) return null;
-  return noteUri(state, relativePath).value;
-}
-
-/** Return headings present in the last indexNote call for `relativePath`, or []. */
-export function headingsFor(ctx: ProjectContext, relativePath: string): HeadingSnapshot[] {
-  const state = getState(ctx);
-  return state?.headingsPerNote.get(relativePath) ?? [];
-}
-
-// ── Citation / anchor link lookups ──────────────────────────────────────────
-
-/** Notes with a `thought:cites` edge to the given source URI. */
-export function findNotesCitingSource(ctx: ProjectContext, sourceId: string): string[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  const target = sourceUri(state, sourceId);
-  return collectNotePathsWithPredicate(state, THOUGHT('cites'), target);
-}
-
-/** Notes with a `thought:quotes` edge to the given excerpt URI. */
-export function findNotesQuotingExcerpt(ctx: ProjectContext, excerptId: string): string[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  const target = excerptUri(state, excerptId);
-  return collectNotePathsWithPredicate(state, THOUGHT('quotes'), target);
-}
-
-function collectNotePathsWithPredicate(
-  state: GraphState,
-  predicate: ReturnType<typeof MINERVA>,
-  target: $rdf.NamedNode,
-): string[] {
-  const { store } = state;
-  const stmts = store.statementsMatching(undefined, predicate, target);
-  const seen = new Set<string>();
-  for (const st of stmts) {
-    const pathStmts = store.statementsMatching(st.subject, MINERVA('relativePath'), undefined);
-    const p = pathStmts[0]?.object.value;
-    if (p && p.endsWith('.md')) seen.add(p);
-  }
-  return [...seen];
-}
-
-/** Relative paths of every note typed `thought:Term` — glossary entries
- *  (#1142). Used to give term nodes a distinct rendering in the neighborhood
- *  graph. Returned as a Set for O(1) membership during graph classification. */
-export function termNotePaths(ctx: ProjectContext): Set<string> {
-  const state = getState(ctx);
-  if (!state) return new Set();
-  const { store } = state;
-  const paths = new Set<string>();
-  for (const st of store.statementsMatching(undefined, RDF('type'), THOUGHT('Term'))) {
-    const pathStmts = store.statementsMatching(st.subject, MINERVA('relativePath'), undefined);
-    const p = pathStmts[0]?.object.value;
-    if (p && p.endsWith('.md')) paths.add(p);
-  }
-  return paths;
-}
-
-/** All indexed `.md` note paths in the thoughtbase (#215 — cross-note
- *  rules use this to reason about which link shortenings are unambiguous). */
-export function allNotePaths(ctx: ProjectContext): string[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  return [...state.indexedNotePaths].filter((p) => p.endsWith('.md'));
-}
-
-/** Like findNotesLinkingTo, but scoped to links whose anchor is exactly `slug`. */
-export function findNotesLinkingToAnchor(
-  ctx: ProjectContext,
-  targetRelativePath: string,
-  slug: string,
-): string[] {
-  const state = getState(ctx);
-  if (!state) return [];
-  return findNotesLinkingToAnchorImpl(state, targetRelativePath, slug);
-}
-
-export function findNotesLinkingToAnchorImpl(
-  state: GraphState,
-  targetRelativePath: string,
-  slug: string,
-): string[] {
-  const { store } = state;
-  const exactTarget = `${noteUri(state, targetRelativePath).value}#${slug}`;
-  const seen = new Set<string>();
-  for (const lt of LINK_TYPES) {
-    if (lt.targetKind && lt.targetKind !== 'note') continue;
-    const stmts = store.statementsMatching(undefined, linkPredicate(lt), undefined);
-    for (const st of stmts) {
-      if (st.object.value !== exactTarget) continue;
-      const sourceNode = st.subject;
-      const pathStmts = store.statementsMatching(sourceNode, MINERVA('relativePath'), undefined);
-      const sourcePath = pathStmts[0]?.object.value;
-      if (sourcePath && sourcePath.endsWith('.md')) seen.add(sourcePath);
-    }
-  }
-  return [...seen];
-}
-
-// ── SPARQL ──────────────────────────────────────────────────────────────────
-
-export function injectSparqlPrefixes(sparql: string): string {
-  // Only inject prefixes the user hasn't already declared. SPARQL's
-  // PREFIX keyword is case-insensitive and allows varied whitespace,
-  // so a naive includes("PREFIX x:") test misses `Prefix x:` and
-  // `PREFIX  x :` — both legal, both would produce duplicate-decl
-  // errors from the evaluator if we blindly injected on top.
-  const lines: string[] = [];
-  for (const [prefix, iri] of STANDARD_PREFIXES) {
-    const re = new RegExp(`\\bprefix\\s+${prefix}\\s*:`, 'i');
-    if (!re.test(sparql)) {
-      lines.push(`PREFIX ${prefix}: <${iri}>`);
-    }
-  }
-  return lines.length > 0 ? lines.join('\n') + '\n' + sparql : sparql;
-}
-
-export interface SchemaEntry {
-  iri: string;
-  /** Prefixed form when a known prefix covers the IRI (e.g. "minerva:hasTag"). */
-  prefixed?: string;
-}
-
-export interface GraphSchema {
-  /** Standard prefixes the query path auto-injects. */
-  prefixes: Array<{ prefix: string; iri: string }>;
-  /** Distinct predicate IRIs in the live graph. */
-  predicates: SchemaEntry[];
-  /** Distinct class IRIs (objects of `rdf:type`) in the live graph. */
-  classes: SchemaEntry[];
-}
-
-/**
- * Snapshot of the live graph’s predicates + classes for autocomplete (#198).
- * Sorted alphabetically by prefixed form when available, otherwise by full
- * IRI. Safe to call often — cheap walk over the store.
- */
-export function schemaForCompletion(ctx: ProjectContext): GraphSchema {
-  const prefixes = STANDARD_PREFIXES.map(([prefix, iri]) => ({ prefix, iri }));
-  const state = getState(ctx);
-  if (!state) return { prefixes, predicates: [], classes: [] };
-  const { store } = state;
-
-  const rdfTypeIri = RDF('type').value;
-  const predicateIris = new Set<string>();
-  const classIris = new Set<string>();
-
-  for (const st of store.statements) {
-    predicateIris.add(st.predicate.value);
-    if (st.predicate.value === rdfTypeIri && st.object.termType === 'NamedNode') {
-      classIris.add(st.object.value);
-    }
-  }
-
-  function toEntry(iri: string): SchemaEntry {
-    for (const { prefix, iri: base } of prefixes) {
-      if (iri.startsWith(base)) {
-        return { iri, prefixed: `${prefix}:${iri.slice(base.length)}` };
-      }
-    }
-    return { iri };
-  }
-
-  const sortKey = (e: SchemaEntry) => (e.prefixed ?? e.iri).toLowerCase();
-
-  return {
-    prefixes,
-    predicates: [...predicateIris].map(toEntry).sort((a, b) => sortKey(a).localeCompare(sortKey(b))),
-    classes: [...classIris].map(toEntry).sort((a, b) => sortKey(a).localeCompare(sortKey(b))),
-  };
-}
-
-export async function queryGraph(
-  ctx: ProjectContext,
-  sparql: string,
-): Promise<{ results: unknown[]; columns: string[]; error?: string }> {
-  const state = getState(ctx);
-  if (!state) return { results: [], columns: [] };
-  const engine = getEngine();
-  try {
-    // Build the mirror if cold, yielding so a large rebuild doesn't jank the
-    // main thread (#1115). Warm queries return the live mirror with no yield.
-    const n3Store = await ensureN3Cache(state);
-    const prefixed = injectSparqlPrefixes(sparql);
-
-    // Use the full query() API (not queryBindings) so we can read the result
-    // metadata: the SELECT projection — in order, including variables that end
-    // up unbound in every row. Deriving columns from the bindings alone would
-    // silently drop an always-unbound column.
-    const result = await engine.query(prefixed, { sources: [n3Store] });
-    if (result.resultType !== 'bindings') {
-      return { results: [], columns: [] };
-    }
-    const metadata = await result.metadata();
-    // Comunica's runtime shape for `variables` has drifted from its types: some
-    // versions expose `RDF.Variable[]` (the element IS the variable), others
-    // `{ variable: RDF.Variable }[]`. Handle both so the column list is robust.
-    const vars = metadata.variables as unknown as Array<{ value?: string; variable?: { value: string } }>;
-    let columns = vars.map((v) => v.variable?.value ?? v.value ?? '').filter(Boolean);
-
-    const bindingsStream = await result.execute();
-    const bindings = await bindingsStream.toArray();
-    const results = bindings.map((binding) => {
-      const obj: Record<string, string> = {};
-      for (const [variable, term] of binding) {
-        obj[variable.value] = term.value;
-      }
-      return obj;
-    });
-
-    if (columns.length === 0) {
-      // Fallback (e.g. metadata unavailable): union of keys across all rows.
-      const seen = new Set<string>();
-      for (const row of results) for (const k of Object.keys(row)) seen.add(k);
-      columns = [...seen];
-    }
-
-    return { results, columns };
-  } catch (e) {
-    return { results: [], columns: [], error: String(e) };
-  }
-}
+// SPARQL plumbing lives in `./queries/sparql` (#1838).
+export {
+  injectSparqlPrefixes,
+  schemaForCompletion,
+  queryGraph,
+} from './queries/sparql';
+export type { SchemaEntry, GraphSchema } from './queries/sparql';

--- a/src/main/graph/queries/notes.ts
+++ b/src/main/graph/queries/notes.ts
@@ -1,0 +1,114 @@
+/**
+ * Note-identity and frontmatter lookups (#1838 — the last family out of
+ * `queries.ts`).
+ *
+ * What the store knows about a note AS a note: its aliases (both directions),
+ * the project's frontmatter vocabulary, its IRI, and its heading snapshot.
+ * Everything here is keyed by a note path or resolves one.
+ *
+ * Read-only, reaches only `../state`, re-exported by `queries.ts`.
+ */
+import type { ProjectContext } from '../../project-context-types';
+import { stripNoteExt } from '../../../shared/note-extensions';
+import { type HeadingSnapshot, getState, noteUri } from '../state';
+
+/**
+ * Snapshot of the live alias map (#469). Returns alias → relativePath
+ * pairs as a plain object; the renderer uses it for wiki-link
+ * navigation and (eventually) autocomplete. Keys are lower-cased.
+ */
+export function getAliasMap(ctx: ProjectContext): Record<string, string> {
+  const state = getState(ctx);
+  if (!state) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of state.aliasMap) out[k] = v;
+  return out;
+}
+
+/**
+ * Entries form of the alias map, preserving original casing (#492).
+ * `getAliasMap` lowercases everything for case-insensitive resolution;
+ * the wiki-link autocomplete needs the original casing so picking a
+ * suggested alias inserts `[[JFK]]` rather than `[[jfk]]`.
+ *
+ * Same conflict policy as `rebuildAliasMap`:
+ *   - Alphabetical-first-writer wins on alias collisions.
+ *   - Aliases that lowercase-collide with a real note's path stem or
+ *     basename are dropped.
+ */
+export interface AliasEntry {
+  alias: string;
+  relativePath: string;
+}
+/** The frontmatter aliases declared by a single note (#1074) — for pointing the
+ *  unlinked-mentions embeddings query at an object's title + aliases. */
+export function aliasesForNote(ctx: ProjectContext, relativePath: string): string[] {
+  const state = getState(ctx);
+  return state?.aliasesPerNote.get(relativePath) ?? [];
+}
+
+export function getAliasEntries(ctx: ProjectContext): AliasEntry[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const claimed = new Set<string>(); // lowercase aliases already taken
+  // Drop any alias whose lowercase form collides with a real note's
+  // canonical name — matches rebuildAliasMap's second pass.
+  const canonicals = new Set<string>();
+  for (const path of state.indexedNotePaths) {
+    const stem = stripNoteExt(path).toLowerCase();
+    canonicals.add(stem);
+    const basename = stem.split('/').pop() ?? '';
+    if (basename) canonicals.add(basename);
+  }
+  const out: AliasEntry[] = [];
+  const paths = [...state.aliasesPerNote.keys()].sort();
+  for (const path of paths) {
+    const aliases = state.aliasesPerNote.get(path) ?? [];
+    for (const alias of aliases) {
+      const key = alias.toLowerCase();
+      if (canonicals.has(key)) continue;
+      if (claimed.has(key)) continue;
+      claimed.add(key);
+      out.push({ alias, relativePath: path });
+    }
+  }
+  return out;
+}
+
+/**
+ * Deduped, alphabetically-sorted list of every frontmatter key
+ * currently in use across the project. Powers the Properties panel's
+ * Add-Property autocomplete (#488). Empty when the project has no
+ * graph state yet.
+ */
+export function getAllFrontmatterKeys(ctx: ProjectContext): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const seen = new Set<string>();
+  for (const keys of state.frontmatterKeysPerNote.values()) {
+    for (const k of keys) seen.add(k);
+  }
+  return [...seen].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * The IRI Minerva uses to identify the note at `relativePath` in the
+ * graph for project `ctx`. Exposed so callers outside graph/index.ts
+ * (notably the conversation module, which writes thought:contextNote
+ * triples) can write a real IRI instead of stuffing a relative path
+ * into an angle-bracket slot. Returns null when the project has no
+ * graph state yet — caller should treat that as "no triple to write".
+ */
+export function noteUriFor(ctx: ProjectContext, relativePath: string): string | null {
+  const state = getState(ctx);
+  if (!state) return null;
+  return noteUri(state, relativePath).value;
+}
+
+/** Return headings present in the last indexNote call for `relativePath`, or []. */
+export function headingsFor(ctx: ProjectContext, relativePath: string): HeadingSnapshot[] {
+  const state = getState(ctx);
+  return state?.headingsPerNote.get(relativePath) ?? [];
+}
+
+

--- a/src/main/graph/queries/references.ts
+++ b/src/main/graph/queries/references.ts
@@ -1,0 +1,115 @@
+/**
+ * Reference lookups (#1838 — split by family out of `queries.ts`).
+ *
+ * "Which notes point at this thing?", where the thing is a source, an excerpt,
+ * or a heading anchor — as distinct from `./links`, which answers the same
+ * question for note-to-note edges. Also the two whole-project note listings
+ * (`allNotePaths`, `termNotePaths`) that the refactor and glossary paths walk.
+ *
+ * `findNotesLinkingToAnchorImpl` is imported by `graph/indexers.ts` through the
+ * `queries.ts` facade — the one place the write side reaches into the read
+ * side, and it stays a one-way edge.
+ *
+ * Read-only, reaches only `../state`, re-exported by `queries.ts`.
+ */
+import * as $rdf from 'rdflib';
+import type { ProjectContext } from '../../project-context-types';
+import { LINK_TYPES } from '../../../shared/link-types';
+import {
+  type GraphState,
+  getState,
+  MINERVA, RDF, THOUGHT,
+  noteUri, sourceUri, excerptUri,
+  linkPredicate,
+} from '../state';
+
+/** Notes with a `thought:cites` edge to the given source URI. */
+export function findNotesCitingSource(ctx: ProjectContext, sourceId: string): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const target = sourceUri(state, sourceId);
+  return collectNotePathsWithPredicate(state, THOUGHT('cites'), target);
+}
+
+/** Notes with a `thought:quotes` edge to the given excerpt URI. */
+export function findNotesQuotingExcerpt(ctx: ProjectContext, excerptId: string): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  const target = excerptUri(state, excerptId);
+  return collectNotePathsWithPredicate(state, THOUGHT('quotes'), target);
+}
+
+function collectNotePathsWithPredicate(
+  state: GraphState,
+  predicate: ReturnType<typeof MINERVA>,
+  target: $rdf.NamedNode,
+): string[] {
+  const { store } = state;
+  const stmts = store.statementsMatching(undefined, predicate, target);
+  const seen = new Set<string>();
+  for (const st of stmts) {
+    const pathStmts = store.statementsMatching(st.subject, MINERVA('relativePath'), undefined);
+    const p = pathStmts[0]?.object.value;
+    if (p && p.endsWith('.md')) seen.add(p);
+  }
+  return [...seen];
+}
+
+/** Relative paths of every note typed `thought:Term` — glossary entries
+ *  (#1142). Used to give term nodes a distinct rendering in the neighborhood
+ *  graph. Returned as a Set for O(1) membership during graph classification. */
+export function termNotePaths(ctx: ProjectContext): Set<string> {
+  const state = getState(ctx);
+  if (!state) return new Set();
+  const { store } = state;
+  const paths = new Set<string>();
+  for (const st of store.statementsMatching(undefined, RDF('type'), THOUGHT('Term'))) {
+    const pathStmts = store.statementsMatching(st.subject, MINERVA('relativePath'), undefined);
+    const p = pathStmts[0]?.object.value;
+    if (p && p.endsWith('.md')) paths.add(p);
+  }
+  return paths;
+}
+
+/** All indexed `.md` note paths in the thoughtbase (#215 — cross-note
+ *  rules use this to reason about which link shortenings are unambiguous). */
+export function allNotePaths(ctx: ProjectContext): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  return [...state.indexedNotePaths].filter((p) => p.endsWith('.md'));
+}
+
+/** Like findNotesLinkingTo, but scoped to links whose anchor is exactly `slug`. */
+export function findNotesLinkingToAnchor(
+  ctx: ProjectContext,
+  targetRelativePath: string,
+  slug: string,
+): string[] {
+  const state = getState(ctx);
+  if (!state) return [];
+  return findNotesLinkingToAnchorImpl(state, targetRelativePath, slug);
+}
+
+export function findNotesLinkingToAnchorImpl(
+  state: GraphState,
+  targetRelativePath: string,
+  slug: string,
+): string[] {
+  const { store } = state;
+  const exactTarget = `${noteUri(state, targetRelativePath).value}#${slug}`;
+  const seen = new Set<string>();
+  for (const lt of LINK_TYPES) {
+    if (lt.targetKind && lt.targetKind !== 'note') continue;
+    const stmts = store.statementsMatching(undefined, linkPredicate(lt), undefined);
+    for (const st of stmts) {
+      if (st.object.value !== exactTarget) continue;
+      const sourceNode = st.subject;
+      const pathStmts = store.statementsMatching(sourceNode, MINERVA('relativePath'), undefined);
+      const sourcePath = pathStmts[0]?.object.value;
+      if (sourcePath && sourcePath.endsWith('.md')) seen.add(sourcePath);
+    }
+  }
+  return [...seen];
+}
+
+

--- a/src/main/graph/queries/sparql.ts
+++ b/src/main/graph/queries/sparql.ts
@@ -1,0 +1,139 @@
+/**
+ * SPARQL plumbing (#1838 — split by family out of `queries.ts`).
+ *
+ * The query engine's own surface: prefix injection, the schema the editor's
+ * completion reads, and `queryGraph` itself. Distinct from every other family
+ * here — those answer specific questions about notes, and this one runs
+ * whatever the user asked.
+ *
+ * Read-only, reaches only `../state`, re-exported by `queries.ts`.
+ */
+import type { ProjectContext } from '../../project-context-types';
+import {
+  getState, getEngine, ensureN3Cache,
+  RDF,
+  STANDARD_PREFIXES,
+} from '../state';
+
+export function injectSparqlPrefixes(sparql: string): string {
+  // Only inject prefixes the user hasn't already declared. SPARQL's
+  // PREFIX keyword is case-insensitive and allows varied whitespace,
+  // so a naive includes("PREFIX x:") test misses `Prefix x:` and
+  // `PREFIX  x :` — both legal, both would produce duplicate-decl
+  // errors from the evaluator if we blindly injected on top.
+  const lines: string[] = [];
+  for (const [prefix, iri] of STANDARD_PREFIXES) {
+    const re = new RegExp(`\\bprefix\\s+${prefix}\\s*:`, 'i');
+    if (!re.test(sparql)) {
+      lines.push(`PREFIX ${prefix}: <${iri}>`);
+    }
+  }
+  return lines.length > 0 ? lines.join('\n') + '\n' + sparql : sparql;
+}
+
+export interface SchemaEntry {
+  iri: string;
+  /** Prefixed form when a known prefix covers the IRI (e.g. "minerva:hasTag"). */
+  prefixed?: string;
+}
+
+export interface GraphSchema {
+  /** Standard prefixes the query path auto-injects. */
+  prefixes: Array<{ prefix: string; iri: string }>;
+  /** Distinct predicate IRIs in the live graph. */
+  predicates: SchemaEntry[];
+  /** Distinct class IRIs (objects of `rdf:type`) in the live graph. */
+  classes: SchemaEntry[];
+}
+
+/**
+ * Snapshot of the live graph’s predicates + classes for autocomplete (#198).
+ * Sorted alphabetically by prefixed form when available, otherwise by full
+ * IRI. Safe to call often — cheap walk over the store.
+ */
+export function schemaForCompletion(ctx: ProjectContext): GraphSchema {
+  const prefixes = STANDARD_PREFIXES.map(([prefix, iri]) => ({ prefix, iri }));
+  const state = getState(ctx);
+  if (!state) return { prefixes, predicates: [], classes: [] };
+  const { store } = state;
+
+  const rdfTypeIri = RDF('type').value;
+  const predicateIris = new Set<string>();
+  const classIris = new Set<string>();
+
+  for (const st of store.statements) {
+    predicateIris.add(st.predicate.value);
+    if (st.predicate.value === rdfTypeIri && st.object.termType === 'NamedNode') {
+      classIris.add(st.object.value);
+    }
+  }
+
+  function toEntry(iri: string): SchemaEntry {
+    for (const { prefix, iri: base } of prefixes) {
+      if (iri.startsWith(base)) {
+        return { iri, prefixed: `${prefix}:${iri.slice(base.length)}` };
+      }
+    }
+    return { iri };
+  }
+
+  const sortKey = (e: SchemaEntry) => (e.prefixed ?? e.iri).toLowerCase();
+
+  return {
+    prefixes,
+    predicates: [...predicateIris].map(toEntry).sort((a, b) => sortKey(a).localeCompare(sortKey(b))),
+    classes: [...classIris].map(toEntry).sort((a, b) => sortKey(a).localeCompare(sortKey(b))),
+  };
+}
+
+export async function queryGraph(
+  ctx: ProjectContext,
+  sparql: string,
+): Promise<{ results: unknown[]; columns: string[]; error?: string }> {
+  const state = getState(ctx);
+  if (!state) return { results: [], columns: [] };
+  const engine = getEngine();
+  try {
+    // Build the mirror if cold, yielding so a large rebuild doesn't jank the
+    // main thread (#1115). Warm queries return the live mirror with no yield.
+    const n3Store = await ensureN3Cache(state);
+    const prefixed = injectSparqlPrefixes(sparql);
+
+    // Use the full query() API (not queryBindings) so we can read the result
+    // metadata: the SELECT projection — in order, including variables that end
+    // up unbound in every row. Deriving columns from the bindings alone would
+    // silently drop an always-unbound column.
+    const result = await engine.query(prefixed, { sources: [n3Store] });
+    if (result.resultType !== 'bindings') {
+      return { results: [], columns: [] };
+    }
+    const metadata = await result.metadata();
+    // Comunica's runtime shape for `variables` has drifted from its types: some
+    // versions expose `RDF.Variable[]` (the element IS the variable), others
+    // `{ variable: RDF.Variable }[]`. Handle both so the column list is robust.
+    const vars = metadata.variables as unknown as Array<{ value?: string; variable?: { value: string } }>;
+    let columns = vars.map((v) => v.variable?.value ?? v.value ?? '').filter(Boolean);
+
+    const bindingsStream = await result.execute();
+    const bindings = await bindingsStream.toArray();
+    const results = bindings.map((binding) => {
+      const obj: Record<string, string> = {};
+      for (const [variable, term] of binding) {
+        obj[variable.value] = term.value;
+      }
+      return obj;
+    });
+
+    if (columns.length === 0) {
+      // Fallback (e.g. metadata unavailable): union of keys across all rows.
+      const seen = new Set<string>();
+      for (const row of results) for (const k of Object.keys(row)) seen.add(k);
+      columns = [...seen];
+    }
+
+    return { results, columns };
+  } catch (e) {
+    return { results: [], columns: [], error: String(e) };
+  }
+}
+


### PR DESCRIPTION
Closes #1838.

`queries.ts` is **61 lines** and carries no logic. Six families under `graph/queries/`, and a file whose only job is that `graph/index` and the ~40 `import … from './queries'` call sites don't have to know which family a function belongs to.

```
1,294  →  377 (tags, sources, links)  →  61 (notes, references, sparql)
```

| Module | Lines | What makes it a family |
| --- | --- | --- |
| `sources.ts` | 523 | questions about a source |
| `links.ts` | 345 | note-to-note edges, both directions |
| `tags.ts` | 145 | questions keyed by tag |
| `sparql.ts` | 139 | the engine surface: prefixes, completion schema, `queryGraph` |
| `references.ts` | 115 | what points at a source / excerpt / anchor |
| `notes.ts` | 114 | a note's own identity: aliases, frontmatter keys, headings |

The split is by **question, not by table** — `sources.ts` owns `listAllSources` because it calls `collectSourceMetadata`, even though it sat among the tag queries for years. That's now written in the facade header, which is the part that was genuinely missing.

Checked in both directions before moving, as with the earlier three: no family calls into another, and each private helper is used only by its own family. `findNotesLinkingToAnchorImpl` stays reachable through the facade, which is how `indexers.ts` gets it — the one edge from the write side into the read side, still one-way.

### On my earlier argument

I said in #1874 that the remaining ~340 lines were one concern and splitting further would "buy directory entries rather than clarity", and left the call to you. Having done it: I was wrong about the SPARQL third, which is obviously its own thing — it runs whatever the user asked, where every other family answers a specific question about notes. And separating "what does this note look like" from "what points at it" reads better than I expected. The `references` / `links` distinction in particular is one I'd have wanted a comment to explain, and now it's a filename.

Whole suite passes **with no test edits** — the same proof the earlier extractions carried. `pnpm lint` clean; 6,609 tests (619 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy