### PR TITLE
build(docs): generate website/docs from a nav tree + content fragments (#1842)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,11 @@
     "typecheck:clipper": "tsc -p clipper/tsconfig.json --noEmit",
     "fetch:model": "node scripts/fetch-embedding-model.mjs",
     "fetch:help-corpus": "vite-node scripts/build-help-corpus.mjs",
-    "predev": "node scripts/fetch-embedding-model.mjs && vite-node scripts/build-help-corpus.mjs",
-    "prebuild": "node scripts/fetch-embedding-model.mjs && vite-node scripts/build-help-corpus.mjs",
-    "prebuild:e2e": "node scripts/fetch-embedding-model.mjs && vite-node scripts/build-help-corpus.mjs"
+    "build:docs": "node scripts/build-docs.mjs",
+    "check:docs": "node scripts/build-docs.mjs --check",
+    "predev": "node scripts/build-docs.mjs && node scripts/fetch-embedding-model.mjs && vite-node scripts/build-help-corpus.mjs",
+    "prebuild": "node scripts/build-docs.mjs && node scripts/fetch-embedding-model.mjs && vite-node scripts/build-help-corpus.mjs",
+    "prebuild:e2e": "node scripts/build-docs.mjs && node scripts/fetch-embedding-model.mjs && vite-node scripts/build-help-corpus.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.117.1",

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -1,0 +1,62 @@
+/**
+ * Generate the docs site (#1842).
+ *
+ * Writes `website/docs/*.html` from `_layout.html` + `_nav.json` +
+ * `_content/*.html` (see `scripts/lib/docs-model.mjs` for the model). The
+ * generated HTML stays committed — the site deploys straight from the repo via
+ * `scripts/deploy-to-gh-pages.sh`, and there is no build step on gh-pages —
+ * so this is a "regenerate and commit" step, not a dist target. Wired into
+ * `predev`/`prebuild` ahead of the help-corpus build, which consumes the same
+ * fragments.
+ *
+ * Adding a docs page is now two files: one `_content/<page>.html` fragment and
+ * one entry in `_nav.json`. Every other page's sidebar and pager follows.
+ *
+ *   node scripts/build-docs.mjs           write changed pages
+ *   node scripts/build-docs.mjs --check   exit 1 if anything would change
+ *
+ * `--check` is what CI/the test use; it never writes.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildDocs } from './lib/docs-model.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DOCS_DIR = path.join(ROOT, 'website', 'docs');
+const check = process.argv.includes('--check');
+
+const pages = buildDocs(DOCS_DIR);
+
+const changed = [];
+for (const [name, html] of pages) {
+  const file = path.join(DOCS_DIR, name);
+  const existing = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : null;
+  if (existing === html) continue;
+  changed.push(name);
+  if (!check) fs.writeFileSync(file, html);
+}
+
+// A page whose fragment was deleted would otherwise linger as a stale file the
+// generator no longer owns — and would still be picked up by the deploy.
+const stale = fs.readdirSync(DOCS_DIR)
+  .filter((f) => f.endsWith('.html') && !f.startsWith('_') && !pages.has(f));
+
+if (check) {
+  if (!changed.length && !stale.length) {
+    console.log(`docs are up to date — ${pages.size} pages match website/docs/`);
+    process.exit(0);
+  }
+  if (changed.length) console.error(`docs are stale — ${changed.length} page(s) differ from the generator:\n  ${changed.join('\n  ')}`);
+  if (stale.length) console.error(`orphaned page(s) in website/docs/ with no _content fragment:\n  ${stale.join('\n  ')}`);
+  console.error('\nRun `pnpm build:docs` and commit the result.');
+  process.exit(1);
+}
+
+if (stale.length) {
+  console.warn(`warning: ${stale.length} page(s) in website/docs/ have no _content fragment and were left alone: ${stale.join(', ')}`);
+}
+console.log(changed.length
+  ? `docs built: ${changed.length} of ${pages.size} page(s) rewritten in website/docs/`
+  : `docs built: all ${pages.size} pages already up to date`);

--- a/scripts/build-help-corpus.mjs
+++ b/scripts/build-help-corpus.mjs
@@ -1,8 +1,10 @@
 /**
  * Build the precomputed help-docs corpus (#1284, epic:docs-grounding, #1154).
  *
- * Embeds `website/docs/*.html` (extracted into chunks by
- * `scripts/lib/extract-docs-corpus.mjs`) with the same bundled all-MiniLM-L6-v2
+ * Embeds the docs content fragments `website/docs/_content/*.html` (extracted
+ * into chunks by `scripts/lib/extract-docs-corpus.mjs` — the same fragments
+ * `scripts/build-docs.mjs` renders the site from, #1842) with the same
+ * bundled all-MiniLM-L6-v2
  * model the thoughtbase's own semantic search uses, and writes the result to
  * `resources/help-docs/corpus.json` — a static asset shipped alongside the app
  * (via forge's `extraResource: ['resources']`), not rebuilt at runtime. The
@@ -32,6 +34,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { extractDocsCorpus } from './lib/extract-docs-corpus.mjs';
+import { CONTENT_DIR } from './lib/docs-model.mjs';
 import { createWasmEmbedder } from '../src/main/embeddings/wasm-embedder.ts';
 import { MODEL } from '../src/main/embeddings/embedder.ts';
 
@@ -40,7 +43,9 @@ const DOCS_DIR = path.join(ROOT, 'website', 'docs');
 const OUT_DIR = path.join(ROOT, 'resources', 'help-docs');
 const OUT_FILE = path.join(OUT_DIR, 'corpus.json');
 const THIS_FILE = fileURLToPath(import.meta.url);
+const CONTENT_PATH = path.join(DOCS_DIR, CONTENT_DIR);
 const EXTRACT_FILE = path.join(ROOT, 'scripts', 'lib', 'extract-docs-corpus.mjs');
+const MODEL_FILE = path.join(ROOT, 'scripts', 'lib', 'docs-model.mjs');
 
 function latestMtimeMs(dir) {
   let latest = 0;
@@ -63,8 +68,9 @@ function isUpToDate() {
 
   const outMtime = fs.statSync(OUT_FILE).mtimeMs;
   const inputsMtime = Math.max(
-    latestMtimeMs(DOCS_DIR),
+    latestMtimeMs(CONTENT_PATH),
     fs.statSync(EXTRACT_FILE).mtimeMs,
+    fs.statSync(MODEL_FILE).mtimeMs,
     fs.statSync(THIS_FILE).mtimeMs,
   );
   return outMtime >= inputsMtime;
@@ -77,7 +83,7 @@ if (isUpToDate()) {
 
 const chunks = extractDocsCorpus(DOCS_DIR);
 if (chunks.length === 0) {
-  throw new Error(`no chunks extracted from ${DOCS_DIR} — is website/docs/ present?`);
+  throw new Error(`no chunks extracted from ${CONTENT_PATH} — is website/docs/_content/ present?`);
 }
 
 // Embedding all ~500 chunks in one batch pads every row to the single
@@ -107,7 +113,7 @@ try {
   fs.writeFileSync(OUT_FILE, JSON.stringify(corpus));
 
   const sizeKb = Math.round(fs.statSync(OUT_FILE).size / 1024);
-  console.log(`help-docs corpus built: ${chunks.length} chunks from website/docs/ → resources/help-docs/corpus.json (${sizeKb} KB)`);
+  console.log(`help-docs corpus built: ${chunks.length} chunks from website/docs/_content/ → resources/help-docs/corpus.json (${sizeKb} KB)`);
 } finally {
   await embedder.dispose();
 }

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -40,9 +40,12 @@ rm -rf "$WORKTREE_DIR"/*
 cp -r website/* "$WORKTREE_DIR/"
 
 # Strip dev-only files that live under website/ but aren't part of the
-# published site: the Playwright screenshot harness (specs, fixtures, helpers)
-# and the internal README. The captured images live in docs/img/ and DO ship.
-rm -rf "$WORKTREE_DIR/screenshots" "$WORKTREE_DIR/README.txt"
+# published site: the Playwright screenshot harness (specs, fixtures, helpers),
+# the internal README, and the docs generator's inputs — layout, nav tree and
+# content fragments, from which docs/*.html is already built (#1842). The
+# captured images live in docs/img/ and DO ship.
+rm -rf "$WORKTREE_DIR/screenshots" "$WORKTREE_DIR/README.txt" \
+  "$WORKTREE_DIR/docs/_content" "$WORKTREE_DIR/docs/_nav.json" "$WORKTREE_DIR/docs/_layout.html"
 
 # Commit and push
 cd "$WORKTREE_DIR"

--- a/scripts/lib/docs-model.mjs
+++ b/scripts/lib/docs-model.mjs
@@ -1,0 +1,226 @@
+/**
+ * The docs-site model (#1842).
+ *
+ * `website/docs/` used to be 118 hand-maintained HTML pages in which ~36% of
+ * the lines were byte-identical copy-pasted chrome, and "add a page" meant a
+ * scripted edit across all 118 to insert its sidebar entry and fix its
+ * neighbours' pagers. This module is the single source of truth those pages
+ * are now generated from — `scripts/build-docs.mjs` writes the HTML,
+ * `scripts/lib/extract-docs-corpus.mjs` reads the same fragments for the
+ * in-app help corpus, and `tests/scripts/docs-generated.test.ts` asserts the
+ * committed HTML still matches.
+ *
+ * Three inputs, all under `website/docs/`:
+ *
+ *   `_layout.html`   the chrome — head, top nav (inline SVG logo), the
+ *                    `<div class="docs">` shell and the footer — with four
+ *                    placeholders: {{title}}, {{description}}, {{sidebar}},
+ *                    {{content}}. Verbatim from the pages it replaced.
+ *   `_nav.json`      sections → items → optional children, each `{ href,
+ *                    label }` plus optional `title`/`crumb` overrides. This one
+ *                    file drives EVERY page's sidebar, breadcrumbs and
+ *                    prev/next pager, so those can no longer drift page to
+ *                    page — which they had: four sidebars were missing a
+ *                    sibling added after they were last copy-pasted, and
+ *                    conversations.html's "previous" still pointed two pages
+ *                    back.
+ *   `_content/*.html` one fragment per page, named for the page it produces.
+ *
+ * ## Why the fragments carry front-matter
+ *
+ * A page needs exactly three per-page inputs: `<title>`, the description meta,
+ * and the `<main>` body between the crumbs and the pager. Everything else is
+ * derived. Those first two are metadata about the fragment, so they live at the
+ * top of the fragment rather than in a parallel JSON sidecar — one file to add,
+ * one file to edit, nothing to keep in sync. The delimiter is the usual
+ * `---` front-matter fence, parsed with a four-line reader instead of a YAML
+ * dependency: both values are single-line HTML attribute/element text (a title
+ * cannot contain `<`, a description cannot contain `"`), and body lines are
+ * always indented, so a bare `---` can never appear where the fence is looked
+ * for. `parseFragment` enforces the shape rather than trusting it.
+ *
+ * Strings in `_nav.json` and the fragments are HTML source, not plain text
+ * (`Data &amp; workflows`) — they are substituted verbatim, never escaped.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const LAYOUT_FILE = '_layout.html';
+export const NAV_FILE = '_nav.json';
+export const CONTENT_DIR = '_content';
+/** The docs root — the one page with no breadcrumb trail, and what the first
+ *  crumb on every other page links back to. */
+export const INDEX_PAGE = 'index.html';
+const PLACEHOLDER = /\{\{(title|description|sidebar|content)\}\}/g;
+
+/** An href that leaves `website/docs/` (e.g. `../getting-started.html`). Such a
+ *  page still appears in the sidebar and still takes its turn in the pager
+ *  chain, but it is not generated here and has no content fragment. */
+export const isExternal = (href) => href.startsWith('../') || /^[a-z]+:/.test(href);
+
+/**
+ * Read `_nav.json` and flatten it into the lookups every renderer needs.
+ * @param {string} docsDir
+ */
+export function loadNav(docsDir) {
+  const nav = JSON.parse(fs.readFileSync(path.join(docsDir, NAV_FILE), 'utf-8'));
+  const order = []; // depth-first: each top-level item, then its children
+  const byHref = new Map();
+  const parentOf = new Map();
+  for (const section of nav.sections) {
+    for (const item of section.items) {
+      order.push(item.href);
+      byHref.set(item.href, item);
+      for (const child of item.children ?? []) {
+        order.push(child.href);
+        byHref.set(child.href, child);
+        parentOf.set(child.href, item);
+      }
+    }
+  }
+  const dupes = order.filter((h, i) => order.indexOf(h) !== i);
+  if (dupes.length) throw new Error(`${NAV_FILE}: duplicate href(s): ${dupes.join(', ')}`);
+  return { sections: nav.sections, order, byHref, parentOf };
+}
+
+/** Pages the generator is responsible for, in nav order. */
+export const generatedPages = (nav) => nav.order.filter((href) => !isExternal(href));
+
+/** A page names itself in up to three registers, longest to shortest:
+ *  `title` in the pager (the page's own name — `Data` is labelled `Working
+ *  with data` there), `crumb` in the breadcrumb trail (where a long name like
+ *  `The propose → review → approve loop` is shortened again), and `label` in
+ *  the sidebar. Only `label` is required; each of the others falls back. */
+const entry = (nav, href) => {
+  const item = nav.byHref.get(href);
+  if (!item) throw new Error(`${NAV_FILE}: no entry for ${href}`);
+  return item;
+};
+const titleOf = (nav, href) => { const i = entry(nav, href); return i.title ?? i.label; };
+const crumbOf = (nav, href) => { const i = entry(nav, href); return i.crumb ?? i.title ?? i.label; };
+
+/**
+ * Split a `_content/*.html` fragment into its front-matter and body.
+ * @param {string} raw
+ * @param {string} name for error messages
+ */
+export function parseFragment(raw, name) {
+  const fence = '---\n';
+  if (!raw.startsWith(fence)) throw new Error(`${name}: missing opening --- front-matter fence`);
+  const end = raw.indexOf(`\n${fence}`, fence.length - 1);
+  if (end === -1) throw new Error(`${name}: missing closing --- front-matter fence`);
+  const meta = {};
+  for (const line of raw.slice(fence.length, end + 1).split('\n')) {
+    if (!line.trim()) continue;
+    const at = line.indexOf(': ');
+    if (at === -1) throw new Error(`${name}: front-matter line is not "key: value": ${line}`);
+    meta[line.slice(0, at)] = line.slice(at + 2);
+  }
+  for (const key of ['title', 'description']) {
+    if (!meta[key]) throw new Error(`${name}: front-matter is missing "${key}"`);
+  }
+  const body = raw.slice(end + 1 + fence.length).replace(/^\n+/, '').replace(/\n+$/, '');
+  if (!body) throw new Error(`${name}: empty body`);
+  return { title: meta.title, description: meta.description, body };
+}
+
+/** Read every content fragment, keyed by the page it produces. */
+export function loadFragments(docsDir) {
+  const dir = path.join(docsDir, CONTENT_DIR);
+  const out = new Map();
+  for (const name of fs.readdirSync(dir).filter((f) => f.endsWith('.html')).sort()) {
+    out.set(name, parseFragment(fs.readFileSync(path.join(dir, name), 'utf-8'), `${CONTENT_DIR}/${name}`));
+  }
+  return out;
+}
+
+/** The `<aside class="docs-nav">` inner HTML for one page: the flat top-level
+ *  list, with only the active page's own family expanded beneath its parent. */
+function renderSidebar(nav, href) {
+  const family = nav.parentOf.get(href)?.href ?? href;
+  const lines = [];
+  for (const section of nav.sections) {
+    if (lines.length) lines.push('');
+    lines.push(`    <h4>${section.label}</h4>`);
+    for (const item of section.items) {
+      lines.push(`    <a href="${item.href}"${item.href === href ? ' class="active"' : ''}>${item.label}</a>`);
+      if (item.href !== family) continue;
+      for (const child of item.children ?? []) {
+        lines.push(`    <a href="${child.href}" class="sub${child.href === href ? ' active' : ''}">${child.label}</a>`);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+/** `Docs / [family] / Page` — the family link only on a child page. The docs
+ *  root is its own root, so it gets no crumbs at all. */
+function renderCrumbs(nav, href) {
+  if (href === INDEX_PAGE) return null;
+  const sep = '<span class="sep">/</span>';
+  const parent = nav.parentOf.get(href);
+  const mid = parent ? `<a href="${parent.href}">${crumbOf(nav, parent.href)}</a>${sep}` : '';
+  return `    <p class="crumbs"><a href="${INDEX_PAGE}">Docs</a>${sep}${mid}${crumbOf(nav, href)}</p>`;
+}
+
+/** Prev/next from the depth-first nav order, with an empty `<span>` holding
+ *  the slot at either end so the flex row keeps "next" on the right. */
+function renderPager(nav, href) {
+  const i = nav.order.indexOf(href);
+  const link = (dir, target, dirLabel, ttl) => [
+    `      <a class="${dir}" href="${target}">`,
+    `        <span class="dir">${dirLabel}</span>`,
+    `        <span class="ttl">${ttl}</span>`,
+    '      </a>',
+  ].join('\n');
+  const prev = nav.order[i - 1];
+  const next = nav.order[i + 1];
+  return [
+    '    <div class="pager">',
+    prev ? link('prev', prev, 'Previous', `← ${titleOf(nav, prev)}`) : '      <span></span>',
+    next ? link('next', next, 'Next', `${titleOf(nav, next)} →`) : '      <span></span>',
+    '    </div>',
+  ].join('\n');
+}
+
+/**
+ * Render one page.
+ * @param {string} layout contents of `_layout.html`
+ * @param {ReturnType<typeof loadNav>} nav
+ * @param {string} href page filename, e.g. `right-sidebar-history.html`
+ * @param {{ title: string, description: string, body: string }} fragment
+ */
+export function renderPage(layout, nav, href, fragment) {
+  const crumbs = renderCrumbs(nav, href);
+  const content = [crumbs, fragment.body, renderPager(nav, href)].filter(Boolean).join('\n\n');
+  const values = {
+    title: fragment.title,
+    description: fragment.description,
+    sidebar: renderSidebar(nav, href),
+    content,
+  };
+  const unknown = layout.replace(PLACEHOLDER, '').match(/\{\{[^}]*\}\}/);
+  if (unknown) throw new Error(`${LAYOUT_FILE}: unknown placeholder ${unknown[0]}`);
+  // A function replacer, never a string one: docs prose is full of `$$…$$`
+  // (display math) and would contain `$&`, both of which `String.replace` reads
+  // as substitution patterns in a *string* replacement and silently eats —
+  // that turned every `$$…$$` in notes-math.html into `$…$`.
+  return layout.replace(PLACEHOLDER, (_, key) => values[key]);
+}
+
+/**
+ * Render every page. Returns filename → HTML, in nav order.
+ * @param {string} docsDir
+ */
+export function buildDocs(docsDir) {
+  const layout = fs.readFileSync(path.join(docsDir, LAYOUT_FILE), 'utf-8');
+  const nav = loadNav(docsDir);
+  const fragments = loadFragments(docsDir);
+  const pages = generatedPages(nav);
+  const missing = pages.filter((href) => !fragments.has(href));
+  if (missing.length) throw new Error(`${NAV_FILE} lists pages with no ${CONTENT_DIR}/ fragment: ${missing.join(', ')}`);
+  const orphans = [...fragments.keys()].filter((href) => !nav.byHref.has(href));
+  if (orphans.length) throw new Error(`${CONTENT_DIR}/ fragments missing from ${NAV_FILE}: ${orphans.join(', ')}`);
+  return new Map(pages.map((href) => [href, renderPage(layout, nav, href, fragments.get(href))]));
+}

--- a/scripts/lib/extract-docs-corpus.mjs
+++ b/scripts/lib/extract-docs-corpus.mjs
@@ -1,27 +1,33 @@
 /**
  * Extraction for the help-docs corpus (#1283, part of #1154's epic:docs-grounding).
  *
- * Turns the user-facing docs site (`website/docs/*.html`) into indexable text
- * chunks — one per `<h2>` section, plus a preamble chunk (h1 + lede) per page —
- * so the in-app assistant can ground "how do I…" answers in Minerva's real
- * documentation instead of guessing from training-data priors about a product
- * it's never seen.
+ * Turns the user-facing docs site into indexable text chunks — one per `<h2>`
+ * section, plus a preamble chunk (h1 + lede) per page — so the in-app
+ * assistant can ground "how do I…" answers in Minerva's real documentation
+ * instead of guessing from training-data priors about a product it's never
+ * seen.
  *
- * Every docs page shares one template (verified across all 76 pages): content
- * lives entirely inside `<main class="docs-content">`, is headed by an `<h1>`
- * + `<p class="lede">`, and is split into `<h2 id="...">` sections — chrome
- * (`<nav>`, `<aside class="docs-nav">`, `<footer>`) lives outside `<main>` and
- * is never touched by scoping extraction there. `.crumbs`/`.pager` are the two
- * bits of navigation noise that live *inside* `<main>`, so those are removed
- * explicitly. `.shot` screenshot-placeholder captions are also dropped: they
- * mostly restate the surrounding prose ("Screenshot — X: a rendered note
- * showing Y") in service of a not-yet-taken screenshot, so keeping them would
- * dilute a chunk's embedding without adding real instructional content.
+ * **The input is `website/docs/_content/*.html`, not the generated pages**
+ * (#1842). Those fragments — one per page, body only — are exactly the
+ * per-page content the docs generator wraps in shared chrome, so reading them
+ * means never re-parsing chrome back out of the output it was just injected
+ * into. Chunk ids are unchanged by the switch: a fragment is named for the
+ * page it produces, and the crumbs/pager the old scoping had to strip aren't
+ * in a fragment to begin with.
+ *
+ * Every page shares one template: content is headed by an `<h1>` +
+ * `<p class="lede">` and split into `<h2 id="...">` sections.
+ * {@link extractPageChunks} still takes a whole page and scopes itself to
+ * `<main class="docs-content">`, so it works on either shape; `.crumbs` and
+ * `.pager` stay in `NOISE_SELECTORS` for that path. `.shot`
+ * screenshot-placeholder captions are dropped from both: they mostly restate
+ * the surrounding prose ("Screenshot — X: a rendered note showing Y") in
+ * service of a not-yet-taken screenshot, so keeping them would dilute a
+ * chunk's embedding without adding real instructional content.
  */
 
-import fs from 'node:fs';
-import path from 'node:path';
 import { parseHTML } from 'linkedom';
+import { loadFragments } from './docs-model.mjs';
 
 const DEFAULT_MAX_CHARS = 1000;
 const NOISE_SELECTORS = ['.crumbs', '.pager', '.shot'];
@@ -110,19 +116,31 @@ function joinChildren(el) {
 }
 
 /**
- * Extract chunks from every `*.html` page in a docs directory (i.e.
- * `website/docs`). Touches the filesystem — the I/O counterpart to
- * {@link extractPageChunks}, used by the build-time embedding script.
+ * Extract chunks from one content fragment's body. Pure, like
+ * {@link extractPageChunks} — the body is wrapped in the `<main>` the rest of
+ * this module scopes to, rather than duplicating the walk.
+ *
+ * @param {string} body a `_content/*.html` body (no chrome, no crumbs, no pager)
+ * @param {string} sourcePage e.g. "notes-links.html"
+ * @param {{ maxChars?: number }} [opts]
+ */
+export function extractFragmentChunks(body, sourcePage, opts = {}) {
+  return extractPageChunks(`<main class="docs-content">${body}</main>`, sourcePage, opts);
+}
+
+/**
+ * Extract chunks from every content fragment under a docs directory (i.e.
+ * `website/docs`, whose fragments live in `website/docs/_content`). Touches the
+ * filesystem — the I/O counterpart to {@link extractFragmentChunks}, used by
+ * the build-time embedding script.
  *
  * @param {string} docsDir
  * @param {{ maxChars?: number }} [opts]
  */
 export function extractDocsCorpus(docsDir, opts = {}) {
-  const files = fs.readdirSync(docsDir).filter((f) => f.endsWith('.html')).sort();
   const chunks = [];
-  for (const file of files) {
-    const html = fs.readFileSync(path.join(docsDir, file), 'utf-8');
-    chunks.push(...extractPageChunks(html, file, opts));
+  for (const [page, fragment] of loadFragments(docsDir)) {
+    chunks.push(...extractFragmentChunks(fragment.body, page, opts));
   }
   return chunks;
 }

--- a/tests/scripts/docs-generated.test.ts
+++ b/tests/scripts/docs-generated.test.ts
@@ -1,0 +1,47 @@
+/**
+ * `website/docs/*.html` is generated, and the generated output is committed (#1842).
+ *
+ * Both halves of that sentence are load-bearing. The site deploys straight
+ * from the repo (`scripts/deploy-to-gh-pages.sh` copies `website/` onto
+ * gh-pages — there is no build step there), so the HTML has to be in git. But
+ * committed generated files invite hand-edits, and a hand-edit to a generated
+ * file is worse than no generator at all: it survives review, then vanishes
+ * the next time anyone runs `pnpm build:docs`.
+ *
+ * So this asserts the committed HTML is exactly what `scripts/build-docs.mjs`
+ * produces from `_layout.html` + `_nav.json` + `_content/*.html`. Editing a
+ * page directly fails here; the fix is to edit the fragment (or the nav) and
+ * run `pnpm build:docs`.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// @ts-expect-error -- plain JS build-time module, no .d.ts
+import { buildDocs as buildDocsImpl } from '../../scripts/lib/docs-model.mjs';
+
+const buildDocs = buildDocsImpl as (docsDir: string) => Map<string, string>;
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DOCS_DIR = path.join(ROOT, 'website', 'docs');
+
+describe('website/docs is generated (#1842)', () => {
+  const pages = buildDocs(DOCS_DIR);
+
+  it('generates every page listed in _nav.json', () => {
+    expect(pages.size).toBeGreaterThan(100);
+  });
+
+  it('leaves no page in website/docs/ that the generator does not own', () => {
+    // `_`-prefixed files are the generator's own inputs, not output pages.
+    const onDisk = fs.readdirSync(DOCS_DIR)
+      .filter((f) => f.endsWith('.html') && !f.startsWith('_'))
+      .sort();
+    expect(onDisk).toEqual([...pages.keys()].sort());
+  });
+
+  it.each([...pages.keys()])('%s matches the generator byte for byte', (name) => {
+    const committed = fs.readFileSync(path.join(DOCS_DIR, name), 'utf-8');
+    expect(committed).toBe(pages.get(name));
+  });
+});

--- a/tests/scripts/docs-model.test.ts
+++ b/tests/scripts/docs-model.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit cover for the docs-site model (#1842) — the parts `docs-generated.test.ts`
+ * can only assert indirectly, against the real 118 pages: what the generator
+ * does with a MALFORMED input, and the one substitution bug that got past a
+ * first byte-diff.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error -- plain JS build-time module, no .d.ts
+import * as modelImpl from '../../scripts/lib/docs-model.mjs';
+
+interface NavItem { href: string; label: string; title?: string; crumb?: string; children?: NavItem[] }
+interface Fragment { title: string; description: string; body: string }
+interface Nav { sections: { label: string; items: NavItem[] }[]; order: string[]; byHref: Map<string, NavItem>; parentOf: Map<string, NavItem> }
+
+const model = modelImpl as {
+  parseFragment: (raw: string, name: string) => Fragment;
+  renderPage: (layout: string, nav: Nav, href: string, fragment: Fragment) => string;
+  isExternal: (href: string) => boolean;
+};
+
+/** A nav shaped like `loadNav`'s return, without touching the filesystem. */
+function navOf(sections: { label: string; items: NavItem[] }[]): Nav {
+  const order: string[] = [];
+  const byHref = new Map<string, NavItem>();
+  const parentOf = new Map<string, NavItem>();
+  for (const section of sections) {
+    for (const item of section.items) {
+      order.push(item.href);
+      byHref.set(item.href, item);
+      for (const child of item.children ?? []) {
+        order.push(child.href);
+        byHref.set(child.href, child);
+        parentOf.set(child.href, item);
+      }
+    }
+  }
+  return { sections, order, byHref, parentOf };
+}
+
+const NAV = navOf([
+  {
+    label: 'Section',
+    items: [
+      { href: 'index.html', label: 'Overview' },
+      {
+        href: 'data.html',
+        label: 'Data',
+        title: 'Working with data',
+        children: [{ href: 'maths.html', label: 'The long name for maths', crumb: 'Maths' }],
+      },
+      { href: '../getting-started.html', label: 'Getting started' },
+    ],
+  },
+]);
+
+const LAYOUT = '<title>{{title}}</title>\n<meta content="{{description}}" />\n<aside>\n{{sidebar}}\n</aside>\n<main>\n{{content}}\n</main>\n';
+
+describe('parseFragment', () => {
+  const ok = '---\ntitle: T\ndescription: D\n---\n\n    <h1>Body</h1>\n';
+
+  it('splits front-matter from body and trims the body\'s blank edges', () => {
+    expect(model.parseFragment(ok, 'x.html')).toEqual({ title: 'T', description: 'D', body: '    <h1>Body</h1>' });
+  });
+
+  it.each([
+    ['<h1>no fence</h1>', 'missing opening'],
+    ['---\ntitle: T\ndescription: D\n\n    <h1>x</h1>\n', 'missing closing'],
+    ['---\ntitle: T\n---\n\n    <h1>x</h1>\n', 'missing "description"'],
+    ['---\ntitle T\ndescription: D\n---\n\n    <h1>x</h1>\n', 'not "key: value"'],
+    ['---\ntitle: T\ndescription: D\n---\n\n', 'empty body'],
+  ])('rejects %j', (raw, message) => {
+    expect(() => model.parseFragment(raw, 'x.html')).toThrow(message);
+  });
+});
+
+describe('renderPage', () => {
+  const fragment = { title: 'T', description: 'D', body: '    <h1>Maths</h1>' };
+
+  it('substitutes `$$…$$` display math verbatim', () => {
+    // A *string* replacement would read `$$` as an escaped `$` and halve it —
+    // which is exactly what notes-math.html's `$$\int…$$` blocks hit.
+    const math = { ...fragment, body: '    <p>$$\\int_0^\\infty$$ and $& and $1</p>' };
+    expect(model.renderPage(LAYOUT, NAV, 'maths.html', math)).toContain('<p>$$\\int_0^\\infty$$ and $& and $1</p>');
+  });
+
+  it('expands only the active page\'s own family, and marks it active', () => {
+    const html = model.renderPage(LAYOUT, NAV, 'maths.html', fragment);
+    expect(html).toContain('<a href="data.html">Data</a>');
+    expect(html).toContain('<a href="maths.html" class="sub active">The long name for maths</a>');
+
+    // …and not when a sibling family is the active one.
+    const other = model.renderPage(LAYOUT, NAV, 'index.html', fragment);
+    expect(other).toContain('<a href="index.html" class="active">Overview</a>');
+    expect(other).not.toContain('maths.html');
+  });
+
+  it('uses `crumb` in the trail and `title` in the pager', () => {
+    const html = model.renderPage(LAYOUT, NAV, 'maths.html', fragment);
+    // Crumb: shortest form for this page, its parent's `title` for the family.
+    expect(html).toContain('<a href="data.html">Working with data</a><span class="sep">/</span>Maths');
+    // Pager: the page's own (longer) name, from the neighbour's entry.
+    expect(html).toContain('<span class="ttl">← Working with data</span>');
+    expect(html).toContain('<span class="ttl">Getting started →</span>');
+  });
+
+  it('gives the docs root no crumbs and no previous link', () => {
+    const html = model.renderPage(LAYOUT, NAV, 'index.html', fragment);
+    expect(html).not.toContain('class="crumbs"');
+    expect(html).toContain('<div class="pager">\n      <span></span>');
+  });
+
+  it('rejects a layout with a placeholder it cannot fill', () => {
+    expect(() => model.renderPage(`${LAYOUT}{{author}}`, NAV, 'index.html', fragment))
+      .toThrow('unknown placeholder {{author}}');
+  });
+});
+
+describe('isExternal', () => {
+  it.each([['../getting-started.html', true], ['https://example.com', true], ['notes.html', false]])(
+    '%s → %s',
+    (href, expected) => { expect(model.isExternal(href)).toBe(expected); },
+  );
+});

--- a/tests/scripts/extract-docs-corpus.test.ts
+++ b/tests/scripts/extract-docs-corpus.test.ts
@@ -3,7 +3,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 // @ts-expect-error -- plain JS build-time module, no .d.ts
-import { extractPageChunks as extractPageChunksImpl, extractDocsCorpus as extractDocsCorpusImpl } from '../../scripts/lib/extract-docs-corpus.mjs';
+import {
+  extractPageChunks as extractPageChunksImpl,
+  extractFragmentChunks as extractFragmentChunksImpl,
+  extractDocsCorpus as extractDocsCorpusImpl,
+} from '../../scripts/lib/extract-docs-corpus.mjs';
 
 interface DocChunk {
   id: string;
@@ -15,6 +19,11 @@ interface DocChunk {
 
 const extractPageChunks = extractPageChunksImpl as (
   html: string,
+  sourcePage: string,
+  opts?: { maxChars?: number },
+) => DocChunk[];
+const extractFragmentChunks = extractFragmentChunksImpl as (
+  body: string,
   sourcePage: string,
   opts?: { maxChars?: number },
 ) => DocChunk[];
@@ -191,32 +200,57 @@ describe('extractPageChunks', () => {
   });
 });
 
+describe('extractFragmentChunks', () => {
+  it('reads a bare content fragment — no chrome to scope past (#1842)', () => {
+    const chunks = extractFragmentChunks(
+      '<h1>Widgets</h1>\n<p class="lede">All about widgets.</p>\n<h2 id="making">Making one</h2>\n<p>Press the button.</p>',
+      'widgets.html',
+    );
+    expect(chunks.map((c: DocChunk) => [c.id, c.text])).toEqual([
+      ['widgets.html', 'All about widgets.'],
+      ['widgets.html#making', 'Press the button.'],
+    ]);
+    expect(chunks[0].pageTitle).toBe('Widgets');
+  });
+
+  it('produces the same chunks as the generated page it renders to', () => {
+    const body = '<h1>Widgets</h1>\n<p class="lede">All about widgets.</p>\n<h2 id="making">Making one</h2>\n<p>Press the button.</p>';
+    const page = PAGE_SHELL(
+      `    <p class="crumbs"><a href="index.html">Docs</a>/Widgets</p>\n${body}\n    <div class="pager"><a class="next" href="x.html">Next</a></div>`,
+    );
+    expect(extractFragmentChunks(body, 'widgets.html')).toEqual(extractPageChunks(page, 'widgets.html'));
+  });
+});
+
 describe('extractDocsCorpus', () => {
   let dir: string;
 
   beforeAll(() => {
+    // The real shape: fragments in `<docsDir>/_content`, one per page.
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-corpus-test-'));
-    fs.writeFileSync(
-      path.join(dir, 'a.html'),
-      PAGE_SHELL('<h1>A</h1><p class="lede">Lede A.</p><h2 id="x">X</h2><p>Body A.</p>'),
-    );
-    fs.writeFileSync(
-      path.join(dir, 'b.html'),
-      PAGE_SHELL('<h1>B</h1><p class="lede">Lede B.</p><h2 id="y">Y</h2><p>Body B.</p>'),
-    );
-    // A non-html file must be ignored.
+    const content = path.join(dir, '_content');
+    fs.mkdirSync(content);
+    const fragment = (letter: string, id: string) =>
+      `---\ntitle: ${letter}\ndescription: Page ${letter}.\n---\n\n<h1>${letter}</h1><p class="lede">Lede ${letter}.</p><h2 id="${id}">${id.toUpperCase()}</h2><p>Body ${letter}.</p>\n`;
+    fs.writeFileSync(path.join(content, 'a.html'), fragment('A', 'x'));
+    fs.writeFileSync(path.join(content, 'b.html'), fragment('B', 'y'));
+    // A non-html file must be ignored, and so must the generated pages
+    // sitting alongside `_content` in the docs dir.
+    fs.writeFileSync(path.join(content, 'notes.txt'), 'not a fragment');
     fs.writeFileSync(path.join(dir, 'docs.css'), 'body { color: red; }');
+    fs.writeFileSync(path.join(dir, 'a.html'), PAGE_SHELL('<h1>Stale</h1><p class="lede">Should never be read.</p>'));
   });
 
   afterAll(() => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it('aggregates chunks across every html page, ignoring non-html files', () => {
+  it('aggregates chunks across every content fragment, ignoring everything else', () => {
     const chunks = extractDocsCorpus(dir);
     const sourcePages = [...new Set(chunks.map((c: DocChunk) => c.sourcePage))].sort();
     expect(sourcePages).toEqual(['a.html', 'b.html']);
     expect(chunks.some((c: DocChunk) => c.text === 'Lede A.')).toBe(true);
     expect(chunks.some((c: DocChunk) => c.text === 'Lede B.')).toBe(true);
+    expect(chunks.some((c: DocChunk) => c.text === 'Should never be read.')).toBe(false);
   });
 });

--- a/website/README.txt
+++ b/website/README.txt
@@ -15,3 +15,26 @@ Blue dashed blocks = author-fill markers (only visible in draft; delete when fil
 Dashed screenshot boxes = where real product images/screencasts go.
 
 Nav order is consistent across pages: Features · Getting Started · About · Privacy · [Download]
+
+docs/ is GENERATED — do not hand-edit docs/*.html
+=================================================
+
+Every page under docs/ is produced by `pnpm build:docs`
+(scripts/build-docs.mjs) from three inputs, and the output is committed
+because gh-pages deploys the repo as-is:
+
+  docs/_layout.html    the shared chrome (head, top nav, footer) with
+                       {{title}} {{description}} {{sidebar}} {{content}}
+  docs/_nav.json       the nav tree — sections, items, children. Drives every
+                       page's sidebar, breadcrumbs and prev/next pager.
+  docs/_content/*.html one fragment per page: `title`/`description`
+                       front-matter plus the page body, named for the page it
+                       produces.
+
+To edit a page, edit its fragment. To add one, add a fragment and one entry in
+_nav.json — every other page's sidebar and pager follows. Then run
+`pnpm build:docs` and commit the regenerated HTML;
+tests/scripts/docs-generated.test.ts fails if the two ever disagree.
+
+The same fragments are the input to the in-app help search corpus
+(scripts/build-help-corpus.mjs).

--- a/website/docs/_content/connecting-cli.html
+++ b/website/docs/_content/connecting-cli.html
@@ -1,0 +1,86 @@
+---
+title: Minerva — Docs — CLI use
+description: Use the Minerva command-line interface: build and run it, query the knowledge graph with SPARQL and SQL, search and read notes, gather context, and file gated proposals — all as JSON.
+---
+
+    <h1>CLI use</h1>
+    <p class="lede">The Minerva CLI gives headless, scriptable access to a thoughtbase from your shell — the same core the app runs on, so it works with the app closed. Every result is printed as <b>JSON</b> on standard output, so it pipes straight into <code>jq</code> or feeds an agent directly.</p>
+
+    <h2 id="build">Getting the command</h2>
+    <p>If you installed Minerva from the download, choose <b>Help → Install ‘minerva’ Command in PATH…</b> in the app. That writes a <code>minerva</code> launcher to <code>~/.local/bin</code> — the app runs its own bundled Node, so there's nothing else to install. If <code>~/.local/bin</code> isn't on your <code>PATH</code>, the dialog shows how to add it, and gives the full path to use for MCP clients.</p>
+    <p>Working from the source tree instead? Build and link it:</p>
+    <pre><code>pnpm cli:build        # builds .vite/build/cli.js
+pnpm link --global    # exposes it globally as `minerva`</code></pre>
+    <p>Either way, <code>minerva</code> then works anywhere. Point any command at a thoughtbase with <code>--project &lt;path&gt;</code> — it defaults to the current directory.</p>
+    <pre><code>minerva &lt;command&gt; [args] [--project &lt;path&gt;]</code></pre>
+
+    <h2 id="commands">Commands</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>query &lt;sparql&gt;</code></div>
+        <div class="v">Run a <b>SPARQL</b> query over the knowledge graph. The standard prefixes are injected for you, so you can write <code>minerva:</code>, <code>dc:</code>, and the rest without declaring them.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>sql &lt;sql&gt;</code></div>
+        <div class="v">Run <b>DuckDB SQL</b> over your CSV <a href="data.html">tables</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>search &lt;text&gt;</code></div>
+        <div class="v">Full-text search over notes (<code>--limit &lt;n&gt;</code>, default 20).</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>semantic &lt;text&gt;</code></div>
+        <div class="v">Meaning-based search over notes. It covers only what the app has already embedded — against a thoughtbase never opened in the app, it returns no hits.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>read &lt;path&gt;</code></div>
+        <div class="v">A note's raw markdown, by its path within the thoughtbase.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>context &lt;topic&gt;</code></div>
+        <div class="v">A task-relevant slice: the notes matching a topic plus each one's link neighborhood (backlinks and outgoing links) and content, returned as one bundle for an agent to seed itself with.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>propose-note &lt;path&gt;</code></div>
+        <div class="v">File a new note as a pending proposal, with the body read from <b>stdin</b>. Gated — see below.</div>
+      </div>
+    </div>
+
+    <h2 id="grounded">Grounded JSON output</h2>
+    <p>Every result is grounded and printed as JSON, so it composes with the rest of your tools — query bindings carry node identifiers, search hits carry the note path, and <code>read</code> echoes the path back.</p>
+    <pre><code># What do I already know about photosynthesis?
+minerva search photosynthesis --project ~/vault | jq '.hits[].relativePath'
+
+# Every note with a title, alphabetized.
+minerva query \
+  'SELECT ?title WHERE { ?n a minerva:Note ; dc:title ?title } ORDER BY ?title' \
+  --project ~/vault</code></pre>
+
+    <h2 id="proposing">Proposing a note</h2>
+    <p>External tools never write your thoughtbase directly. <code>propose-note</code> files a note as a <b>pending proposal</b> through Minerva's approval engine — the same gate the built-in AI uses — stamped with who proposed it. Nothing lands until you review and approve it in Minerva's Proposals panel (see <a href="conversations.html">Conversations</a>).</p>
+    <pre><code>cat draft.md | minerva propose-note notes/idea.md --by cli --project ~/vault</code></pre>
+    <p>The body comes from stdin, so it composes with anything upstream. <code>--by &lt;id&gt;</code> records who proposed it (default <code>cli</code>), and that attribution survives a reindex — a note proposed while the app was closed still shows up, and stays attributed, once you reopen it.</p>
+
+    <div class="box">
+      <span class="label">One writer at a time</span>
+      <p>A proposal is written into the thoughtbase's graph file. If Minerva has the same thoughtbase open, both processes write it, so file proposals when the app isn't actively editing — and expect the app to surface them after its next refresh.</p>
+    </div>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="connecting-mcp.html">
+        <span class="em">🔌</span>
+        <h3>MCP use</h3>
+        <p>The same commands as tools for an AI agent.</p>
+      </a>
+      <a class="doc-card" href="data.html">
+        <span class="em">🔎</span>
+        <h3>Working with data</h3>
+        <p>The SPARQL and SQL you'll run, from the app's side.</p>
+      </a>
+      <a class="doc-card" href="conversations.html">
+        <span class="em">💬</span>
+        <h3>Conversations</h3>
+        <p>Where proposals surface for you to approve.</p>
+      </a>
+    </div>

--- a/website/docs/_content/connecting-mcp.html
+++ b/website/docs/_content/connecting-mcp.html
@@ -1,0 +1,87 @@
+---
+title: Minerva — Docs — MCP use
+description: Connect an AI agent to a Minerva thoughtbase over the Model Context Protocol: start the stdio MCP server, point a client at it, and use the read and propose tools — grounded and gated.
+---
+
+    <h1>MCP use</h1>
+    <p class="lede">The <b>Model Context Protocol (MCP)</b> is a standard way to give an AI agent tools. Minerva's MCP server exposes the same reads and proposals as the <a href="connecting-cli.html">CLI</a> — as tools any MCP client can call — so an agent like Claude Desktop, a coding agent, or an editor can ground itself in your thoughtbase and hand work back through the approval gate.</p>
+
+    <h2 id="start">Starting the server</h2>
+    <p>The MCP server is the <code>mcp</code> subcommand of the same CLI — <a href="connecting-cli.html#build">install it once</a> (Help → Install ‘minerva’ Command, or build from source) and you have the <code>minerva</code> command. The server runs over standard input/output as a subprocess — you don't start it by hand so much as tell a client how to launch it. On its own:</p>
+    <pre><code>minerva mcp --project /path/to/thoughtbase</code></pre>
+    <p>It speaks newline-delimited JSON-RPC 2.0 and stays running until its input closes. Each modality initializes once and stays warm across tool calls.</p>
+
+    <h2 id="connect">Connecting a client</h2>
+    <p>Most MCP clients take a small JSON entry naming a command to launch. Point it at <code>minerva</code> with the <code>mcp</code> subcommand and your thoughtbase path — the client runs it as a subprocess:</p>
+    <pre><code>{
+  "mcpServers": {
+    "minerva": {
+      "command": "minerva",
+      "args": ["mcp", "--project", "/path/to/thoughtbase"]
+    }
+  }
+}</code></pre>
+    <p>Some clients launch from a bare environment without your shell's PATH, so <code>minerva</code> may not resolve. If so, give the absolute path to the built file instead:</p>
+    <pre><code>{
+  "mcpServers": {
+    "minerva": {
+      "command": "node",
+      "args": ["/absolute/path/to/minerva/.vite/build/cli.js", "mcp", "--project", "/path/to/thoughtbase"]
+    }
+  }
+}</code></pre>
+
+    <h2 id="tools">Tools</h2>
+    <p>The server exposes seven tools — the reads return grounded JSON, and the one write is gated:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>query_graph</code></div>
+        <div class="v">SPARQL over the knowledge graph.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>sql_query</code></div>
+        <div class="v">DuckDB SQL over your CSV <a href="data.html">tables</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>search_notes</code></div>
+        <div class="v">Full-text search over notes.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>semantic_search</code></div>
+        <div class="v">Meaning-based search over notes the app has embedded.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>read_note</code></div>
+        <div class="v">A note's raw markdown, by path.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>gather_context</code></div>
+        <div class="v">A topic slice — matching notes plus their link neighborhood — for the agent to seed itself.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>propose_note</code></div>
+        <div class="v">File a new note as a pending proposal (gated).</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Grounded and gated</span>
+      <p>Reads come back grounded, so the agent can cite the exact notes it drew on. The only write is <code>propose_note</code>, which files a <b>pending proposal</b> stamped <code>mcp:&lt;client-name&gt;</code> — taken from the client's own name at connect time — and nothing lands until you approve it in the Proposals panel. In Minerva, proposals from an MCP client are labelled distinctly from the built-in AI, so the graph stays an audit log of who contributed what. See <a href="conversations.html">Conversations</a>.</p>
+    </div>
+
+    <h2 id="freshness">A note on freshness</h2>
+    <p>The server reads your thoughtbase once at startup and serves results as of that moment. If you edit notes in the app while it's running, restart the server to pick up the changes. And as with the CLI, file proposals when the app isn't actively editing the same thoughtbase, so the two aren't writing the graph at once.</p>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="connecting-cli.html">
+        <span class="em">⌥</span>
+        <h3>CLI use</h3>
+        <p>The same operations from your shell, as JSON.</p>
+      </a>
+      <a class="doc-card" href="conversations.html">
+        <span class="em">💬</span>
+        <h3>Conversations</h3>
+        <p>Review and approve what an agent proposes.</p>
+      </a>
+    </div>

--- a/website/docs/_content/connecting.html
+++ b/website/docs/_content/connecting.html
@@ -1,0 +1,63 @@
+---
+title: Minerva — Docs — Connecting to Minerva
+description: Reach into a thoughtbase from outside the app: a command-line interface and an MCP server let scripts and AI agents query your notes and propose new ones — grounded reads, gated writes.
+---
+
+    <h1>Connecting to Minerva</h1>
+    <p class="lede">A <a href="thoughtbase.html">thoughtbase</a> is plain files and a <a href="data.html">knowledge graph</a>, so you don't have to be sitting in the app to use it. Minerva ships a command-line interface and a <b>Model Context Protocol (MCP)</b> server that let scripts and AI agents query your notes and propose new ones from outside — even while the app is closed. They reuse the same core the app does, so what they see is exactly what Minerva sees.</p>
+
+    <h2 id="two-ways">Two ways in</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="connecting-cli.html">CLI use</a></div>
+        <div class="v">Headless, scriptable access from your shell — query the graph, search notes, and file proposals, with grounded JSON output you can pipe straight into other tools.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="connecting-mcp.html">MCP use</a></div>
+        <div class="v">The same reads and proposals exposed as tools to any MCP client — Claude Desktop, a coding agent, an editor — so an AI agent can ground itself in your thoughtbase and hand work back.</div>
+      </div>
+    </div>
+
+    <h2 id="what">What you can do</h2>
+    <p>Both surfaces expose the same core operations over an open thoughtbase:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Query</div>
+        <div class="v">Run <b>SPARQL</b> over the knowledge graph or <b>SQL</b> over your CSV tables — the same queries you'd write in the app's <a href="data.html">Query</a> panel.</div>
+      </div>
+      <div class="row">
+        <div class="k">Search</div>
+        <div class="v">Full-text or meaning-based (semantic) search across your notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Read</div>
+        <div class="v">Fetch a note's raw markdown by path.</div>
+      </div>
+      <div class="row">
+        <div class="k">Gather context</div>
+        <div class="v">Pull a task-relevant slice for a topic — the matching notes <em>plus</em> their link neighborhood — so an agent can seed itself before it starts work.</div>
+      </div>
+      <div class="row">
+        <div class="k">Propose a note</div>
+        <div class="v">File a new note as a <b>pending proposal</b> — never a direct write.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Grounded reads, gated writes</span>
+      <p>Reads come back <b>grounded</b>: query results carry node identifiers, search hits carry the note's path — so an agent can cite exactly what it drew on. Writes are never direct. A proposal goes through the <em>same</em> approval gate as the built-in AI, stamped with who proposed it, and nothing touches your notes until you approve it in the Proposals panel. See <a href="conversations.html">Conversations</a> for that review flow.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="connecting-cli.html">
+        <span class="em">⌥</span>
+        <h3>CLI use</h3>
+        <p>Query, search, and propose from your shell, with JSON output.</p>
+      </a>
+      <a class="doc-card" href="connecting-mcp.html">
+        <span class="em">🔌</span>
+        <h3>MCP use</h3>
+        <p>Expose the thoughtbase to an AI agent as MCP tools.</p>
+      </a>
+    </div>

--- a/website/docs/_content/conversations-chatting.html
+++ b/website/docs/_content/conversations-chatting.html
@@ -1,0 +1,98 @@
+---
+title: Minerva — Docs — Chatting with the AI
+description: How to start a conversation with the assistant, how it searches your notes and the web when it needs to, and what a reply with a citation looks like.
+---
+
+    <h1>Chatting with the AI</h1>
+    <p class="lede">Conversations let you think out loud with an assistant that knows your notes. The panel has your open conversations on the left and the active chat on the right. Instead of quietly reading everything you've ever written, the assistant searches your notes, follows links, or looks something up on the web only when it actually needs to — and tells you what it found.</p>
+
+    <h2 id="opening">Opening a conversation</h2>
+    <p>The conversations panel sits below the editor and stays out of sight until you call for it. There are a few ways to start:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Show or hide the panel</div>
+        <div class="v"><b>View → Toggle Conversations</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>K</kbd>) opens or tucks away the panel. Hiding it leaves everything in place — your conversations are waiting when you bring it back.</div>
+      </div>
+      <div class="row">
+        <div class="k">Start fresh</div>
+        <div class="v">The <b>New Conversation</b> button above the editor, the <b>+</b> button in the conversation list, or <b>Learning → Ask a Question</b>. This opens a blank conversation with no particular note attached.</div>
+      </div>
+      <div class="row">
+        <div class="k">Ask about a note</div>
+        <div class="v">Right-click a note's tab above the editor and choose <b>Ask About This…</b>. This starts a conversation focused on that note, which the assistant knows is your starting point.</div>
+      </div>
+      <div class="row">
+        <div class="k">Close a conversation</div>
+        <div class="v">The × on a conversation puts it away for good, so you'll be asked to confirm first — a closed conversation can't be reopened.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">"This note" follows you</span>
+      <p>A conversation started from a note isn't locked to it. If you switch to a different note while chatting, the assistant keeps track of both — the note you started from and the one you're looking at now — so when you say "this note," it knows which one you mean.</p>
+    </div>
+
+    <h2 id="scoping">How the assistant knows your notes</h2>
+    <p>The assistant doesn't read your whole knowledge base every time you send a message. Instead it reaches for what it needs, when it needs it, and can:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Search your notes</div>
+        <div class="v">Look across everything you've written to answer "what have I said about this?"</div>
+      </div>
+      <div class="row">
+        <div class="k">Read a note</div>
+        <div class="v">Open a specific note in full when it needs the details.</div>
+      </div>
+      <div class="row">
+        <div class="k">Explore connections</div>
+        <div class="v">Answer questions about how your notes relate — what links to what, which notes share a tag, which claims cite a given source.</div>
+      </div>
+      <div class="row">
+        <div class="k">Search the web</div>
+        <div class="v">Look up facts, current events, or documentation that isn't in your notes, and read a specific page in full.</div>
+      </div>
+    </div>
+
+    <p>The only thing the assistant always knows up front is today's date and which note you're working with. Everything else it goes and finds on purpose.</p>
+
+    <div class="box">
+      <span class="label">Reading is free; changing is not</span>
+      <p>The assistant can read and reason across your notes freely, since reading changes nothing. But it can never edit your knowledge base on its own. When it wants to add or change something, it offers a draft you can accept or discard — see <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a>.</p>
+    </div>
+
+    <h2 id="sending">Sending a message</h2>
+    <p>Type in the composer and press <kbd>⏎</kbd> to send, or <kbd>⇧</kbd><kbd>⏎</kbd> for a new line. Starting a line with <code>/</code> brings up a menu of quick commands and thinking tools you can run in the chat — for example, a command to tidy up a long conversation into a shorter summary. If voice input is turned on, a mic button next to Send lets you dictate your message out loud. Your message appears in the transcript right away, so you can see it while the assistant works on a reply.</p>
+
+    <h2 id="streaming">Watching a reply come in</h2>
+    <p>Replies appear a little at a time as the assistant writes, with a small "thinking" indicator that stays put during any pause — including while it's off searching your notes or the web. Formatting shows up as it goes, so nothing jumps around when the reply finishes. While a reply is in progress, the Send button turns into <b>Cancel</b> so you can stop it at any time.</p>
+
+    <h2 id="model">Choosing a model for one conversation</h2>
+    <p>Above each conversation is a model picker. It starts on <b>Default</b> — which names the model your <a href="settings-ai.html#model">AI settings</a> currently point at, so you can see what "default" actually means without going to look — and switching it affects only that conversation. Two conversations open side by side can be running on different models from different companies.</p>
+    <p>The list is grouped by who makes each model: Claude, GPT and the o-series, Gemini, and any local models you've added. You'll only get an answer from a service you've <a href="settings-ai.html#keys">set a key for</a>; pick one you haven't and Minerva says so and offers to open Settings rather than failing quietly.</p>
+    <p>Beside it sits an effort picker, when the chosen model has something to offer there:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">It only appears when it means something</div>
+        <div class="v">Models with no thinking control of their own — the quick, cheap ones — simply don't show the picker rather than showing one that does nothing.</div>
+      </div>
+      <div class="row">
+        <div class="k">The levels follow the model</div>
+        <div class="v">Each model offers what it actually supports. Switch a conversation from a model with five levels to one with three and a setting the new model can't honour drops to the nearest one it can, rather than being silently ignored or erroring at send time.</div>
+      </div>
+      <div class="row">
+        <div class="k">Default names its inheritance</div>
+        <div class="v">Leaving effort on Default shows the level it's inheriting from your settings, so an unset conversation is still a known quantity.</div>
+      </div>
+    </div>
+    <p>Switching mid-conversation is fine and often useful: think something through with a fast model, then hand the hard part to a more capable one with the whole conversation already in front of it.</p>
+
+    <h2 id="citations">Citations and references</h2>
+    <p>When the assistant uses the web, each source it relied on shows up as a numbered note beneath the reply, with the title, the site, and the exact passage it quoted. Click one to open the page in your browser. A <b>cite</b> action next to it saves the source to your library and drops a citation into whichever note the conversation is tied to — the same way you'd cite a source anywhere else in Minerva.</p>
+    <p>When the assistant refers to your own notes, it simply names them in its reply, so you can jump straight to what it was reading.</p>
+
+    <figure class="shot-img">
+      <img src="img/conversations-chatting.png" alt="The conversations panel: your list of conversations on the left; a banner showing which note the chat started from and which assistant is answering; a reply arriving a bit at a time with the &quot;thinking&quot; indicator still showing; and above it, a finished reply with a numbered web citation and a &quot;cite&quot; action." loading="lazy" />
+      <figcaption>Screenshot — A conversation mid-reply</figcaption>
+    </figure>

--- a/website/docs/_content/conversations-drafts.html
+++ b/website/docs/_content/conversations-drafts.html
@@ -1,0 +1,35 @@
+---
+title: Minerva — Docs — Drafts
+description: When the AI suggests a change, it hands you a draft card inside the conversation — accept it to file the change, or discard it. Nothing happens until you decide.
+---
+
+    <h1>Drafts</h1>
+    <p class="lede">When you ask the AI to change something in your project, it doesn't just do it. Instead it hands you a draft card — a proposed note, set of tags, claim, or rewrite — right there in the conversation. Nothing it suggests becomes real until you accept it.</p>
+
+    <h2 id="when">When a draft card appears</h2>
+    <p>A draft card shows up whenever the AI produces something that would change your project. Ask it to file a new note, summarize a source, tag a batch of files, pull claims out of a paper, reorganize or rename notes, or rewrite a note — and each time you get a card describing exactly what it wants to do. The card appears right under the AI's message, so you never have to go looking for it.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Accept</div>
+        <div class="v">Files the draft exactly as shown. The button is labeled for the task at hand — "Approve &amp; file" for a note, "Approve &amp; ingest" for a source, "Approve &amp; apply" for tags or properties — and once you accept, the card collapses into a short "Filed:" line that links straight to whatever was created.</div>
+      </div>
+      <div class="row">
+        <div class="k">Edit before running</div>
+        <div class="v">When the AI proposes a runnable cell, you can tweak the contents before it runs — your edited version is what gets used. Other kinds of drafts aren't edited in place; you're deciding on exactly what the AI produced.</div>
+      </div>
+      <div class="row">
+        <div class="k">Discard</div>
+        <div class="v">Removes the card and does nothing else. Nothing is written and nothing is saved — if you change your mind, just ask the AI to try again.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Why there's no second step</span>
+      <p>Because you already made the call at the card itself, accepting a draft files the change straight away — you don't then have to approve it a second time in the <a href="left-sidebar-proposals.html">Proposals panel</a>. If you'd rather review a change more carefully before it lands — comparing the before and after side by side — see <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a>.</p>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/conversations-drafts.png" alt="A note draft sitting inline in the conversation: a bold headline (&quot;2 notes&quot;), a one-line explanation of why the AI is suggesting it, an expandable preview of what each note would contain, and Approve &amp; file / Discard buttons along the bottom." loading="lazy" />
+      <figcaption>Screenshot — A draft card awaiting your decision</figcaption>
+    </figure>

--- a/website/docs/_content/conversations-propose-review-approve.html
+++ b/website/docs/_content/conversations-propose-review-approve.html
@@ -1,0 +1,39 @@
+---
+title: Minerva — Docs — The Propose, Review, Approve Loop
+description: Nothing the AI suggests changes your knowledge base until you say so. Here's how Minerva turns every AI suggestion into a proposal you review and approve or reject.
+---
+
+    <h1>The propose, review, approve loop</h1>
+    <p class="lede">The AI in Minerva can suggest changes to your knowledge base — new claims, rewritten notes, fresh tags, a summary of a source. But it never makes those changes on its own. Every suggestion waits for you to look it over and say yes or no. Nothing the AI proposes becomes part of what you know until you approve it.</p>
+
+    <div class="box">
+      <span class="label">The idea in one line</span>
+      <p><b>The AI proposes, you decide.</b> Treat what the AI gives you as evidence to weigh and file, not as the final word. This is the most important design choice in Minerva: your knowledge base stays yours.</p>
+    </div>
+
+    <h2 id="why">Why suggestions wait for you</h2>
+    <p>The AI is a helpful source of ideas about your notes, not an editor with the keys to your knowledge base. So everything it wants to change stays a suggestion until you look at it. A wrong claim, a bad link, or an invented detail simply sits waiting for review — it never quietly slips into what you know.</p>
+
+    <h2 id="one-proposal">Everything is a proposal</h2>
+    <p>There are no exceptions to learn and no changes that skip review. Whatever the AI comes up with — a new claim, a link between notes, a moved or renamed note, a deletion, a rewrite, or details about a source — it all arrives as a proposal you can find in the <a href="left-sidebar-proposals.html">Proposals</a> panel, and none of it is applied until you act on it.</p>
+
+    <p>This is true even for changes that feel automatic. When the AI suggests tags for a note, for instance, accepting them on the conversation card is what approves the change — so it still passes through the same review, just with one quick tap.</p>
+
+    <h2 id="diff">Reviewing a proposal</h2>
+    <p>A proposal isn't a vague one-line promise you have to trust. It shows you exactly what would change, so you can read the real thing before deciding:</p>
+
+    <ul>
+      <li>For a new note, you see the whole note that would be created and where it would be filed — not a summary of it.</li>
+      <li>For a rewrite, you see the full new version of the note. Approving keeps a copy of the old version, so the change can be undone later.</li>
+      <li>For a move or a deletion, you see which note is being moved or removed.</li>
+    </ul>
+
+    <p>A single proposal can bundle several changes together, and they travel as a set: approving applies all of them, rejecting discards all of them — never half.</p>
+
+    <figure class="shot-img panel">
+      <img src="img/conversations-propose-review-approve.png" alt="A pending proposal open in the Proposals panel, showing what kind of change it is and the exact content that would land, so you can read it in full before you approve or reject." loading="lazy" />
+      <figcaption>Screenshot — Reviewing a pending proposal</figcaption>
+    </figure>
+
+    <h2 id="decide">Approving and rejecting</h2>
+    <p>Once you've read a proposal, the decision is one keystroke: <kbd>y</kbd> to approve, <kbd>n</kbd> to reject. Approving applies the change; rejecting throws it away. Either way the proposal stays on record, so you always have a history of what was suggested and what you decided. See <a href="left-sidebar-proposals.html">Proposals</a> for the full set of shortcuts and ways to filter what you're looking at.</p>

--- a/website/docs/_content/conversations-slash-commands.html
+++ b/website/docs/_content/conversations-slash-commands.html
@@ -1,0 +1,83 @@
+---
+title: Minerva — Docs — Slash commands
+description: Type a slash in the composer to run a quick command or a thinking tool without leaving the keyboard — clear or compact a conversation, or launch a skill right from the chat.
+---
+
+    <h1>Slash commands</h1>
+    <p class="lede">Slash commands are a keyboard shortcut into everything you'd otherwise reach with a menu or a button. Type <code>/</code> at the start of a message and a small menu appears with a couple of housekeeping commands for the conversation itself, plus any <a href="thinking-tools.html">thinking tools</a> that have a shorthand — so you can compact a long thread, or fire off a quiz or a summary, without lifting your hands from the keyboard.</p>
+
+    <h2 id="opening">Opening the menu</h2>
+    <p>In the conversation composer, type <code>/</code> as the very first thing in an otherwise empty message. A menu floats up above the composer showing the commands you can run. Keep typing to filter the list — <code>/sum</code> narrows to <code>/summarize</code>, and so on. The menu only appears while what you've typed is a single unbroken command word; add a space, or start with anything other than a slash, and you're just writing an ordinary message.</p>
+
+    <div class="box">
+      <span class="label">Nothing runs until you pick it</span>
+      <p>Opening the menu changes nothing on its own. A command only fires when you choose it — and anything a thinking tool wants to change your notes still comes back as a draft for you to accept or discard. See <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a>.</p>
+    </div>
+
+    <h2 id="built-in">Built-in commands</h2>
+    <p>Two commands act on the conversation itself. They're always available, at the top of the menu.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>/clear</code></div>
+        <div class="v">Files the current conversation away and opens a fresh one in its place, carrying over the same starting note and assistant so you can pick up a new line of thought without losing the old thread. A brand-new, empty conversation is left alone, so there's no harm in reaching for it out of habit.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>/compact</code></div>
+        <div class="v">Summarizes the earlier turns of a long conversation into a shorter one and swaps it in, keeping the gist while trimming the length. The original is filed away untouched. A conversation that's already short is left as-is.</div>
+      </div>
+    </div>
+
+    <h2 id="thinking-tools">Thinking-tool commands</h2>
+    <p>Below the built-ins, the menu lists <a href="thinking-tools.html">thinking tools</a> that carry a slash shorthand — the same skills you'd otherwise launch from the Learning, Research, and Analysis menus. Picking one from the slash menu is just a faster way in: it opens the tool exactly as the menus would, running straight away when the tool needs nothing else from you.</p>
+    <p>Which tools show up depends on which skills are turned on and whether they declare a shorthand, so your list may differ. A few of the stock ones:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>/summarize</code></div>
+        <div class="v">Condense the note you're working with into a short summary.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>/quiz</code></div>
+        <div class="v">Turn a note into quiz questions to test yourself.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>/steelman</code></div>
+        <div class="v">Build the strongest possible version of an argument.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>/find-sources</code></div>
+        <div class="v">Suggest sources that would back up or challenge a claim.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>/visualize</code></div>
+        <div class="v">Propose a chart for the data in a note.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Your own shortcuts</span>
+      <p>Skills you add yourself can carry a slash shorthand too, and they'll appear here alongside the stock tools. They can't take over one of the built-in names, so <code>/clear</code> and <code>/compact</code> always mean the same thing. For how to give a skill a slash command, see <a href="thinking-tools.html">Thinking tools</a>.</p>
+    </div>
+
+    <h2 id="keyboard">Getting around the menu</h2>
+    <p>The menu is built for the keyboard:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>↑</kbd> <kbd>↓</kbd></div>
+        <div class="v">Move up and down the list. The selection wraps around at either end.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⏎</kbd> or <kbd>⇥</kbd></div>
+        <div class="v">Run the highlighted command.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>Esc</kbd></div>
+        <div class="v">Dismiss the menu and leave what you typed in place, so you can carry on writing an ordinary message.</div>
+      </div>
+      <div class="row">
+        <div class="k">Mouse</div>
+        <div class="v">Hover to highlight, click to run — whichever's closer to hand.</div>
+      </div>
+    </div>

--- a/website/docs/_content/conversations.html
+++ b/website/docs/_content/conversations.html
@@ -1,0 +1,56 @@
+---
+title: Minerva — Docs — Conversations
+description: Chatting with the AI about your notes, drafts, and the propose → review → approve loop that keeps you in control of what changes.
+---
+
+    <h1>Conversations</h1>
+    <p class="lede">Conversations is where you think alongside the AI instead of editing everything by hand. You chat, it reads your notes as it works, and when it wants to change something — add a claim, rewrite a note, suggest a tag — it hands you a suggestion instead of just doing it. One rule holds throughout: the AI proposes, you decide. Nothing changes your notes until you approve it.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>K</kbd></div>
+        <div class="v"><a href="conversations-chatting.html"><b>Chatting with the AI</b></a> — open the panel, start a conversation, and watch it look through your notes as it answers.</div>
+      </div>
+      <div class="row">
+        <div class="k">/</div>
+        <div class="v"><a href="conversations-slash-commands.html"><b>Slash commands</b></a> — type <code>/</code> in the composer to run a quick command or a thinking tool without leaving the keyboard.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="conversations-drafts.html"><b>Drafts</b></a> — a suggested change waiting in the conversation for you to accept or discard.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="conversations-propose-review-approve.html"><b>The propose → review → approve loop</b></a> — why nothing the AI produces changes your notes on its own.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">You stay in control</span>
+      <p>Treat what the AI offers as a suggestion to weigh and file, not a decision already made. This is the most important idea in Minerva — see <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a> for the full picture.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="conversations-chatting.html">
+        <span class="em">💭</span>
+        <h3>Chatting with the AI</h3>
+        <p>Start a conversation and watch it read your notes as it answers.</p>
+      </a>
+      <a class="doc-card" href="conversations-slash-commands.html">
+        <span class="em">⌨️</span>
+        <h3>Slash commands</h3>
+        <p>Run a command or a thinking tool right from the composer.</p>
+      </a>
+      <a class="doc-card" href="conversations-drafts.html">
+        <span class="em">📝</span>
+        <h3>Drafts</h3>
+        <p>Suggested changes you can accept or discard.</p>
+      </a>
+      <a class="doc-card" href="conversations-propose-review-approve.html">
+        <span class="em">🔁</span>
+        <h3>The propose → review → approve loop</h3>
+        <p>The AI proposes, you confirm — you stay in control.</p>
+      </a>
+    </div>

--- a/website/docs/_content/data-operations.html
+++ b/website/docs/_content/data-operations.html
@@ -1,0 +1,50 @@
+---
+title: Minerva — Docs — Data operations
+description: The Query menu commands for working with your data in Minerva: New Query, Stock Queries, Saved Queries, and Export Knowledge Graph.
+---
+
+    <h1>Data operations</h1>
+    <p class="lede">The commands for working with your <a href="data.html">data</a> live in the <b>Query</b> menu — running a query, reaching for a ready-made or saved one, and taking the whole knowledge graph out as a file.</p>
+
+    <h2 id="asking">Asking questions</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">New Query</div>
+        <div class="v"><b>Query → New Query</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>Q</kbd>) opens a fresh query in the Query panel, where you write <b>SPARQL</b> (for the knowledge graph) or <b>SQL</b> (for tables) and run it to see the results. See <a href="query-menu-panel.html">Query menu &amp; panel</a> for how the panel and cells work.</div>
+      </div>
+      <div class="row">
+        <div class="k">Stock Queries</div>
+        <div class="v"><b>Query → Stock Queries</b> is a library of ready-made queries, grouped into <b>SPARQL</b> and <b>SQL</b> submenus. Pick one to open it in the panel — run it as-is, or use it as a starting point you adapt.</div>
+      </div>
+      <div class="row">
+        <div class="k">Saved Queries</div>
+        <div class="v"><b>Query → Saved Queries</b> lists queries you've kept, so a query you'll want again is one click away. Saved queries can be scoped to this thoughtbase or shared across all of them, and <b>Edit Saved Queries…</b> at the bottom opens them for managing.</div>
+      </div>
+    </div>
+
+    <h2 id="export-graph">Exporting the graph</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Export Knowledge Graph…</div>
+        <div class="v"><b>Query → Export Knowledge Graph…</b> saves the entire knowledge graph — everything Minerva knows about your notes and how they connect — to a <b>Turtle</b> (<code>.ttl</code>) file you can keep, share, or load into other tools. It lives in the Query menu because it's the graph you query, written out in full; it isn't a note export. (To get your <em>notes</em> out as documents, a website, or citations, see <a href="export.html">Export</a> instead.)</div>
+      </div>
+    </div>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="query-menu-panel.html">
+        <span class="em">🔎</span>
+        <h3>Query panel &amp; cells</h3>
+        <p>The Query panel, runnable cells, and how result blocks work.</p>
+      </a>
+      <a class="doc-card" href="notes-tables.html">
+        <span class="em">📋</span>
+        <h3>Tables &amp; CSV</h3>
+        <p>Bring in CSV files as tables you can query with SQL.</p>
+      </a>
+      <a class="doc-card" href="maintenance.html">
+        <span class="em">🛠️</span>
+        <h3>Maintenance</h3>
+        <p>Rebuild the graph and search indexes if anything looks stale.</p>
+      </a>
+    </div>

--- a/website/docs/_content/data.html
+++ b/website/docs/_content/data.html
@@ -1,0 +1,96 @@
+---
+title: Minerva — Docs — Working with data
+description: How data works in Minerva: everything you write becomes a queryable knowledge graph and your tables become a database, so you can ask precise questions, compute, and chart — right inside your notes.
+---
+
+    <h1>Working with data</h1>
+    <p class="lede">In Minerva, everything you write is also data you can question. As you work, your notes become a <b>knowledge graph</b> and your tables become a <b>database</b> — built automatically, kept current, and queryable. So instead of only reading your notes back, you can ask precise questions of them and get answers, right inside a note or from a dedicated panel.</p>
+
+    <h2 id="two-kinds">Two kinds of data</h2>
+    <p>Minerva keeps your work as data in two forms, each with its own query language:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">The knowledge graph</div>
+        <div class="v">A precise map of your notes and how they connect — titles, tags, links, properties, and any facts you write down. It's built automatically from your writing on every save, and you query it with <b>SPARQL</b>. This is what lets you ask things like "every claim tagged <em>unresolved</em>" or "which notes contradict this one."</div>
+      </div>
+      <div class="row">
+        <div class="k">Tables</div>
+        <div class="v">Your <a href="notes-tables.html">CSV files and note tables</a> become typed tables in a built-in database, which you query with <b>SQL</b> — the familiar language for rows and columns. Good for numbers, records, and anything tabular.</div>
+      </div>
+    </div>
+
+    <h2 id="what-becomes-data">What becomes data</h2>
+    <p>You don't set any of this up or maintain a schema — Minerva reads the structure out of ordinary writing. These are the parts of a note that fold into the graph automatically:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Titles &amp; tags</div>
+        <div class="v">Each note's title and every <code>#tag</code> become things you can filter and group by.</div>
+      </div>
+      <div class="row">
+        <div class="k">Links</div>
+        <div class="v"><a href="notes-links.html">Wiki-links and typed links</a> (supports, rebuts, depends-on…) become the edges of the graph — the connections you can traverse.</div>
+      </div>
+      <div class="row">
+        <div class="k">Properties</div>
+        <div class="v">The <a href="notes-frontmatter.html">properties</a> at the top of a note — status, dates, and any fields you add — become structured details attached to it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Tables &amp; CSV</div>
+        <div class="v">Markdown tables and <code>.csv</code> files become queryable tables.</div>
+      </div>
+      <div class="row">
+        <div class="k">Embedded facts</div>
+        <div class="v">Blocks of <a href="notes-rdf.html">Turtle / RDF</a> let you state structured facts by hand, right inside a note, when you want more than tags and links can express.</div>
+      </div>
+    </div>
+
+    <h2 id="do-with-it">What you can do with it</h2>
+    <p>Once your work is data, you can query it, compute over it, and visualize it — each has its own page:</p>
+    <div class="doc-cards">
+      <a class="doc-card" href="query-menu-panel.html">
+        <span class="em">🔎</span>
+        <h3>Query menu &amp; panel</h3>
+        <p>A dedicated place to write a question, run it, and reuse it — with ready-made and saved queries.</p>
+      </a>
+      <a class="doc-card" href="query-runnable-cells.html">
+        <span class="em">▶️</span>
+        <h3>Runnable cells</h3>
+        <p>A question you write and run right inside a note, with the answer appearing just below it.</p>
+      </a>
+      <a class="doc-card" href="query-result-blocks.html">
+        <span class="em">📊</span>
+        <h3>Result blocks</h3>
+        <p>Drop a question's answer into a note as a live list, table, or chart that stays up to date.</p>
+      </a>
+      <a class="doc-card" href="notes-tables.html">
+        <span class="em">📋</span>
+        <h3>Tables &amp; CSV</h3>
+        <p>Turn CSV files into typed SQL tables you can query and chart.</p>
+      </a>
+      <a class="doc-card" href="notes-code.html">
+        <span class="em">🧮</span>
+        <h3>Compute cells</h3>
+        <p>Run Python over your notes and tables, with output rendered inline.</p>
+      </a>
+      <a class="doc-card" href="notes-charts.html">
+        <span class="em">📈</span>
+        <h3>Charts</h3>
+        <p>Turn query results and tables into interactive charts, live in the note.</p>
+      </a>
+      <a class="doc-card" href="notes-rdf.html">
+        <span class="em">🐢</span>
+        <h3>Turtle / RDF</h3>
+        <p>State structured facts by hand when tags and links aren't enough.</p>
+      </a>
+    </div>
+
+    <div class="box">
+      <span class="label">Asking questions yourself vs. asking the assistant</span>
+      <p>When you chat with the assistant, it can look things up in your knowledge base for you — see <a href="conversations.html">Conversations</a>. This section is about doing that yourself, whether from the Query panel or right inside a note.</p>
+    </div>
+
+    <h2 id="where">Where your data lives</h2>
+    <p>Both forms are generated from your files and stored inside the thoughtbase's hidden <code>.minerva</code> folder — the knowledge graph as a Turtle file, the tables in a local database. You never edit these directly: they're rebuilt from your notes as you work, so your markdown files always remain the source of truth. If something ever looks out of date, <a href="maintenance.html">Maintenance</a> can rebuild them on demand.</p>
+
+    <h2 id="operations">Data operations</h2>
+    <p>The <b>Query</b> menu gathers the commands for asking questions and taking the graph out — running a new query, stock and saved queries, and exporting the knowledge graph. See <a href="data-operations.html">Data operations</a> for each one.</p>

--- a/website/docs/_content/editor-keyboard-shortcuts.html
+++ b/website/docs/_content/editor-keyboard-shortcuts.html
@@ -1,0 +1,157 @@
+---
+title: Minerva — Docs — Keyboard Shortcuts
+description: A complete reference of Minerva's editor keyboard shortcuts — formatting, editing, and navigation — gathered in one place.
+---
+
+    <h1>Keyboard shortcuts</h1>
+    <p class="lede">Every shortcut the editor answers to, gathered in one place: formatting, editing, and getting around the app. On Windows and Linux, use <kbd>Ctrl</kbd> wherever you see <kbd>⌘</kbd> and <kbd>Alt</kbd> wherever you see <kbd>⌥</kbd>.</p>
+
+    <h2 id="formatting">Formatting</h2>
+    <p>These wrap the text you've selected in the matching style. Press the same shortcut again on already-formatted text to remove it. See <a href="editor-markdown-formatting.html">Markdown formatting</a> for what each one looks like.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>B</kbd></div>
+        <div class="v">Toggle <b>bold</b>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>I</kbd></div>
+        <div class="v">Toggle <i>italic</i>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>E</kbd></div>
+        <div class="v">Toggle inline <code>code</code> styling.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>X</kbd></div>
+        <div class="v">Toggle strikethrough.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>Y</kbd></div>
+        <div class="v">Toggle <a href="notes-highlights.html">highlight</a>. Press again to cycle the color: yellow, green, blue, pink, orange, then off.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>K</kbd></div>
+        <div class="v">Insert a link around the selected text, or an empty link with the cursor ready for the address.</div>
+      </div>
+    </div>
+
+    <p>Headings, quotes, lists, task lists, tables, footnotes, and links are also available from the editor's menus and the command palette, even where no shortcut is assigned.</p>
+
+    <div class="box">
+      <span class="label">You can remap these</span>
+      <p>The shortcuts on this page are the defaults. If a combination doesn't behave the way it's described here, check Settings — any of them can be reassigned to keys you prefer.</p>
+    </div>
+
+    <h2 id="file-and-editing">Editing</h2>
+    <p>Saving, undo, and reshaping the text you're working on.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>S</kbd></div>
+        <div class="v">Save now. Minerva <a href="notes.html">saves your work automatically</a> as you type, so this is mostly for peace of mind.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>Z</kbd></div>
+        <div class="v">Undo.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>Z</kbd></div>
+        <div class="v">Redo.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>D</kbd></div>
+        <div class="v">Duplicate the current line, or the selected text if you have any.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌥</kbd><kbd>↑</kbd> / <kbd>⌥</kbd><kbd>↓</kbd></div>
+        <div class="v">Grow or shrink the selection one step at a time — from a word out to the sentence, paragraph, section, and eventually the whole note, then back in again.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>U</kbd></div>
+        <div class="v">Cycle the case of the selection (or the current word): lowercase, UPPERCASE, Title Case, and back.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>Ctrl</kbd><kbd>⇧</kbd><kbd>J</kbd></div>
+        <div class="v">Join lines — merges the current line with the one below, or all the lines you've selected, into a single line.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>V</kbd></div>
+        <div class="v">Start or stop <a href="editor-voice-dictation.html">voice dictation</a> at the cursor.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>F</kbd></div>
+        <div class="v">Find within the note you're editing.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>H</kbd></div>
+        <div class="v">Find and replace within the note you're editing.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Searching one note vs. all of them</span>
+      <p><kbd>⌘</kbd><kbd>F</kbd> and <kbd>⌘</kbd><kbd>H</kbd> only look inside the note you're editing. To search across every note, use <a href="navigation-search.html">Find in Notes…</a> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd>) instead.</p>
+    </div>
+
+    <h2 id="navigation">Getting around</h2>
+    <p>Shortcuts that move you through the app rather than change your text. Each has its own page with more detail — here they are all in one place.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>K</kbd></div>
+        <div class="v">Open the <a href="navigation-command-palette.html">command palette</a> — a do-anything launcher over commands and actions.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>P</kbd></div>
+        <div class="v"><a href="navigation-quick-switch.html">Quick switch</a> — jump to any note, source, or query by name.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd></div>
+        <div class="v"><a href="navigation-search.html">Find in Notes…</a> — project-wide search across every file's actual content.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>[</kbd> / <kbd>⌘</kbd><kbd>]</kbd></div>
+        <div class="v"><a href="navigation-back-forward.html">Back / Forward</a> through your navigation history.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd></div>
+        <div class="v">Cycle the active pane's <a href="viewing-options-view-modes.html">view mode</a> — Source → Preview → Editor + Preview → Source.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>\</kbd> / <kbd>⌘</kbd><kbd>⇧</kbd><kbd>\</kbd></div>
+        <div class="v"><a href="viewing-options-split-panes-windows.html">Split the editor</a> right or down.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd></div>
+        <div class="v"><a href="viewing-options-split-panes-windows.html">New window</a> — opens a second, blank Minerva window.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>N</kbd></div>
+        <div class="v"><a href="notes.html">New Note</a> — prompts for a name and, optionally, a starting template.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>G</kbd></div>
+        <div class="v">Go to line, when a note is focused.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>Q</kbd></div>
+        <div class="v">New query tab, when a project is open.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>I</kbd></div>
+        <div class="v">Open a <a href="conversations.html">conversation</a> with the assistant.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>B</kbd></div>
+        <div class="v">Toggle the <a href="right-sidebar.html">right sidebar</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd></div>
+        <div class="v">Cycle the <a href="viewing-options-themes.html">theme</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>W</kbd></div>
+        <div class="v">Close the active tab, when one is open.</div>
+      </div>
+    </div>

--- a/website/docs/_content/editor-link-autocomplete.html
+++ b/website/docs/_content/editor-link-autocomplete.html
@@ -1,0 +1,36 @@
+---
+title: Minerva — Docs — Link Autocomplete
+description: Typing [[ suggests matching notes as you type, so you can link to another note without remembering its exact name.
+---
+
+    <h1>Link autocomplete</h1>
+    <p class="lede">To link one note to another, type <code>[[</code> and a suggestion list appears. Keep typing to narrow it down, then pick the note you want. You never have to remember a note's exact name, and you won't accidentally create a link that points nowhere.</p>
+
+    <h2 id="trigger">How it works</h2>
+    <p>Type <code>[[</code> anywhere in a note and the suggestion list opens. As you keep typing, it filters live to the notes that match. Choose one and Minerva drops its name into your link.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Open</div>
+        <div class="v">Type <code>[[</code> to open the list. It stays open and keeps filtering as you type, and closes when you finish the link with <code>]]</code> or move away.</div>
+      </div>
+      <div class="row">
+        <div class="k">Filter</div>
+        <div class="v">Whatever you type after <code>[[</code> narrows the list. Matching is forgiving — the letters just have to appear in order, so <code>mtg</code> still finds <code>Meeting Notes</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move and pick</div>
+        <div class="v">Use the arrow keys or click to move through the list. <kbd>Tab</kbd> or <kbd>Enter</kbd> accepts the highlighted note; <kbd>Esc</kbd> closes the list and leaves your text as-is.</div>
+      </div>
+      <div class="row">
+        <div class="k">No match</div>
+        <div class="v">If nothing matches, the list is empty. Minerva won't invent a note for you.</div>
+      </div>
+    </div>
+
+    <p>The list includes every note by name, plus any alternate names you've given a note in its properties — so a nickname is just as easy to link to as the real title. You can also link by relationship: start with a relationship word (for example <code>supports::</code>) to choose one of the built-in <a href="notes-links.html#types">link types</a>, or begin with <code>cite::</code> to point the list at your sources instead of your notes.</p>
+
+    <figure class="shot-img">
+      <img src="img/editor-link-autocomplete.png" alt="Partway through typing a link, a list appears just below the cursor showing the notes that match — such as &quot;Meeting Notes&quot; and &quot;Meeting Prep&quot; — with one highlighted, ready to pick." loading="lazy" />
+      <figcaption>The suggestion list open</figcaption>
+    </figure>

--- a/website/docs/_content/editor-markdown-formatting.html
+++ b/website/docs/_content/editor-markdown-formatting.html
@@ -1,0 +1,99 @@
+---
+title: Minerva — Docs — Markdown Formatting
+description: A scannable reference to the markdown Minerva understands — headings, emphasis, lists, and more — with pointers to the fuller pages for richer content.
+---
+
+    <h1>Markdown formatting</h1>
+    <p class="lede">You write notes in Minerva using markdown — plain text with a few simple marks that turn into formatting. This page is a quick reference: the mark you type on the left, what it becomes on the right. The everyday basics are covered in full here; richer content links out to its own page.</p>
+
+    <h2 id="basics">The basics</h2>
+    <p>Headings, emphasis, lists, quotes, and inline code work the way you'd expect from markdown.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code># … ######</code></div>
+        <div class="v">Headings, from large to small — <code># H1</code>, <code>## H2</code>, and so on down to six levels. You can jump straight to any heading from another note with a link like <code>[[note#heading]]</code>. See <a href="notes-links.html">Links</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>**bold**</code> / <code>__bold__</code></div>
+        <div class="v">Either style gives you <b>bold text</b>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>*italic*</code> / <code>_italic_</code></div>
+        <div class="v">Either style gives you <em>italic text</em>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>- item</code> / <code>* item</code> / <code>1. item</code></div>
+        <div class="v">Bulleted lists (start a line with <code>-</code> or <code>*</code>) and numbered lists (a number followed by <code>.</code>). Indent an item to tuck it under the one above. Start an item with <code>[ ]</code> or <code>[x]</code> and it becomes a checkbox you can tick — see <a href="notes-tasks.html">Task lists</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>&gt; quoted text</code></div>
+        <div class="v">A quote, set off with a line along the left edge. Begin the first line with a tag like <code>[!note]</code>, <code>[!tip]</code>, or <code>[!warning]</code> and it turns into a titled, colored callout instead. See <a href="notes-callouts.html">Callouts</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>---</code></div>
+        <div class="v">Three dashes on their own line draw a horizontal divider. (Three dashes at the very top of a note instead start a <a href="notes-frontmatter.html">properties</a> block.)</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>`inline code`</code></div>
+        <div class="v">Wrap a word in backticks for <code>inline code</code> in a monospaced font.</div>
+      </div>
+      <div class="row">
+        <div class="k">code cells</div>
+        <div class="v">Set off a block of code and label it with a language for syntax coloring. Label a cell <code>sparql</code>, <code>sql</code>, or <code>python</code> and you can run it, with the result written back into the note. See <a href="notes-code.html">Code &amp; compute cells</a>.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/editor-markdown-formatting.png" alt="A note showing a heading, a paragraph with bold and italic words, a bulleted list with a nested item, a quote, a divider, and an inline code span — the everyday building blocks side by side." loading="lazy" />
+      <figcaption>The basics, rendered</figcaption>
+    </figure>
+
+    <h2 id="more">Everything else</h2>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="notes-links.html">Links</a></div>
+        <div class="v">Type <code>[[Note Title]]</code> to link to another note; ordinary <code>[text](url)</code> web links work too. A link can also carry a relationship, like <em>supports</em> or <em>rebuts</em>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-images.html">Images</a></div>
+        <div class="v">Drop in an image with <code>![alt](path)</code>. It shows inline and enlarges when clicked.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-tables.html">Tables</a></div>
+        <div class="v">Build a table with rows of cells separated by <code>|</code> bars. Minerva also treats each table as data you can query.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-footnotes.html">Footnotes</a></div>
+        <div class="v">Drop a marker like <code>[^1]</code> in your text and define it anywhere in the note; the definitions gather at the bottom.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-highlights.html">Highlights</a></div>
+        <div class="v">Wrap text in <code>==double equals==</code> to give it a highlighter tint.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-tasks.html">Task lists</a></div>
+        <div class="v">A list item that starts with <code>[ ]</code> or <code>[x]</code> becomes a checkbox you can click to mark done.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-math.html">Math</a></div>
+        <div class="v">Write mathematical notation between <code>$</code> for inline or <code>$$</code> for a centered formula.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-diagrams.html">Diagrams</a></div>
+        <div class="v">Describe a flowchart, sequence diagram, and more in a diagram cell and Minerva draws it for you.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-charts.html">Charts</a></div>
+        <div class="v">Add a chart cell to turn your data into an interactive graph, optionally fed by a live query.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-callouts.html">Callouts</a></div>
+        <div class="v">A quote that opens with a tag like <code>[!tip]</code> becomes a titled callout box; <code>[!card]</code> makes a two-sided flashcard.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="notes-rdf.html">Graph facts</a></div>
+        <div class="v">Write structured facts directly in a note and Minerva folds them into your knowledge base.</div>
+      </div>
+    </div>

--- a/website/docs/_content/editor-operations.html
+++ b/website/docs/_content/editor-operations.html
@@ -1,0 +1,71 @@
+---
+title: Minerva — Docs — Editor operations
+description: The Edit menu commands in Minerva: undo and redo, find and replace within a note and across notes, insert a template, and sort lines.
+---
+
+    <h1>Editor operations</h1>
+    <p class="lede">The <b>Edit</b> menu holds the text commands that act on the note you're writing — the familiar undo and copy/paste, plus finding and replacing, inserting a template, and tidying lines. Most also carry a keyboard shortcut.</p>
+
+    <h2 id="basics">The basics</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Undo · Redo · Cut · Copy · Paste · Select All</div>
+        <div class="v">The standard editing commands at the top of the <b>Edit</b> menu, with their usual shortcuts (<kbd>⌘</kbd><kbd>Z</kbd>, <kbd>⌘</kbd><kbd>C</kbd>, <kbd>⌘</kbd><kbd>V</kbd>, and so on). Undo history is per note.</div>
+      </div>
+    </div>
+
+    <h2 id="find-replace">Find and replace</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Find</div>
+        <div class="v"><b>Edit → Find</b> (<kbd>⌘</kbd><kbd>F</kbd>) searches within the current note and steps through the matches.</div>
+      </div>
+      <div class="row">
+        <div class="k">Find and Replace</div>
+        <div class="v"><b>Edit → Find and Replace</b> (<kbd>⌘</kbd><kbd>H</kbd>) does the same, with a field to replace matches in the current note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Find in Notes…</div>
+        <div class="v"><b>Edit → Find in Notes…</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd>) searches across <em>every</em> note in the thoughtbase, not just the open one. See <a href="navigation-search.html">Search</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Replace in Notes…</div>
+        <div class="v"><b>Edit → Replace in Notes…</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>H</kbd>) replaces text across every note — a careful, base-wide find-and-replace.</div>
+      </div>
+    </div>
+
+    <h2 id="insert-transform">Inserting and transforming</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Insert Template…</div>
+        <div class="v"><b>Edit → Insert Template…</b> drops a saved template into the note at the cursor — a quick way to reuse boilerplate or a standard structure.</div>
+      </div>
+      <div class="row">
+        <div class="k">Sort Lines</div>
+        <div class="v"><b>Edit → Sort Lines</b> sorts the selected lines into alphabetical order — handy for lists and tables of contents.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Windows / Linux</span>
+      <p>Every shortcut above uses <kbd>Ctrl</kbd> in place of <kbd>⌘</kbd>.</p>
+    </div>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="editor-keyboard-shortcuts.html">
+        <span class="em">⌨️</span>
+        <h3>Keyboard shortcuts</h3>
+        <p>Every shortcut the editor answers to, in one place.</p>
+      </a>
+      <a class="doc-card" href="editor-writing-surface.html">
+        <span class="em">✍️</span>
+        <h3>The writing surface</h3>
+        <p>How your text formats itself as you type.</p>
+      </a>
+      <a class="doc-card" href="editor-voice-dictation.html">
+        <span class="em">🎙️</span>
+        <h3>Voice dictation</h3>
+        <p>Speak, and your words appear in the note.</p>
+      </a>
+    </div>

--- a/website/docs/_content/editor-voice-dictation.html
+++ b/website/docs/_content/editor-voice-dictation.html
@@ -1,0 +1,40 @@
+---
+title: Minerva — Docs — Voice Dictation
+description: Speak into a note and Minerva types it out for you, right where your cursor is. Your voice stays on your computer.
+---
+
+    <h1>Voice dictation</h1>
+    <p class="lede">Would rather talk than type? Speak into the note you're editing and Minerva writes down what you said, dropping the text right where your cursor is. Everything happens on your own computer — your voice never leaves it.</p>
+
+    <div class="box">
+      <span class="label">Private by default</span>
+      <p>Dictation runs entirely on your machine. Your recorded voice is used to produce the text and is never sent anywhere. The very first time you dictate, Minerva downloads a small speech model; after that it works even offline.</p>
+    </div>
+
+    <h2 id="using-it">Starting and stopping</h2>
+    <p>Dictation is a simple on/off toggle: trigger it once to start listening, and again to stop and drop the text into your note. You can start it three ways:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Keyboard — <kbd>⌘</kbd><kbd>⇧</kbd><kbd>V</kbd></div>
+        <div class="v">Starts listening at your cursor. Press it again to stop and insert what you said, right where you left off.</div>
+      </div>
+      <div class="row">
+        <div class="k">Right-click menu</div>
+        <div class="v">Right-click in the editor and choose <b>Dictate…</b></div>
+      </div>
+      <div class="row">
+        <div class="k">Command palette</div>
+        <div class="v">Search for <b>Dictate (Voice to Text)</b>.</div>
+      </div>
+    </div>
+
+    <p>While you're speaking, a small pill at the bottom of the window shows <b>Listening…</b> with <b>Insert</b> and <b>Cancel</b> buttons. Press <kbd>Esc</kbd> to cancel without inserting anything. When you stop, the pill briefly shows that it's writing out your words; the finished text appears at your cursor, with a space added automatically so it doesn't run into the word before it.</p>
+
+    <h2 id="accuracy">Speed vs. accuracy</h2>
+    <p>In Settings you can choose how carefully Minerva listens. A lighter option is fastest but a little rougher; a heavier one is more accurate but takes longer. The middle option is a good default for most people.</p>
+
+    <figure class="shot-img">
+      <img src="img/editor-voice-dictation.png" alt="A note being written by voice: the cursor sits in the text, and a floating pill at the bottom of the window shows a pulsing &quot;Listening…&quot; indicator with Insert and Cancel buttons." loading="lazy" />
+      <figcaption>Dictating into a note</figcaption>
+    </figure>

--- a/website/docs/_content/editor-writing-surface.html
+++ b/website/docs/_content/editor-writing-surface.html
@@ -1,0 +1,49 @@
+---
+title: Minerva — Docs — The Writing Surface
+description: How the editor styles your writing as you type — headers, emphasis, and links come to life in place, without ever hiding what you actually typed.
+---
+
+    <h1>The writing surface</h1>
+    <p class="lede">The editor styles your writing as you type. Headings, emphasis, links, and more come to life right where you wrote them — you never have to switch to a preview to see how your note is shaping up. This page is about the editing pane itself. For how it sits alongside Preview and Side by side, see <a href="viewing-options-view-modes.html">View modes</a>.</p>
+
+    <h2 id="live-rendering">Your writing, styled as you type</h2>
+    <p>As soon as the editor recognizes a piece of markup, it styles it in place. A heading turns bold and colored the moment you start the line with <code>#</code>. Bold and italic text takes on real weight and slant as soon as you close it. Links become clickable, and highlights get a tinted background — all while you keep typing.</p>
+
+    <p>The one thing the editor never does is hide what you typed. The <code>#</code>, <code>**</code>, <code>==</code>, and <code>[[ ]]</code> markers stay right where you put them, styled along with the text rather than vanishing when your cursor moves away. You always see exactly what's in your note, just dressed up — so nothing is ever a surprise when you look at it again later.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Headings</div>
+        <div class="v">Turn bold and colored as soon as the line starts with <code>#</code>. The <code>#</code> markers stay visible.</div>
+      </div>
+      <div class="row">
+        <div class="k">Bold, italic, strikethrough</div>
+        <div class="v"><code>**bold**</code>, <code>_italic_</code>, and <code>~~struck~~</code> take on real weight, slant, or a line-through the moment you close them — the markers stay on screen, just styled along with the text.</div>
+      </div>
+      <div class="row">
+        <div class="k">Highlights</div>
+        <div class="v"><code>==text==</code> picks up a tinted background as you type it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Links</div>
+        <div class="v">Wiki links and web addresses become soft, clickable chips. You can still move your cursor through the link text to edit it, and hovering one briefly shows a preview of where it leads.</div>
+      </div>
+      <div class="row">
+        <div class="k">Footnotes</div>
+        <div class="v">A footnote marker becomes clickable, jumping between the reference and its note at the bottom; hovering shows the footnote's text.</div>
+      </div>
+      <div class="row">
+        <div class="k">Runnable cells</div>
+        <div class="v">A run marker appears next to any cell you can run, and its results are written back into the note just below it — no separate panel to check. See <a href="notes-code.html">Code &amp; queries</a>.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/editor-writing-surface.png" alt="A note in the editor: a heading in bold color with its &quot;#&quot; still showing, bold text with its &quot;**&quot; markers intact, and a wiki link shown as a rounded chip — the cursor resting inside the bold text to show that your markup stays on screen while you edit." loading="lazy" />
+      <figcaption>Writing styled as you type</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">Themes come along</span>
+      <p>The editor takes on whatever <a href="viewing-options-themes.html">theme</a> you choose. Switch themes and your writing re-colors instantly, right along with the rest of the app.</p>
+    </div>

--- a/website/docs/_content/editor.html
+++ b/website/docs/_content/editor.html
@@ -1,0 +1,74 @@
+---
+title: Minerva — Docs — Editor
+description: Where you write: the writing surface, formatting shortcuts, keyboard shortcuts, link autocomplete, and voice dictation.
+---
+
+    <h1>Editor</h1>
+    <p class="lede">You write in a single pane, and your text takes on its formatting right where you type — a heading looks like a heading, bold looks bold. There's no separate preview to flip to. These pages cover that writing experience, the simple marks you use to format text, the keyboard shortcuts, the pop-up list that helps you link notes as you type, and dictation for when you'd rather talk than type.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Edit menu</div>
+        <div class="v"><a href="editor-operations.html"><b>Editor operations</b></a> — the Edit menu at a glance: find &amp; replace, insert a template, and sort lines.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="editor-writing-surface.html"><b>The writing surface</b></a> — how your text formats itself as you type.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="editor-markdown-formatting.html"><b>Formatting</b></a> — the simple marks that turn plain text into headings, lists, links, and more.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="editor-keyboard-shortcuts.html"><b>Keyboard shortcuts</b></a> — every shortcut the editor answers to, in one place.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[[</code></div>
+        <div class="v"><a href="editor-link-autocomplete.html"><b>Link autocomplete</b></a> — a live list of matching notes so you can link without remembering titles.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>V</kbd></div>
+        <div class="v"><a href="editor-voice-dictation.html"><b>Voice dictation</b></a> — speak, and your words appear in the note.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Windows / Linux</span>
+      <p>Every shortcut above uses <kbd>Ctrl</kbd> in place of <kbd>⌘</kbd>.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="editor-operations.html">
+        <span class="em">🧰</span>
+        <h3>Editor operations</h3>
+        <p>The Edit menu commands, grouped and explained.</p>
+      </a>
+      <a class="doc-card" href="editor-writing-surface.html">
+        <span class="em">🖋️</span>
+        <h3>The writing surface</h3>
+        <p>One pane where your text takes on its formatting as you type.</p>
+      </a>
+      <a class="doc-card" href="editor-markdown-formatting.html">
+        <span class="em">🔤</span>
+        <h3>Formatting</h3>
+        <p>The simple marks that turn plain text into headings, lists, and links.</p>
+      </a>
+      <a class="doc-card" href="editor-keyboard-shortcuts.html">
+        <span class="em">⌨️</span>
+        <h3>Keyboard shortcuts</h3>
+        <p>Every shortcut the editor answers to, gathered in one place.</p>
+      </a>
+      <a class="doc-card" href="editor-link-autocomplete.html">
+        <span class="em">🔮</span>
+        <h3>Link autocomplete</h3>
+        <p>Type <code>[[</code> and pick from a live list of matching notes.</p>
+      </a>
+      <a class="doc-card" href="editor-voice-dictation.html">
+        <span class="em">🎙️</span>
+        <h3>Voice dictation</h3>
+        <p>Speak your notes — the transcription happens on your own machine.</p>
+      </a>
+    </div>

--- a/website/docs/_content/export-bibliography.html
+++ b/website/docs/_content/export-bibliography.html
@@ -1,0 +1,35 @@
+---
+title: Minerva — Docs — Bibliography &amp; Citations
+description: Get your citations out for use in other reference and writing tools, and choose the style your citations appear in.
+---
+
+    <h1>Bibliography &amp; citations</h1>
+    <p class="lede">When you cite sources in your notes, Minerva can hand your citations off to other reference and writing tools, and let you choose the style your citations appear in.</p>
+
+    <h2 id="bibtex">Export a reference list</h2>
+    <p>Minerva can gather every source you've cited and save it as a standard reference list that most citation managers and academic writing tools can open. Each source becomes one entry with a short, readable citation key like <em>smith-2020-functions</em>. You choose how much to include: a single note, a folder, or your whole project.</p>
+
+    <h2 id="pandoc">Export for Word, PDF, and beyond</h2>
+    <p>If you want a finished document in Word, PDF, or another format, Minerva can export a note together with its citations and a matching reference file, ready to convert with a document-conversion tool of your choice. It comes with clear step-by-step instructions and uses the citation style you've picked.</p>
+
+    <h2 id="settings">Choose your citation style</h2>
+    <p>Minerva formats your citations in whatever style you prefer, and the same choice applies everywhere your citations appear.</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Citation style</div>
+        <div class="v">Pick from a list of common styles. APA is the default.</div>
+      </div>
+      <div class="row">
+        <div class="k">Import a style</div>
+        <div class="v">Bring in a citation style Minerva doesn't already include.</div>
+      </div>
+      <div class="row">
+        <div class="k">Language</div>
+        <div class="v">Set the language used when formatting citations. You can import an additional language the same way you import a style.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/export-bibliography.png" alt="The bibliography settings, showing the citation style set to APA, the styles you've added, and the button to import another one." loading="lazy" />
+      <figcaption>Screenshot — Choosing a citation style</figcaption>
+    </figure>

--- a/website/docs/_content/export-documents.html
+++ b/website/docs/_content/export-documents.html
@@ -1,0 +1,57 @@
+---
+title: Minerva — Docs — Document Exports
+description: Turn your notes into shareable documents — Markdown, web pages, or PDF — as a single note or a whole set of linked notes.
+---
+
+    <h1>Document exports</h1>
+    <p class="lede">When you want to share your work outside Minerva, you can turn a note into a document. Pick a format — Markdown, a web page, or a PDF — and choose whether to export just one note or a note along with everything it links to.</p>
+
+    <h2 id="exporters">What you can export</h2>
+    <p>Every export starts from a note. You decide the format and whether to include the notes it links to.</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Markdown</div>
+        <div class="v">A plain copy of your notes, exactly as you wrote them — the simplest way to get your files out.</div>
+      </div>
+      <div class="row">
+        <div class="k">A note as clean Markdown</div>
+        <div class="v">A single note, tidied up so it reads well on its own.</div>
+      </div>
+      <div class="row">
+        <div class="k">A note and its links as Markdown</div>
+        <div class="v">A note together with every note it links to, gathered into one downloadable set of Markdown files.</div>
+      </div>
+      <div class="row">
+        <div class="k">A note as a web page</div>
+        <div class="v">A single note saved as a self-contained web page you can open in any browser.</div>
+      </div>
+      <div class="row">
+        <div class="k">A note and its links as web pages</div>
+        <div class="v">A note and everything it links to, saved as a set of linked web pages.</div>
+      </div>
+      <div class="row">
+        <div class="k">A note as a PDF</div>
+        <div class="v">A single note rendered to a polished PDF.</div>
+      </div>
+      <div class="row">
+        <div class="k">A note and its links as one PDF</div>
+        <div class="v">A note and everything it links to, combined into a single PDF.</div>
+      </div>
+    </div>
+
+    <h2 id="link-policies">What happens to links</h2>
+    <p>Your notes connect to each other with <code>[[wiki links]]</code>. When you export, you choose how those links should appear in the finished document:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Remove the link</div>
+        <div class="v">The link becomes plain text. A good fit when you're exporting a single note and the linked note isn't coming along.</div>
+      </div>
+      <div class="row">
+        <div class="k">Show the note's title</div>
+        <div class="v">The link is replaced by the title of the note it points to — helpful when the reader can't click through anyway.</div>
+      </div>
+      <div class="row">
+        <div class="k">Keep it clickable</div>
+        <div class="v">When the linked note is part of the same export, the link stays live so readers can follow it; otherwise it falls back to showing the title. Best when you're exporting a whole set of connected notes.</div>
+      </div>
+    </div>

--- a/website/docs/_content/export-flashcards.html
+++ b/website/docs/_content/export-flashcards.html
@@ -1,0 +1,27 @@
+---
+title: Minerva — Docs — Flashcards
+description: Write study cards inside your notes and export them as a deck you can review in a flashcard app.
+---
+
+    <h1>Flashcards</h1>
+    <p class="lede">As you write, you can mark spots in your notes as study cards — a question and its answer. Minerva gathers those cards into a deck you can export and review in a flashcard app. Only the cards you mark are included; the rest of your notes are left alone.</p>
+
+    <h2 id="writing">Writing a card</h2>
+    <p>A card is a short block that starts with <code>[!card]</code> and uses a <code>---</code> divider to separate the question (on top) from the answer (below):</p>
+    <div class="box">
+      <span class="label">Example</span>
+      <p><code>[!card] Geography<br>What is the capital of France?<br>---<br>**Paris**</code></p>
+    </div>
+    <p>The word after <code>[!card]</code> names the deck the card belongs to, and it's optional. Write as many cards as you like across your notes.</p>
+
+    <h2 id="decks">Which deck a card lands in</h2>
+    <p>Minerva decides a card's deck by looking, in order, for the first of these:</p>
+    <div class="deflist">
+      <div class="row"><div class="k">The card's own label</div><div class="v">The deck name you wrote right after <code>[!card]</code> — <em>Geography</em> in the example above.</div></div>
+      <div class="row"><div class="k">The note's deck setting</div><div class="v">A deck name set once in the note's properties, used for every card in that note.</div></div>
+      <div class="row"><div class="k">The note's folder</div><div class="v">If you haven't named a deck, cards are grouped by the folder the note lives in, so related notes end up together.</div></div>
+      <div class="row"><div class="k">A default deck</div><div class="v">Anything left over goes into a general deck so no card is lost.</div></div>
+    </div>
+
+    <h2 id="ids">Editing cards later</h2>
+    <p>You can go back and reword a card at any time. When you export again, Minerva recognizes it as the same card and updates it in place rather than creating a duplicate — so your review progress carries over.</p>

--- a/website/docs/_content/export-publishing.html
+++ b/website/docs/_content/export-publishing.html
@@ -1,0 +1,102 @@
+---
+title: Minerva — Docs — Publishing
+description: Turn your notes into a browseable website, customize how each note looks when shared, and put it online.
+---
+
+    <h1>Publishing</h1>
+    <p class="lede">Turn your notes into a website other people can browse — and, when you're ready, put that website online.</p>
+
+    <h2 id="static-site">Make a website</h2>
+    <p>Minerva can turn your whole collection of notes into a self-contained website, complete with a sidebar, a search box, and a page for each note. Anyone you share it with can read and search it in a browser.</p>
+
+    <p>If you want a particular note to look a certain way when it's shared, you can set a few extra properties at the top of that note:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Preview image</div>
+        <div class="v">The thumbnail that appears when the note's link is shared on social media or in a chat.</div>
+      </div>
+      <div class="row">
+        <div class="k">Background</div>
+        <div class="v">A custom background color for the note's page.</div>
+      </div>
+      <div class="row">
+        <div class="k">Custom styling</div>
+        <div class="v">Your own styling to give the page a distinct look.</div>
+      </div>
+    </div>
+
+
+    <h2 id="publish-to-web">Put it online</h2>
+    <p>Making a website leaves the files on your computer. When you want it live for others to visit, <b>Publish to Web</b> sends it to a destination you set up once. After that, republishing is a single action whenever you've made changes and want the live version to catch up.</p>
+    <p>There are two kinds of destination. Pick whichever you already have, or whichever sounds less like work:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">A GitHub repository</div>
+        <div class="v">Free hosting through GitHub Pages, with a real web address. Minerva can set the whole thing up for you, including creating the repository. Best if you don't already have somewhere to host a site.</div>
+      </div>
+      <div class="row">
+        <div class="k">An S3 bucket</div>
+        <div class="v">Amazon S3, or anything that speaks the same language — Cloudflare R2, Backblaze B2, DigitalOcean Spaces, MinIO on your own server. Best if you already have storage, or want the site behind your own domain and CDN.</div>
+      </div>
+    </div>
+    <p>Add one from the Publish window: give it a name, choose which kind, and fill in the handful of details below. You can keep several destinations — a public site and a private draft copy, say — and publish to whichever you mean today.</p>
+
+    <figure class="shot-img">
+      <img src="img/export-publishing.png" alt="The Publish to Web window listing two saved destinations — a GitHub repository publishing to the gh-pages branch, and an S3 bucket — each with Preview and Publish buttons." loading="lazy" />
+      <figcaption>Screenshot — Publish to Web, with a destination of each kind</figcaption>
+    </figure>
+
+    <h3 id="github-pages">Publishing to GitHub Pages</h3>
+    <p>Give Minerva the repository's address and the branch to publish to (<code>gh-pages</code> is the usual choice, and the default). Then either sign in with the GitHub command-line tool, or paste a personal access token into the destination — the token is stored encrypted on your machine and never leaves it except to talk to GitHub. <b>Test connection</b> checks it before you rely on it.</p>
+    <p>Two things Minerva handles so you don't have to visit GitHub's settings:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Creating the repository</div>
+        <div class="v">If the repository doesn't exist yet, publishing stops and offers to create it — <b>public</b> or <b>private</b>, your choice. Nothing is created until you pick one, and nothing is published in the meantime.</div>
+      </div>
+      <div class="row">
+        <div class="k">Turning Pages on</div>
+        <div class="v">After the first successful publish, Minerva points GitHub Pages at your branch and shows you the address of the finished site. GitHub takes a minute or so to build it the first time.</div>
+      </div>
+    </div>
+    <p>A few things GitHub decides, not Minerva:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Where the site can live</div>
+        <div class="v">Pages serves from the top of the repository or from a <code>docs</code> folder — nowhere else. If you've set your destination to publish into some other subdirectory, the files still get pushed; you'd just point Pages at them yourself.</div>
+      </div>
+      <div class="row">
+        <div class="k">Private repositories</div>
+        <div class="v">GitHub only serves Pages from a private repository on a paid plan. On a free account, choose public.</div>
+      </div>
+      <div class="row">
+        <div class="k">What your token may do</div>
+        <div class="v">Publishing needs permission to push. Creating the repository for you needs a little more than that, and switching Pages on more again. If a token can push but not create, Minerva says exactly which permission is missing rather than leaving you with a number.</div>
+      </div>
+    </div>
+
+    <h3 id="s3-bucket">Publishing to S3 or compatible storage</h3>
+    <p>Give Minerva the bucket name and the credentials to write to it. The secret key is stored encrypted, the same as the GitHub token, and <b>Test connection</b> confirms the bucket is reachable before you publish into it.</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Endpoint</div>
+        <div class="v">Leave blank for Amazon S3. For R2, B2, Spaces, or a MinIO server, paste that provider's endpoint address — that one field is what makes the others work.</div>
+      </div>
+      <div class="row">
+        <div class="k">Region</div>
+        <div class="v">Your bucket's region, where the provider uses one.</div>
+      </div>
+      <div class="row">
+        <div class="k">Key prefix</div>
+        <div class="v">A folder inside the bucket to publish into, if you don't want the site at the very top.</div>
+      </div>
+    </div>
+    <p>Minerva uploads the site; serving it is the bucket's job. Whichever provider you're using, its own docs will tell you how to switch on website hosting — or you can put a CDN in front of it and use your own domain.</p>
+
+    <h3 id="trial-run">Try it before it's live</h3>
+    <p>Every destination offers <b>Preview</b>: Minerva does everything except the last step — the push, or the upload — and shows you exactly which pages would be added, changed, or removed. It's the quickest way to confirm you're publishing what you think you are, particularly the first time or after a big reorganization.</p>
+
+    <div class="box">
+      <span class="label">This one goes public</span>
+      <p>Everything else in this section stays on your own machine until you decide otherwise. Publishing to the web is the exception — when you run it for real, your site goes live. It's worth a quick glance to confirm you've picked the right destination before you do.</p>
+    </div>

--- a/website/docs/_content/export-scopes-privacy.html
+++ b/website/docs/_content/export-scopes-privacy.html
@@ -1,0 +1,44 @@
+---
+title: Minerva — Docs — Scopes &amp; Privacy
+description: Choose how much to export, keep private notes out by default, and review exactly what you'll get before you run any export.
+---
+
+    <h1>Scopes &amp; privacy</h1>
+    <p class="lede">Whenever you export, two things get settled first: how much of your work to include, and what to hold back even if it would otherwise be swept in. Every export shows you a preview so you can see exactly what you'll get before you commit.</p>
+
+    <h2 id="scope">How much to export</h2>
+    <p>Every export lets you choose how wide to cast the net:</p>
+    <div class="deflist">
+      <div class="row"><div class="k">Single note</div><div class="v">Just the note you're looking at.</div></div>
+      <div class="row"><div class="k">Folder</div><div class="v">A folder and everything inside it.</div></div>
+      <div class="row"><div class="k">Everything</div><div class="v">Your whole knowledge base.</div></div>
+      <div class="row"><div class="k">Linked notes</div><div class="v">Start from one note and follow its links outward, gathering everything it connects to. This stops after a few steps so you capture the surrounding context without pulling in your entire base.</div></div>
+      <div class="row"><div class="k">A source</div><div class="v">A single piece of reading you've brought in, for exporting an annotated copy of it.</div></div>
+    </div>
+
+    <h2 id="privacy">Keeping private notes out</h2>
+    <p>Your knowledge base holds personal thinking, half-formed ideas, and reading notes you never meant to share. So exports leave private notes out by default unless you choose otherwise. A note is treated as private if any of these are true:</p>
+    <div class="deflist">
+      <div class="row"><div class="k">It lives in a private folder</div><div class="v">Anything kept in a folder named "private."</div></div>
+      <div class="row"><div class="k">It's marked private</div><div class="v">You've set the note's properties to private.</div></div>
+      <div class="row"><div class="k">It's tagged private</div><div class="v">The note carries a <code>#private</code> tag.</div></div>
+    </div>
+    <p>Nothing is dropped silently — each left-out note comes with a plain reason so you can see why it was held back.</p>
+
+    <h2 id="reviewing">Reviewing before you export</h2>
+    <p>The preview shows two lists: what's <b>included</b> and what's <b>left out</b>, each with its reason. You can adjust either one, just for this export:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Add something back in</div>
+        <div class="v">Click a left-out note to include it this time. The note itself stays private for future exports.</div>
+      </div>
+      <div class="row">
+        <div class="k">Take something out</div>
+        <div class="v">Uncheck an included note to leave it out of this export.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/export-scopes-privacy.png" alt="A side-by-side view: on one side the notes that will be included, each with a checkbox; on the other, the notes being left out, each with a short reason like &quot;in a private folder&quot; or &quot;tagged private,&quot; ready to be added back with a click." loading="lazy" />
+      <figcaption>Screenshot — the export preview</figcaption>
+    </figure>

--- a/website/docs/_content/export.html
+++ b/website/docs/_content/export.html
@@ -1,0 +1,60 @@
+---
+title: Minerva — Docs — Export
+description: Getting your work back out of Minerva: documents to share, a website to publish, citation files, flashcards, and control over what's included.
+---
+
+    <h1>Export</h1>
+    <p class="lede">When you want to take your work out of Minerva, exporting gets it into a shape you can share or reuse — a document, a website, citation files, or study cards. Every export lets you choose what to include before you run it.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="export-documents.html"><b>Document exports</b></a> — turn a note into a shareable Markdown, web page, or PDF file, on its own or bundled with the notes it links to.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="export-publishing.html"><b>Publishing</b></a> — turn your notes into a browseable website and put it online.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="export-bibliography.html"><b>Bibliography &amp; citations</b></a> — export your references as citation files, and set the citation style that shapes them.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="export-flashcards.html"><b>Flashcards</b></a> — build a deck of study cards from the cards you mark in your notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="export-scopes-privacy.html"><b>Scopes &amp; privacy</b></a> — what an export includes, and what Minerva holds back by default.</div>
+      </div>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="export-documents.html">
+        <span class="em">📄</span>
+        <h3>Document exports</h3>
+        <p>Save a note as Markdown, a web page, or a PDF — alone or bundled with linked notes.</p>
+      </a>
+      <a class="doc-card" href="export-publishing.html">
+        <span class="em">🌐</span>
+        <h3>Publishing</h3>
+        <p>Turn your notes into a website and put it online.</p>
+      </a>
+      <a class="doc-card" href="export-bibliography.html">
+        <span class="em">📚</span>
+        <h3>Bibliography &amp; citations</h3>
+        <p>Export your references, and choose the citation style.</p>
+      </a>
+      <a class="doc-card" href="export-flashcards.html">
+        <span class="em">🗂️</span>
+        <h3>Flashcards</h3>
+        <p>Turn cards you mark in your notes into a study deck.</p>
+      </a>
+      <a class="doc-card" href="export-scopes-privacy.html">
+        <span class="em">🔒</span>
+        <h3>Scopes &amp; privacy</h3>
+        <p>What gets included, and what's held back by default.</p>
+      </a>
+    </div>

--- a/website/docs/_content/index.html
+++ b/website/docs/_content/index.html
@@ -1,0 +1,66 @@
+---
+title: Minerva — Documentation
+description: How to use Minerva: notes, navigation, viewing options, the editor, the sidebars, conversations, thinking tools, and settings.
+---
+
+    <h1>Minerva documentation</h1>
+    <p class="lede">Minerva is a desktop workspace for taking notes and thinking with the help of AI. This guide covers everything you can do in it: how notes work, how to move around, how to write and view, and what each panel of the workspace is for. New here? Start with <a href="../getting-started.html">Getting started</a>, then come back for the details.</p>
+
+    <h2 id="sections">Browse by section</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="thoughtbase.html">
+        <span class="em">📚</span>
+        <h3>What is a thoughtbase?</h3>
+        <p>The big picture — what a thoughtbase is, what people build one for, everything it holds, and how to create, open, and switch between them.</p>
+      </a>
+      <a class="doc-card" href="notes.html">
+        <span class="em">🧵</span>
+        <h3>Notes</h3>
+        <p>What a note is — and every kind of content you can embed: links, callouts, math, diagrams, charts, code, tables, images, and more.</p>
+      </a>
+      <a class="doc-card" href="navigation.html">
+        <span class="em">🧭</span>
+        <h3>Navigation</h3>
+        <p>Move between notes: the command palette, quick switch, wiki-links, search, breadcrumbs, and back/forward.</p>
+      </a>
+      <a class="doc-card" href="viewing-options.html">
+        <span class="em">👁️</span>
+        <h3>Viewing options</h3>
+        <p>Source, preview, and split view modes; themes; font size and zoom; splitting panes and windows.</p>
+      </a>
+      <a class="doc-card" href="editor.html">
+        <span class="em">✍️</span>
+        <h3>Editor</h3>
+        <p>The writing surface: markdown formatting, keyboard shortcuts, link autocomplete, footnotes, and voice dictation.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar.html">
+        <span class="em">📂</span>
+        <h3>Left sidebar</h3>
+        <p>The workspace rail: the Notes tree, Sources, Tags, Tables, and Bookmarks.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar.html">
+        <span class="em">🕸️</span>
+        <h3>Right sidebar</h3>
+        <p>Context on the current note: backlinks, outline, properties, proposals, citations, tags, and related notes.</p>
+      </a>
+      <a class="doc-card" href="conversations.html">
+        <span class="em">💬</span>
+        <h3>Conversations</h3>
+        <p>Think alongside the AI, then review and file what it proposes — nothing lands until you approve it.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools.html">
+        <span class="em">🧠</span>
+        <h3>Thinking tools</h3>
+        <p>The Learning, Research, and Analysis skills — structured thinking moves you run over a note.</p>
+      </a>
+      <a class="doc-card" href="settings.html">
+        <span class="em">⚙️</span>
+        <h3>Settings</h3>
+        <p>Tune the editor, appearance, behaviors, formatter, bibliography, compute, AI, and skills.</p>
+      </a>
+      <a class="doc-card" href="data.html">
+        <span class="em">🔎</span>
+        <h3>Working with data</h3>
+        <p>How your notes become a queryable knowledge graph and database — and the Query menu commands for asking questions of them.</p>
+      </a>
+    </div>

--- a/website/docs/_content/ingest-adding-sources.html
+++ b/website/docs/_content/ingest-adding-sources.html
@@ -1,0 +1,58 @@
+---
+title: Minerva — Docs — Adding Sources
+description: The different ways to bring a source into Minerva: from a web page, a DOI or paper identifier, a file on your computer, or a whole reference library at once.
+---
+
+    <h1>Adding sources</h1>
+    <p class="lede">A source is any reference you want to keep alongside your notes — a web article, a research paper, a PDF on your computer. Minerva pulls in the text and citation details so you can read, cite, and think with it. There are a few ways to add one, depending on what you're starting from.</p>
+
+    <h2 id="menu">From the File menu</h2>
+    <p>The File menu has a handful of dedicated actions for adding sources, each for a different starting point:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Add a web page<br><kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd></div>
+        <div class="v">Paste in the address of an article or page. Minerva pulls in the readable text, leaving the ads and clutter behind.</div>
+      </div>
+      <div class="row">
+        <div class="k">Add by identifier<br><kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd></div>
+        <div class="v">Paste a paper's DOI, arXiv id, or PubMed id and Minerva looks up its citation details for you. If a freely available PDF exists, it's fetched too; if not, the source still comes in with its details and a link to the original record so you can grab the PDF yourself.</div>
+      </div>
+      <div class="row">
+        <div class="k">Add a file</div>
+        <div class="v">Pick a PDF, web page, or text file from your computer.</div>
+      </div>
+      <div class="row">
+        <div class="k">Import a reference library</div>
+        <div class="v">Bring in a whole exported reference collection at once, along with any PDFs attached to its entries. When it finishes, Minerva tells you how many came in and how many were skipped as duplicates.</div>
+      </div>
+    </div>
+
+    <h2 id="panel">From the Sources panel</h2>
+    <p>The quickest way to add a single source: click <b>+</b> in the <a href="left-sidebar-sources.html">Sources panel</a> and paste in a web address or a paper identifier. It figures out on its own which kind of thing you pasted and handles it accordingly. It's forgiving, too — paste a sentence with an identifier buried in it ("see 10.1145/xxxx for details") and it plucks out just the identifier.</p>
+
+    <figure class="shot-img">
+      <img src="img/ingest-adding-sources.png" alt="The Sources panel with the + button highlighted and the box where you paste a web address or paper identifier." loading="lazy" />
+      <figcaption>Screenshot — Adding a source from the Sources panel</figcaption>
+    </figure>
+
+    <h2 id="drop">By dragging a file in</h2>
+    <p>You can also drag a file straight into Minerva. What happens depends on the kind of file:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">A PDF</div>
+        <div class="v">Added as a source, just like picking one from the File menu.</div>
+      </div>
+      <div class="row">
+        <div class="k">A note or data file</div>
+        <div class="v">Added to your knowledge base as an ordinary file wherever you dropped it — not as a source. If the name is already taken, it's kept under a slightly different name rather than replacing what's there.</div>
+      </div>
+      <div class="row">
+        <div class="k">Anything else</div>
+        <div class="v">Skipped, with a short note about why. One unsupported file won't stop the rest of a batch from coming in.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Adding the same paper twice is safe</span>
+      <p>Minerva recognizes when a source is one you already have, so re-adding the same paper simply does nothing rather than creating a duplicate. See <a href="ingest-citing-duplicates.html">Citing &amp; duplicates</a> for what happens when the same paper turns up under two different identifiers.</p>
+    </div>

--- a/website/docs/_content/ingest-citing-duplicates.html
+++ b/website/docs/_content/ingest-citing-duplicates.html
@@ -1,0 +1,34 @@
+---
+title: Minerva — Docs — Citing Sources &amp; Duplicates
+description: How to cite a source from a note, and what happens when you bring the same source in more than once.
+---
+
+    <h1>Citing sources &amp; duplicates</h1>
+    <p class="lede">A source is a paper, article, or document you've brought into Minerva to work from. Once it's in, you can cite it from any note, and bringing the same source in again won't clobber what you already have.</p>
+
+    <h2 id="citing">Citing a source in a note</h2>
+    <p>To reference a source while writing, type <code>[[cite::</code> and pick the source, or <code>[[quote::</code> to point at a specific excerpt you've saved from it. This is the same linking you use to connect one note to another.</p>
+    <p>The <a href="right-sidebar-citations.html">Citations panel</a> on the right gathers all of these for the note you're reading: one row per source, how many times you've cited it, and the exact passage for any quotes.</p>
+
+    <h2 id="duplicates">Bringing in the same source twice</h2>
+    <p>If you try to bring in a source you already have, Minerva recognizes it and simply opens the copy you've got instead of making a second one. Your work is protected:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Your edits stay</div>
+        <div class="v">If you've edited a source since bringing it in, doing it again leaves your changes untouched.</div>
+      </div>
+      <div class="row">
+        <div class="k">Details are added, not replaced</div>
+        <div class="v">If the second attempt turns up details the first one missed, they're folded into what you already have rather than overwriting it.</div>
+      </div>
+      <div class="row">
+        <div class="k">You're told what happened</div>
+        <div class="v">Minerva says plainly that you already have this source, and opens it for you.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Same source, two different ways in</span>
+      <p>If the same paper reaches you by two different routes — a web link today, a formal reference next month — Minerva may not realize they're the same and will keep both. When you notice, right-click one in the <a href="left-sidebar-sources.html">Sources panel</a>, choose <b>Merge into…</b>, pick the other, and confirm. Its excerpts and citations move over and the extra copy goes away.</p>
+    </div>

--- a/website/docs/_content/ingest-clipper.html
+++ b/website/docs/_content/ingest-clipper.html
@@ -1,0 +1,42 @@
+---
+title: Minerva — Docs — Browser Clipper
+description: Save the web page you're reading straight into Minerva with the browser clipper — either curate it first, or grab it instantly with a keyboard shortcut.
+---
+
+    <h1>Browser clipper</h1>
+    <p class="lede">The browser clipper saves the page you're reading straight into Minerva, without leaving your browser. Because it captures the page exactly as your browser shows it, pages that need you to be signed in — or that sit behind a paywall — come across cleanly. If you've highlighted some text on the page, that selection is saved too, as a linked excerpt.</p>
+
+    <h2 id="install">Set it up</h2>
+    <p>Add the clipper to your browser, then pair it once with Minerva so the two can talk to each other.</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">1. Add it</div>
+        <div class="v">Install the clipper in your browser, then pin it so its button stays visible in the toolbar.</div>
+      </div>
+      <div class="row">
+        <div class="k">2. Get a code</div>
+        <div class="v">In Minerva, open <b>Settings → Browser Clipper</b> with a thoughtbase open, turn it on, and copy the pairing code shown there.</div>
+      </div>
+      <div class="row">
+        <div class="k">3. Pair</div>
+        <div class="v">Paste that code into the clipper's settings and pair. A <b>Test connection</b> button confirms everything is linked and that Minerva is open and ready to receive pages.</div>
+      </div>
+    </div>
+
+    <h2 id="capture">Two ways to capture</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Curate, then save</div>
+        <div class="v">Click the clipper button to open a small window showing the page title. Add tags and a note if you like, then hit Save.</div>
+      </div>
+      <div class="row">
+        <div class="k">Instant save</div>
+        <div class="v">Press <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> on Windows) on any page to save it right away, with no window to fill in. A quick badge on the button confirms it worked.</div>
+      </div>
+    </div>
+    <p>Either way, any text you've highlighted on the page when you capture is saved as a linked excerpt on the new source, tied to the exact words you picked out.</p>
+
+    <figure class="shot-img">
+      <img src="img/ingest-clipper.png" alt="The clipper's window open over a web page, showing the page title, a place for tags, a place for a note, and a Save button." loading="lazy" />
+      <figcaption>Screenshot — Saving a page with the clipper</figcaption>
+    </figure>

--- a/website/docs/_content/ingest-pdf.html
+++ b/website/docs/_content/ingest-pdf.html
@@ -1,0 +1,35 @@
+---
+title: Minerva — Docs — PDF ingest
+description: Adding a PDF to your thoughtbase, and how Minerva handles scanned PDFs that need text recognition.
+---
+
+    <h1>PDF ingest</h1>
+    <p class="lede">Add a PDF and Minerva pulls its text in so you can read, search, and cite it alongside your notes. Most PDFs come in cleanly. Scanned documents — pages that are really just images of text — get one extra step.</p>
+
+    <h2 id="text-layer">Most PDFs</h2>
+    <p>Whether you add a PDF from your computer or from a link, Minerva reads its text page by page and saves it as a source, along with any title, author, and date the PDF already carries. From there it behaves like any other source you've added: readable, searchable, and ready to cite.</p>
+
+    <h2 id="ocr">Scanned PDFs</h2>
+    <p>Some PDFs are scans, so their pages are pictures rather than text Minerva can read. When that happens, Minerva offers to recognize the text for you and asks before it starts. This runs entirely on your own machine.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">If you run it</div>
+        <div class="v">Minerva reads each page and fills in the text, so the PDF becomes fully readable and searchable like any other source.</div>
+      </div>
+      <div class="row">
+        <div class="k">If you skip it</div>
+        <div class="v">The PDF is still saved with its details intact. Nothing is lost — you can open it later and run text recognition whenever you like.</div>
+      </div>
+    </div>
+
+    <div class="shot wide">
+      <div class="icon">🔍</div>
+      <div class="k">Screenshot — Offer to recognize a scanned PDF</div>
+      <div class="d">A short prompt appears after you add a scanned PDF, telling you how many pages it has and letting you start text recognition or skip it for now.</div>
+    </div>
+
+    <div class="box">
+      <span class="label">Good to know</span>
+      <p>A password-protected PDF can't be added until you remove its protection first. And if the same paper reaches you more than one way — say, a PDF now and a link later — see <a href="ingest-citing-duplicates.html">Citing &amp; duplicates</a> for how Minerva keeps them tidy.</p>
+    </div>

--- a/website/docs/_content/ingest.html
+++ b/website/docs/_content/ingest.html
@@ -1,0 +1,56 @@
+---
+title: Minerva — Docs — Ingest
+description: Bring outside material — papers, articles, web pages, PDFs — into Minerva as sources you can cite, quote, and search alongside your notes.
+---
+
+    <h1>Ingest</h1>
+    <p class="lede">Bring outside material — papers, articles, web pages, PDFs — into Minerva as <b>sources</b> you can cite, quote, and search right alongside your own notes. Add them by pasting a link, dropping in a file, or capturing a page straight from your browser.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="ingest-adding-sources.html"><b>Adding sources</b></a> — paste a web link or a paper's identifier, add a file from your computer, or import a whole reference library at once.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="ingest-pdf.html"><b>PDF ingest</b></a> — pull the text out of a PDF so you can read, search, and quote it, including scanned documents.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="ingest-clipper.html"><b>Browser clipper</b></a> — save the page you're reading with one click, no copy-paste required.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="ingest-citing-duplicates.html"><b>Citing &amp; duplicates</b></a> — reference a source from a note, and what happens if you add the same one twice.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Sources sit right beside your notes</span>
+      <p>Once you add a source, it keeps its own details and a readable copy of its text. It appears in the <a href="left-sidebar-sources.html">Sources panel</a>, can be cited from any note, and turns up in search just like everything else you've written.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="ingest-adding-sources.html">
+        <span class="em">➕</span>
+        <h3>Adding sources</h3>
+        <p>Link, identifier, file, or a whole library — every way in, one place.</p>
+      </a>
+      <a class="doc-card" href="ingest-pdf.html">
+        <span class="em">📄</span>
+        <h3>PDF ingest</h3>
+        <p>Get readable, searchable text out of any PDF, even scanned ones.</p>
+      </a>
+      <a class="doc-card" href="ingest-clipper.html">
+        <span class="em">✂️</span>
+        <h3>Browser clipper</h3>
+        <p>Save the page you're reading straight from your browser.</p>
+      </a>
+      <a class="doc-card" href="ingest-citing-duplicates.html">
+        <span class="em">🔗</span>
+        <h3>Citing &amp; duplicates</h3>
+        <p>Reference a source from a note, and what adding it twice does.</p>
+      </a>
+    </div>

--- a/website/docs/_content/left-sidebar-bookmarks.html
+++ b/website/docs/_content/left-sidebar-bookmarks.html
@@ -1,0 +1,45 @@
+---
+title: Minerva — Docs — Bookmarks
+description: The Bookmarks tab saves places you want to return to — a whole note, a section, or an exact line — in a folder tree you name and organize yourself.
+---
+
+    <h1>Bookmarks</h1>
+    <p class="lede">The Bookmarks tab is a folder tree of saved places you want to return to — a whole note, a section under a heading, or an exact line. Click any entry and Minerva opens the note and jumps straight to that spot. Unlike <a href="left-sidebar-notes-tree.html">Notes</a> or <a href="left-sidebar-tags.html">Tags</a>, nothing appears here automatically — every entry is one you chose to save.</p>
+
+    <h2 id="creating">Creating a bookmark</h2>
+    <p>You make bookmarks from right-click menus. There are three kinds, depending on how precise you want to be:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Bookmark This Note</div>
+        <div class="v">Saves a whole note. You can reach it by right-clicking in the editor, on a tab, or on a note in the <a href="left-sidebar-notes-tree.html">Notes tree</a>. Selecting it later just opens the note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Bookmark Section</div>
+        <div class="v">Right-click in the editor to save the section your cursor is in. It's named after that section's heading. If your cursor isn't under any heading, Minerva lets you know and asks you to place it inside a section first.</div>
+      </div>
+      <div class="row">
+        <div class="k">Bookmark Line</div>
+        <div class="v">Right-click in the editor to save the exact spot your cursor is on. Minerva names it from the text on that line, or "Line N" if the line is blank.</div>
+      </div>
+    </div>
+
+    <p>New bookmarks appear at the top level of the tree. From there you can drag one onto a folder to file it away, or make a folder first with the <b>+ Folder</b> button in the panel header.</p>
+
+    <figure class="shot-img panel">
+      <img src="img/left-sidebar-bookmarks.png" alt="The Bookmarks tab in the left sidebar, with a &quot;+ Folder&quot; button and a search box at the top. One folder is open, holding a saved section and a saved line, with a whole-note bookmark sitting at the top level. Each entry shows its name with the note it points to underneath." loading="lazy" />
+      <figcaption>Screenshot — the Bookmarks tab</figcaption>
+    </figure>
+
+    <h2 id="selecting">Jumping to a bookmark</h2>
+    <p>Click any bookmark to go there. A whole-note bookmark opens the note; a section bookmark opens the note and scrolls to the heading; a line bookmark opens the note and drops your cursor at the saved spot, centered in view and ready to type.</p>
+
+    <div class="box">
+      <span class="label">A saved line can drift if you edit heavily above it</span>
+      <p>A line bookmark remembers the exact position it had when you made it. If you later add or remove a lot of text above that line, the bookmark can land you a little off — a few lines away, or mid-word. Renaming or moving the note, or renaming the heading a section bookmark points at, is always safe: those bookmarks follow along automatically. It's only heavy editing above a saved line that can throw it off.</p>
+    </div>
+
+    <h2 id="managing">Renaming, moving, and deleting</h2>
+    <p>Right-click any bookmark or folder to <b>Rename</b> or <b>Delete</b> it. Renaming changes only the label in the tree — it doesn't change where the bookmark points. To reorganize, drag a bookmark onto a folder to file it inside, or onto empty space to move it back to the top level. Deleting a folder removes everything inside it, with no confirmation — a bookmark is just a pointer to a note, never the note itself, so removing one is harmless.</p>
+
+    <p>The search box in the panel header filters the tree to matching names, and the header also has controls to expand or collapse the whole tree at once.</p>

--- a/website/docs/_content/left-sidebar-notes-tree.html
+++ b/website/docs/_content/left-sidebar-notes-tree.html
@@ -1,0 +1,96 @@
+---
+title: Minerva — Docs — Notes Tree
+description: The Notes panel: browse your project's folders and notes, and create, rename, move, and organize them right from the tree.
+---
+
+    <h1>Notes tree</h1>
+    <p class="lede">The <b>Notes</b> tab is the left sidebar's home base — a tidy tree of the folders and notes in your project. It's where you browse what you've written and where you create, rename, move, and organize notes. For what a note actually is and everything you can put in one, see <a href="notes.html">Notes</a>.</p>
+
+    <h2 id="header">The panel header</h2>
+    <p>At the top of the panel is the "Notes" title with a running count of how many notes your project holds, kept up to date as you add and remove them. Once you have at least one note, three small buttons appear just below:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Expand all / Collapse all</div>
+        <div class="v">Open every folder in the project at once, or fold them all shut, in a single click.</div>
+      </div>
+      <div class="row">
+        <div class="k">Auto-reveal active note</div>
+        <div class="v">A toggle that keeps the tree in step with whatever note you're editing: open a note and the tree opens its folders and scrolls it into view. Browsing the tree by hand never fights back — it only reveals when you switch notes.</div>
+      </div>
+    </div>
+
+    <h2 id="tree">Reading the tree</h2>
+    <p>Folders and notes appear together in a single indented list. A few handy things to know:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Empty folders</div>
+        <div class="v">Shown, not hidden. An empty folder stays visible so you can open it or drop a note into it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Every kind of file</div>
+        <div class="v">The tree lists everything in your project — notes, tables, and other files — each with its own icon so you can tell them apart at a glance.</div>
+      </div>
+      <div class="row">
+        <div class="k">Last edited</div>
+        <div class="v">Each note shows a relative time on the right, like "3h ago," so you can spot what you touched recently.</div>
+      </div>
+      <div class="row">
+        <div class="k">Open vs. select</div>
+        <div class="v">Click the little arrow to open or close a folder; click the rest of the row to select it without opening it. That way you can select a folder — to rename, tag, or delete it — without it springing open under your cursor.</div>
+      </div>
+      <div class="row">
+        <div class="k">Keyboard navigation</div>
+        <div class="v">Click into the tree, then use <kbd>↑</kbd>/<kbd>↓</kbd> to move through the visible rows. <kbd>Enter</kbd> opens the note or toggles the folder you're on. <kbd>Space</kbd> adds or removes a row from your selection, <kbd>⌘</kbd><kbd>A</kbd> selects everything visible, and <kbd>Esc</kbd> clears the selection.</div>
+      </div>
+      <div class="row">
+        <div class="k">Selecting several at once</div>
+        <div class="v"><kbd>⌘</kbd>-click picks individual rows; <kbd>Shift</kbd>-click grabs a whole run between two rows. A small count ("3 of 42 selected") appears above the tree, with a link to clear it. Any action you then choose — delete, tag, and so on — applies to the whole selection.</div>
+      </div>
+    </div>
+
+    <h2 id="create">Creating notes and folders</h2>
+    <p>Right-click empty space in the tree to get <b>New Note</b> and <b>New Folder</b>. Right-click an existing folder for the same two options, creating the new item inside that folder instead. This is the place to make a new folder.</p>
+
+    <h2 id="rename-move">Renaming and moving</h2>
+    <p>Right-clicking a note or folder opens a fuller menu — Cut, Copy, Paste, New Note, New Folder, Rename, and more, down to Delete. The most common ways to reorganize:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Rename</div>
+        <div class="v">Right-click and choose Rename. Links to that note from elsewhere in your project are updated automatically so nothing breaks.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move by dragging</div>
+        <div class="v">Drag a note or folder onto another folder to move it there, or drop it in the empty space below the tree to move it to the top level.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move by Cut and Paste</div>
+        <div class="v">Cut a note, then Paste onto the destination folder. Same result as dragging — handy when the two spots aren't both on screen at once.</div>
+      </div>
+      <div class="row">
+        <div class="k">Copy</div>
+        <div class="v">Copy a note, then Paste elsewhere to make a duplicate rather than moving the original.</div>
+      </div>
+      <div class="row">
+        <div class="k">Bring files in</div>
+        <div class="v">Drag files from your computer onto the tree to add them to your project at the spot where you drop them.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/left-sidebar-notes-tree.png" alt="The Notes panel showing its title and note count, the expand, collapse, and auto-reveal buttons, and the tree below with a folder opened to reveal a mix of notes and an empty subfolder. A right-click menu is open on a note, offering Cut, Copy, New Note, New Folder, Rename, tag options, and Delete." loading="lazy" />
+      <figcaption>The Notes panel with a right-click menu open</figcaption>
+    </figure>
+
+    <h2 id="label-version">Naming a restore point across several notes</h2>
+    <p>Select the notes you're about to change — several at once, or a whole folder — then right-click and choose <b>Label Version…</b>. The current version of every note in the selection is given the name you type, so a whole set of notes gets one restore point before a refactor or a big AI-assisted pass. Nothing is written into the notes themselves; the name attaches to each note's <a href="right-sidebar-history.html">history</a>, and a named version is never dropped by the usual <a href="settings-versioning.html">retention limits</a>.</p>
+
+    <div class="box">
+      <span class="label">Deleting is calm, not scary</span>
+      <p>Deleting a note is a normal, everyday action — you get a plain confirmation with a "don't ask again" option, no alarming warnings.</p>
+    </div>
+
+    <h2 id="empty-project">No notes yet</h2>
+    <p>A brand-new project shows a simple "No notes yet" message where the tree would be. Right-click that empty space and you can still make your first note or folder, so you're never stuck.</p>

--- a/website/docs/_content/left-sidebar-objects.html
+++ b/website/docs/_content/left-sidebar-objects.html
@@ -1,0 +1,46 @@
+---
+title: Minerva — Docs — Left sidebar: Objects
+description: The Objects panel — your project browsed by kind rather than by folder, with list, table, and gallery views.
+---
+
+    <h1>Objects</h1>
+    <p class="lede">The Objects panel is your project seen by kind rather than by folder. Every <a href="notes-typed-notes.html">object type</a> you have — Book, Person, Meeting — appears with a count of how many notes are of that kind, and expanding one lists them. It's a way to find things by what they <em>are</em>, without having filed them together in the first place.</p>
+
+    <h2 id="list">The list of types</h2>
+    <p>Each row is one type: its icon, its name, and how many notes carry it. Types with no notes yet are still listed, so creating your first Book is something you can find rather than something you have to remember exists.</p>
+
+    <p>Click a type to expand it and see its notes; click again to collapse. Clicking a note opens it in the editor. Each note carries its own icon, which matters when a type has more specific kinds beneath it — a Book that's really a Novel shows the Novel icon while still being counted as a Book.</p>
+
+    <h2 id="views">Opening a type as a collection</h2>
+    <p>The ⤢ button on a type row opens all of its notes in the main area, where they're more than a list. Three ways to look at the same set:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">List</div>
+        <div class="v">A readable stack of titles, each with a line of detail drawn from its first filled-in field.</div>
+      </div>
+      <div class="row">
+        <div class="k">Table</div>
+        <div class="v">One row per note and one column per field, sortable by any column. Use the Columns button to hide the ones you don't need.</div>
+      </div>
+      <div class="row">
+        <div class="k">Gallery</div>
+        <div class="v">Cards with cover images, for types whose notes have a picture worth seeing — book jackets, people, places.</div>
+      </div>
+    </div>
+
+    <p>Switching between the three doesn't re-fetch anything; it's the same set of notes shown three ways. Clicking any row or card opens that note.</p>
+
+    <div class="box">
+      <span class="label">A more general type includes the specific ones</span>
+      <p>If a type has a parent — Novel's parent being Book — then asking for Books gives you the Novels too. The count on the Book row includes them, and so does its table.</p>
+    </div>
+
+    <h2 id="saved-views">Saved views</h2>
+    <p>Once you've arranged a type's table the way you like it — sorted by rating, with three columns showing — you can save that arrangement with a name. Saved views appear as their own rows under the type they belong to, and opening one restores the whole arrangement exactly. Use the manage action to rename, reorder, or remove them.</p>
+
+    <h2 id="excerpts">Excerpts</h2>
+    <p>Below your types sits Excerpts — the passages you've saved from <a href="left-sidebar-sources.html">sources</a>. It isn't an object type you defined, but it belongs here for the same reason: it's a kind of thing you accumulate, and you often want to browse all of it at once.</p>
+
+    <h2 id="related">Where types come from</h2>
+    <p>The types listed here are defined in <a href="settings-object-types.html">Settings → Object Types</a>, where you can add fields, change an icon, or create your own. A note becomes one of them by carrying a <code>type:</code> property — see <a href="notes-typed-notes.html">Typed notes</a>.</p>

--- a/website/docs/_content/left-sidebar-proposals.html
+++ b/website/docs/_content/left-sidebar-proposals.html
@@ -1,0 +1,55 @@
+---
+title: Minerva — Docs — Proposals
+description: The Proposals panel is where every change the AI wants to make to your notes waits for your approval — review it, then approve or reject with a single keystroke.
+---
+
+    <h1>Proposals</h1>
+    <p class="lede">In Minerva, the AI never changes your notes on its own. When it wants to add a claim, link some evidence, tag a note, or rewrite a passage, it files the change here first — as a card you can read and decide on. This panel is where <b>the AI suggests and you confirm</b>. Nothing lands in your knowledge base until you say so.</p>
+
+    <h2 id="what">What shows up here</h2>
+    <p>Every change the AI wants to make becomes a card in this list — a new note, a set of connections between notes, a rewrite, a deletion, or a set of properties for a source. Each card applies as a whole: approving it makes all of its changes at once, and rejecting it makes none of them. You never end up with half a change.</p>
+
+    <p>Like the other panels in the left sidebar, Proposals is about your project as a whole rather than the note you happen to have open. It lists every proposal you have, with tabs to filter by <b>All</b>, <b>Pending</b>, <b>Approved</b>, or <b>Rejected</b>. That makes the panel a running record of everything the AI has suggested — not just what's still waiting on you.</p>
+
+    <h2 id="review">Reviewing a proposal</h2>
+    <p>Click a card to expand it, then click any part inside to preview its exact contents — the full text of a note, or the specific connections being added. You're always reading precisely what will be written, not a summary of it, before you decide.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Approve — <kbd>y</kbd></div>
+        <div class="v">Makes the change and marks the card approved. A short banner confirms what landed, including which notes were affected.</div>
+      </div>
+      <div class="row">
+        <div class="k">Reject — <kbd>n</kbd></div>
+        <div class="v">Discards the change and marks the card rejected. The card stays in your history, so you can always see what the AI suggested even when you turned it down.</div>
+      </div>
+      <div class="row">
+        <div class="k">Close — <kbd>s</kbd> / <kbd>Esc</kbd></div>
+        <div class="v">Collapses the card without deciding either way.</div>
+      </div>
+      <div class="row">
+        <div class="k">Find a proposal</div>
+        <div class="v">The status tabs, a search box, and a sort control (newest first, or grouped by kind) sit above the list to help you find one card in a long history.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/left-sidebar-proposals.png" alt="The Proposals panel with the Pending tab selected and one card expanded, showing what kind of change it is, who proposed it, a preview of exactly what would be added, and the Approve, Reject, and Close buttons." loading="lazy" />
+      <figcaption>Screenshot — Reviewing a pending proposal</figcaption>
+    </figure>
+
+    <h2 id="audit">Every AI change lands here</h2>
+    <p>There's no side door: every change the AI makes to your knowledge base passes through this panel, so it's a complete record of what the AI has touched. The only difference is which tab a proposal lands under.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Waiting on you</div>
+        <div class="v">New claims, evidence links, rewrites, deletions, and source properties all wait under <b>Pending</b> and happen only after you approve — the everyday case.</div>
+      </div>
+      <div class="row">
+        <div class="k">Already approved</div>
+        <div class="v">A few actions you sign off on elsewhere — like accepting suggested tags or links right on a conversation — are recorded straight under <b>Approved</b>. They still appear here as a record of what happened, so nothing is hidden.</div>
+      </div>
+    </div>
+
+    <p>Either way, the change is here and you can inspect it. Nothing the AI does to your notes skips this panel.</p>

--- a/website/docs/_content/left-sidebar-sources.html
+++ b/website/docs/_content/left-sidebar-sources.html
@@ -1,0 +1,103 @@
+---
+title: Minerva — Docs — Sources
+description: The Sources panel: your working bibliography. Browse collections and a reading queue, capture web pages, PDFs, and references, and cite them from your notes.
+---
+
+    <h1>Sources</h1>
+    <p class="lede">The <b>Sources</b> tab is your working bibliography. A source is a web page, PDF, or reference you've captured — with its own details, its full text to read, and quotable passages you can cite from your notes. It lives alongside your notes as its own kind of content: not a list of bookmarks, but the library you're actually reading and writing from.</p>
+
+    <h2 id="what-is-a-source">What a source is</h2>
+    <p>Each source keeps two things together: its bibliographic details — title, authors, year, publisher, and more — and its text, which you can read and lightly edit right inside Minerva. Sources are kept separate from your notes, so your reading library never clutters your writing. You can still write a note <em>about</em> a source: the source view has a <b>New note about this source</b> action that starts a note already linked back to it.</p>
+
+    <h2 id="browsing">Browsing the panel</h2>
+    <p>Above the list of sources are three ways to narrow it down:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Collections</div>
+        <div class="v">Groupings you organize sources into. Some you fill by hand; <b>smart collections</b> fill themselves from a rule you set, so anything matching shows up automatically. Each collection shows how many sources it holds, and picking one narrows the list to just those. See <a href="#collections">Managing collections</a> below.</div>
+      </div>
+      <div class="row">
+        <div class="k">Reading queue</div>
+        <div class="v">Four ready-made views — <b>Unread</b>, <b>Reading</b>, <b>Due this week</b>, and <b>Recently finished</b> — that fill themselves from each source's reading status and due date. Nothing to curate; just mark where you are and the queue keeps up.</div>
+      </div>
+      <div class="row">
+        <div class="k">Filter box</div>
+        <div class="v">Type to narrow the list by title, author, or year, within whatever collection or queue view you're looking at.</div>
+      </div>
+    </div>
+
+    <p>Each row shows the title, a small dot if you've set a reading status, and a byline with the authors, year, and — if you've set one — a due date. Click a row to open the source in its own tab, just like opening a note. Right-click for quick actions: rename, add a tag, add to or remove from a collection, set reading status or a due date, copy the reference identifier, pull in the works it cites, merge it into another source, or delete it.</p>
+
+    <h2 id="collections">Managing collections</h2>
+    <p>Collections are how you sort your library into groups that make sense to you — a project, a class, a topic, a paper you're writing. A source can sit in as many collections as you like, so filing it in one place never takes it out of another. There are two kinds: ones you fill by hand, and smart ones that fill themselves.</p>
+
+    <h3 id="manual-collections">Collections you fill by hand</h3>
+    <p>Use the small <b>+</b> beside the <b>Collections</b> heading and choose <b>New collection</b>, then give it a name. To put sources in it, right-click any source and choose <b>Add to collection</b>, then pick the one you want; the same menu lets you take a source back out again.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Nest one inside another</div>
+        <div class="v">Right-click a collection and choose <b>New nested collection</b> to file it underneath. Click the little arrow to fold a group open or shut, and selecting a parent shows everything filed under it and its nested collections together.</div>
+      </div>
+      <div class="row">
+        <div class="k">Rename or delete</div>
+        <div class="v">Right-click a collection to rename or delete it. Deleting a collection keeps every source — only the grouping goes away — and anything nested inside simply moves up to the top level.</div>
+      </div>
+    </div>
+
+    <h3 id="smart-collections">Smart collections</h3>
+    <p>A smart collection gathers sources for you from a rule, instead of being filled by hand. Use the same <b>+</b> beside the <b>Collections</b> heading and choose <b>New smart collection</b>, give it a name, and set its rule: either a set of <b>tags</b> (a source has to carry all of them to appear) or a <b>reading status</b> — Unread, Reading, Read, or Skipped. From then on it keeps itself current, adding and dropping sources as you tag them or change where you are in your reading. Smart collections appear under their own <b>Smart</b> heading; right-click one to change its rule, rename it, or delete it. Deleting a smart collection removes no sources, since its contents were only ever the result of its rule.</p>
+
+    <h2 id="adding">Getting sources in</h2>
+    <p>Sources are always captured on purpose — nothing gets pulled in behind your back. There are a few ways to add one:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">The "+" button</div>
+        <div class="v">Right by the filter box. Paste a web address or a reference identifier and Minerva figures out what it is and brings it in. The quickest way when you're already looking at the panel.</div>
+      </div>
+      <div class="row">
+        <div class="k">Add a web page <span style="white-space:nowrap"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>I</kbd></span></div>
+        <div class="v">Give Minerva a web address and it pulls in the article's text, cleaned up and ready to read. Add the same page again later and it refreshes the details while leaving your read-through untouched.</div>
+      </div>
+      <div class="row">
+        <div class="k">Add by reference identifier <span style="white-space:nowrap"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>D</kbd></span></div>
+        <div class="v">Look up an academic paper by its identifier and Minerva fills in the full citation details, grabbing the PDF too when it's freely available.</div>
+      </div>
+      <div class="row">
+        <div class="k">Add a file</div>
+        <div class="v">Bring in a PDF, web page, or text file from your computer. Minerva reads the text out of it — even scanned PDFs, using text recognition — so you can read and quote from it like any other source.</div>
+      </div>
+      <div class="row">
+        <div class="k">Import a bibliography</div>
+        <div class="v">Bring an existing reference library into a project all at once, rather than adding sources one at a time.</div>
+      </div>
+      <div class="row">
+        <div class="k">Browser clipper</div>
+        <div class="v">A companion browser extension sends the page you're reading straight into Minerva, so you can capture while you browse without switching over to the app. Pair it from Settings → Browser Clipper.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Good to know</span>
+      <p>Adding a page again later refreshes its details but leaves its text as you left it — so any edits or reading progress you've made are safe.</p>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/left-sidebar-sources.png" alt="The Sources panel showing collections, the reading queue, and a filtered list of sources (each with a title, status dot, and author-and-year byline), next to an open source showing its title, byline, tags, its details, an abstract, and its full text." loading="lazy" />
+      <figcaption>Screenshot — Sources panel with a source open</figcaption>
+    </figure>
+
+    <h2 id="detail">Opening a source</h2>
+    <p>Clicking a row opens the source in a tab. The top shows what kind of source it is, its title, its byline, and its tags. Below that are its details — publisher, year, a link to the original, reading-status buttons (click the active one again to clear it), and a due-date picker — plus buttons to open the original PDF (when there is one), rename the source, or remove it.</p>
+
+    <p>If the source has an abstract, it appears above the text. The text reads just like a note, and an <b>Edit body</b> toggle lets you make small corrections. Select any passage to save it as an <b>excerpt</b> — a quotation you can cite later — and a marker along the scrollbar shows where your saved excerpts sit. Further down, a <b>References</b> section lists the works this source cites, and a <b>Referenced from</b> section lists your notes that cite or quote it. Everything there is clickable.</p>
+
+    <div class="box">
+      <span class="label">Deleting a source</span>
+      <p>Deleting a source also removes the excerpts you saved from it. Minerva asks once to confirm — with a "don't ask again" option — and any links in your notes pointing to it will stop working.</p>
+    </div>
+
+    <h2 id="citations">Citing a source from a note</h2>
+    <p>You cite a source while writing, not from this panel. Reference a whole source to add it to a note's bibliography, or point at a saved excerpt to quote it directly — and every note that does so shows up in the source's <b>Referenced from</b> list. See <a href="notes-links.html">Notes → Links</a> for how citing works while you write.</p>

--- a/website/docs/_content/left-sidebar-tables.html
+++ b/website/docs/_content/left-sidebar-tables.html
@@ -1,0 +1,75 @@
+---
+title: Minerva — Docs — Tables
+description: The Tables panel lists every spreadsheet and captioned table in your project so you can query it with SQL in a click.
+---
+
+    <h1>Tables</h1>
+    <p class="lede">The Tables panel gathers all the tabular data in your project into one place so you can ask questions of it with SQL. It lists two kinds of table: spreadsheet files you've dropped into the project, and named tables you've written inside notes. A small tag on each row tells you which kind it is.</p>
+
+    <h2 id="registration">What shows up here</h2>
+    <p>Any spreadsheet file you add to your project appears here automatically — there's no import step. Just drop it into the project and it's ready to query. Edit it, and the panel keeps up; remove it, and its row disappears.</p>
+
+    <h3 id="markdown-tables">Naming a table inside a note</h3>
+    <p>You can also query a table you've written directly in a note. To make one queryable, give it a name by putting a caption line just above it:</p>
+    <pre><code>Table: Q3 Sales
+| item  | amount |
+| ----- | ------ |
+| pens  | 3      |
+| ink   | 7      |</code></pre>
+    <p>Once captioned, the table joins this panel and you can query it by name — <code>SELECT sum(amount) FROM Q3_Sales</code>, for example. Save the note to update it; remove the caption to take it back out. Tables without a caption stay private to the note and don't appear here. See <a href="notes-tables.html">Tables &amp; CSV</a> for more.</p>
+
+    <div class="box">
+      <span class="label">Give each table a distinct name</span>
+      <p>Every table shares one pool of names, so no two can be called the same thing. If two would clash, only the first stays queryable — rename one of them to give them both a home in the panel.</p>
+    </div>
+
+    <h2 id="panel">What each row shows</h2>
+    <p>Rows are listed alphabetically, with a filter box at the top that narrows the list by name as you type.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Table name</div>
+        <div class="v">The name you use to query the table.</div>
+      </div>
+      <div class="row">
+        <div class="k">Kind</div>
+        <div class="v">A small tag says whether the table comes from a spreadsheet file or from a note. Note tables also show which note they live in.</div>
+      </div>
+      <div class="row">
+        <div class="k">Size</div>
+        <div class="v">A live count of the table's rows and columns.</div>
+      </div>
+      <div class="row">
+        <div class="k">Location</div>
+        <div class="v">Hover a row to see where the table comes from.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/left-sidebar-tables.png" alt="The Tables panel with a filter box above a list of tables. Each row shows a table name, a small tag marking it as a spreadsheet or a note table, and a line giving its row and column count. One row's right-click menu is open, showing Query, Copy Name, Open, and Reveal in file browser." loading="lazy" />
+      <figcaption>Screenshot — the Tables panel</figcaption>
+    </figure>
+
+    <h2 id="clicking">Querying a table</h2>
+    <p>Click any row to open a fresh query already filled in to show you that table's data. From there you can edit the query, run it again, and explore the data however you like.</p>
+
+    <p>Right-click a row for a few more options:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Query</div>
+        <div class="v">The same as clicking the row — opens the table in a new query.</div>
+      </div>
+      <div class="row">
+        <div class="k">Copy Name</div>
+        <div class="v">Copies the table's name so you can drop it into a query you're writing elsewhere.</div>
+      </div>
+      <div class="row">
+        <div class="k">Open</div>
+        <div class="v">Opens the spreadsheet file, or the note the table lives in.</div>
+      </div>
+      <div class="row">
+        <div class="k">Reveal in file browser</div>
+        <div class="v">Shows the underlying file on your computer.</div>
+      </div>
+    </div>

--- a/website/docs/_content/left-sidebar-tags.html
+++ b/website/docs/_content/left-sidebar-tags.html
@@ -1,0 +1,63 @@
+---
+title: Minerva — Docs — Tags
+description: The left sidebar's Tags panel: an alphabetical list of every tag in your project, with counts, that you click to see what carries each tag.
+---
+
+    <h1>Tags</h1>
+    <p class="lede">Tags are simple labels you attach to notes to group related material. The Tags panel gathers every tag in your project into one alphabetical list, and clicking a tag shows you everything that carries it. It's a way to browse and filter — you add and remove tags in a note itself, not here.</p>
+
+    <h2 id="sources">Where tags come from</h2>
+    <p>There are two ways to tag a note, and both feed the same list.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">In a note's properties</div>
+        <div class="v">List tags in the properties at the top of a note, for example <code>tags: [neuroscience, consciousness]</code>. See <a href="notes-frontmatter.html#keys">Properties</a> for details.</div>
+      </div>
+      <div class="row">
+        <div class="k">Inline while writing</div>
+        <div class="v">Type a <code>#</code> directly followed by a word anywhere in a note — <code>#draft</code>, <code>#project/ui</code>. The tag runs until the next space or punctuation.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Headings aren't tags</span>
+      <p>A heading like <code># Heading</code> has a space after the <code>#</code>, so it's never mistaken for a tag. To tag something, write <code>#tag</code> with no space. A <code>#</code> inside a code sample is ignored too, so it won't clutter your tag list.</p>
+    </div>
+
+    <h2 id="panel">What the panel shows</h2>
+    <p>Tags appear as chips sorted alphabetically, each labelled with the tag name and a count.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Count</div>
+        <div class="v">The number tells you how many notes carry the tag — and how many sources too, when the sources toggle is on. Hover a chip for the exact breakdown, such as "3 notes, 1 source."</div>
+      </div>
+      <div class="row">
+        <div class="k">Chip size</div>
+        <div class="v">Your most-used tags appear slightly larger, a quick visual cue for which topics dominate your project.</div>
+      </div>
+      <div class="row">
+        <div class="k">Highlighted tags</div>
+        <div class="v">A couple of special tags — <code>entrypoint</code> and <code>open-question</code> — always stand out in the accent color, because they mark places worth returning to.</div>
+      </div>
+      <div class="row">
+        <div class="k">Sources toggle</div>
+        <div class="v">A checkbox above the list, on by default, includes tagged sources alongside tagged notes. Turn it off to see notes only.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/left-sidebar-tags.png" alt="A wrapped row of tag chips sorted alphabetically, with one chip highlighted as selected. Beneath it, a &quot;Tagged #neuroscience&quot; section lists the matching notes and sources." loading="lazy" />
+      <figcaption>The Tags panel with a tag selected</figcaption>
+    </figure>
+
+    <h2 id="selecting">Selecting a tag</h2>
+    <p>Click a chip to see everything that carries that tag. Matching notes and sources are listed right below the chips. Click a note to open it in the editor, or a source to open it in the source viewer.</p>
+
+    <p>One tag is active at a time — clicking another chip switches to it. Click the active chip again to deselect it and clear the results.</p>
+
+    <div class="box">
+      <span class="label">This is a separate list</span>
+      <p>Selecting a tag doesn't change what's shown in the <a href="left-sidebar-notes-tree.html">Notes tree</a>. It builds its own list of matches inside the Tags panel; your full notes list stays exactly as you left it.</p>
+    </div>

--- a/website/docs/_content/left-sidebar.html
+++ b/website/docs/_content/left-sidebar.html
@@ -1,0 +1,78 @@
+---
+title: Minerva — Docs — Left Sidebar
+description: The left sidebar's seven panels — Notes tree, Sources, Tags, Tables, and Bookmarks — and what each one is for.
+---
+
+    <h1>Left sidebar</h1>
+    <p class="lede">The left sidebar is your workspace rail — seven panels, each a different way to look at your project. Switch between them with the row of tab icons at the top of the sidebar.</p>
+
+    <h2 id="glance">The seven panels</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="left-sidebar-notes-tree.html">Notes tree</a></div>
+        <div class="v">The main panel — your notes and folders, and where you create, rename, and move them.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="left-sidebar-sources.html">Sources</a></div>
+        <div class="v">Web pages, PDFs, and references you've saved — kept apart from your notes, but easy to cite from them.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="left-sidebar-tags.html">Tags</a></div>
+        <div class="v">An alphabetical list of every tag in your project, so you can jump to everything sharing a label.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="left-sidebar-tables.html">Tables</a></div>
+        <div class="v">The data tables in your project, ready to browse and search.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="left-sidebar-objects.html">Objects</a></div>
+        <div class="v">Your notes grouped by what kind of thing they are, rather than by which folder they're in.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="left-sidebar-bookmarks.html">Bookmarks</a></div>
+        <div class="v">Spots you've saved yourself — a whole note, a section, or an exact line — kept in folders of your own.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="left-sidebar-proposals.html">Proposals</a></div>
+        <div class="v">Everything the AI has suggested for your project, waiting on your approval.</div>
+      </div>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="left-sidebar-notes-tree.html">
+        <span class="em">🌳</span>
+        <h3>Notes tree</h3>
+        <p>Your notes and folders — create, rename, and move them.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar-sources.html">
+        <span class="em">📚</span>
+        <h3>Sources</h3>
+        <p>Saved references you can cite from your notes.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar-tags.html">
+        <span class="em">#️⃣</span>
+        <h3>Tags</h3>
+        <p>Every tag in your project, in one alphabetical list.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar-tables.html">
+        <span class="em">🗄️</span>
+        <h3>Tables</h3>
+        <p>Your project's data tables, ready to browse and search.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar-objects.html">
+        <span class="em">🧩</span>
+        <h3>Objects</h3>
+        <p>Your project by kind — every Book, every Person.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar-bookmarks.html">
+        <span class="em">🔖</span>
+        <h3>Bookmarks</h3>
+        <p>Saved locations — a note, a section, or an exact line.</p>
+      </a>
+      <a class="doc-card" href="left-sidebar-proposals.html">
+        <span class="em">📋</span>
+        <h3>Proposals</h3>
+        <p>The AI's suggested changes, waiting on your approval.</p>
+      </a>
+    </div>

--- a/website/docs/_content/maintenance.html
+++ b/website/docs/_content/maintenance.html
@@ -1,0 +1,41 @@
+---
+title: Minerva — Docs — Maintenance
+description: A small set of housekeeping actions for the rare moment when something looks stale or stuck: refreshing search, restarting the Python kernel, and a few others.
+---
+
+    <h1>Maintenance</h1>
+    <p class="lede">Minerva keeps search, tables, related-note suggestions, and everything else up to date on its own as you write — you don't run any of this on a schedule. The handful of actions below are here for the rare moment when something looks stale or stuck and you want to give it a nudge. You'll almost never need them.</p>
+
+    <h2 id="actions">The actions</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Rebuild All Indexes<br><span class="v" style="opacity:.7">File menu</span></div>
+        <div class="v">Refreshes everything Minerva keeps behind the scenes — search, tables, and the connections between notes — from your notes as they are right now. Use it if something looks out of date and you want to be sure nothing was missed.</div>
+      </div>
+      <div class="row">
+        <div class="k">Rebuild Semantic Index<br><span class="v" style="opacity:.7">File menu</span></div>
+        <div class="v">Rebuilds the "related notes" and meaning-based search from scratch. Minerva normally keeps this current for you; reach for this only if related-note suggestions seem clearly wrong. It runs in the background and you can keep working while it finishes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Interrupt Cell<br><span class="v" style="opacity:.7">File menu</span></div>
+        <div class="v">Stops a code cell that's taking too long, while keeping the results you've already built up. Handy when a cell is caught in a loop or is slower than you expected. If nothing is running, Minerva says so rather than looking like it did something.</div>
+      </div>
+      <div class="row">
+        <div class="k">Restart Python Kernel<br><span class="v" style="opacity:.7">File menu</span></div>
+        <div class="v">Clears everything your code cells have worked out and starts them fresh. Reach for this when results look confused or you want a clean slate. See <a href="notes-code.html">Code &amp; compute cells</a> for how they work.</div>
+      </div>
+    </div>
+
+    <h2 id="progress">Knowing where it's up to</h2>
+    <p>None of these leave you guessing. Rebuilding all indexes and restarting the Python kernel both put a message on screen while they work — the rebuild counts the notes as it goes — and the app waits until they're done, because a half-rebuilt thoughtbase isn't much use to search or query against. Rebuilding the semantic index is different: it stays out of the way in the status bar and you can keep writing while it runs.</p>
+    <p>Each one tells you when it's finished, with a brief note of what it did. If something goes wrong — a file it can't read, a disk that's full — you'll be told that too, rather than being left to wonder whether it worked.</p>
+
+    <figure class="shot-img">
+      <img src="img/maintenance.png" alt="The File menu open, showing Rebuild All Indexes, Rebuild Semantic Index, Interrupt Cell, and Restart Python Kernel grouped together." loading="lazy" />
+      <figcaption>The File menu's maintenance actions</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">You don't need a routine</span>
+      <p>There's no checkup to run and no "repair" button to press on a schedule. Minerva keeps itself in order as you work, so treat this menu as an occasional nudge for the rare case when something looks off — not something to reach for out of habit.</p>
+    </div>

--- a/website/docs/_content/navigation-back-forward.html
+++ b/website/docs/_content/navigation-back-forward.html
@@ -1,0 +1,63 @@
+---
+title: Minerva — Docs — Back / Forward
+description: Step back and forward through the notes, sources, and queries you've been viewing, using the ⌘[ and ⌘] shortcuts or the arrows in the title bar.
+---
+
+    <h1>Back / forward</h1>
+    <p class="lede">As you move between notes, sources, and queries, Minerva remembers where you've been — so you can retrace your steps. Press <kbd>⌘</kbd><kbd>[</kbd> to go back and <kbd>⌘</kbd><kbd>]</kbd> to go forward (use <kbd>Ctrl</kbd> on Windows and Linux), or click the two arrows in the title bar. It works just like the back and forward buttons in a web browser.</p>
+
+    <h2 id="controls">The controls</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>[</kbd></div>
+        <div class="v"><b>Back.</b> Returns you to the previous place you were. Dimmed when there's nothing behind you.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>]</kbd></div>
+        <div class="v"><b>Forward.</b> Returns you to a place you just came back from. Dimmed once you've caught back up to where you started.</div>
+      </div>
+      <div class="row">
+        <div class="k">Title-bar arrows</div>
+        <div class="v">Two arrow buttons at the left edge of the title bar do the same thing as the shortcuts. Each dims when there's nowhere to go in that direction.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/navigation-back-forward.png" alt="The two arrow buttons at the left edge of the title bar, just before the breadcrumb trail for the note you're viewing. The back arrow is active and the forward arrow is dimmed." loading="lazy" />
+      <figcaption>Screenshot — the back and forward arrows</figcaption>
+    </figure>
+
+    <p>Going back doesn't just reopen a note — it returns you to the exact spot you were reading, not the top of the note. Sources and queries are remembered the same way, so you can step back out of a query or a source you were looking at just as easily.</p>
+
+    <h2 id="what-counts">What counts as a step</h2>
+    <p>Most ways of moving around leave a trail you can walk back along, but a couple don't:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Clicking in the sidebar</div>
+        <div class="v"><b>Remembered.</b> Opening a note from the sidebar records where you came from and where you landed.</div>
+      </div>
+      <div class="row">
+        <div class="k">Following a <a href="navigation-wiki-links.html">wiki-link</a></div>
+        <div class="v"><b>Remembered.</b> Clicking a <code>[[link]]</code> to hop from one note to another builds a trail, so you can walk right back out of a chain of linked notes.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="navigation-quick-switch.html">Quick switch</a> (<kbd>⌘</kbd><kbd>P</kbd>)</div>
+        <div class="v"><b>Remembered.</b> Jumping to a note, source, or saved query from Quick Switch records a step, just like clicking it in the sidebar.</div>
+      </div>
+      <div class="row">
+        <div class="k">A <a href="navigation-search.html">search</a> result</div>
+        <div class="v"><b>Remembered.</b> Jumping to a search match records a step, so Back returns you to where you were before the search.</div>
+      </div>
+      <div class="row">
+        <div class="k">Back and forward themselves</div>
+        <div class="v">Retracing your steps doesn't add new ones, so you can step back and forth freely without cluttering the trail.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Going somewhere new clears the way forward</span>
+      <p>If you step back a few notes and then head off in a new direction — clicking a link or opening something from the sidebar — the forward trail is cleared, just like in a web browser. To revisit those notes you'd navigate to them again.</p>
+    </div>
+
+    <p>Your trail is per-project: opening a different thoughtbase starts fresh with an empty history.</p>

--- a/website/docs/_content/navigation-breadcrumbs.html
+++ b/website/docs/_content/navigation-breadcrumbs.html
@@ -1,0 +1,36 @@
+---
+title: Minerva — Docs — Breadcrumbs
+description: The breadcrumb trail above the note title shows where the current note lives, and lets you jump back to its folder in the sidebar with a click.
+---
+
+    <h1>Breadcrumbs</h1>
+    <p class="lede">A thin bar above the note title shows where the current note sits in your folders — each folder along the way, then the note's own name. It's just a signpost telling you where you are, plus a quick way to jump back to that folder in the sidebar.</p>
+
+    <h2 id="trail">What the trail shows</h2>
+    <p>The bar lists each folder that contains the note, from the outermost inward, ending with the note's own name. A note filed under research, then interviews, shows as <b>research › interviews › q3-notes</b>. A note that isn't inside any folder shows just its own name.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Folder steps</div>
+        <div class="v">One for each folder the note lives inside. Click any of them to reveal that folder in the sidebar.</div>
+      </div>
+      <div class="row">
+        <div class="k">The note's name</div>
+        <div class="v">Always last, shown in italic. It isn't clickable — you're already looking at it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Heading trail <span style="opacity:0.7;font-weight:400;">(optional)</span></div>
+        <div class="v">You can turn on an extra trail of the headings your cursor currently sits under, in <b>Settings → Behaviors</b>. Click a heading to jump straight to it in the note. It's off by default because it updates as you move around, which some people find busy.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/navigation-breadcrumbs.png" alt="The thin breadcrumb bar above a note's title, showing a folder path like &quot;research › interviews › transcripts&quot; in muted text followed by the note's name in italic, with the folder steps highlighting as clickable on hover." loading="lazy" />
+      <figcaption>Screenshot — Breadcrumb trail for a note in nested folders</figcaption>
+    </figure>
+
+    <h2 id="clicking">Clicking a folder</h2>
+    <p>Click any folder in the trail to reveal it in the sidebar: Minerva switches to the Notes panel, opens that folder and everything above it, and scrolls it into view — so you can see what else is filed alongside the note you're reading.</p>
+
+    <h2 id="updates">As you move around</h2>
+    <p>The trail updates the moment you switch to a different note or tab. When no note is open, the bar simply isn't there.</p>

--- a/website/docs/_content/navigation-command-palette.html
+++ b/website/docs/_content/navigation-command-palette.html
@@ -1,0 +1,38 @@
+---
+title: Minerva — Docs — Command Palette
+description: The command palette (⌘K / Ctrl+K): a keyboard launcher for running any command in Minerva without reaching for the menus.
+---
+
+    <h1>Command palette</h1>
+    <p class="lede">The command palette is a keyboard launcher for everything Minerva can do. Press <kbd>⌘</kbd><kbd>K</kbd> (or <kbd>Ctrl</kbd><kbd>K</kbd> on Windows and Linux) from anywhere, type a few letters, and press <kbd>↵</kbd> to run the highlighted command — no hunting through menus. It finds <b>commands and actions</b>; to jump to a note, source, or saved query by name, use <a href="navigation-quick-switch.html">Quick switch</a> instead.</p>
+
+    <p>The palette floats over your note without dimming or covering it, so you can still see what you're about to act on as you type.</p>
+
+    <h2 id="empty">Browsing everything</h2>
+    <p>Open the palette with nothing typed and it lists every command Minerva offers — creating notes, editing, viewing, navigating, refactoring, research, queries, and app-wide actions. Commands you've run recently appear at the top, most recent first; everything else follows in alphabetical order.</p>
+
+    <h2 id="filtering">Finding a command</h2>
+    <p>As you type, the list narrows and re-sorts to put the best matches first. You don't have to type a command's exact name — a few letters from anywhere in it usually gets you there, and initials work too (type <b>nn</b> to find "New Note"). Commands you've used recently are nudged toward the top, so the things you reach for most stay close at hand.</p>
+
+    <figure class="shot-img">
+      <img src="img/navigation-command-palette.png" alt="The palette open over a note with &quot;link&quot; typed in, and a ranked list of matching commands below — each row showing the command name, a small label for its category, and its keyboard shortcut on the right where it has one. The top result is highlighted." loading="lazy" />
+      <figcaption>Screenshot — the command palette with a typed query</figcaption>
+    </figure>
+
+    <p>If nothing matches what you typed, the palette simply tells you so.</p>
+
+    <h2 id="keyboard">Getting around by keyboard</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>↑</kbd> <kbd>↓</kbd></div>
+        <div class="v">Move the highlight up or down through the results. Hovering a row with the mouse selects it too.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>↵</kbd></div>
+        <div class="v">Run the highlighted command. The palette closes right away and focus returns to your note.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>esc</kbd></div>
+        <div class="v">Close the palette without running anything.</div>
+      </div>
+    </div>

--- a/website/docs/_content/navigation-quick-switch.html
+++ b/website/docs/_content/navigation-quick-switch.html
@@ -1,0 +1,94 @@
+---
+title: Minerva — Docs — Quick Switch
+description: Quick switch (⌘P) lets you jump straight to a note, source, or saved query by typing its name.
+---
+
+    <h1>Quick switch</h1>
+    <p class="lede">Press <kbd>⌘</kbd><kbd>P</kbd> (or <kbd>Ctrl</kbd><kbd>P</kbd>) and start typing to jump straight to a note, a source, or a saved query by name. The list narrows as you type, and the arrow keys plus <kbd>Enter</kbd> take you the rest of the way — no mouse, no hunting through the sidebar.</p>
+
+    <h2 id="scope">Search notes, sources, and queries</h2>
+    <p>Quick switch isn't limited to notes. When your project also has sources or saved queries, a row of filter chips appears and the picker searches across all three at once:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">All</div>
+        <div class="v">The default. Matches notes, sources, and saved queries together, each labeled with a small icon showing what it is.</div>
+      </div>
+      <div class="row">
+        <div class="k">Notes</div>
+        <div class="v">Matches on a note's title and its location in your folders.</div>
+      </div>
+      <div class="row">
+        <div class="k">Sources</div>
+        <div class="v">Matches on a source's title and author. Shown only when you have at least one source.</div>
+      </div>
+      <div class="row">
+        <div class="k">Queries</div>
+        <div class="v">Matches on a saved query's name and description. Shown only when you have at least one saved query.</div>
+      </div>
+    </div>
+
+    <p>Each chip shows how many results it holds. If you don't have any sources or saved queries yet, the chips simply don't appear and quick switch acts as a plain notes picker.</p>
+
+    <figure class="shot-img">
+      <img src="img/navigation-quick-switch.png" alt="The picker open with the All filter active, showing a mixed list: a note with its folder location, a source with its author, and a saved query with its description, each marked with a small icon for its kind." loading="lazy" />
+      <figcaption>Screenshot — Quick switch with mixed results</figcaption>
+    </figure>
+
+    <h2 id="matching">Typing to find things</h2>
+    <p>You don't have to type a title exactly. Quick switch is forgiving, so a few well-chosen letters usually surface what you want:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Part of the name</div>
+        <div class="v">Type any run of letters that appears in the title. This gives the strongest match.</div>
+      </div>
+      <div class="row">
+        <div class="k">Initials</div>
+        <div class="v">Type the first letter of each word — "rf" finds "Raft Foundations."</div>
+      </div>
+      <div class="row">
+        <div class="k">Scattered letters</div>
+        <div class="v">Type letters that appear in order but not together — a handy fallback when you only half-remember a title.</div>
+      </div>
+    </div>
+
+    <p>Quick switch also looks at a note's folder location, a source's author, and a query's description, so those can help pin down a match too. Before you type anything, the list simply shows your items in their normal order.</p>
+
+    <h2 id="keys">Keyboard control</h2>
+    <p>Once the picker is open, you can do everything from the keyboard:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>↑</kbd> / <kbd>↓</kbd></div>
+        <div class="v">Move the highlight up and down the list.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>Enter</kbd></div>
+        <div class="v">Open the highlighted result — a note opens for editing, a source opens in the source viewer, a saved query runs.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>Esc</kbd></div>
+        <div class="v">Close without going anywhere.</div>
+      </div>
+    </div>
+
+    <h2 id="contrast">Quick switch, command palette, and search</h2>
+    <p>Minerva gives you three ways to get around, each suited to a different question:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Quick switch — <kbd>⌘</kbd><kbd>P</kbd></div>
+        <div class="v">Jump to a <i>thing</i> — a note, source, or saved query — by name.</div>
+      </div>
+      <div class="row">
+        <div class="k">Command palette — <kbd>⌘</kbd><kbd>K</kbd></div>
+        <div class="v">Run an <i>action</i> — a command or setting — by name. See <a href="navigation-command-palette.html">Command palette</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Search</div>
+        <div class="v">Find a <i>passage</i> — search the text inside your notes, not just their titles. See <a href="navigation-search.html">Search</a>.</div>
+      </div>
+    </div>
+
+    <p>If you roughly know what a note is called, quick switch is the fastest way to it. If you remember something you wrote but not its title, reach for Search instead — quick switch matches names, not the words inside a note.</p>

--- a/website/docs/_content/navigation-search.html
+++ b/website/docs/_content/navigation-search.html
@@ -1,0 +1,84 @@
+---
+title: Minerva — Docs — Search
+description: Search (⌘⇧F) finds and replaces text across every note in your project. Results update as you type and click to jump straight to a match.
+---
+
+    <h1>Search</h1>
+    <p class="lede">Press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd> (or <kbd>Ctrl</kbd><kbd>⇧</kbd><kbd>F</kbd>) to open <b>Find in Notes</b> — a search across the text of every note in your project, not just their titles. Results update as you type, and clicking any match opens the note with your cursor already on that line, ready to edit.</p>
+
+    <h2 id="opening">Opening it</h2>
+    <p>The search window has two modes: <b>Find</b> and <b>Find and Replace</b>. You can switch between them at any time with the toggle at the top. There are three ways in:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd></div>
+        <div class="v">Opens in <b>Find</b> mode. Works from anywhere in the app, whether or not you're typing in a note.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>H</kbd></div>
+        <div class="v">Opens straight into <b>Find and Replace</b> mode.</div>
+      </div>
+      <div class="row">
+        <div class="k">Command palette</div>
+        <div class="v">Type "Find in Notes" in the <a href="navigation-command-palette.html">command palette</a> (<kbd>⌘</kbd><kbd>K</kbd>), for when your hands are already there.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Not the same as ⌘F</span>
+      <p><kbd>⌘</kbd><kbd>F</kbd> (without Shift) searches only within the note you're currently reading. The full <kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd> search covers your whole project. If you're only finding matches in the note you already have open, you pressed the wrong one.</p>
+    </div>
+
+    <h2 id="scope">What gets searched</h2>
+    <p>Search looks through the actual text of your notes, line by line. If you can read it in a note, search can find it — including things like tags or links, which match simply because their text is there.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Note content</div>
+        <div class="v">Yes. Every line of every note is searched.</div>
+      </div>
+      <div class="row">
+        <div class="k">Note titles and names</div>
+        <div class="v">No — only what's written inside a note. To jump to a note by its name, use <a href="navigation-quick-switch.html">Quick switch</a> instead.</div>
+      </div>
+      <div class="row">
+        <div class="k">Match case</div>
+        <div class="v">Off by default, so uppercase and lowercase are treated the same. Turn on the <kbd>Aa</kbd> button to match capitalization exactly.</div>
+      </div>
+      <div class="row">
+        <div class="k">Pattern matching</div>
+        <div class="v">By default your search is treated as plain text. Turn on the <kbd>.*</kbd> button if you want to search with a pattern for more advanced matches.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/navigation-search.png" alt="The search window with a word typed into the search field and results below, grouped by note. Each result shows a snippet of the line with the matching text highlighted." loading="lazy" />
+      <figcaption>Screenshot — Search results for a query</figcaption>
+    </figure>
+
+    <h2 id="results">Reading results and jumping in</h2>
+    <p>Results are grouped by note. Each group can be collapsed to tidy away a note with many matches. Click any result to open that note with your cursor placed right on the match — you can start typing immediately.</p>
+
+    <h2 id="live">Search as you type</h2>
+    <p>Results update automatically as you type — there's no button to press or Enter key to hit. Turning match case or pattern matching on or off refreshes the results the same way. A running count of matches sits at the top.</p>
+
+    <h2 id="replace">Find and Replace</h2>
+    <p>In Replace mode you add the replacement text, and each result gets a checkbox so you can pick which matches to change. <b>Replace Selected</b> changes only the checked ones; <b>Replace All</b> changes every match. Each result previews how the line will read afterward.</p>
+
+    <h2 id="contrast">Search vs. Quick switch vs. the command palette</h2>
+    <p>Three tools that each answer a different question:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Search — <kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd></div>
+        <div class="v">Find a <i>passage</i>. Use it when you remember something you wrote but not which note it's in.</div>
+      </div>
+      <div class="row">
+        <div class="k">Quick switch — <kbd>⌘</kbd><kbd>P</kbd></div>
+        <div class="v">Jump to a <i>note</i> by its title. See <a href="navigation-quick-switch.html">Quick switch</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Command palette — <kbd>⌘</kbd><kbd>K</kbd></div>
+        <div class="v">Run an <i>action</i> — a menu command, a tool, a setting — by name. See <a href="navigation-command-palette.html">Command palette</a>.</div>
+      </div>
+    </div>

--- a/website/docs/_content/navigation-wiki-links.html
+++ b/website/docs/_content/navigation-wiki-links.html
@@ -1,0 +1,33 @@
+---
+title: Minerva — Docs — Wiki-links
+description: Following wiki-links in Minerva: click a link to jump to the note it points to, and peek at where it leads by hovering.
+---
+
+    <h1>Wiki-links</h1>
+    <p class="lede">A wiki-link, written as <code>[[Note Name]]</code>, connects one note to another. Wherever a link appears, you can click it to jump straight to the note it points to. This page is about moving around by following links; for how to write them, see <a href="notes-links.html">Links</a>.</p>
+
+    <h2 id="following">Following a link</h2>
+    <p>Clicking a wiki-link takes you to the note it names. This works the same whether you're reading a note or writing one.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">While reading</div>
+        <div class="v">Click a link to follow it — no modifier key needed.</div>
+      </div>
+      <div class="row">
+        <div class="k">While writing</div>
+        <div class="v">A plain click still follows the link. To place your cursor inside the link and edit it instead, hold <kbd>⌘</kbd> (or <kbd>Ctrl</kbd>) as you click.</div>
+      </div>
+      <div class="row">
+        <div class="k">A link that leads nowhere</div>
+        <div class="v">If a link names a note that doesn't exist, clicking it simply does nothing — no note is created and no error appears.</div>
+      </div>
+    </div>
+
+    <h2 id="hover">Peek before you jump</h2>
+    <p>Rest your pointer on a link, without clicking, and a small popover shows the title of the note it points to along with a few lines from its opening. It's just a peek — move away and it disappears, and nothing changes. If the link leads to a note that doesn't exist, the popover says so quietly instead of showing an excerpt.</p>
+
+    <figure class="shot-img">
+      <img src="img/navigation-wiki-links.png" alt="A note with the pointer resting on a link, showing a small popover beneath it with the linked note's title and a couple of lines of its opening text." loading="lazy" />
+      <figcaption>Screenshot — Peeking at a linked note</figcaption>
+    </figure>

--- a/website/docs/_content/navigation.html
+++ b/website/docs/_content/navigation.html
@@ -1,0 +1,74 @@
+---
+title: Minerva — Docs — Navigation
+description: Every way to move around Minerva: the command palette, quick switch, wiki-links, search, breadcrumbs, and back/forward.
+---
+
+    <h1>Navigation</h1>
+    <p class="lede">There are six ways to get from one note to another, and the fastest depends on what you already know. Know the command you want? The palette. Know the name? Quick switch. Following a link someone already laid down? A wiki-link. Only remember a phrase? Search. Lost track of where you are? The breadcrumb trail. Went one note too far? Step back.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>K</kbd></div>
+        <div class="v"><a href="navigation-command-palette.html"><b>Command palette</b></a> — run a command or action by name. No notes, sources, or queries here.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>P</kbd></div>
+        <div class="v"><a href="navigation-quick-switch.html"><b>Quick switch</b></a> — jump straight to a note, source, or saved query by name.</div>
+      </div>
+      <div class="row">
+        <div class="k">click</div>
+        <div class="v"><a href="navigation-wiki-links.html"><b>Wiki-links</b></a> — follow a <code>[[link]]</code> where it's rendered, with a hover preview first.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>F</kbd></div>
+        <div class="v"><a href="navigation-search.html"><b>Search</b></a> — find any word or phrase across the full text of every note.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="navigation-breadcrumbs.html"><b>Breadcrumbs</b></a> — a persistent trail above the note title; no shortcut, it's always there.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>[</kbd> / <kbd>⌘</kbd><kbd>]</kbd></div>
+        <div class="v"><a href="navigation-back-forward.html"><b>Back / forward</b></a> — retrace your steps like browser history.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Windows / Linux</span>
+      <p>Every shortcut above uses <kbd>Ctrl</kbd> in place of <kbd>⌘</kbd>.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="navigation-command-palette.html">
+        <span class="em">⌘</span>
+        <h3>Command palette</h3>
+        <p>The do-anything launcher — search commands and actions, ranked as you type.</p>
+      </a>
+      <a class="doc-card" href="navigation-quick-switch.html">
+        <span class="em">⚡</span>
+        <h3>Quick switch</h3>
+        <p>Jump to a note, source, or query by name — no browsing the sidebar.</p>
+      </a>
+      <a class="doc-card" href="navigation-wiki-links.html">
+        <span class="em">🖱️</span>
+        <h3>Wiki-links</h3>
+        <p>Click to follow, hover to preview, and what happens on an unresolved target.</p>
+      </a>
+      <a class="doc-card" href="navigation-search.html">
+        <span class="em">🔍</span>
+        <h3>Search</h3>
+        <p>Search the full text of everything, with live results as you type.</p>
+      </a>
+      <a class="doc-card" href="navigation-breadcrumbs.html">
+        <span class="em">🍞</span>
+        <h3>Breadcrumbs</h3>
+        <p>A live trail showing where the current note sits, click to jump up a level.</p>
+      </a>
+      <a class="doc-card" href="navigation-back-forward.html">
+        <span class="em">↩️</span>
+        <h3>Back / forward</h3>
+        <p>Retrace your steps like browser history.</p>
+      </a>
+    </div>

--- a/website/docs/_content/notes-callouts.html
+++ b/website/docs/_content/notes-callouts.html
@@ -1,0 +1,80 @@
+---
+title: Minerva — Docs — Callouts
+description: Callouts turn a passage into a titled, colored box — a note, tip, warning, or quote — that stands out from the surrounding text.
+---
+
+    <h1>Callouts</h1>
+    <p class="lede">A callout is a titled, colored box that makes a passage stand out from the text around it — a note, a tip, a warning, a quote. You write one as a quote block that starts by naming its kind. (One kind, the card, becomes a two-sided flashcard — that has its own <a href="notes-flashcards.html">Flashcards</a> page.)</p>
+
+    <h2 id="syntax">Writing a callout</h2>
+    <p>Start a quote block and make its first line <code>[!type]</code>, where <code>type</code> is the kind you want. Everything below that first line becomes the body of the box.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>&gt; [!tip]</code></div>
+        <div class="v"><b>The usual form.</b> A quote block whose first line names the kind. Every following quoted line is the body.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[!note]</code></div>
+        <div class="v"><b>Shorthand.</b> A plain paragraph that begins with <code>[!type]</code> also becomes a callout, even without the leading <code>&gt;</code>. This form is always shown fully expanded.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>&gt; [!tip]+</code></div>
+        <div class="v"><b>Collapsible, starts open.</b> Add a <code>+</code> and the box can be folded shut with a click, but begins expanded.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>&gt; [!tip]-</code></div>
+        <div class="v"><b>Collapsible, starts closed.</b> Add a <code>-</code> and the body stays hidden until you click to open it.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>&gt; [!tip] Your own title</code></div>
+        <div class="v"><b>Custom title.</b> Any text after the marker replaces the kind's default title at the top of the box.</div>
+      </div>
+    </div>
+
+    <p>An example, plus the shorthand form:</p>
+<pre><code>&gt; [!warning] Before you continue
+&gt; This changes every note. Back up your work first.
+
+&gt; [!tip]-
+&gt; Collapsed by default — click to expand.
+
+[!note]
+No leading &gt; required — this still becomes a callout.</code></pre>
+
+    <h2 id="kinds">The kinds you can use</h2>
+    <p>Each kind comes with its own icon, a default title, and a color. Pick whichever fits what you're saying — and if you type a kind that isn't in the list, it still works: it just gets a neutral dot icon and its name as the title, which makes it easy to invent your own labels.</p>
+
+    <div class="deflist">
+      <div class="row"><div class="k"><code>note</code></div><div class="v">A general aside.</div></div>
+      <div class="row"><div class="k"><code>info</code></div><div class="v">Background or context.</div></div>
+      <div class="row"><div class="k"><code>tip</code></div><div class="v">A helpful suggestion.</div></div>
+      <div class="row"><div class="k"><code>success</code></div><div class="v">Something that worked, marked with a checkmark.</div></div>
+      <div class="row"><div class="k"><code>question</code></div><div class="v">An open question.</div></div>
+      <div class="row"><div class="k"><code>warning</code></div><div class="v">Something to be careful about, in a warm amber tone.</div></div>
+      <div class="row"><div class="k"><code>failure</code></div><div class="v">Something that didn't work.</div></div>
+      <div class="row"><div class="k"><code>danger</code></div><div class="v">A strong caution.</div></div>
+      <div class="row"><div class="k"><code>bug</code></div><div class="v">A known problem.</div></div>
+      <div class="row"><div class="k"><code>example</code></div><div class="v">A worked example.</div></div>
+      <div class="row"><div class="k"><code>quote</code></div><div class="v">A quotation — styled quietly, so it reads as a citation.</div></div>
+      <div class="row"><div class="k"><code>abstract</code></div><div class="v">A summary or overview.</div></div>
+      <div class="row"><div class="k"><code>todo</code></div><div class="v">Something still to do.</div></div>
+      <div class="row"><div class="k"><code>card</code></div><div class="v">A two-sided flashcard with a front and back — see <a href="notes-flashcards.html">Flashcards</a>.</div></div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/notes-callouts.png" alt="A note showing three boxes stacked top to bottom: a &quot;Note&quot; callout with a pencil icon, a &quot;Warning&quot; callout in a warm amber tone with a triangle icon, and a collapsed &quot;Tip&quot; callout with a lightbulb icon waiting to be clicked open." loading="lazy" />
+      <figcaption>Callout kinds in a note</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">Invent your own kinds</span>
+      <p>You aren't limited to the kinds above. Type any name — say <code>[!idea]</code> — and it still renders as a tidy box, titled with that name. This makes callouts a flexible way to mark up your notes however you like.</p>
+    </div>
+
+    <h2 id="nesting">Good to know</h2>
+    <ul>
+      <li><b>Callouts can nest.</b> Put a callout inside another callout to group related boxes.</li>
+      <li><b>Only quote-block callouts fold.</b> The shorthand form (no leading <code>&gt;</code>) is always fully shown; to make a box collapsible, use the quote-block form with <code>+</code> or <code>-</code>.</li>
+      <li><b>Kind names ignore capitalization.</b> <code>[!Warning]</code> and <code>[!warning]</code> mean the same thing.</li>
+    </ul>

--- a/website/docs/_content/notes-charts.html
+++ b/website/docs/_content/notes-charts.html
@@ -1,0 +1,62 @@
+---
+title: Minerva — Docs — Charts
+description: Add live, interactive charts to your notes — draw them from a chart type in the menu, or feed them live data from a query, a table, or a compute cell.
+---
+
+    <h1>Charts</h1>
+    <p class="lede">You can drop a live, interactive chart right into a note. Hover any bar or point for a tooltip, and use the chart's corner menu to save it as an image. A chart can hold its own numbers, or draw from live data elsewhere in your project — a query over your knowledge base, a table, or the output of a compute cell — so it stays up to date instead of freezing a snapshot.</p>
+
+    <h2 id="insert">Adding a chart</h2>
+    <p>The quickest way is to right-click in the editor and choose <b>Elements → Chart…</b>. Pick a shape — Bar, Line, Area, Scatter, Time Series, or Pie — and Minerva drops in a ready-made chart with sample numbers already in place, with your cursor sitting in the data so your first edit is just swapping in your own values.</p>
+
+    <p>A chart lives in a chart cell that holds a short specification describing what to draw. Here is what a simple bar chart looks like:</p>
+
+<pre><code>```vega-lite
+{
+  "data": { "values": [
+    { "category": "A", "value": 28 },
+    { "category": "B", "value": 55 },
+    { "category": "C", "value": 43 },
+    { "category": "D", "value": 91 }
+  ] },
+  "mark": "bar",
+  "encoding": {
+    "x": { "field": "category", "type": "nominal" },
+    "y": { "field": "value", "type": "quantitative" }
+  }
+}
+```</code></pre>
+
+    <p>You describe the data, the shape to draw, and which values go on each axis; Minerva works out the axes, scales, and legend for you. That concise style covers ordinary bar, line, area, scatter, and pie charts. For a chart that needs finer control than the concise style allows, there is also a more detailed form where you spell out every part yourself — reach for it only when you need something the concise style can't express.</p>
+
+    <h2 id="rendering">How it looks</h2>
+    <p>The chart draws right in the note, sized to fit the column so it never spills off the side. It's fully interactive: hover a bar or point for a tooltip, and open the "⋯" menu in the corner to save the chart as an image. Colors follow your current theme automatically, so a chart looks at home whether you're in a light or dark look — though any color you set yourself is always kept.</p>
+
+    <figure class="shot-img">
+      <img src="img/notes-charts.png" alt="A note with a bar chart drawn inline, sized to the width of the column. A tooltip shows the value of the bar under the pointer, and the &quot;⋯&quot; menu for saving the chart sits in the corner." loading="lazy" />
+    </figure>
+
+    <h2 id="data">Live data</h2>
+    <p>The simple approach is to list your numbers right in the chart, as above. But a chart can also pull its data from elsewhere in your project so it updates as that data changes. In place of listing values, point the chart at one of these:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">A query over your knowledge base</div>
+        <div class="v">Each result becomes a point on the chart, so the chart reflects your notes as they grow and change.</div>
+      </div>
+      <div class="row">
+        <div class="k">A table</div>
+        <div class="v">Draw straight from a table of data you've brought into your project.</div>
+      </div>
+      <div class="row">
+        <div class="k">A compute cell's output</div>
+        <div class="v">Chart the results of a compute cell elsewhere in the note. Run that cell at least once first, so there's an output to draw from.</div>
+      </div>
+    </div>
+
+    <p>A chart that draws from live data gets a refresh button, so after the underlying data changes you can redraw it in place without touching the note.</p>
+
+    <div class="box">
+      <span class="label">Data stays in your project</span>
+      <p>A chart draws only from numbers in the note or from data already in your project — it won't reach out to the web to fetch anything. This keeps notes that arrive from an import or from someone else safe to open and view.</p>
+    </div>

--- a/website/docs/_content/notes-code.html
+++ b/website/docs/_content/notes-code.html
@@ -1,0 +1,57 @@
+---
+title: Minerva — Docs — Code &amp; Compute Cells
+description: Add code to a note with syntax highlighting, or make a cell runnable and see its result land right in the note.
+---
+
+    <h1>Code &amp; compute cells</h1>
+    <p class="lede">Drop a block of code into any note and it comes out neatly color-highlighted. Three kinds go further — queries over your knowledge base, queries over your tables, and Python — and become <b>runnable</b>: a small ▶ appears, and running the cell drops its result right into the note, just below the code.</p>
+
+    <h2 id="syntax">Plain code vs. runnable cells</h2>
+    <p>What decides whether a cell just looks nice or actually runs is the language you label it with.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Any language</div>
+        <div class="v"><b>Plain.</b> Label a cell with a language — JavaScript, Rust, shell, and so on — and it's shown with color highlighting to make it easy to read. Nothing runs; it's there for reference.</div>
+      </div>
+      <div class="row">
+        <div class="k">Knowledge base</div>
+        <div class="v"><b>Runnable.</b> Ask a question of your project's knowledge base and get back a table of answers — the same kind of question you'd ask from the Query panel.</div>
+      </div>
+      <div class="row">
+        <div class="k">Tables</div>
+        <div class="v"><b>Runnable.</b> Query the data in your imported tables and spreadsheets, and get back a table of matching rows.</div>
+      </div>
+      <div class="row">
+        <div class="k">Python</div>
+        <div class="v"><b>Runnable.</b> Run a bit of Python. The result can be text, a table, an inline image or chart — whatever the code produces.</div>
+      </div>
+    </div>
+
+    <h2 id="running">Running a cell</h2>
+    <p>A runnable cell shows a small ▶ button, whether you're writing the note or reading it in preview. You can run one a few ways:</p>
+    <ul>
+      <li><b>Click ▶</b> next to the cell. It shows a brief pause while the cell runs.</li>
+      <li><b><kbd>⌘</kbd><kbd>⇧</kbd><kbd>Enter</kbd></b> (or <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>Enter</kbd>) runs the cell your cursor is in.</li>
+      <li><b>Recompute all</b>, above the note, re-runs every runnable cell from top to bottom. It appears whenever a note has at least one.</li>
+    </ul>
+
+    <h2 id="output">Where output goes</h2>
+    <p>A cell's result is written into the note itself, right below the cell — not a panel that vanishes when you close the note. Run the cell again and its result is refreshed in place. Depending on what the cell produces, the result might be a table, a block of text, an image, or a chart. If something goes wrong, you get a clearly-marked error with the message instead, so you can fix the cell and try again.</p>
+
+    <figure class="shot-img">
+      <img src="img/notes-code.png" alt="A note showing a Python cell with its ▶ button, and just beneath it the result it produced — a small table of data." loading="lazy" />
+      <figcaption>Screenshot — Runnable cell with output</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">Big results are trimmed, not hidden</span>
+      <p>Very large tables are shown up to a generous limit. When there's more, the result notes how many rows you're seeing out of the total, so you always know there's more — just narrow your query to see the rest.</p>
+    </div>
+
+    <h2 id="python">A note on Python</h2>
+    <p>Python cells run on your own machine and can do real work — read and write files, reach the network, and use whatever you have installed. Because of that, Minerva asks you to confirm once per project before it runs Python; after that it remembers your choice. You can point Minerva at the Python you want to use in Settings → Compute.</p>
+    <p>Within a single note, Python cells build on each other: a value or import from an earlier cell is available to later ones. Cells in different notes stay separate, and each knowledge-base or table query stands on its own.</p>
+
+    <h2 id="trust">Running is always your call</h2>
+    <p>A cell only ever runs when you run it — by clicking ▶, pressing the shortcut, or choosing Recompute all. Since you're the one asking, it just runs, the same way typing in a note doesn't need approval. Cells run the query you wrote exactly as written, so treat them with the same care you'd give any query you run yourself.</p>

--- a/website/docs/_content/notes-diagrams.html
+++ b/website/docs/_content/notes-diagrams.html
@@ -1,0 +1,54 @@
+---
+title: Minerva — Docs — Diagrams
+description: Draw live diagrams inside a note — flowcharts, sequence diagrams, and more — by writing them in a simple text syntax.
+---
+
+    <h1>Diagrams</h1>
+    <p class="lede">You can draw diagrams right inside a note — flowcharts, sequence diagrams, and more — by describing them in a simple text syntax. When you preview the note, your description turns into a clean, finished diagram, so you never have to fiddle with boxes and arrows by hand.</p>
+
+    <h2 id="syntax">Writing a diagram</h2>
+    <p>Add a cell labelled <code>mermaid</code> and describe the diagram inside it. Each line names a step and how it connects to the next. To drop one in quickly, right-click in the editor and choose <b>Elements → Mermaid Diagram</b>; you'll get an empty cell with your cursor ready inside.</p>
+
+<pre><code>```mermaid
+flowchart LR
+  A[Draft] --> B{Reviewed?}
+  B -- yes --> C[Published]
+  B -- no --> A
+```</code></pre>
+
+    <h2 id="types">Kinds of diagrams</h2>
+    <p>Many diagram styles are supported — flowcharts, sequence diagrams, class and state diagrams, entity relationships, timelines, and more. Two of the most useful:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Flowchart</div>
+        <div class="v"><b>Boxes and arrows.</b> Show steps and how they branch. You can lay it out left-to-right (<code>LR</code>) or top-down (<code>TD</code>).
+<pre><code>```mermaid
+flowchart TD
+  Start --> Decision{OK?}
+  Decision -->|yes| End
+  Decision -->|no| Start
+```</code></pre>
+        </div>
+      </div>
+      <div class="row">
+        <div class="k">Sequence diagram</div>
+        <div class="v"><b>Who talks to whom.</b> Show the participants and the messages passing between them, in order.
+<pre><code>```mermaid
+sequenceDiagram
+  Alice->>Bob: Question
+  Bob-->>Alice: Answer
+```</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/notes-diagrams.png" alt="A finished note showing a small decision-branch flowchart, drawn neatly in its own block with colors that match the rest of the note." loading="lazy" />
+      <figcaption>A flowchart in a note</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">Diagrams match your theme</span>
+      <p>Diagrams use the same colors as the note around them. Switch between light, dark, or high-contrast, and your diagrams redraw to match — there's nothing extra to set up.</p>
+    </div>

--- a/website/docs/_content/notes-flashcards.html
+++ b/website/docs/_content/notes-flashcards.html
@@ -1,0 +1,34 @@
+---
+title: Minerva — Docs — Flashcards
+description: Turn any note into two-sided flashcards for study — write a front and a back, and reveal the answer with a click.
+---
+
+    <h1>Flashcards</h1>
+    <p class="lede">A flashcard is a two-sided prompt for study, written right inside a note: a question on the front, the answer on the back. In the note the front shows on its own with a <b>Show answer</b> button, so you can test yourself before revealing the rest. You can scatter cards through your notes wherever a fact is worth remembering.</p>
+
+    <h2 id="writing">Writing a flashcard</h2>
+    <p>Start a quote block and make its first line <code>[!card]</code>. Put a line with three dashes — <code>---</code> — in the body: everything above it becomes the front of the card, and everything below it the back. When you're done writing, the note shows just the front with a <b>Show answer</b> button; click it to flip the card over.</p>
+
+    <p>Any text you add after <code>[!card]</code> becomes the card's title — a handy place to name the deck a card belongs to.</p>
+
+<pre><code>&gt; [!card] Biology deck
+&gt; What organelle produces most of a cell's energy?
+&gt; ---
+&gt; The mitochondrion.</code></pre>
+
+    <p>The front and back can hold anything a note can — bold text, links, images, math, even a picture to identify. A card without a <code>---</code> divider simply shows its front with nothing to reveal, which is fine for a plain prompt or reminder.</p>
+
+    <figure class="shot-img">
+      <img src="img/notes-flashcards.png" alt="A note with a flashcard box titled &quot;Biology deck&quot;: the front shows the question &quot;What organelle produces most of a cell's energy?&quot; above a &quot;Show answer&quot; button, with the answer hidden until you click." loading="lazy" />
+      <figcaption>A flashcard in a note</figcaption>
+    </figure>
+
+    <h2 id="study">Turning cards into a study session</h2>
+    <p>Flashcards you write this way aren't just for reading in place — you can gather them up and review them as a deck, or send them out to study elsewhere. See <a href="export-flashcards.html">Flashcards export</a> for collecting and sharing them.</p>
+
+    <h2 id="good-to-know">Good to know</h2>
+    <ul>
+      <li><b>A card is a kind of callout.</b> It's written like the titled boxes on the <a href="notes-callouts.html">Callouts</a> page, just with the special <code>card</code> label and a front/back divider.</li>
+      <li><b>One divider per card.</b> The first <code>---</code> splits front from back; keep the rest of the card to those two sides.</li>
+      <li><b>Name your decks.</b> Give related cards the same title after <code>[!card]</code> so they read as one set.</li>
+    </ul>

--- a/website/docs/_content/notes-footnotes.html
+++ b/website/docs/_content/notes-footnotes.html
@@ -1,0 +1,65 @@
+---
+title: Minerva — Docs — Footnotes
+description: Add footnotes to your notes: mark a spot in your text, write the note at the bottom, and jump between the two in every view.
+---
+
+    <h1>Footnotes</h1>
+    <p class="lede">Footnotes let you move an aside, a caveat, or a citation out of the sentence and down to the bottom of the note. You mark the spot in your text and write the note itself elsewhere in the file, and Minerva keeps the two linked wherever you're reading.</p>
+
+    <h2 id="syntax">Writing a footnote</h2>
+    <p>A footnote has two parts: a <b>marker</b> that sits inline where the thought occurs, and the <b>note text</b> that supplies its content.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>[^label]</code></div>
+        <div class="v"><b>The marker.</b> Drop it inline in your text. The label can be a number (<code>[^1]</code>) or a word (<code>[^caveat]</code>) — anything without spaces.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[^label]: text…</code></div>
+        <div class="v"><b>The note text.</b> Start a fresh line with the same label, a colon, and the footnote's content. These usually collect at the bottom of the note, but you can put them anywhere.</div>
+      </div>
+    </div>
+
+    <p>Need more than a sentence? Continue a footnote across several paragraphs by indenting the lines that follow. Here's a complete example:</p>
+<pre><code>The results replicate the 2019 study,[^rep] though with a smaller
+effect size.[^size]
+
+[^rep]: Only the primary outcome was replicated; the secondary
+    measures did not reach significance.
+
+[^size]: d = 0.31 vs. the original d = 0.62.</code></pre>
+
+    <h2 id="rendering">How footnotes look</h2>
+    <p>When your note is rendered, each marker turns into a small numbered superscript, and all the footnote text gathers into a tidy section at the bottom. Click a number to glide down to the matching footnote; each one ends with a small arrow that takes you back to where you were reading. Prefer not to leave your place? Hover a number and the footnote appears in a tooltip right there.</p>
+
+    <figure class="shot-img">
+      <img src="img/notes-footnotes.png" alt="A rendered note showing a superscript number in a paragraph with its hover tooltip open, and the collected footnotes gathered at the bottom of the note." loading="lazy" />
+      <figcaption>Screenshot — Footnote in a rendered note</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">Labels vs. numbers</span>
+      <p>Your label is just a name for you — it isn't what readers see. Footnotes are numbered automatically in the order their markers appear, so <code>[^caveat]</code> shows up as ¹ if it's the first one. Use whatever labels help you keep track; the finished note stays neat.</p>
+    </div>
+
+    <h2 id="editor">Jumping between marker and note</h2>
+    <p>While you're writing, markers and their notes act as two-way links:</p>
+    <ul>
+      <li><b>Click a marker</b> — jump to its footnote text.</li>
+      <li><b>Click a footnote's text</b> — jump to the first place it's used.</li>
+      <li><b>Hover a marker</b> — preview the footnote without leaving the sentence. If you haven't written it yet, the preview tells you so.</li>
+    </ul>
+    <p>To add one quickly, use the <b>Insert Footnote</b> command: it drops the next free numbered marker where your cursor is, adds a matching line at the end of the note, and puts your cursor there so you can start typing.</p>
+
+    <h2 id="panel">The Footnotes panel</h2>
+    <p>The right sidebar's <b>Footnotes</b> panel lists every footnote in the note, with a preview of each and a search box for long documents. Click an entry to jump to where it's used. The panel also catches loose ends:</p>
+    <ul>
+      <li><b>Defined, never used</b> — a footnote you wrote but never pointed to.</li>
+      <li><b>Referenced, not defined</b> — a marker in your text with no footnote written yet. Click it to go straight to the spot and fill it in.</li>
+    </ul>
+
+    <div class="shot">
+      <div class="icon">🗂️</div>
+      <div class="k">Screenshot — Footnotes panel</div>
+      <div class="d">The right-sidebar Footnotes panel showing several footnotes with their labels and previews, including one flagged as never used and one flagged as not yet written.</div>
+    </div>

--- a/website/docs/_content/notes-frontmatter.html
+++ b/website/docs/_content/notes-frontmatter.html
@@ -1,0 +1,68 @@
+---
+title: Minerva — Docs — Properties
+description: Properties are the structured details at the top of a note — its title, tags, author, and dates — that you can edit in the note or through the Properties panel.
+---
+
+    <h1>Properties</h1>
+    <p class="lede">Properties are a small block of structured details at the top of a note — its title, tags, author, dates, and anything else you want to record about it. You can edit them right in the note text or through the Properties panel in the right sidebar, and the two always stay in step.</p>
+
+    <h2 id="syntax">The properties block</h2>
+    <p>Properties live at the very top of a note, between a pair of <code>---</code> lines. Each line inside is a simple <code>name: value</code> pair. Everything after the closing <code>---</code> is the note itself.</p>
+
+<pre><code>---
+title: The Attention Schema
+tags: [neuroscience, consciousness]
+created: 2024-03-01
+---
+
+The body of the note starts here.</code></pre>
+
+    <p>The opening <code>---</code> has to be the first thing in the note, with nothing above it. If a property is mistyped — a stray quote, a crooked indent — the Properties panel points out what needs fixing, and the note still opens and works normally in the meantime.</p>
+
+    <h2 id="keys">Properties Minerva knows</h2>
+    <p>You can name a property anything you like, but Minerva gives special meaning to a handful of common ones. If you spell one a natural way — <code>author</code> instead of <code>creator</code>, say — Minerva understands it and tidies it to its standard name for you.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>title</code></div>
+        <div class="v">The note's title, shown everywhere in the app. Without it, Minerva falls back to the note's first heading.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>tags</code></div>
+        <div class="v">A list of tags. These join up with any <code>#tags</code> you write in the body, so it's one combined set either way.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>aliases</code></div>
+        <div class="v">Other names this note can be found under when you write <code>[[wiki links]]</code>. See <a href="notes-links.html#resolving">Links</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>creator</code>, <code>description</code>, <code>publisher</code>, <code>language</code></div>
+        <div class="v">Who wrote it, a short summary, who published it, and what language it's in.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>about</code></div>
+        <div class="v">Which note or source this note is about — usually written as a <code>[[wiki link]]</code>.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>created</code>, <code>modified</code>, <code>issued</code></div>
+        <div class="v">Dates, written as <code>YYYY-MM-DD</code>. Handy for when a note was made or when its source was published.</div>
+      </div>
+      <div class="row">
+        <div class="k">Source details</div>
+        <div class="v">When a note stands in for something you read, you can record the usual bibliographic details — its web address, publication, page range, and identifiers like a DOI or ISBN. The research tools fill many of these in for you.</div>
+      </div>
+    </div>
+
+    <p>That's the common set; you're free to add your own properties alongside them, and Minerva will also add properties on its own when its research and thinking tools file claims, summaries, and where things came from.</p>
+
+    <h2 id="custom">Your own properties</h2>
+    <p>Any property Minerva doesn't already know is kept exactly as you wrote it — nothing is dropped. A field of your own like <code>status: draft</code> is saved with the note and can be searched and used just like the built-in ones, so you can organize notes around whatever matters to your work.</p>
+    <p>One property changes how a note behaves: setting <code>format: false</code> tells Minerva to leave that note's layout alone when you tidy up formatting elsewhere — an escape hatch for notes you prefer to arrange by hand. The <a href="settings-formatter.html#exempt">formatting settings</a> explain the options.</p>
+
+    <h2 id="values">Editing in the panel</h2>
+    <p>The Properties panel gives each value the right kind of editor for its shape: a checkbox for yes/no values, removable chips for a list of tags, a date picker for dates, and a clickable chip for a linked note. More complex values stay editable in the note text.</p>
+
+    <figure class="shot-img panel">
+      <img src="img/notes-frontmatter.png" alt="The Properties panel in the right sidebar, open on a note. It shows a title, a row of tags as removable chips, a created date with a date picker, a linked &quot;about&quot; note as a clickable chip, and a custom &quot;status&quot; field — with an &quot;Add property&quot; row at the bottom for adding more." loading="lazy" />
+      <figcaption>The Properties panel</figcaption>
+    </figure>

--- a/website/docs/_content/notes-highlights.html
+++ b/website/docs/_content/notes-highlights.html
@@ -1,0 +1,39 @@
+---
+title: Minerva — Docs — Highlights
+description: Highlighting text in Minerva notes: wrap a passage in double equals signs to mark it, and pick from a small palette of colors.
+---
+
+    <h1>Highlights</h1>
+    <p class="lede">Wrap a passage in double equals signs and Minerva highlights it — a tinted mark behind the text, just like running a highlighter pen across the page. It's a quick way to flag something as important while you're reading or drafting.</p>
+
+    <h2 id="syntax">How to highlight</h2>
+    <p>Put <code>==</code> on both sides of the text you want to mark. To give it a color, start with a color name and a colon; leave that off and you get the default tint.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>==text==</code></div>
+        <div class="v"><b>Highlight.</b> Marks the enclosed text with the default tint.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>==color:text==</code></div>
+        <div class="v"><b>Colored highlight.</b> Choose from <code>yellow</code>, <code>green</code>, <code>blue</code>, <code>pink</code>, or <code>orange</code>. Anything else is simply treated as part of the highlighted text, so <code>==Pythagorean: a²+b²==</code> highlights the whole phrase rather than guessing at a color.</div>
+      </div>
+    </div>
+
+    <p>A short example:</p>
+<pre><code>The migration is safe as long as ==the backfill runs before the
+constraint is added==. Everything else is cosmetic.
+
+Flagged for review: ==orange:re-check this once the rebuild finishes==.</code></pre>
+
+    <p>Leave a space just inside the equals signs and nothing is highlighted, so ordinary prose like <code>x == y</code> stays untouched.</p>
+
+    <h2 id="rendering">How highlights look</h2>
+    <p>A highlight appears as a soft color wash behind the text, right in line with the surrounding words. You'll see the same tint whether you're writing or reading the finished page.</p>
+
+    <figure class="shot-img">
+      <img src="img/notes-highlights.png" alt="A paragraph with two highlighted phrases — one in the default tint, one in yellow — each shown as a soft color wash behind the words, in line with the surrounding text." loading="lazy" />
+      <figcaption>Highlighted text in a note</figcaption>
+    </figure>
+
+    <p>The five colors are tuned to each of Minerva's themes, so a highlight stays easy to read and on-palette whichever theme you're using.</p>

--- a/website/docs/_content/notes-images.html
+++ b/website/docs/_content/notes-images.html
@@ -1,0 +1,74 @@
+---
+title: Minerva — Docs — Images
+description: Add images to your notes in Minerva: drag and drop, paste, or type a link, view them inline, and click to enlarge.
+---
+
+    <h1>Images</h1>
+    <p class="lede">Drop a picture into a note and it just shows up. The quickest way to add one is to drag it in or paste it from your clipboard — Minerva keeps a copy with your notes so it's always there. Images appear inline as you read, and a click enlarges them to full screen.</p>
+
+    <h2 id="uploading">Adding an image</h2>
+    <p>There are three easy ways to get an image into a note.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Drag and drop</div>
+        <div class="v"><b>Drag a picture into the note.</b> Grab an image file from your desktop or a folder and drop it where you're writing. Minerva tucks a copy away with your notes and drops the image in at your cursor.</div>
+      </div>
+      <div class="row">
+        <div class="k">Paste</div>
+        <div class="v"><b>Copy an image, then paste.</b> Take a screenshot or copy a picture from the web and paste it in with <kbd>⌘V</kbd> (or <kbd>Ctrl</kbd>+<kbd>V</kbd>). It appears right away.</div>
+      </div>
+      <div class="row">
+        <div class="k">Type a link</div>
+        <div class="v"><b>Point to an image you already have.</b> If a picture is already in your notes, or lives online, you can write a link to it yourself (see below).</div>
+      </div>
+    </div>
+
+    <p>Paste or drop the same picture twice and Minerva reuses the one copy it already has, so your notes stay tidy.</p>
+
+    <h2 id="syntax">Writing an image link by hand</h2>
+    <p>To type an image link yourself, use this shape: an exclamation mark, a short description in square brackets, then the location of the picture in parentheses.</p>
+
+<pre><code>![System architecture](architecture.png)</code></pre>
+
+    <p>The description in the brackets is the picture's caption for anyone who can't see it, and it shows as a tooltip when you hover. The part in parentheses can point to a picture stored with your notes or to a web address.</p>
+
+    <h2 id="rendering">Viewing images</h2>
+    <p>As you read a note, images show up right in the flow of your writing. Click one to open it full screen so you can see the detail, then click away or press <kbd>Esc</kbd> to close it.</p>
+
+    <figure class="shot-img">
+      <img src="img/notes-images.png" alt="A picture displayed inline within a note. Clicking it opens a full-screen view so you can inspect the detail without leaving your writing." loading="lazy" />
+      <figcaption>An image in a note, and full screen</figcaption>
+    </figure>
+
+    <h2 id="formats">Supported formats</h2>
+    <p>You can add the most common kinds of picture:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">PNG</div>
+        <div class="v">Crisp and supports transparency. Best for diagrams, screenshots, and graphics.</div>
+      </div>
+      <div class="row">
+        <div class="k">JPEG</div>
+        <div class="v">Smaller files. Best for photographs.</div>
+      </div>
+      <div class="row">
+        <div class="k">GIF</div>
+        <div class="v">Supports animation, which plays as you read.</div>
+      </div>
+      <div class="row">
+        <div class="k">WebP</div>
+        <div class="v">A modern format that keeps files small.</div>
+      </div>
+      <div class="row">
+        <div class="k">SVG</div>
+        <div class="v">Line art that stays sharp at any size. Great for diagrams and icons.</div>
+      </div>
+      <div class="row">
+        <div class="k">AVIF</div>
+        <div class="v">A newer format with excellent quality at small file sizes.</div>
+      </div>
+    </div>
+
+    <p>Pictures can be up to 5 MB each. If you have something larger, shrink it in your image editor first.</p>

--- a/website/docs/_content/notes-links.html
+++ b/website/docs/_content/notes-links.html
@@ -1,0 +1,113 @@
+---
+title: Minerva — Docs — Links
+description: Connect notes with wiki-links: the double-bracket syntax, links to a heading or spot in a note, typed links that describe the relationship, and backlinks.
+---
+
+    <h1>Links</h1>
+    <p class="lede">Wiki-links are how you connect one note to another. Type a note's title inside double brackets and Minerva turns it into a live link you can click. A link can also carry a <b>type</b> — <em>supports</em>, <em>rebuts</em>, <em>depends on</em>, and more — so it says what kind of relationship it is, not just that one exists.</p>
+
+    <h2 id="syntax">Writing a link</h2>
+    <p>The simplest link is a note title wrapped in double brackets. From there you can add a few optional pieces:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>[[target]]</code></div>
+        <div class="v"><b>Basic link.</b> The target is the note you want to point at. Start typing after <code>[[</code> and Minerva suggests matching notes.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[[target|display]]</code></div>
+        <div class="v"><b>Custom wording.</b> Whatever you put after the <code>|</code> is shown in the note — handy when the title is long or reads awkwardly in a sentence.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[[target#Heading]]</code></div>
+        <div class="v"><b>Jump to a heading.</b> Points at a specific heading inside the note rather than the top.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>[[type::target]]</code></div>
+        <div class="v"><b>Typed link.</b> Put a relationship type before the target, separated by <code>::</code> — for example <code>[[supports::climate-study]]</code>. See the list below.</div>
+      </div>
+    </div>
+
+    <p>You can combine these however you like — a type, a heading, and custom wording all in one link:</p>
+
+<pre><code>This claim is well established.[[supports::experiment-log#Trial 4]]
+
+See [[depends-on::auth-redesign|the redesign proposal]] before touching this.</code></pre>
+
+    <h2 id="types">Typed links</h2>
+    <p>A typed link is shown in its own color, so you can see the shape of a note's connections at a glance. These types are built in:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>references</code></div>
+        <div class="v"><b>References.</b> General-purpose "points at" link. The default when no type is given.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>supports</code></div>
+        <div class="v"><b>Supports.</b> This note backs up the claim in the target.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>rebuts</code></div>
+        <div class="v"><b>Rebuts.</b> This note argues against the target.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>load-bearing-for</code></div>
+        <div class="v"><b>Load-bearing for.</b> Flags the target as critically dependent on the analysis in this note — a high-leverage link worth double-checking if this note turns out to be wrong.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>expands</code></div>
+        <div class="v"><b>Expands.</b> This note elaborates on or goes deeper into the target.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>depends-on</code></div>
+        <div class="v"><b>Depends On.</b> This note requires the target to hold.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>implements</code></div>
+        <div class="v"><b>Implements.</b> This note is a concrete realization of an idea or spec described in the target.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>alternative-to</code></div>
+        <div class="v"><b>Alternative To.</b> This note proposes a different approach to the same problem as the target.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>supersedes</code></div>
+        <div class="v"><b>Supersedes.</b> This note replaces the target — a signal the target may be stale.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>related-to</code></div>
+        <div class="v"><b>Related To.</b> A loose, non-directional relation — useful when a link matters but none of the sharper types fit.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>cite</code></div>
+        <div class="v"><b>Cites.</b> Points at a <em>source</em> rather than a note — the target is a bibliography-style reference, not another knowledge-base file.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>quote</code></div>
+        <div class="v"><b>Quotes.</b> Points at a specific excerpt anchored in a source, for a direct quotation rather than a general citation.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/notes-links.png" alt="A note with several links in a sentence, each shown in a different color — a green &quot;supports&quot; link, a red &quot;rebuts&quot; link, and a plain blue untyped link." loading="lazy" />
+      <figcaption>Typed links, colored by relationship</figcaption>
+    </figure>
+
+    <h2 id="resolving">Finding the right note</h2>
+    <p>You don't have to type a note's title exactly. Minerva matches on the title, on any alternate names you've given the note in its properties, and even on a short unique piece of the name — so <code>[[raft]]</code> can find a note called "raft" tucked inside a folder. Wherever a link appears, clicking it takes you to the same place.</p>
+
+    <div class="box">
+      <span class="label">Tip</span>
+      <p>If two notes could match the same link, Minerva picks the first one it finds. Give notes distinct names, or add an alternate name in a note's properties, to make sure a link lands where you intend.</p>
+    </div>
+
+    <p>While editing, clicking a link jumps to the note it points at. Hold <kbd>⌘</kbd> (or <kbd>Ctrl</kbd>) and click to place your cursor inside the link and edit it instead.</p>
+
+    <h2 id="backlinks">Backlinks</h2>
+    <p>Links work in both directions. When you're reading a note, the <b>Backlinks</b> panel in the right sidebar lists every other note that links to it, each labeled and colored by its link type — so you can see at a glance which notes support, rebut, or merely reference the one you're looking at.</p>
+
+    <div class="shot">
+      <div class="icon">↩️</div>
+      <div class="k">The Backlinks panel</div>
+      <div class="d">The right sidebar lists the notes that link to the current one, each row showing the note's title and a colored badge for its link type, such as "SUPPORTS" or "RELATED TO".</div>
+    </div>

--- a/website/docs/_content/notes-math.html
+++ b/website/docs/_content/notes-math.html
@@ -1,0 +1,40 @@
+---
+title: Minerva — Docs — Math
+description: Write mathematical notation in your notes with $…$ for inline math and $$…$$ for centered display equations.
+---
+
+    <h1>Math</h1>
+    <p class="lede">Minerva turns mathematical notation into beautifully typeset equations — right inside your notes. Write an equation once and it shows up crisply, whether it sits mid-sentence or stands on its own line. It all works offline.</p>
+
+    <h2 id="syntax">Writing an equation</h2>
+    <p>Wrap your notation in dollar signs. Use a single pair for math that flows inside a sentence, and a double pair for an equation that stands on its own, centered line.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>$…$</code></div>
+        <div class="v"><b>Inline.</b> Appears right in the middle of your sentence. Example: <code>the update rule is $\theta_{t+1} = \theta_t - \eta \nabla L(\theta_t)$.</code></div>
+      </div>
+      <div class="row">
+        <div class="k"><code>$$…$$</code></div>
+        <div class="v"><b>Display.</b> Stands alone as a centered equation. Example: <code>$$\int_0^\infty e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2}$$</code></div>
+      </div>
+    </div>
+
+    <p>A display equation can fit on one line, or spread across several — the closing <code>$$</code> just needs a line of its own:</p>
+
+<pre><code>$$
+P(A \mid B) = \frac{P(B \mid A)\,P(A)}{P(B)}
+$$</code></pre>
+
+    <figure class="shot-img">
+      <img src="img/notes-math.png" alt="A sentence with an inline equation set naturally in the running text, followed by a centered display equation standing on its own below the paragraph." loading="lazy" />
+      <figcaption>A note with typeset math</figcaption>
+    </figure>
+
+    <h2 id="rendering">How it looks</h2>
+    <p>Inline math sits at normal text size, right in the flow of your sentence. A display equation is centered on its own line, and if it's wider than the page it can scroll sideways so nothing gets cut off.</p>
+
+    <div class="box">
+      <span class="label">A typo won't break your note</span>
+      <p>If an equation can't be read, Minerva simply shows what you typed in place — the rest of your note keeps rendering normally. Hover over it and you'll see a short note explaining what went wrong, so you can fix it without leaving the page.</p>
+    </div>

--- a/website/docs/_content/notes-media.html
+++ b/website/docs/_content/notes-media.html
@@ -1,0 +1,32 @@
+---
+title: Minerva — Docs — Media
+description: Embed a YouTube video in a note: paste the link, get a clickable poster card that opens the video in your browser.
+---
+
+    <h1>Media</h1>
+    <p class="lede">You can drop a YouTube video into any note. Minerva shows it as a tidy poster card — the video's thumbnail with a play button — and clicking the card opens the video in your web browser. The video plays where you already watch videos, not inside your notes.</p>
+
+    <h2 id="syntax">Adding a video</h2>
+    <p>The easiest way is to right-click in the editor and choose <b>Elements → YouTube Video</b>. That drops in an empty video cell with the cursor ready for you to paste a link.</p>
+
+    <p>A video cell holds the link on its first line. Anything you type on the lines below becomes a caption, shown under the card in place of the default "Watch on YouTube" label:</p>
+
+<pre><code>```youtube
+https://www.youtube.com/watch?v=aBcDeFgHiJk
+Feynman on how rubber bands work
+```</code></pre>
+
+    <h2 id="urls">Any YouTube link works</h2>
+    <p>Paste the link in whatever form you have it — the one from the address bar, the one the Share button copies, a Shorts link, or a link pulled from an embed snippet. Minerva sorts it out and tidies it up, dropping tracking bits along the way, so the card always points to a clean link to the video.</p>
+
+    <p>If your link starts the video at a particular moment — a "start at 1:30" link — that offset is kept. Click the card and the video opens right at that point.</p>
+
+    <h2 id="rendering">The poster card</h2>
+    <p>In the reading view, the video appears as a poster card: the thumbnail with a play button, your caption beneath it, and a small line showing that the link leads to YouTube. Click the card to open the video in your browser.</p>
+
+    <figure class="shot-img">
+      <img src="img/notes-media.png" alt="A note showing a video as a poster card: the thumbnail with a centered play button, a caption below it, and a line noting the link goes to YouTube." loading="lazy" />
+      <figcaption>Screenshot — a video poster card</figcaption>
+    </figure>
+
+    <p>When you export or publish a note, the card becomes a clickable thumbnail image so anyone reading the exported note can still see the poster and click through to watch.</p>

--- a/website/docs/_content/notes-query.html
+++ b/website/docs/_content/notes-query.html
@@ -1,0 +1,89 @@
+---
+title: Minerva — Docs — Query Cells
+description: Embed a live answer from your knowledge base or tables right inside a note — as a list, a table, or a chart that keeps itself up to date.
+---
+
+    <h1>Query cells</h1>
+    <p class="lede">A query cell puts a live answer from your knowledge base right inside a note — a list of matching notes, a table, or a chart — and keeps it current on its own. Unlike a runnable code cell that you press a button to compute, a query cell simply shows its results whenever you read the note, and refreshes by itself as your notes change. It only ever reads; it never alters your note.</p>
+
+    <h2 id="writing">Writing a query cell</h2>
+    <p>Open a cell with a line that reads <code>:::query-list</code> and close it with a line that reads <code>:::</code>. In between, write your question about the knowledge base. Where the cell sits, Minerva shows the answer as a list of links you can click.</p>
+
+<pre><code>:::query-list
+SELECT ?title ?path WHERE {
+  ?path a minerva:Note ;
+        minerva:hasTag "open-question" ;
+        minerva:title ?title .
+}
+:::</code></pre>
+
+    <h2 id="shapes">List, table, or chart</h2>
+    <p>The word after <code>:::query-</code> chooses how the answer is shown. Pick whichever fits what you're asking.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>:::query-list</code></div>
+        <div class="v"><b>A list.</b> Each result becomes a clickable link — the simplest way to gather related notes in one place.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>:::query-table</code></div>
+        <div class="v"><b>A table.</b> One row per result, with a column for each detail you asked for.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>:::query-timeseries</code></div>
+        <div class="v"><b>A chart.</b> Plots your results over time as a line, bar, or area chart.</div>
+      </div>
+    </div>
+
+    <h2 id="options">Adding options</h2>
+    <p>To adjust how the results look, put a few settings at the top of the cell, one per line, then a line with three dashes — <code>---</code> — to separate them from the question below.</p>
+
+<pre><code>:::query-table
+title: Open questions
+columns: title, path
+limit: 20
+---
+SELECT ?title ?path WHERE {
+  ?path a minerva:Note ;
+        minerva:hasTag "open-question" ;
+        minerva:title ?title .
+}
+:::</code></pre>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">title</div>
+        <div class="v">A heading shown above the results.</div>
+      </div>
+      <div class="row">
+        <div class="k">limit</div>
+        <div class="v">The most results to show.</div>
+      </div>
+      <div class="row">
+        <div class="k">columns</div>
+        <div class="v">For a table: which details to show, in the order you list them.</div>
+      </div>
+      <div class="row">
+        <div class="k">language: sql</div>
+        <div class="v">Ask about the data in your imported tables and spreadsheets instead of your knowledge base. Without it, the cell asks about your notes.</div>
+      </div>
+    </div>
+
+    <p>A chart takes a couple more settings — <code>x</code> and <code>y</code> to pick which columns become the two axes, <code>type</code> for <code>line</code>, <code>bar</code>, or <code>area</code>, and <code>height</code> for how tall it is.</p>
+
+    <figure class="shot-img">
+      <img src="img/notes-query.png" alt="A note with a query cell titled &quot;Open questions&quot;: below it, a tidy list of note links that Minerva gathered from the knowledge base, each one clickable." loading="lazy" />
+      <figcaption>A query cell in a note</figcaption>
+    </figure>
+
+    <h2 id="backlinks">A cell for backlinks</h2>
+    <p>One query cell needs no question at all. Write <code>:::query-backlinks</code> (then a closing <code>:::</code>) and it lists every note that links to the one you're in — a ready-made "mentioned in" section you can drop anywhere. Add a <code>title</code> for a heading, a <code>limit</code> to cap the count, or <code>linkType</code> to show only certain kinds of links, such as citations.</p>
+
+<pre><code>:::query-backlinks
+title: Mentioned in
+:::</code></pre>
+
+    <div class="box">
+      <span class="label">These cells only read</span>
+      <p>A query cell never changes your note or your knowledge base — it just shows what it finds. It refreshes on its own as your notes change, so an embedded list or table always reflects where things stand right now. To run a query once and keep its answer as fixed text, or to explore in a dedicated space, see <a href="notes-code.html">Code &amp; compute cells</a> and <a href="data.html">Working with data</a>.</p>
+    </div>

--- a/website/docs/_content/notes-rdf.html
+++ b/website/docs/_content/notes-rdf.html
@@ -1,0 +1,28 @@
+---
+title: Minerva — Docs — Turtle / RDF
+description: Add hand-authored facts to a note with a turtle cell, so you can state relationships in your knowledge base more precisely than Minerva could infer on its own.
+---
+
+    <h1>Turtle / RDF</h1>
+    <p class="lede">As you write, Minerva quietly builds a knowledge base from your notes — pulling in titles, tags, links, properties, and table data on its own. Sometimes, though, you want to state a fact about a note more precisely than Minerva could guess. A <b>turtle</b> cell lets you write those facts by hand, right inside the note, and they join everything else Minerva already knows.</p>
+
+    <h2 id="syntax">Writing a turtle cell</h2>
+    <p>Start a cell and label it <code>turtle</code>. Whatever you put inside is read as facts about your note rather than shown as a plain code sample. Each fact is a short statement: a subject, a relationship, and a value. Use <code>this:</code> as the subject when the statement is about the current note — the most common case.</p>
+
+    <p>Here's a realistic example: marking a note as a glossary term and connecting it to a broader idea.</p>
+
+<pre><code>```turtle
+this: a thought:Term ;
+    thought:hasStatus thought:established ;
+    minerva:relatesTo &lt;https://minerva.dev/ontology#Provenance&gt; .
+```</code></pre>
+
+    <p>When you save, these three statements about the note join the titles, tags, and links Minerva gathered from the rest of it. Edit the cell and save again, and your facts update to match — just like any other change to the note.</p>
+
+    <figure class="shot-img">
+      <img src="img/notes-rdf.png" alt="A note being written, with ordinary paragraphs above and below a turtle cell that holds a few hand-written facts about the note, set apart from the surrounding text." loading="lazy" />
+      <figcaption>A turtle cell in a note</figcaption>
+    </figure>
+
+    <h2 id="prefixes">Shorthands you can use</h2>
+    <p>You don't have to set anything up first. A handful of common shorthands — including <code>thought:</code>, <code>dc:</code>, and <code>rdf:</code> — are always ready, along with <code>this:</code> for the note itself. Just write <code>thought:Term</code> or <code>dc:title</code> and it works. If you'd rather define your own shorthand to point somewhere else, declare it in the cell and yours takes precedence.</p>

--- a/website/docs/_content/notes-search.html
+++ b/website/docs/_content/notes-search.html
@@ -1,0 +1,53 @@
+---
+title: Minerva — Docs — Search Cells
+description: Drop a live list of related notes into a note — found by meaning or by keyword — that keeps itself up to date as you write.
+---
+
+    <h1>Search cells</h1>
+    <p class="lede">A search cell drops a live list of related notes right into your writing — a ready-made "See also", or a running roundup of everything you've touched on a topic. You can find notes two ways: by <b>meaning</b>, which catches notes that are about the same thing even when they use different words, or by <b>keyword</b>, which finds the exact words you name. Like query cells, a search cell only reads, and refreshes on its own as your notes grow.</p>
+
+    <h2 id="by-meaning">Search by meaning</h2>
+    <p>Open a cell with <code>:::query-semantic</code>, write a sentence or a few words describing what you're after, and close it with <code>:::</code>. Minerva lists the notes closest in meaning, each with a short snippet and a link. Leave the cell empty and it instead lists notes related to the one you're currently in.</p>
+
+<pre><code>:::query-semantic
+how attention shapes what we remember
+:::</code></pre>
+
+    <h2 id="by-keyword">Search by keyword</h2>
+    <p>Open a cell with <code>:::query-search</code> and put your words inside. Minerva lists the notes that contain them, best matches first — the same kind of search as the app's find box, embedded in your note and always current.</p>
+
+<pre><code>:::query-search
+working memory
+:::</code></pre>
+
+    <h2 id="options">Adding options</h2>
+    <p>As with query cells, put a few settings at the top, one per line, then a line of three dashes — <code>---</code> — before the text you're searching for.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">title</div>
+        <div class="v">A heading shown above the results.</div>
+      </div>
+      <div class="row">
+        <div class="k">limit</div>
+        <div class="v">The most results to show.</div>
+      </div>
+      <div class="row">
+        <div class="k">snippet: false</div>
+        <div class="v">Hide the little preview under each result. Or use <code>compact: true</code> for a bare list of links.</div>
+      </div>
+      <div class="row">
+        <div class="k">kind</div>
+        <div class="v">For search by meaning: what to look through — <code>note</code>, <code>source</code>, <code>excerpt</code> (your saved quotations), or <code>all</code>. Notes alone is the default.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/notes-search.png" alt="A note with a search cell titled &quot;See also&quot;: below it, a short list of related notes, each showing its title as a link above a muted one-line snippet of the matching text." loading="lazy" />
+      <figcaption>A search cell in a note</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">Meaning vs. keyword</span>
+      <p>Reach for <b>meaning</b> when you want notes on the same idea however they're worded, and <b>keyword</b> when you know the exact term you're hunting for. Search by meaning draws on the same understanding of your notes that powers <a href="right-sidebar-related.html">Related notes</a> in the sidebar; if that isn't ready yet, a meaning cell simply comes up empty.</p>
+    </div>

--- a/website/docs/_content/notes-tables.html
+++ b/website/docs/_content/notes-tables.html
@@ -1,0 +1,54 @@
+---
+title: Minerva — Docs — Tables
+description: Write tables in your notes with simple markdown, control column alignment, and have every table also become data you can search and query.
+---
+
+    <h1>Tables</h1>
+    <p class="lede">You can add a table to any note with a few keystrokes: a row of column headings, a line beneath it, and as many rows of data as you like. Tables render cleanly in your notes — and, quietly, every table also becomes data you can search and pull together across your knowledge base.</p>
+
+    <h2 id="syntax">Writing a table</h2>
+    <p>A table is a header row, a divider line just below it, and one or more rows of data. Separate the cells in each row with a vertical bar. The divider line is what turns those rows into a table rather than ordinary text.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>| A | B |</code></div>
+        <div class="v"><b>Header row.</b> The column names, separated by vertical bars.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>|---|---|</code></div>
+        <div class="v"><b>Divider line.</b> Goes right under the header and marks where the column names end and the data begins.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>:---</code></div>
+        <div class="v"><b>Left-align</b> a column (this is also the default).</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>---:</code></div>
+        <div class="v"><b>Right-align</b> a column — handy for numbers.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>:---:</code></div>
+        <div class="v"><b>Center-align</b> a column.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>| a \| b |</code></div>
+        <div class="v"><b>A literal bar.</b> Put a backslash before a vertical bar to show it inside a cell instead of starting a new column.</div>
+      </div>
+    </div>
+
+    <p>A short example:</p>
+<pre><code>| Trial | Condition | Effect size |
+|:------|:---------:|------------:|
+| 1     | control   |        0.12 |
+| 2     | treatment |        0.61 |
+| 3     | treatment |        0.58 |</code></pre>
+
+    <figure class="shot-img">
+      <img src="img/notes-tables.png" alt="The table above as it appears in a note: a bold header row over neatly bordered rows, with the first column left-aligned, the middle column centered, and the numbers on the right lined up along their right edge." loading="lazy" />
+      <figcaption>A finished table in a note</figcaption>
+    </figure>
+
+    <p>Each cell is a single box — one row tall and one column wide. Cells can't be merged or made to span across neighbours.</p>
+
+    <h2 id="data">Tables are also data</h2>
+    <p>Beyond looking tidy, every table you write becomes part of your knowledge base as structured data, with its columns and values ready to be searched and combined. That means you can ask questions across the tables scattered through your notes — pulling figures together, comparing rows, or gathering everything under a given column — from the Query view. You don't have to mark a table as special or turn anything on; any well-formed table is picked up automatically as soon as you have a header, a divider line, and at least one row of data.</p>

--- a/website/docs/_content/notes-tasks.html
+++ b/website/docs/_content/notes-tasks.html
@@ -1,0 +1,42 @@
+---
+title: Minerva — Docs — Task Lists
+description: Task lists in Minerva notes: write checkboxes into a note and click to check them off.
+---
+
+    <h1>Task lists</h1>
+    <p class="lede">Turn any list item into a to-do by starting it with a checkbox. In your note it shows up as a real checkbox you can tick off with a click — a simple way to keep a running list of things to do right inside your writing.</p>
+
+    <h2 id="syntax">Writing a task</h2>
+    <p>A task is just a list item whose text begins with a checkbox marker and a space:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><code>- [ ] text</code></div>
+        <div class="v"><b>Not done.</b> Shows an empty checkbox. Your list can be bulleted or numbered — either works.</div>
+      </div>
+      <div class="row">
+        <div class="k"><code>- [x] text</code></div>
+        <div class="v"><b>Done.</b> Shows a ticked checkbox.</div>
+      </div>
+      <div class="row">
+        <div class="k">indented item</div>
+        <div class="v"><b>Sub-task.</b> Indent a task under another to make it a sub-item. Sub-tasks are independent — checking a parent doesn't check its children.</div>
+      </div>
+    </div>
+
+    <p>Remember the space after the closing bracket. An empty task with no text after it is fine too.</p>
+
+<pre><code>- [ ] Draft the outline
+- [x] Circulate for feedback
+- [ ] Incorporate comments
+  - [x] Section 2 rewrite
+  - [ ] Section 4 rewrite
+- [ ] Final pass</code></pre>
+
+    <figure class="shot-img">
+      <img src="img/notes-tasks.png" alt="A note showing a checklist with a mix of ticked and empty boxes, including a top-level item with two indented sub-items beneath it." loading="lazy" />
+      <figcaption>A task list in a note</figcaption>
+    </figure>
+
+    <h2 id="toggling">Ticking things off</h2>
+    <p>Every checkbox in your note is clickable. Click one to check it or uncheck it — the rest of the item stays exactly as you wrote it, and nothing else in the note changes. Your click is saved just like any other edit you make.</p>

--- a/website/docs/_content/notes-typed-notes.html
+++ b/website/docs/_content/notes-typed-notes.html
@@ -1,0 +1,92 @@
+---
+title: Minerva — Docs — Notes: Typed notes
+description: Give a note a type and Minerva knows what fields to expect, what icon to show it with, and how to gather it with its own kind.
+---
+
+    <h1>Typed notes</h1>
+    <p class="lede">Most notes are just notes. But some are clearly a <em>kind</em> of thing — a book you're reading, a person you keep meeting, a project with a deadline. Give a note a type and Minerva knows what to expect from it: the fields it should have, the icon it wears in every list, and how it looks when you gather all of its kind together. It's still an ordinary markdown note underneath, and you can take the type off again at any time.</p>
+
+    <h2 id="making">Making a note typed</h2>
+    <p>A note is typed when its <a href="notes-frontmatter.html">properties</a> include a <code>type:</code> line naming one of your object types — <code>type: book</code>. You rarely write that by hand. There are three ways to get there:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">When you create it</div>
+        <div class="v">The New Note dialog offers your types alongside the blank note. Pick one and the note starts out with its <code>type:</code> already set, plus any starter text the type provides.</div>
+      </div>
+      <div class="row">
+        <div class="k">While you're writing</div>
+        <div class="v">Type <code>/</code> at the start of a line in an empty note and your types appear in the autocomplete — <code>/Book</code>, <code>/Person</code>. Choosing one sets the type without leaving the keyboard.</div>
+      </div>
+      <div class="row">
+        <div class="k">To a note you already have</div>
+        <div class="v">Use <strong>Treat this as…</strong> to give an existing note a type. Its text and existing properties are left exactly as they are — only <code>type:</code> is added — and the Properties panel opens so you can fill in the gaps.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Nothing is invented for you</span>
+      <p>Typing an existing note never writes values you didn't provide. If the note already has an <code>author</code> property and the type declares one, they simply line up. Everything else starts empty and stays that way until you fill it in.</p>
+    </div>
+
+    <h2 id="what-you-get">What the type gives the note</h2>
+    <p>The type is a small description of what notes of its kind look like. Each part of it shows up somewhere:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Fields</div>
+        <div class="v">The properties this kind of note is expected to have — a Book's author and rating, a Meeting's date and attendees. They appear as a form at the top of the <a href="right-sidebar-properties.html">Properties panel</a>, including the ones you haven't filled in yet.</div>
+      </div>
+      <div class="row">
+        <div class="k">Icon and colour</div>
+        <div class="v">A single character — 📖, 👤 — that marks every note of this type wherever notes are listed, tinted with the type's colour.</div>
+      </div>
+      <div class="row">
+        <div class="k">Card fields</div>
+        <div class="v">The handful of fields worth showing when the note appears as a card rather than a row, such as in a link preview.</div>
+      </div>
+      <div class="row">
+        <div class="k">Cover</div>
+        <div class="v">Which field holds a picture, so a gallery of these notes can show it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Parent type</div>
+        <div class="v">A more general type this one is a kind of. A Novel with Book as its parent inherits Book's fields, and shows up whenever you ask for Books.</div>
+      </div>
+    </div>
+
+    <p>All of that is defined once, per type, in <a href="settings-object-types.html">Settings → Object Types</a> — not per note.</p>
+
+    <h2 id="filling-in">Filling in the fields</h2>
+    <p>Open the <a href="right-sidebar-properties.html">Properties panel</a> on a typed note and its fields are laid out as a form above its other properties. Each field gets the control that suits it: a list of choices for a field with fixed options, a date picker for a date, a number box for a number. Fields the note hasn't filled in yet are still shown, so the form answers "what does a Book need?" rather than only "what has this note got?"</p>
+
+    <p>Nothing is required. Leaving a field empty is perfectly fine — it just means you don't know that yet, or it doesn't apply.</p>
+
+    <h2 id="where">Where typed notes show up</h2>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">In every list of notes</div>
+        <div class="v">The type's icon replaces the usual page icon in the <a href="left-sidebar-notes-tree.html">Notes tree</a>, on tabs, in <a href="navigation-quick-switch.html">Quick switch</a>, in backlinks, and in bookmarks — so a folder of mixed notes is readable at a glance.</div>
+      </div>
+      <div class="row">
+        <div class="k">In the Objects panel</div>
+        <div class="v">The <a href="left-sidebar-objects.html">Objects panel</a> groups your notes by type, so you can see every Book you have without having put them in a folder together.</div>
+      </div>
+      <div class="row">
+        <div class="k">As a collection</div>
+        <div class="v">Opening a type gives you every note of that kind as a list, a table of their fields, or a gallery of cover images.</div>
+      </div>
+      <div class="row">
+        <div class="k">In queries</div>
+        <div class="v">Types become part of your project's <a href="notes-rdf.html">graph</a>, so you can ask for them directly — every Book published before 1970, say.</div>
+      </div>
+    </div>
+
+    <h2 id="still-a-note">It's still an ordinary note</h2>
+    <p>Typing a note doesn't move it, lock it, or change how you write in it. The file stays plain markdown in the same folder, with one extra line in its properties. Delete that <code>type:</code> line and it's an untyped note again — the fields you filled in stay behind as ordinary properties, because that's all they ever were.</p>
+
+    <div class="box">
+      <span class="label">Renaming a type keeps your notes</span>
+      <p>If you rename a type in Settings, the notes using it are updated to match. Their values aren't touched — only the name of the kind of thing they are.</p>
+    </div>

--- a/website/docs/_content/notes.html
+++ b/website/docs/_content/notes.html
@@ -1,0 +1,130 @@
+---
+title: Minerva — Docs — Notes
+description: What a note is in Minerva, how to create, rename, move, and delete notes, and a map of everything you can put inside one.
+---
+
+    <h1>Notes</h1>
+    <p class="lede">A note is where you write. Notes are plain text, so anything you type stays readable and portable, and you can organize them into folders however you like. Beyond ordinary prose, a note can hold links to other notes, formatting, images, tables, math, charts, and more — plus an optional block of <a href="notes-frontmatter.html">properties</a> at the top that records structured details like tags or a status.</p>
+
+    <h2 id="lifecycle">Creating and managing notes</h2>
+    <p>You can work with notes from the left sidebar, the command palette, or the File menu:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Create</div>
+        <div class="v"><b>File → New Note</b> (<kbd>⌘</kbd><kbd>N</kbd>), or "New Note" from the command palette. You'll be asked for a name and can optionally start from a template. Pick a name that isn't already in use.</div>
+      </div>
+      <div class="row">
+        <div class="k">Rename</div>
+        <div class="v">Right-click the note in the sidebar and choose Rename. Minerva also updates every <a href="notes-links.html">link</a> elsewhere that pointed at the old name, so nothing breaks.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move</div>
+        <div class="v">Drag the note to a different folder in the sidebar.</div>
+      </div>
+      <div class="row">
+        <div class="k">Delete</div>
+        <div class="v">Right-click the note in the sidebar and choose Delete. You'll get a simple confirmation, with a "don't ask again" option. Deleting a note is a normal, everyday action.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/notes.png" alt="The left sidebar with a right-click menu open on a note showing Rename, Move, and Delete, next to the New Note dialog asking for a name and template." loading="lazy" />
+      <figcaption>Managing notes from the sidebar</figcaption>
+    </figure>
+
+    <h2 id="contents">What you can put in a note</h2>
+    <p>Beyond prose, a note can hold any of the following. Each has its own page showing how to add it and how it looks:</p>
+
+    <div class="doc-cards">
+      <a class="doc-card" href="notes-links.html">
+        <span class="em">🔗</span>
+        <h3>Links</h3>
+        <p>Connect notes to each other and see what links back.</p>
+      </a>
+      <a class="doc-card" href="notes-frontmatter.html">
+        <span class="em">🏷️</span>
+        <h3>Properties</h3>
+        <p>Structured details like tags and status at the top of a note.</p>
+      </a>
+      <a class="doc-card" href="notes-typed-notes.html">
+        <span class="em">📖</span>
+        <h3>Typed notes</h3>
+        <p>Notes that are a <em>kind</em> of thing, with fields to match.</p>
+      </a>
+      <a class="doc-card" href="notes-highlights.html">
+        <span class="em">🖍️</span>
+        <h3>Highlights</h3>
+        <p>Mark a passage as important.</p>
+      </a>
+      <a class="doc-card" href="notes-tasks.html">
+        <span class="em">☑️</span>
+        <h3>Task lists</h3>
+        <p>Checkboxes you can tick off as you go.</p>
+      </a>
+      <a class="doc-card" href="notes-callouts.html">
+        <span class="em">💡</span>
+        <h3>Callouts</h3>
+        <p>Titled note, tip, and warning boxes that stand out.</p>
+      </a>
+      <a class="doc-card" href="notes-images.html">
+        <span class="em">🖼️</span>
+        <h3>Images</h3>
+        <p>Drag, paste, or link images into a note.</p>
+      </a>
+      <a class="doc-card" href="notes-tables.html">
+        <span class="em">📋</span>
+        <h3>Tables &amp; CSV</h3>
+        <p>Tables that also work as structured data.</p>
+      </a>
+      <a class="doc-card" href="notes-footnotes.html">
+        <span class="em">🦶</span>
+        <h3>Footnotes</h3>
+        <p>Asides and citations gathered at the bottom.</p>
+      </a>
+      <a class="doc-card" href="notes-flashcards.html">
+        <span class="em">🃏</span>
+        <h3>Flashcards</h3>
+        <p>Two-sided study cards you write inside a note.</p>
+      </a>
+      <a class="doc-card" href="notes-media.html">
+        <span class="em">🎬</span>
+        <h3>Media</h3>
+        <p>Videos as click-to-open cards.</p>
+      </a>
+      <a class="doc-card" href="notes-math.html">
+        <span class="em">∫</span>
+        <h3>Math</h3>
+        <p>Inline and full-width equations.</p>
+      </a>
+      <a class="doc-card" href="notes-diagrams.html">
+        <span class="em">🔀</span>
+        <h3>Diagrams</h3>
+        <p>Flowcharts, sequence diagrams, and more.</p>
+      </a>
+      <a class="doc-card" href="notes-charts.html">
+        <span class="em">📊</span>
+        <h3>Charts</h3>
+        <p>Interactive charts, live in the note.</p>
+      </a>
+      <a class="doc-card" href="notes-code.html">
+        <span class="em">🧮</span>
+        <h3>Code &amp; compute cells</h3>
+        <p>Highlighted code, plus cells you can run.</p>
+      </a>
+      <a class="doc-card" href="notes-query.html">
+        <span class="em">📊</span>
+        <h3>Query cells</h3>
+        <p>Embed a live answer from your knowledge base or tables.</p>
+      </a>
+      <a class="doc-card" href="notes-search.html">
+        <span class="em">🔎</span>
+        <h3>Search cells</h3>
+        <p>A live list of related notes, by meaning or keyword.</p>
+      </a>
+      <a class="doc-card" href="notes-rdf.html">
+        <span class="em">🐢</span>
+        <h3>Turtle / RDF</h3>
+        <p>Add structured facts directly inside a note.</p>
+      </a>
+    </div>

--- a/website/docs/_content/query-menu-panel.html
+++ b/website/docs/_content/query-menu-panel.html
@@ -1,0 +1,78 @@
+---
+title: Minerva — Docs — Query menu &amp; panel
+description: The Query menu and the Query panel: start a new query, pick a ready-made one, save your own, and drop results into a note.
+---
+
+    <h1>Query menu &amp; panel</h1>
+    <p class="lede">A dedicated tab for asking questions of your knowledge base — the links between your notes, or the data in your tables — and getting back a results table you can sort, save, or drop into a note.</p>
+
+    <h2 id="menu">The Query menu</h2>
+    <p>Everything starts from the Query menu:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>Q</kbd></div>
+        <div class="v"><b>New Query</b> — opens a fresh, empty Query panel ready to write in.</div>
+      </div>
+      <div class="row">
+        <div class="k">Stock Queries</div>
+        <div class="v">A library of ready-made queries for common questions. Pick one to open it pre-filled, then run it as-is or tweak it (see below).</div>
+      </div>
+      <div class="row">
+        <div class="k">Saved Queries</div>
+        <div class="v">Queries you've saved yourself. You can keep one <b>with this project</b> or make it <b>available everywhere</b>, and re-open or edit any of them here.</div>
+      </div>
+    </div>
+
+    <h2 id="panel">The panel</h2>
+    <p>The panel has a place to write your query on top and the results below. You can ask two kinds of questions — one that follows the links and connections between your notes, and one that queries the data in your tables — and a dropdown switches between the two. The toolbar has Run, Save, and Format buttons, and shows how long the last run took and how many results it found.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Results table</div>
+        <div class="v">Click a column heading to sort by it; click again to reverse the order.</div>
+      </div>
+      <div class="row">
+        <div class="k">Copy as…</div>
+        <div class="v">Turns the current results into something you can paste into a note — a <b>List</b> or <b>Table</b> that stays live and refreshes each time you view the note (see <a href="query-result-blocks.html">Result blocks</a>), or an <b>editable cell</b> holding your exact query so you can keep refining it inside the note (see <a href="query-runnable-cells.html">Runnable cells</a>).</div>
+      </div>
+      <div class="row">
+        <div class="k">Export CSV</div>
+        <div class="v">Saves the current results as a spreadsheet file — a one-time snapshot, not a live block.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/query-menu-panel.png" alt="The Query panel: a query written in the top pane, a sortable results table below, and the toolbar with the Run, Save, Format, and &quot;Copy as…&quot; controls." loading="lazy" />
+      <figcaption>Screenshot — Query panel</figcaption>
+    </figure>
+
+    <h2 id="stock-links">Ready-made questions about your notes</h2>
+    <p>A set of ready-made queries for common questions about how your notes connect, ready to run or adapt:</p>
+    <div class="deflist">
+      <div class="row"><div class="k">All notes with tags</div><div class="v">Every note alongside the tags filed on it.</div></div>
+      <div class="row"><div class="k">Backlinks to note</div><div class="v">Name a note, then run it to see everything that links in.</div></div>
+      <div class="row"><div class="k">Orphan notes</div><div class="v">Notes with no links in or out.</div></div>
+      <div class="row"><div class="k">Most-linked notes</div><div class="v">Ranked by how many notes link to them.</div></div>
+      <div class="row"><div class="k">Recently modified</div><div class="v">Notes ordered by when you last changed them.</div></div>
+      <div class="row"><div class="k">All tags with counts</div><div class="v">Every tag in use, and how many notes carry it.</div></div>
+      <div class="row"><div class="k">Notes in folder</div><div class="v">Name a folder to list the notes inside it.</div></div>
+      <div class="row"><div class="k">Typed outgoing links</div><div class="v">A note's labelled links (such as <i>supports</i> or <i>rebuts</i>) grouped by kind.</div></div>
+      <div class="row"><div class="k">Typed backlinks</div><div class="v">The same, for labelled links pointing in.</div></div>
+      <div class="row"><div class="k">All sources with authors and year</div><div class="v">Every source you've added, with its basic citation details.</div></div>
+      <div class="row"><div class="k">Most-cited sources</div><div class="v">Sources ranked by how many notes cite them.</div></div>
+      <div class="row"><div class="k">Sources missing details</div><div class="v">Sources without an author, year, or title — good candidates to tidy up.</div></div>
+    </div>
+
+    <h2 id="stock-tables">Ready-made questions about your tables</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">All tables</div><div class="v">Lists every table you can query.</div></div>
+      <div class="row"><div class="k">Describe a table</div><div class="v">The column names and types for a table you name.</div></div>
+      <div class="row"><div class="k">Summarize a table</div><div class="v">Quick per-column stats such as smallest and largest values and how many entries are blank.</div></div>
+      <div class="row"><div class="k">Blanks per column</div><div class="v">How complete each column actually is.</div></div>
+      <div class="row"><div class="k">Top values for a column</div><div class="v">A quick count of the most common values in a column you name.</div></div>
+    </div>
+
+    <div class="box">
+      <span class="label">Where a saved query lives</span>
+      <p>When you save a query, you choose whether it belongs to <b>this project</b> — handy for something tailored to how this knowledge base is set up — or is <b>available everywhere</b>, so a general-purpose query like "orphan notes" follows you into every project. You can switch this later from the Saved Queries menu.</p>
+    </div>

--- a/website/docs/_content/query-result-blocks.html
+++ b/website/docs/_content/query-result-blocks.html
@@ -1,0 +1,32 @@
+---
+title: Minerva — Docs — Result blocks
+description: Drop a query's results into a note as a live list, table, or chart that refreshes on its own.
+---
+
+    <h1>Result blocks</h1>
+    <p class="lede">A result block puts a query's answer right inside a note and keeps it up to date — as a list, a table, or a chart that refreshes on its own whenever you open the note. You don't have to paste in fresh numbers by hand. The easiest way to create one is the Query panel's "Copy as…" menu (see <a href="query-menu-panel.html">Query menu &amp; panel</a>), which builds the block for you, but you can also write one yourself.</p>
+
+    <h2 id="list-table">Lists &amp; tables</h2>
+    <p>A result block can show your query's answer as a simple list or as a full table. A few settings let you shape what appears:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Columns</div>
+        <div class="v">Choose which columns to show and in what order. Leave it out to show everything the query returns.</div>
+      </div>
+      <div class="row">
+        <div class="k">Link</div>
+        <div class="v">Pick a column whose entries become clickable links that jump straight to the matching note.</div>
+      </div>
+    </div>
+    <p>Tables sort just like results in the Query panel — click a column heading to switch between ascending and descending order.</p>
+
+    <h2 id="timeseries">Charts</h2>
+    <p>When your results are numbers over time, a result block can draw them as a chart instead of a table. You choose which column runs along the bottom, which values to plot, and the look — a line, bars, or a filled area — along with an optional title and height.</p>
+
+    <figure class="shot-img">
+      <img src="img/query-result-blocks.png" alt="An area chart with two lines — for example revenue and cost — appears in the note directly below the query that produced it, and redraws itself whenever the note is opened." loading="lazy" />
+      <figcaption>A chart drawn from a query, right inside a note</figcaption>
+    </figure>
+
+    <h2 id="schema">Know a table's columns before you query</h2>
+    <p>When you're about to query a table you brought in, it helps to see its real column names first. Two ready-made queries do exactly that: <b>Describe schema</b> lists the columns, and <b>Summarize</b> adds a quick statistical snapshot of each one. As you type a query, Minerva also suggests the actual column names for you.</p>

--- a/website/docs/_content/query-runnable-cells.html
+++ b/website/docs/_content/query-runnable-cells.html
@@ -1,0 +1,21 @@
+---
+title: Minerva — Docs — Runnable Cells
+description: Write a query inside a note and run it in place, with the results appearing right below.
+---
+
+    <h1>Runnable cells</h1>
+    <p class="lede">A query written inside a note isn't just an example to read — it's live. Run it right where it sits, and the answer appears just below. It's a natural way to keep a question and its answer together in your notes.</p>
+
+    <h2 id="running">Running a query</h2>
+    <p>Start a query cell and mark it as a SPARQL or SQL query. A run button appears beside it — click it, or place your cursor in the cell and press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Enter</kbd>. The results appear in their own block directly underneath. Minerva keeps that results block up to date for you, so there's no need to write one yourself.</p>
+
+    <figure class="shot-img">
+      <img src="img/query-runnable-cells.png" alt="A query cell with its run button, and the results appearing just below it as a small table." loading="lazy" />
+      <figcaption>A query cell in the middle of a note</figcaption>
+    </figure>
+
+    <h2 id="prefixes">Shorthand that's always ready</h2>
+    <p>When you write a SPARQL query, you can jump straight to asking your question — the common shorthands for referring to your notes, tags, links, claims, titles, dates, and other everyday concepts are already available. You don't have to declare them each time.</p>
+
+    <h2 id="sql-tables">Querying your tables</h2>
+    <p>Any table you add to your notes can be queried with SQL as soon as you save it — the column headings become the fields you can ask about. See <a href="notes-tables.html">Tables &amp; CSV</a> for how tables work, and the <a href="query-menu-panel.html">Query menu &amp; panel</a> for ready-made queries that show you a table's columns before you write against it.</p>

--- a/website/docs/_content/refactoring-ai-assisted.html
+++ b/website/docs/_content/refactoring-ai-assisted.html
@@ -1,0 +1,27 @@
+---
+title: Minerva — Docs — AI-Assisted Refactors
+description: Asking the assistant to rename, move, reorganize, or delete notes for you: the review cards for single renames/moves, batch reorganization, and batch deletion.
+---
+
+    <h1>AI-assisted refactors</h1>
+    <p class="lede">You can ask the assistant to rename, move, reorganize, or delete notes for you. As everywhere else in Minerva, it only proposes a plan — you review it, and nothing changes until you approve.</p>
+
+    <h2 id="single">Single rename or move</h2>
+    <p>Ask to rename or move one note, and you get a review card that shows exactly what will change: a before-and-after view of every note whose links point to it, plus an <b>Approve</b> button. Nothing is touched until you click it.</p>
+
+    <h2 id="batch">Reorganizing several notes at once</h2>
+    <p>Ask for a set of moves and renames together, and the review card lists each one with its own checkbox, so you can approve just the parts you like rather than the whole plan. Open any item to see how that note's links will be rewritten. If two notes would trade places in a way that can't be untangled, the card tells you so and suggests splitting them up.</p>
+
+    <div class="shot wide">
+      <div class="icon">📋</div>
+      <div class="k">Reviewing a reorganization plan</div>
+      <div class="d">The review card lists each proposed rename and move with a checkbox. One item is opened to show how the links pointing at that note will be updated.</div>
+    </div>
+
+    <h2 id="delete">Deleting in bulk</h2>
+    <p>Deletion works the same way, with a checkbox for each note. For every note you're about to remove, the card tells you how many other notes still link to it, so you can see the impact before approving. See <a href="refactoring-safe-delete.html">Safe delete &amp; dangling links</a> for more.</p>
+
+    <div class="box">
+      <span class="label">Whole folders, too</span>
+      <p>The assistant can also propose moving, renaming, or deleting an <em>entire folder</em> at once — the review card shows every note that moves (or every note inside, for a delete), any links that would be rewritten or left dangling, and the count of images and other assets that come along. As always, nothing changes until you approve. Prefer to do it yourself? You still can — just drag it, see <a href="refactoring-manual.html">Manual rename, move &amp; delete</a>.</p>
+    </div>

--- a/website/docs/_content/refactoring-manual.html
+++ b/website/docs/_content/refactoring-manual.html
@@ -1,0 +1,52 @@
+---
+title: Minerva — Docs — Manual Rename, Move &amp; Delete
+description: Rename, move, and delete notes right in the Notes tree, and how Minerva keeps your links pointing to the right place.
+---
+
+    <h1>Manual rename, move &amp; delete</h1>
+    <p class="lede">Reorganize your notes right in the Notes list — and let Minerva keep your links pointing to the right place as you go.</p>
+
+    <h2 id="actions">Rename, move, delete</h2>
+    <p>Everything you need is in the right-click menu on a note, or a simple drag.</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Rename</div>
+        <div class="v">Right-click a note and choose Rename. You can also start it from the command palette by searching <b>Rename Note</b>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move</div>
+        <div class="v">Drag a note onto the folder you want it in. Prefer to type a destination? Use <b>Move Note</b> from the command palette.</div>
+      </div>
+      <div class="row">
+        <div class="k">Delete</div>
+        <div class="v">Right-click and choose Delete. See <a href="refactoring-safe-delete.html">Safe delete &amp; dangling links</a> for how Minerva warns you if other notes still point to it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Cut / Copy / Paste</div>
+        <div class="v">The right-click menu also offers cut, copy, and paste — another way to move or duplicate notes between folders.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/refactoring-manual.png" alt="Right-clicking a note in the Notes list opens its menu, with Rename, Delete, cut, copy, paste, and the rest of the per-note actions." loading="lazy" />
+      <figcaption>The right-click menu on a note</figcaption>
+    </figure>
+
+    <h2 id="auto-update">Your links stay correct</h2>
+    <p>When you rename or move a note, Minerva finds every other note that links to it and updates those links for you, so nothing breaks:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Wiki links</div>
+        <div class="v">A link like <code>[[old title]]</code> becomes <code>[[new title]]</code> everywhere it appears. Any custom display text or heading you added to the link is kept intact.</div>
+      </div>
+      <div class="row">
+        <div class="k">Links and images to files</div>
+        <div class="v">Links to other notes and to images are adjusted so they still point to the right file, both from the note you moved and from the notes that link to it.</div>
+      </div>
+    </div>
+    <p>Citations that point to a source or a saved quote keep working on their own — they refer to the source itself, not to where a note happens to live, so moving a note never disturbs them.</p>
+
+    <div class="box">
+      <span class="label">Renaming folders</span>
+      <p>You can rename or move a whole folder by dragging it, just as you would a single note.</p>
+    </div>

--- a/website/docs/_content/refactoring-operations.html
+++ b/website/docs/_content/refactoring-operations.html
@@ -1,0 +1,91 @@
+---
+title: Minerva — Docs — Refactoring operations
+description: The Refactor menu commands in Minerva: rename, move, and copy a note; split and extract; AI-assisted auto-tag, auto-link, and decompose; format and insert a bibliography.
+---
+
+    <h1>Refactoring operations</h1>
+    <p class="lede">The <b>Refactor</b> menu gathers every structural change you can make to the current note in one place — renaming and moving, splitting a note apart, AI-assisted reorganization, and formatting. Through all of them, Minerva keeps the links between your notes coherent, so a change never leaves a broken reference behind. Each command works on the note you're editing.</p>
+
+    <h2 id="rename-move">Renaming and moving</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Rename…</div>
+        <div class="v"><b>Refactor → Rename…</b> gives the note a new name and updates every <a href="notes-links.html">link</a> that pointed at the old one, so nothing breaks. See <a href="refactoring-manual.html">Manual rename, move &amp; delete</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move…</div>
+        <div class="v"><b>Refactor → Move…</b> moves the note to a different folder; its links follow it. (You can also drag it in the sidebar.)</div>
+      </div>
+      <div class="row">
+        <div class="k">Copy…</div>
+        <div class="v"><b>Refactor → Copy…</b> makes a duplicate of the note at a location you choose.</div>
+      </div>
+    </div>
+
+    <h2 id="splitting">Splitting a note</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Extract Selection to New Note</div>
+        <div class="v"><b>Refactor → Extract Selection to New Note</b> pulls the selected text out into a brand-new note and leaves a link to it in its place. Select some text first.</div>
+      </div>
+      <div class="row">
+        <div class="k">Split Note Here</div>
+        <div class="v"><b>Refactor → Split Note Here</b> divides the note in two at the cursor, keeping the text above and moving the text below into a new, linked note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Split by Heading…</div>
+        <div class="v"><b>Refactor → Split by Heading…</b> breaks one long note into several — one per heading — linked together.</div>
+      </div>
+    </div>
+
+    <h2 id="ai-assisted">AI-assisted</h2>
+    <p>These ask the assistant to do the work and hand you the result as a <a href="conversations.html">proposal</a> to review — nothing changes until you approve it. See <a href="refactoring-ai-assisted.html">AI-assisted refactors</a>.</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Auto-tag</div>
+        <div class="v"><b>Refactor → Auto-tag</b> suggests <a href="notes-frontmatter.html">tags</a> for the note based on what it's about.</div>
+      </div>
+      <div class="row">
+        <div class="k">Auto-link outbound…</div>
+        <div class="v"><b>Refactor → Auto-link outbound…</b> proposes links <em>from</em> this note to other relevant notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Auto-link inbound…</div>
+        <div class="v"><b>Refactor → Auto-link inbound…</b> proposes links <em>to</em> this note from other relevant notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Decompose Note…</div>
+        <div class="v"><b>Refactor → Decompose Note…</b> proposes breaking a long note into smaller, linked notes.</div>
+      </div>
+    </div>
+
+    <h2 id="format-biblio">Formatting and bibliography</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Format</div>
+        <div class="v"><b>Refactor → Format</b> tidies the note's Markdown into a consistent style (or every note selected in the sidebar). See <a href="settings-formatter.html">Formatter settings</a> for what it does.</div>
+      </div>
+      <div class="row">
+        <div class="k">Insert/Update Bibliography</div>
+        <div class="v"><b>Refactor → Insert/Update Bibliography</b> renders a References section listing every <a href="ingest.html">source</a> the note cites, in your configured citation style. See <a href="export-bibliography.html">Bibliography &amp; citations</a>.</div>
+      </div>
+    </div>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="refactoring-manual.html">
+        <span class="em">✏️</span>
+        <h3>Manual rename, move &amp; delete</h3>
+        <p>Right-click and drag in the sidebar, and what updates for you.</p>
+      </a>
+      <a class="doc-card" href="refactoring-ai-assisted.html">
+        <span class="em">🤖</span>
+        <h3>AI-assisted refactors</h3>
+        <p>Ask the assistant — review the plan before anything changes.</p>
+      </a>
+      <a class="doc-card" href="refactoring-safe-delete.html">
+        <span class="em">🔗</span>
+        <h3>Safe delete &amp; dangling links</h3>
+        <p>What Minerva checks before you delete a note others link to.</p>
+      </a>
+    </div>

--- a/website/docs/_content/refactoring-safe-delete.html
+++ b/website/docs/_content/refactoring-safe-delete.html
@@ -1,0 +1,27 @@
+---
+title: Minerva — Docs — Safe Delete &amp; Dangling Links
+description: Before you delete a note, Minerva warns you if other notes still link to it — so you can fix those links first.
+---
+
+    <h1>Safe delete &amp; dangling links</h1>
+    <p class="lede">When your notes link to each other, deleting one can leave others pointing at something that no longer exists. Before a delete goes through, Minerva checks for exactly this and warns you first.</p>
+
+    <h2 id="check">The warning before you delete</h2>
+    <p>Whether you're deleting one note, several at once, or a whole folder, Minerva looks for any other notes — outside what you're removing — that still link to it. If it finds none, the delete proceeds as normal. If it finds some, a warning appears listing the notes that would be left with a link going nowhere.</p>
+
+    <p>From that warning you can:</p>
+    <div class="deflist">
+      <div class="row"><div class="k">Cancel</div><div class="v">Keep everything. Nothing is deleted.</div></div>
+      <div class="row"><div class="k">Open the first reference</div><div class="v">Jump to a note that links in, so you can fix or remove the link before deleting.</div></div>
+      <div class="row"><div class="k">Delete anyway</div><div class="v">Go ahead with the delete, accepting that those links will be left pointing at nothing.</div></div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/refactoring-safe-delete.png" alt="The warning listing a few notes that still link to what you're about to delete, with Cancel, Open first reference, and Delete anyway options." loading="lazy" />
+      <figcaption>Screenshot — The delete warning</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">Deleting doesn't fix the links for you</span>
+      <p>If you choose Delete anyway, the notes that linked in are left exactly as they were — their links now lead nowhere. Minerva won't rewrite or remove them automatically, so it's worth cleaning them up when you get a chance. Using Open the first reference before you delete is the easiest way to handle them ahead of time.</p>
+    </div>

--- a/website/docs/_content/refactoring.html
+++ b/website/docs/_content/refactoring.html
@@ -1,0 +1,56 @@
+---
+title: Minerva — Docs — Refactoring
+description: Renaming, moving, and deleting notes — by hand and via the AI — and what happens to links when you do.
+---
+
+    <h1>Refactoring</h1>
+    <p class="lede">Rename, move, and delete notes — either by hand or by asking the assistant to do it for you. Whichever way you go, the links between your notes stay coherent, because Minerva keeps them up to date for you.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="refactoring-operations.html"><b>Refactoring operations</b></a> — the Refactor menu at a glance: every rename, split, AI-assisted, and formatting command.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="refactoring-manual.html"><b>Manual rename, move &amp; delete</b></a> — right-click, drag, and what updates for you.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="refactoring-safe-delete.html"><b>Safe delete &amp; dangling links</b></a> — a heads-up before you delete a note others link to.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="refactoring-ai-assisted.html"><b>AI-assisted refactors</b></a> — ask the assistant to rename, move, reorganize, or delete, and review before anything changes.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Deleting is a normal operation</span>
+      <p>Renaming, moving, and deleting are everyday actions, not scary ones. Minerva asks for a simple confirmation and then gets out of your way.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="refactoring-operations.html">
+        <span class="em">🧰</span>
+        <h3>Refactoring operations</h3>
+        <p>The Refactor menu commands, grouped and explained.</p>
+      </a>
+      <a class="doc-card" href="refactoring-manual.html">
+        <span class="em">✏️</span>
+        <h3>Manual rename, move &amp; delete</h3>
+        <p>Right-click, drag, and what automatically updates when you do.</p>
+      </a>
+      <a class="doc-card" href="refactoring-safe-delete.html">
+        <span class="em">🔗</span>
+        <h3>Safe delete &amp; dangling links</h3>
+        <p>What Minerva checks before you delete a note others link to.</p>
+      </a>
+      <a class="doc-card" href="refactoring-ai-assisted.html">
+        <span class="em">🤖</span>
+        <h3>AI-assisted refactors</h3>
+        <p>Ask the assistant — review the plan before anything changes.</p>
+      </a>
+    </div>

--- a/website/docs/_content/right-sidebar-backlinks.html
+++ b/website/docs/_content/right-sidebar-backlinks.html
@@ -1,0 +1,41 @@
+---
+title: Minerva — Docs — Backlinks
+description: The Backlinks panel shows every note that links to the one you're reading, so you can see what refers here and jump straight to it.
+---
+
+    <h1>Backlinks</h1>
+    <p class="lede">The <b>Backlinks</b> panel shows every note that links to the one you're reading. It's the reverse of the note's own <a href="right-sidebar-outgoing-links.html">outgoing links</a>: instead of where this note points, it tells you what points here. The list keeps itself up to date, so when you link to this note from somewhere else, it appears here automatically.</p>
+
+    <h2 id="layout">Reading the panel</h2>
+    <p>Each row is a note that links to the one you're viewing, shown by its title. A line at the top gives a running total. If a note links here more than once, each link is its own row, so the count reflects mentions rather than distinct notes.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Search</div>
+        <div class="v">Type in the search field to narrow the list to notes whose titles match, live as you type.</div>
+      </div>
+      <div class="row">
+        <div class="k">Group by type</div>
+        <div class="v">By default, links are grouped into collapsible sections by the kind of link — for example "supports" or "references" — each with a color and a count. Click a section header to fold it away, or use the buttons at the top to collapse or expand everything at once.</div>
+      </div>
+      <div class="row">
+        <div class="k">Sort alphabetically</div>
+        <div class="v">Switch the sort option to list every backlink in one flat list ordered by title. Each row then carries a small colored badge showing its link type.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click to open</div>
+        <div class="v">Click a row to open that note. When you come back, the panel is just as you left it — your search text and folded sections are remembered.</div>
+      </div>
+      <div class="row">
+        <div class="k">Drag to reuse</div>
+        <div class="v">Drag a row into another note to drop in a link to it, the same way you can drag a note from the sidebar.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-backlinks.png" alt="The Backlinks panel grouped by link type, showing a couple of expanded sections — each with a color, a label, and a count — and one folded section, with the search field and sort control at the top." loading="lazy" />
+      <figcaption>Screenshot — Backlinks panel, grouped by type</figcaption>
+    </figure>
+
+    <h2 id="empty">When nothing links here</h2>
+    <p>If no note links to the one you're viewing, the panel says <i>"No backlinks found."</i> That's normal for a brand-new note or one you simply haven't linked to yet. If backlinks do exist but your search doesn't match any of them, it says <i>"No matches"</i> instead, so you can tell whether the panel is empty because nothing links here or because your search is too narrow.</p>

--- a/website/docs/_content/right-sidebar-bookmarks.html
+++ b/website/docs/_content/right-sidebar-bookmarks.html
@@ -1,0 +1,37 @@
+---
+title: Minerva — Docs — Bookmarks (Note)
+description: The right sidebar's Bookmarks panel shows a simple list of the bookmarks that belong to the note you're reading.
+---
+
+    <h1>Bookmarks</h1>
+    <p class="lede">Bookmarks are quick markers you drop on the notes and passages you want to find again. This panel in the right sidebar gives you a simple list of just the bookmarks that belong to the note you're currently reading — no folders, no clutter.</p>
+
+    <p>These are the same bookmarks you see in the <a href="left-sidebar-bookmarks.html">Bookmarks panel on the left</a>, where you can organize all of them into folders and search across your whole project. This panel is the focused version: it drops the folders and shows only what's relevant to the note in front of you. Delete a bookmark here and it's gone from the left panel too.</p>
+
+    <h2 id="what-shows">What shows up here</h2>
+    <p>Whenever a note is open, this panel lists every bookmark that points at it. Switch notes and the list updates right away.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">No note open</div>
+        <div class="v">The panel says there's no active note — there's nothing to list.</div>
+      </div>
+      <div class="row">
+        <div class="k">A note with no bookmarks</div>
+        <div class="v">The panel tells you this note has no bookmarks yet.</div>
+      </div>
+      <div class="row">
+        <div class="k">Different kinds of bookmark</div>
+        <div class="v">You can bookmark a whole note, a particular section, or a specific spot in the text, and all three appear together. A small icon on each row tells them apart.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-bookmarks.png" alt="A short list of the bookmarks on the current note — one for the whole note, one for a section, one for a spot in the text — each with a name and a small delete button that appears when you hover." loading="lazy" />
+      <figcaption>Bookmarks for the open note</figcaption>
+    </figure>
+
+    <h2 id="actions">What you can do from here</h2>
+    <p>Click a row to jump to what it marks: a section bookmark scrolls you to that heading, and a spot bookmark takes you to that place in the text. Hover a row to reveal its delete button, which removes the bookmark everywhere.</p>
+    <p>To make a new bookmark, right-click in your note or on its tab and choose <b>Bookmark This Note</b>, <b>Bookmark Section</b>, or <b>Bookmark Line</b>. To rename bookmarks or sort them into folders, use the <a href="left-sidebar-bookmarks.html">Bookmarks panel on the left</a>.</p>
+    

--- a/website/docs/_content/right-sidebar-citations.html
+++ b/website/docs/_content/right-sidebar-citations.html
@@ -1,0 +1,38 @@
+---
+title: Minerva — Docs — Citations
+description: The Citations panel is a live bibliography for the note you're reading — every source it cites or quotes, with a quick way to jump back to the original.
+---
+
+    <h1>Citations</h1>
+    <p class="lede">The Citations panel is a bibliography for the note you're reading. It gathers every source the note cites or quotes into one tidy list, so you can see what you drew on and jump straight back to the original — no hand-kept reference list required.</p>
+
+    <h2 id="how-it-works">What it shows</h2>
+    <p>As you cite and quote sources in your writing, the panel collects them here. Each source appears once, even if you referenced it several times, and the list stays in step with what you type. Cite a source with a <code>cite</code> link and quote it with a <code>quote</code> link, and both show up on the same row.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Source row</div>
+        <div class="v">Shows the source's title and its author and year, when known. A small chip on the right tells you how many times you cited it and how many times you quoted it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click a source</div>
+        <div class="v">Opens that source so you can read it in full.</div>
+      </div>
+      <div class="row">
+        <div class="k">Expand a source</div>
+        <div class="v">Any source you've quoted can be opened up to list each passage you pulled in, with a preview of the quoted words and a page number or location when there is one.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click an excerpt</div>
+        <div class="v">Jumps straight to that passage inside the source — handy for landing back on the exact spot in a long document you quoted from.</div>
+      </div>
+      <div class="row">
+        <div class="k">Search and sort</div>
+        <div class="v">Search by title, author, or a phrase you remember quoting to find a source fast. Sort by most cited or alphabetically by title.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-citations.png" alt="The Citations panel listing several sources by title, each with its author and year and a count of cites and quotes; one row is opened to show two quoted passages beneath it, each with a page number." loading="lazy" />
+      <figcaption>Screenshot — Citations panel with an expanded source</figcaption>
+    </figure>

--- a/website/docs/_content/right-sidebar-footnotes.html
+++ b/website/docs/_content/right-sidebar-footnotes.html
@@ -1,0 +1,35 @@
+---
+title: Minerva — Docs — Footnotes Panel
+description: The Footnotes panel lists every footnote in the note you're reading, lets you jump to where each one is used, and flags footnotes that have drifted out of sync.
+---
+
+    <h1>Footnotes</h1>
+    <p class="lede">The <b>Footnotes</b> panel gathers every footnote in the note you're reading into one tidy list, so you can see them at a glance and jump straight to where each one is used. It also quietly flags footnotes that have drifted out of sync.</p>
+
+    <p>Want to know how to write footnotes in the first place — the markup, how they look, and clicking to jump between a note and its footnote? See <a href="notes-footnotes.html">Notes → Footnotes</a>. This page is about the panel itself.</p>
+
+    <h2 id="layout">Reading the panel</h2>
+    <p>Each row shows a footnote's label and a one-line preview of its text, listed in the order they appear in your note. Start typing in the search box at the top to narrow the list to footnotes whose label or text matches — the results update as you type, and only this note is searched.</p>
+    <p><b>Click a row</b> to jump to where that footnote is used in your note, so you can pick up right where it belongs.</p>
+
+    <h2 id="stale">Footnotes that have drifted</h2>
+    <p>The panel also catches the two ways a footnote can fall out of sync, each shown as its own row with a small note underneath:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Written but never used</div>
+        <div class="v">A footnote you've written that nothing in the note points to. It isn't broken — just unused — so it's shown in a muted style. Click it to jump to the footnote.</div>
+      </div>
+      <div class="row">
+        <div class="k">Used but never written</div>
+        <div class="v">A spot in your text that refers to a footnote you haven't written yet. Click it to jump to that spot so you can fill in the missing footnote.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-footnotes.png" alt="The Footnotes panel with text typed into its search box, narrowing the list to a few matching rows below — one flagged as written but never used, one flagged as used but never written, and ordinary rows each showing a label and a preview of the footnote text." loading="lazy" />
+      <figcaption>Screenshot — Footnotes panel with search and drift flags</figcaption>
+    </figure>
+
+    <h2 id="empty">When there's nothing to show</h2>
+    <p>If a note has no footnotes, the panel simply says <i>"No footnotes."</i> If it has footnotes but none match what you've typed, it says <i>"No matches"</i> instead — so you can always tell whether the note is empty or your search is just too narrow.</p>

--- a/website/docs/_content/right-sidebar-heading-graph.html
+++ b/website/docs/_content/right-sidebar-heading-graph.html
@@ -1,0 +1,45 @@
+---
+title: Minerva — Docs — Heading Graph
+description: The Heading graph panel draws the current note's headings as an interactive tree, so you can see the shape of a long note at a glance.
+---
+
+    <h1>Heading graph</h1>
+    <p class="lede">The Heading graph panel draws your note's headings as a tree you can pan and click around — a starting node for the note itself, with each heading branching off the section that contains it. It shows the same headings as the <a href="right-sidebar-outline.html">Outline</a> panel, just in a different shape: reach for it when you want to see how a long note branches at a glance instead of reading down a list.</p>
+
+    <h2 id="how-it-works">How it works</h2>
+    <p>The tree updates itself as you write. Each heading becomes a node, connected back to the section it sits inside, so your top-level sections fan out from the note and their subsections branch out one step further. Deeper headings are styled differently from top-level ones, so the tiers are easy to tell apart.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Click a heading</div>
+        <div class="v">Jumps the editor to that heading, just like clicking it in the Outline. A small toggle above the tree lets you choose whether a single click jumps straight there, or first selects the heading and needs a double-click (or Enter) to jump.</div>
+      </div>
+      <div class="row">
+        <div class="k">Pan and zoom</div>
+        <div class="v">Drag to move the tree around, and scroll or pinch to zoom in and out. The view re-fits on its own when you resize the sidebar.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-heading-graph.png" alt="A starting node named after the note branches into its main sections, two of which have subsections of their own one step further out, all laid out top-down with connecting lines. A small toggle above the tree sets how clicks behave." loading="lazy" />
+      <figcaption>The Heading graph for a multi-section note</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">It's about structure, not links</span>
+      <p>The lines here show which section contains which — nothing more. A link you type inside a heading doesn't connect it to anything; the tree only cares about how your headings nest.</p>
+    </div>
+
+    <h2 id="contrast">Heading graph or Outline?</h2>
+    <p>Both panels show the same headings for a note — they'll never disagree. The difference is just how they look:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="right-sidebar-outline.html">Outline</a></div>
+        <div class="v">A compact, indented list you can collapse and filter by typing. Quick to scan and the better everyday choice for most notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Heading graph</div>
+        <div class="v">An interactive tree you can pan around. Best for taking in the overall shape of a note at a glance — how many sections it has and how deep each one goes.</div>
+      </div>
+    </div>

--- a/website/docs/_content/right-sidebar-history.html
+++ b/website/docs/_content/right-sidebar-history.html
@@ -1,0 +1,77 @@
+---
+title: Minerva — Docs — History
+description: The right sidebar's History panel keeps every saved version of a note, says what caused each one, and puts an old version back with one click.
+---
+
+    <h1>History</h1>
+    <p class="lede">Every time a note is saved, Minerva keeps a copy of what it looked like before. This panel is where you read that record: a list of versions with the date, the time, and a line saying what produced each one — your own edit, a thinking tool, a restore. Pick a version to see what changed since, and put it back with one click if you'd rather have it.</p>
+
+    <div class="box">
+      <span class="label">This is not git</span>
+      <p>Nothing here needs setting up, and none of it is a commit. History is kept automatically, on this machine, for every note — including the <code>.csv</code>, <code>.ttl</code> and <code>.py</code> notes, not just the markdown ones. It lives in the <code>.minerva</code> folder beside your notes and never leaves your computer, so it isn't part of <a href="export-publishing.html">publishing</a> and doesn't travel with a note you export.</p>
+    </div>
+
+    <h2 id="timeline">Reading the timeline</h2>
+    <p>Versions are listed newest first. Each row carries two lines: when the version was saved, and what caused it.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">The date and time</div>
+        <div class="v">To the minute, because two versions saved a minute apart are exactly the ones you need to tell apart. The year is shown only when it isn't this one.</div>
+      </div>
+      <div class="row">
+        <div class="k">What caused it</div>
+        <div class="v">The line underneath names the action, not the machinery. A save you made reads <b>Edit</b>. A version a thinking tool produced carries that skill's name — <b>Antithesize</b>, <b>Auto-tag</b> — so you can see at a glance which changes were yours and which weren't.</div>
+      </div>
+      <div class="row">
+        <div class="k">Initial version</div>
+        <div class="v">The oldest version of every note, and the one "undo everything" gets you back to. It's created the first time a note is written through Minerva — including for notes that already existed before there was any history, whose text is captured before your first edit lands on top of it. It is never dropped, however old it gets.</div>
+      </div>
+      <div class="row">
+        <div class="k">Restored from…</div>
+        <div class="v">Restoring is itself a save, so it appears as a new version naming the one you brought back. A timeline with several restores in it still reads in order.</div>
+      </div>
+      <div class="row">
+        <div class="k">A name</div>
+        <div class="v">Versions you've named show the name as a chip on the right. See <a href="#naming">naming a version</a> below.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel-wide">
+      <img src="img/right-sidebar-history.png" alt="The History panel showing five versions of a note — an AI rewrite, a version named 'before rewrite', an Auto-tag change, an edit, and the initial version — with the selected version's differences shown below as added and removed lines." loading="lazy" />
+      <figcaption>Screenshot — the History panel, with a version selected and its differences below</figcaption>
+    </figure>
+
+    <h2 id="comparing">Comparing and restoring</h2>
+    <p>Click any version to compare it with the note as it stands now. The count at the top says how many lines would be added and removed, and the lines themselves are listed below — added in green, removed in red.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Restore</div>
+        <div class="v">Puts the selected version's text back into the note. Nothing is lost: the text you're replacing is saved as a version of its own first, so restoring the wrong one costs you a second click, not your work. The open editor reloads to match.</div>
+      </div>
+      <div class="row">
+        <div class="k">"Contents are identical"</div>
+        <div class="v">Shown instead of a comparison when the version you picked matches the note's current text word for word — which happens for the newest version, and for any older one you've since edited your way back to. There's nothing to restore, so no button is offered.</div>
+      </div>
+    </div>
+
+    <h2 id="naming">Naming a version</h2>
+    <p>A date and time tells you when something happened, not why it mattered. Right-click any version and choose <b>Label Version…</b> to give it a name — <i>before rewrite</i>, <i>submitted draft</i>, <i>last good copy</i> — and it becomes easy to find weeks later. Right-clicking a version that already has one offers <b>Rename Label…</b> and <b>Remove Label</b> instead.</p>
+
+    <div class="box">
+      <span class="label">Named versions don't expire</span>
+      <p>Unnamed versions are dropped once they age out of the retention window or fall off the per-note limit (see <a href="settings-versioning.html">Settings → Versioning</a>). A named version is exempt from both — naming one is how you keep a particular state of a note indefinitely.</p>
+    </div>
+
+    <figure class="shot-img panel-wide">
+      <img src="img/right-sidebar-history-label.png" alt="Right-clicking a version in the History panel opens a small menu offering 'Label Version…'." loading="lazy" />
+      <figcaption>Screenshot — naming a version from the timeline</figcaption>
+    </figure>
+
+    <h2 id="many-notes">Naming several notes at once</h2>
+    <p>A restore point is often bigger than one note. In the <a href="left-sidebar-notes-tree.html">Notes panel</a>, select the notes (or a folder) you're about to change, right-click and choose <b>Label Version…</b>: the current version of every note in the selection gets the same name. One name, one moment, however many notes — the thing to reach for before a refactor or a big AI-assisted pass.</p>
+    <p>Nothing is written into the notes themselves; the name is attached to their history, exactly as it would be from this panel. Notes that can't be labelled are reported afterwards, and the rest still get their restore point.</p>
+
+    <h2 id="limits">How much is kept</h2>
+    <p>By default a note keeps its unnamed versions for 30 days, up to 500 of them, and files over 1 MB aren't recorded at all. All three are adjustable — see <a href="settings-versioning.html">Settings → Versioning</a>.</p>

--- a/website/docs/_content/right-sidebar-inspections.html
+++ b/website/docs/_content/right-sidebar-inspections.html
@@ -1,0 +1,100 @@
+---
+title: Minerva — Docs — Inspections
+description: Standing checks over your thoughtbase — broken links, stale notes, sources missing citation details — with one-click fixes.
+---
+
+    <h1>Inspections</h1>
+    <p class="lede">Inspections are standing checks Minerva can run over your whole thoughtbase — links that point at nothing, notes quietly drifting out of date, sources missing the details a citation needs. The panel lists what they found, in the order worth caring about, and for many of them it can do the fixing for you. Nothing here changes a note on its own.</p>
+
+    <h2 id="running">When the checks run</h2>
+    <p>Mostly, without you asking:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">When you save</div>
+        <div class="v">A couple of seconds after any change to a note, the checks run again — so if you've just broken a link, the panel says so while you're still looking at the note that did it. A burst of changes (a folder move, a batch of AI edits) settles into one pass rather than one per file.</div>
+      </div>
+      <div class="row">
+        <div class="k">When you open a thoughtbase</div>
+        <div class="v">Once at the start, so the panel has something to show the moment you open it from the right sidebar's <b>Activity</b> group.</div>
+      </div>
+      <div class="row">
+        <div class="k">Every few minutes</div>
+        <div class="v">A quiet backstop for the checks that go off with the calendar rather than with an edit — a note becoming stale, or a stub ageing past its threshold. Nothing changes in your notes when that happens, so there'd otherwise be nothing to trigger a re-check.</div>
+      </div>
+    </div>
+    <p>There's also a <b>Run</b> button, if you'd rather not wait the couple of seconds — or you've changed which checks are switched on and want the list to catch up straight away.</p>
+
+    <div class="box">
+      <span class="label">Broken links get flagged twice, on purpose</span>
+      <p>A broken <code>[[wiki-link]]</code> is underlined in the editor and the preview <i>as you type</i>, with a quick-fix on the spot — that's live, and separate from this panel. The panel is the standing, whole-thoughtbase view: every broken link at once, including the ones in notes you haven't opened lately.</p>
+    </div>
+
+    <h2 id="what">What it looks for</h2>
+    <p>Every check can be switched off in <a href="settings-inspections.html">Settings → Inspections</a> if it isn't telling you anything useful.</p>
+
+    <h3>Notes</h3>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Stale notes</div>
+        <div class="v">Notes you haven't touched in a while, in case they've quietly gone out of date. How long "a while" is, is yours to set.</div>
+      </div>
+    </div>
+
+    <h3>Links</h3>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Broken note links</div>
+        <div class="v">A <code>[[wiki-link]]</code> pointing at a note that doesn't exist — usually a rename that left a link behind, or a typo.</div>
+      </div>
+      <div class="row">
+        <div class="k">Broken heading links</div>
+        <div class="v">A link to a particular heading or block that has since been renamed or removed. The note is still there; the spot inside it isn't.</div>
+      </div>
+      <div class="row">
+        <div class="k">Broken citations and quotes</div>
+        <div class="v">A cite or quote link whose source or excerpt is no longer in the thoughtbase.</div>
+      </div>
+    </div>
+
+    <h3>Sources</h3>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Sources missing details</div>
+        <div class="v">Sources with no author, title, or date — the fields a citation needs to come out right.</div>
+      </div>
+      <div class="row">
+        <div class="k">Malformed DOIs</div>
+        <div class="v">A DOI that isn't shaped like one, so it won't resolve or look up.</div>
+      </div>
+      <div class="row">
+        <div class="k">Duplicate sources</div>
+        <div class="v">Two sources with the same DOI or address — usually the same thing ingested twice from different directions.</div>
+      </div>
+      <div class="row">
+        <div class="k">Cited but unread</div>
+        <div class="v">Sources you've cited without marking them read. Worth a look before you lean on them.</div>
+      </div>
+      <div class="row">
+        <div class="k">Long-unresolved stubs</div>
+        <div class="v">Source stubs that have sat unfilled for a while — a reference you meant to come back to.</div>
+      </div>
+    </div>
+
+    <h2 id="reading">Reading the list</h2>
+    <p>Findings are grouped by how much they matter — <b>Concerns</b>, then <b>Warnings</b>, then <b>Info</b> — so the top of the list is the part worth reading first. Switch the sort to <b>By type</b> when you'd rather work through one kind at a time (every broken link in one pass, say), and use the search box to narrow to a particular note or source.</p>
+
+    <h2 id="scope">This note, or the whole thoughtbase</h2>
+    <p>The panel opens on <b>This note</b>, showing only findings anchored to the note you're reading — the usual case, and quiet enough to leave open while you work.</p>
+    <p>Switch to <b>Project</b> for everything at once. Some findings only appear there: duplicate sources, unread citations, and unfilled stubs are about your library rather than any one note, so they have no note to be anchored to.</p>
+
+    <h2 id="fixing">Fixing what it finds</h2>
+    <p>Many findings carry a fix, shown as a label at the end of the row — <i>Create the note</i>, <i>Remove the heading</i>, and so on. Click the row and Minerva applies it, then re-runs the checks so the row disappears if it's genuinely resolved.</p>
+    <p>Findings with no mechanical fix — a note going stale is a judgement call, not a repair — open a conversation about that finding instead, with the assistant already told what was flagged and what it suggests.</p>
+
+    <div class="box">
+      <span class="label">Nothing happens without you</span>
+      <p>Inspections never edit your notes on their own. A fix applies when you click its row; anything the assistant proposes in the conversation still goes through the usual review-and-approve step.</p>
+    </div>
+
+    <h2 id="settings">Turning checks off</h2>
+    <p>A check that isn't earning its place is noise. <a href="settings-inspections.html">Settings → Inspections</a> has a switch for each one, plus the two thresholds that decide what counts as "stale" and "long-unresolved".</p>

--- a/website/docs/_content/right-sidebar-outgoing-links.html
+++ b/website/docs/_content/right-sidebar-outgoing-links.html
@@ -1,0 +1,36 @@
+---
+title: Minerva — Docs — Outgoing Links
+description: The Outgoing links panel lists every note the current note points to, grouped by link type, with broken targets flagged and one click to jump to a note.
+---
+
+    <h1>Outgoing links</h1>
+    <p class="lede">The Outgoing links panel lists every <a href="notes-links.html">link</a> the current note points to — the notes it references, not the notes that reference it. It's the mirror image of <a href="right-sidebar-backlinks.html">Backlinks</a>, read in the opposite direction. Click any row to open that note.</p>
+
+    <h2 id="contents">What's in the list</h2>
+    <p>Each link in the note becomes a row showing the title of the note it points to.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Working link</div>
+        <div class="v">Shows a document icon and the title of the note it points to. Click the row to open that note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Broken link</div>
+        <div class="v">Shows a warning icon and a tinted title when the link doesn't point to any note that exists. The row still appears so you can spot it and fix it, but there's nowhere to go, so clicking it does nothing.</div>
+      </div>
+    </div>
+
+    <p>By default, links are grouped by <a href="notes-links.html#types">type</a> — each group has a colored marker, a label, and a count, matching the color that type shows in the note itself. Collapse a group to tidy it away, or use the toolbar buttons to expand or collapse them all at once. Switch the sort control to <b>Alphabetical</b> to see one title-sorted list instead, with a small type badge on each row.</p>
+
+    <p>The toolbar also has a filter field to narrow the list to targets whose title contains what you type, and a button to view the note's links as a graph instead of a list.</p>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-outgoing-links.png" alt="The Outgoing links tab for a note with several links, showing collapsible groups by type with counts, one row flagged as a broken link, and the toolbar's filter field, sort control, and graph button." loading="lazy" />
+      <figcaption>Screenshot — Outgoing links panel</figcaption>
+    </figure>
+
+    <h2 id="cite-quote">Links to sources</h2>
+    <p>Some links point to a source in your bibliography rather than to a note. This panel treats every link as if it points to a note, so a link to a source appears here as a broken row. To browse links to your sources, use the <a href="right-sidebar-citations.html">Citations</a> panel instead.</p>
+
+    <h2 id="empty">When there's nothing to show</h2>
+    <p>A note with no links shows "No outgoing links." If you've typed a filter and nothing matches it, you'll see "No matches" instead.</p>

--- a/website/docs/_content/right-sidebar-outline.html
+++ b/website/docs/_content/right-sidebar-outline.html
@@ -1,0 +1,29 @@
+---
+title: Minerva — Docs — Outline
+description: The Outline panel shows a collapsible map of every heading in the current note, so you can scan its structure at a glance and click any heading to jump there.
+---
+
+    <h1>Outline</h1>
+    <p class="lede">The Outline panel is a map of the note you're reading. It lists every heading as an indented tree, so you can take in the shape of a long note at a glance, and click any heading to jump straight to that section.</p>
+
+    <p>The outline updates itself as you write — add, rename, or remove a heading and the tree keeps up automatically. Deeper headings are tucked under the higher-level ones above them, mirroring the way you've organized the note.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Collapse and expand</div>
+        <div class="v">Any heading that has subheadings shows a small triangle. Click it to fold that section away, or use the buttons above the tree to collapse or expand everything at once — handy for zooming out on a big note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Filter</div>
+        <div class="v">Start typing in the search field above the tree to narrow the outline to headings that match. Matches stay visible even if they sit inside a folded section.</div>
+      </div>
+      <div class="row">
+        <div class="k">Jump to a section</div>
+        <div class="v">Click a heading and the note scrolls to it, dropping your cursor at the start of that line so you can begin editing right away.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-outline.png" alt="The Outline panel open beside a long note. Top-level sections are listed in order, one expanded to reveal its subheadings indented beneath it and another folded to a single row. A search field and collapse/expand buttons sit above the tree." loading="lazy" />
+      <figcaption>The Outline panel for a note with several sections</figcaption>
+    </figure>

--- a/website/docs/_content/right-sidebar-properties.html
+++ b/website/docs/_content/right-sidebar-properties.html
@@ -1,0 +1,87 @@
+---
+title: Minerva — Docs — Properties
+description: The Properties panel in Minerva's right sidebar: a simple editor for a note's properties, so you can add, change, and remove them without editing anything by hand.
+---
+
+    <h1>Properties</h1>
+    <p class="lede">Every note can carry a few pieces of structured information — a title, some tags, a date, and anything else you find useful. The Properties panel is a friendly way to view and edit those <a href="notes-frontmatter.html">properties</a> as a tidy list, so you can add, change, and remove them without typing anything special. It's just another way to work with the same information you can also edit at the top of the note itself, and the two always stay in step. When the note has a <a href="notes-typed-notes.html">type</a>, the panel also knows which fields that kind of note is expected to have, and puts them first.</p>
+
+    <h2 id="where">Where it lives</h2>
+    <p>Properties is one of the panels in the right sidebar that describe the note you're looking at, alongside Outline, Footnotes, Tags, and Tables. Open it and you'll see the current note's properties laid out as a list of rows. Switch to another note and the panel simply shows that note's properties instead.</p>
+
+    <h2 id="editing">Editing, adding, and removing properties</h2>
+    <p>Each property is a row: its name on the left, its value on the right, with a small icon showing what kind of value it is. The value's control fits its type — a text box for text, a checkbox for yes/no, a date picker for dates, chips for tags, and so on.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Renaming a property</div>
+        <div class="v">The name is editable, not just a label. Type a new name and click away to rename it, keeping its value and its place in the list. (Fields that come from the note's <a href="notes-typed-notes.html">type</a> are the exception — see below.)</div>
+      </div>
+      <div class="row">
+        <div class="k">Removing a property</div>
+        <div class="v">Hover over a row and a × appears at its edge; click it to delete that property. If you remove the last one, the note simply goes back to having no properties at all.</div>
+      </div>
+      <div class="row">
+        <div class="k">Adding a property</div>
+        <div class="v">An "Add property…" row sits at the bottom of the list. Type a name and press Enter, or click the + button, and the new property appears with its value box ready for you to fill in right away.</div>
+      </div>
+      <div class="row">
+        <div class="k">Helpful suggestions</div>
+        <div class="v">As you type a name, Minerva suggests properties you already use elsewhere in your notes, plus common ones this note doesn't have yet. A few of the most common are offered as one-click chips just below the add row, so you often don't need to type a name at all.</div>
+      </div>
+      <div class="row">
+        <div class="k">Starting from scratch</div>
+        <div class="v">A note with no properties yet shows a short prompt instead of a list. Adding your first property from here sets everything up in one step — there's no separate action to find first.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Your own property names are welcome</span>
+      <p>You're not limited to Minerva's suggested names. Add any property name you like and it works exactly the same way — it's just shown in a slightly quieter color so you can tell your custom ones apart from the familiar ones.</p>
+    </div>
+
+    <h2 id="typed">When the note has a type</h2>
+    <p>Give a note a <a href="notes-typed-notes.html">type</a> — Book, Person, Meeting — and the panel gains a section above the ordinary list, headed with the type's icon and name. It holds the fields that kind of note is expected to have.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Every field, filled in or not</div>
+        <div class="v">Fields the note hasn't filled in yet are shown too, with a dashed outline. The form answers "what does a Book need?", not just "what has this note got?" Nothing is required — an empty field is a perfectly good answer.</div>
+      </div>
+      <div class="row">
+        <div class="k">The right control for each</div>
+        <div class="v">The type says what kind of value a field holds, so a field with a fixed set of choices becomes a dropdown of exactly those, a date becomes a date picker, a number becomes a number box.</div>
+      </div>
+      <div class="row">
+        <div class="k">Field names are fixed</div>
+        <div class="v">A field's name comes from the type, so it's shown as a label rather than an editable box. Renaming it here would only detach this one note from its type. Rename it in <a href="settings-object-types.html">Settings → Object Types</a> instead, and every note of that type follows.</div>
+      </div>
+      <div class="row">
+        <div class="k">Everything else, below</div>
+        <div class="v">Properties the type doesn't mention — your own additions, tags, the <code>type</code> line itself — sit under an "Other" divider and behave exactly as they always have.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Clearing a field is safe</span>
+      <p>Emptying one of the type's fields removes the property from the note rather than leaving it blank. The field itself stays on the form, because the type still declares it — so you can fill it in again whenever you like.</p>
+    </div>
+
+    <h2 id="invalid">When a value doesn't fit</h2>
+    <p>The panel quietly protects you from entering something that doesn't make sense, without popups or warnings:</p>
+
+    <ul>
+      <li>A number field ignores anything that isn't a number, leaving the property as it was until you type a real one.</li>
+      <li>The link picker leaves a property unchanged if you clear it out, rather than saving an empty link.</li>
+      <li>For richer values that don't fit a simple control — a nested list or grouping — the panel shows them as read-only and invites you to edit them at the top of the note instead.</li>
+    </ul>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-properties.png" alt="The right sidebar showing a note's properties as a list of rows: a title, tags as chips, a date shown with a date picker, and one custom property in a quieter color. The cursor sits in a freshly added, empty value box, with the &quot;Add property…&quot; row and its quick-add suggestion chips below." loading="lazy" />
+      <figcaption>The Properties panel while editing</figcaption>
+    </figure>
+
+    <h2 id="related">Two ways to edit, one set of properties</h2>
+    <p>Everything the panel does, you can also do by editing the properties at the top of the note directly — and the two always match, whichever way you make a change. Reach for the panel when you want quick, mistake-free edits: flip a checkbox, pick a date, add a tag. Edit the note directly when you want to rearrange properties or write a value the panel doesn't have a control for yet.</p>
+
+    <p>If you find yourself adding the same handful of properties to note after note, that's a sign they want to be a <a href="notes-typed-notes.html">type</a> — declare the fields once in <a href="settings-object-types.html">Settings → Object Types</a> and every note of that kind gets the form for free.</p>

--- a/website/docs/_content/right-sidebar-related.html
+++ b/website/docs/_content/right-sidebar-related.html
@@ -1,0 +1,39 @@
+---
+title: Minerva — Docs — Related
+description: The Related panel suggests notes, sources, and excerpts that read like the one you're viewing — connections found by meaning, not by links you typed.
+---
+
+    <h1>Related</h1>
+    <p class="lede">The <b>Related</b> panel suggests notes, sources, and quoted excerpts that read like the one you're viewing — without either side having to link to the other. It finds connections by meaning, so it's the one panel that surfaces things you never thought to link together.</p>
+
+    <div class="box">
+      <span class="label">Found by meaning, not by links</span>
+      <p><a href="right-sidebar-backlinks.html">Backlinks</a> and <a href="right-sidebar-outgoing-links.html">Outgoing links</a> only ever show connections you made by typing a wiki-link. Related is different: it doesn't care whether two notes link to each other, only whether they cover similar ground. A note with no links at all can be full of related suggestions, and a heavily-linked note may have nothing related if nothing else you've written resembles it.</p>
+    </div>
+
+    <h2 id="how-it-works">How matches are chosen</h2>
+    <p>Minerva compares the meaning of the note you're viewing against everything else in your project and lists the closest matches first. Matching happens quietly on its own as you write and save — there's nothing to run or refresh.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">What's compared</div>
+        <div class="v">Your current note against every other note, source, and highlighted excerpt in the project — all three appear in one ranked list, each marked with a small icon showing what kind of item it is.</div>
+      </div>
+      <div class="row">
+        <div class="k">How closeness is shown</div>
+        <div class="v">A short bar next to each title, with the exact percentage in its tooltip. It's meant to be read at a glance — a low match isn't a problem to fix, just a looser connection.</div>
+      </div>
+    </div>
+
+    <h2 id="reading">Reading a result</h2>
+    <p>Each result shows what kind of item it is, its title, the closeness bar, the heading of the part that matched best, and a short snippet of that text. Click a note or excerpt to jump straight to the matching section; click a source to open it. You can also drag any result into the editor to drop in a link to it, just like dragging a file from the sidebar.</p>
+
+    <div class="box">
+      <span class="label">Suggesting a link</span>
+      <p>When a note is a strong match and isn't already linked to the one you're viewing, it gets a gentle accent and a small link button — a quiet nudge that it might be worth connecting, not a demand. Clicking it drops a link to that note under a "See also" heading. The × beside it dismisses that one suggestion so it won't keep coming back. A note that's already linked can still show up here — being related and being linked aren't the same thing — it just won't get the nudge.</p>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-related.png" alt="The Related panel listing several results — a mix of notes and sources, each with a closeness bar, the heading that matched, and a short snippet — with the top row showing the accent and link and dismiss buttons that mark a strong, not-yet-linked suggestion." loading="lazy" />
+      <figcaption>Screenshot — Related panel with a link suggestion</figcaption>
+    </figure>

--- a/website/docs/_content/right-sidebar-tables.html
+++ b/website/docs/_content/right-sidebar-tables.html
@@ -1,0 +1,33 @@
+---
+title: Minerva — Docs — Tables (Note)
+description: The right sidebar's Tables panel lists the data tables the current note's queries reference and shows which of them are available to query.
+---
+
+    <h1>Tables</h1>
+    <p class="lede">When a note contains a query against your data, this panel lists the tables that query relies on and tells you, at a glance, which of them are available. Click a table to open it in a fresh query tab and see all of its rows.</p>
+
+    <h2 id="contents">What's in the list</h2>
+    <p>The panel looks through the current note for data queries and gathers the names of every table those queries read from. Each distinct name gets its own row, listed alphabetically, along with whether it's available to query.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Available table</div>
+        <div class="v">Shows the table's name and its size — the number of rows and columns. Click the row to open it in a new query tab and browse everything in it. A shortcut button appears when you hover, doing the same thing.</div>
+      </div>
+      <div class="row">
+        <div class="k">Missing table</div>
+        <div class="v">A name your query mentions that doesn't match any table currently in the project — usually a typo, or a data file you haven't added yet. It's marked "not registered" and can't be clicked, since there's nothing to open.</div>
+      </div>
+    </div>
+
+    <p>Use the search box at the top to filter the list by name. If the note doesn't query any data, the panel simply reads "No tables referenced."</p>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-tables.png" alt="The Tables tab for a note with two data queries: an available table, &quot;sessions,&quot; showing its size of 1,204 rows by 6 columns with a shortcut button on hover; and a missing table, &quot;sesssions&quot; (a typo), marked &quot;not registered&quot; and shown in a warning tint." loading="lazy" />
+      <figcaption>Screenshot — Tables panel for a note that queries data</figcaption>
+    </figure>
+
+    <h2 id="relationship">This panel and the left sidebar</h2>
+    <p>The <a href="left-sidebar-tables.html">left sidebar's Tables panel</a> lists every data table in your whole project, so you can browse and query all of them. This panel is narrower and note-focused: it shows only the tables the current note's queries depend on, and flags any that are missing. In short, the left sidebar answers "what data do I have?" while this one answers "does this note's queries have what they need?"</p>
+
+    <p>You add a table by dropping a data file into your project — Minerva picks it up automatically, and it then becomes available everywhere you can query.</p>

--- a/website/docs/_content/right-sidebar-tags.html
+++ b/website/docs/_content/right-sidebar-tags.html
@@ -1,0 +1,63 @@
+---
+title: Minerva — Docs — Tags
+description: The right sidebar's Tags panel shows the tags on the note you're reading, arranged as a tidy hierarchy, and lets you jump to other notes that share a tag.
+---
+
+    <h1>Tags</h1>
+    <p class="lede">Tags are short labels you add to a note to group it with others on the same theme. This panel in the right sidebar shows the tags on the note you're currently reading, arranged as a tidy tree so a tag like <code>#project/minerva/docs</code> reads as nested rows instead of one long string. It's a read-only view — to change a note's tags, you edit the note.</p>
+
+    <div class="box">
+      <span class="label">Two Tags panels, two jobs</span>
+      <p>Minerva has a Tags panel on each side, and they answer different questions. The one in the <b>left</b> sidebar is a project-wide list of every tag you've used anywhere, alphabetical and with counts — good for browsing your whole vocabulary and jumping to any tagged note. This one, in the <b>right</b> sidebar, is about the note in front of you: it lists only the tags that note carries. Switch to another note and its contents change to match.</p>
+    </div>
+
+    <h2 id="hierarchy">Reading the tree</h2>
+    <p>Tags with slashes in them — <code>#area/health</code>, <code>#project/minerva/docs</code> — read as paths, and the panel nests them accordingly. If a note carries only <code>#foo/bar/baz</code>, you'll still see <code>foo</code> and <code>foo/bar</code> as parent rows above it, standing in as the branches that hold the tree together.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Expand / collapse</div>
+        <div class="v">Click the arrow on any row that has children to fold or unfold that branch. The panel remembers which branches you've opened.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click a tag</div>
+        <div class="v">Lists every note and source that carries that exact tag, shown beneath the tree — a quick way to jump from the note you're reading to everything else that shares one of its tags.</div>
+      </div>
+      <div class="row">
+        <div class="k">Click a parent tag</div>
+        <div class="v">Lists everything tagged at or below that branch — for example, every note under <code>#area/health</code> no matter how specific the tag goes. Handy for a broad sweep across a whole theme.</div>
+      </div>
+      <div class="row">
+        <div class="k">Highlighted rows</div>
+        <div class="v">Rows for tags the note actually carries are tinted so they stand out from the parent rows that only exist to organize the tree.</div>
+      </div>
+      <div class="row">
+        <div class="k">Filter box</div>
+        <div class="v">Type in the search box to narrow the tree to matching tags. A match stays visible along with the branches above it, so you can see where it sits.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img panel">
+      <img src="img/right-sidebar-tags.png" alt="The right sidebar's Tags panel open on a note with a nested tag, showing the branch expanded, the note's own tag highlighted, and a list beneath the tree of other notes and sources that share that tag." loading="lazy" />
+      <figcaption>Screenshot — Tags panel for a note with nested tags</figcaption>
+    </figure>
+
+    <h2 id="add-remove">Adding and removing tags</h2>
+    <p>This panel only reads — there's no box to type into. You tag a note by editing the note itself, and Minerva recognizes tags written two ways; the panel shows both together.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Inline hashtags</div>
+        <div class="v">Type <code>#tagname</code> anywhere in the note's text. It's picked up as a tag as soon as you save.</div>
+      </div>
+      <div class="row">
+        <div class="k">A tags list in properties</div>
+        <div class="v">Add tags to the <code>tags:</code> list in the note's properties at the top. Many notes are tagged only this way, with nothing typed inline.</div>
+      </div>
+      <div class="row">
+        <div class="k">Removing a tag</div>
+        <div class="v">Delete the hashtag text or the properties entry and save. The panel simply stops showing a tag once the note no longer contains it.</div>
+      </div>
+    </div>
+
+    <p>The tree updates the moment you save — no manual refresh needed. For browsing tags across your whole project, see <a href="left-sidebar-tags.html">Left sidebar → Tags</a>.</p>

--- a/website/docs/_content/right-sidebar.html
+++ b/website/docs/_content/right-sidebar.html
@@ -1,0 +1,133 @@
+---
+title: Minerva — Docs — Right Sidebar
+description: The right sidebar's panels give you context about the note you're reading: what links here, its outline, properties, citations, related notes, and more.
+---
+
+    <h1>Right sidebar</h1>
+    <p class="lede">The right sidebar gives you context about the note you're reading. Each panel answers a different question: What links here? What does this note link to? What's its shape? What does it cite? Which notes are related? Panels don't change your writing — they're different lenses on the note in front of you, and they update as you move from note to note.</p>
+
+    <div class="box">
+      <span class="label">One exception</span>
+      <p>Every panel here follows the note you're reading, and changes as you move between notes. For views of your project as a whole — including <a href="left-sidebar-proposals.html">Proposals</a>, where the AI's suggestions wait for you — see the <a href="left-sidebar.html">left sidebar</a>.</p>
+    </div>
+
+    <h2 id="glance">The panels at a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="right-sidebar-backlinks.html">Backlinks</a></div>
+        <div class="v">Other notes that link to this one.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-outgoing-links.html">Outgoing links</a></div>
+        <div class="v">The notes this one links out to.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-outline.html">Outline</a></div>
+        <div class="v">A collapsible list of headings for scanning a long note fast.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-properties.html">Properties</a></div>
+        <div class="v">A note's properties as simple, editable fields.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-citations.html">Citations</a></div>
+        <div class="v">Every source this note cites or quotes, with excerpts.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-tags.html">Tags</a></div>
+        <div class="v">This note's tags, shown as a hierarchy.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-related.html">Related</a></div>
+        <div class="v">Other notes that read alike, so you can find connections you didn't make by hand.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-footnotes.html">Footnotes</a></div>
+        <div class="v">Every footnote in this note, and a heads-up about any that don't line up.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-history.html">History</a></div>
+        <div class="v">Every saved version of this note, and one click to put an old one back.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-tables.html">Tables</a></div>
+        <div class="v">The data tables this note works with.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-heading-graph.html">Heading graph</a></div>
+        <div class="v">The note's headings drawn as a visual tree.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="right-sidebar-bookmarks.html">Bookmarks</a></div>
+        <div class="v">The spots you've bookmarked within this note.</div>
+      </div>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="right-sidebar-backlinks.html">
+        <span class="em">↙️</span>
+        <h3>Backlinks</h3>
+        <p>Other notes that link to this one.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-outgoing-links.html">
+        <span class="em">↗️</span>
+        <h3>Outgoing links</h3>
+        <p>The notes this one links out to.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-outline.html">
+        <span class="em">📑</span>
+        <h3>Outline</h3>
+        <p>A collapsible list of headings for scanning a long note fast.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-properties.html">
+        <span class="em">🎛️</span>
+        <h3>Properties</h3>
+        <p>A note's properties as simple, editable fields.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-citations.html">
+        <span class="em">📖</span>
+        <h3>Citations</h3>
+        <p>Every source this note cites or quotes, with excerpts.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-tags.html">
+        <span class="em">🌿</span>
+        <h3>Tags</h3>
+        <p>This note's tags, shown as a hierarchy.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-related.html">
+        <span class="em">🧲</span>
+        <h3>Related</h3>
+        <p>Other notes that read alike.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-footnotes.html">
+        <span class="em">📎</span>
+        <h3>Footnotes</h3>
+        <p>Every footnote in this note, and a heads-up about any that don't line up.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-history.html">
+        <span class="em">🕰️</span>
+        <h3>History</h3>
+        <p>Every saved version of this note, what caused it, and one click to put an old one back.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-tables.html">
+        <span class="em">🧾</span>
+        <h3>Tables</h3>
+        <p>The data tables this note works with.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-heading-graph.html">
+        <span class="em">🌐</span>
+        <h3>Heading graph</h3>
+        <p>The note's headings drawn as a visual tree.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-bookmarks.html">
+        <span class="em">📌</span>
+        <h3>Bookmarks</h3>
+        <p>The spots you've bookmarked within this note.</p>
+      </a>
+      <a class="doc-card" href="right-sidebar-inspections.html">
+        <span class="em">🩺</span>
+        <h3>Inspections</h3>
+        <p>Broken links, stale notes, sources missing details — and one-click fixes.</p>
+      </a>
+    </div>

--- a/website/docs/_content/settings-ai.html
+++ b/website/docs/_content/settings-ai.html
@@ -1,0 +1,82 @@
+---
+title: Minerva — Docs — Settings: AI
+description: The AI tab of Settings: choosing a default model and reasoning effort, saving your API key, and turning on voice dictation.
+---
+
+    <h1>AI</h1>
+    <p class="lede">This tab sets what every new conversation starts with — which model it uses and how hard that model thinks — plus the keys for the AI services you want to use, and voice dictation. If you want a particular thinking tool to use a different model, that's set on the <a href="settings-skills.html">Skills</a> tab; here you're setting the defaults everything else falls back to.</p>
+
+    <h2 id="model">Default model and effort</h2>
+    <p>Two dropdowns pick the starting point for a fresh conversation. They're only defaults: each conversation has <a href="conversations-chatting.html#model">its own model and effort pickers</a> that override them, and changing them here never disturbs a conversation you already have open.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Default model</div>
+        <div class="v">Every model from every service you've set up, grouped by who makes it. Faster models answer quickly and cost less; more capable ones handle harder, more nuanced work.</div>
+      </div>
+      <div class="row">
+        <div class="k">Default reasoning effort</div>
+        <div class="v">How long the model spends thinking before it answers, from Low up to Max — or leave it at the model's own default. More effort can mean better answers on tricky questions at the cost of a little speed. Not every model offers every level, and you're only offered the ones the chosen model actually supports.</div>
+      </div>
+    </div>
+
+    <h2 id="providers">Bring your own model</h2>
+    <p>Minerva talks to four kinds of AI service. You only need to set up the ones you intend to use — a key for one is enough to get started, and you can add others later without disturbing anything.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Anthropic</div>
+        <div class="v">The Claude models. Minerva is built around them and they're what the defaults point at.</div>
+      </div>
+      <div class="row">
+        <div class="k">OpenAI</div>
+        <div class="v">GPT-5 and the o-series reasoning models.</div>
+      </div>
+      <div class="row">
+        <div class="k">Google Gemini</div>
+        <div class="v">The Gemini 2.5 models.</div>
+      </div>
+      <div class="row">
+        <div class="k">Local / OpenAI-compatible</div>
+        <div class="v">Anything that speaks the OpenAI protocol at an address you give it — Ollama or LM Studio on your own machine, a vLLM or llama.cpp server, or a gateway like OpenRouter or Together. See <a href="#local">Running models locally</a> below.</div>
+      </div>
+    </div>
+
+    <h2 id="keys">Keys</h2>
+    <p>Each service gets its own section with its own key. A line above the field tells you whether one is saved, and says <b>encrypted at rest</b> when your operating system provides a secure store for it. For your privacy a saved key is never shown back to you and can't be copied out of the field.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Entering a key</div>
+        <div class="v">Paste it into that service's field and click <b>Done</b>. If a key is already saved, typing a new one replaces it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Clearing a key</div>
+        <div class="v">A <b>Clear saved key</b> link appears once one is saved. Nothing is removed until you click Done, and <b>Cancel clear</b> lets you change your mind first.</div>
+      </div>
+      <div class="row">
+        <div class="k">Check connection</div>
+        <div class="v">Confirms the service accepts the key before you rely on it — much easier than discovering the problem halfway through a conversation. It tests whatever the app would actually use, so it works on a key you've just typed as well as one already saved.</div>
+      </div>
+      <div class="row">
+        <div class="k">Environment variables</div>
+        <div class="v">If you'd rather not store a key in the app, each service names the environment variable it will fall back to (<code>ANTHROPIC_API_KEY</code>, <code>OPENAI_API_KEY</code>, <code>GEMINI_API_KEY</code>). A key saved here takes precedence over one in the environment.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">You choose who sees your notes</span>
+      <p>Everything else in Minerva stays on your machine. A conversation is the exception — the parts of your notes the assistant looks at are sent to whichever service that conversation is set to use. Picking the model is therefore also picking who that is, which is the main reason the choice is per conversation and not buried in a preference.</p>
+    </div>
+
+    <h2 id="local">Running models locally</h2>
+    <p>The <b>Local / OpenAI-compatible</b> section takes a <b>base URL</b> instead of assuming one — <code>http://localhost:11434/v1</code> for a default Ollama install, or wherever your server actually listens. Most local servers don't need a key; leave it blank if yours doesn't.</p>
+    <p>Minerva can't know what your endpoint serves, so you list the models yourself: type the model's id (the name the server knows it by, like <code>llama3.1:70b</code>) and, if you like, a friendlier label to show in the pickers. They then appear alongside the built-in models everywhere a model can be chosen. Remove one and it disappears from the pickers; conversations already using it keep their setting.</p>
+
+    <h2 id="voice">Voice dictation</h2>
+    <p>Turn on <b>Enable voice dictation</b> to speak instead of type, and pick a voice model from the dropdown beside it. Dictation runs entirely on your own machine — your audio never leaves it. The first time you use it, the voice model downloads once and is then ready to use offline.</p>
+
+    <figure class="shot-img">
+      <img src="img/settings-ai.png" alt="The AI settings tab: default model and reasoning effort dropdowns, then a section per service — Anthropic with a key saved and encrypted at rest, OpenAI and Google Gemini with none set — each with its own key field, Check connection button, and the environment variable it falls back to." loading="lazy" />
+      <figcaption>Screenshot — one section per service, each with its own key</figcaption>
+    </figure>

--- a/website/docs/_content/settings-appearance.html
+++ b/website/docs/_content/settings-appearance.html
@@ -1,0 +1,49 @@
+---
+title: Minerva — Docs — Settings: Appearance
+description: The Appearance tab in Settings: pick a theme and choose the font your notes are written and read in.
+---
+
+    <h1>Appearance</h1>
+    <p class="lede">This tab holds two choices: the theme the whole app wears, and the font your notes are written and read in. Both take effect the moment you change them.</p>
+
+    <h2 id="theme">Theme</h2>
+    <p>The <b>Theme</b> dropdown lets you pick Dark, Light, High Contrast, or System (which follows your computer's own light-or-dark setting). You can also switch themes from the status bar or with <kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd>. For a closer look at each theme, see the <a href="viewing-options-themes.html">Themes</a> page.</p>
+
+    <h2 id="content-font">Content font</h2>
+    <p>The <b>Content font</b> dropdown sets the typeface your notes appear in, both as you write and in the reading view. It changes only your note text — the app's menus, sidebars, and dialogs keep their usual look. Choose whichever reads best for you:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Minerva default</div>
+        <div class="v">Minerva's built-in typewriter-style font. The look you start with.</div>
+      </div>
+      <div class="row">
+        <div class="k">System Sans</div>
+        <div class="v">A clean, rounded font for a relaxed, prose-first reading feel.</div>
+      </div>
+      <div class="row">
+        <div class="k">Serif</div>
+        <div class="v">A book-like serif for long-form notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Monospace</div>
+        <div class="v">An even-width font where every character lines up.</div>
+      </div>
+      <div class="row">
+        <div class="k">JetBrains Mono</div>
+        <div class="v">A popular even-width font, used if you have it installed.</div>
+      </div>
+      <div class="row">
+        <div class="k">Berkeley Mono</div>
+        <div class="v">Another even-width font, used if you have it installed.</div>
+      </div>
+      <div class="row">
+        <div class="k">System mono</div>
+        <div class="v">Your computer's own even-width font.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/settings-appearance.png" alt="The Appearance tab in Settings, with the Theme dropdown at the top and the Content font dropdown below it, its list of font choices open." loading="lazy" />
+      <figcaption>The Appearance tab</figcaption>
+    </figure>

--- a/website/docs/_content/settings-behaviors.html
+++ b/website/docs/_content/settings-behaviors.html
@@ -1,0 +1,31 @@
+---
+title: Minerva — Docs — Settings: Behaviors
+description: The Behaviors settings: two small app-wide toggles, plus a list that lets you switch confirmation dialogs back on after you've told Minerva to stop asking.
+---
+
+    <h1>Behaviors</h1>
+    <p class="lede">Two small toggles that fine-tune how the app follows along as you work, plus a place to switch confirmation prompts back on after you've told Minerva to stop asking. Nothing here changes what Minerva can do — only how much it chimes in while you do it.</p>
+
+    <h2 id="toggles">Behavior toggles</h2>
+    <p>These two checkboxes take effect right away.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Auto-reveal active file in sidebar</div>
+        <div class="v">As you move between notes, the sidebar scrolls to highlight the one you're viewing and opens the folders it lives in. It only ever reveals — it never closes folders you opened yourself.</div>
+      </div>
+      <div class="row">
+        <div class="k">Show heading chain in breadcrumbs</div>
+        <div class="v">When your cursor is inside a section, the breadcrumb bar above the editor shows the headings leading down to it, updating as you move around. See <a href="navigation-breadcrumbs.html">Breadcrumbs</a> for more.</div>
+      </div>
+    </div>
+
+    <h2 id="confirmations">Confirmation dialogs</h2>
+    <p>Whenever Minerva asks you to confirm something — deleting a note, closing a conversation, and so on — the prompt includes a "Don't ask again" option. Once you use it, that prompt stops appearing. This list is where you can turn any of them back on.</p>
+
+    <p>Each prompt gets its own row with a checkbox: checked means it still asks, unchecked means you've silenced it. Turning one off here is the same as ticking "Don't ask again" when the prompt shows up. Every prompt is independent — silencing one never quiets another, even when two cover similar situations.</p>
+
+    <figure class="shot-img">
+      <img src="img/settings-behaviors.png" alt="The Behaviors settings scrolled to the confirmations section: the two toggles at the top, then a checklist of prompts — each with a title, a checkbox, and a one-line description, such as Delete file or folder or Close conversation — all switched on or off on their own." loading="lazy" />
+      <figcaption>Screenshot — the Behaviors settings, confirmation list</figcaption>
+    </figure>

--- a/website/docs/_content/settings-bibliography.html
+++ b/website/docs/_content/settings-bibliography.html
@@ -1,0 +1,34 @@
+---
+title: Minerva — Docs — Settings: Bibliography
+description: The Bibliography tab in Settings — choose the citation style Minerva uses for your reference lists, and add more styles or languages.
+---
+
+    <h1>Bibliography</h1>
+    <p class="lede">The Bibliography tab in <b>Settings</b> is where you choose the citation style Minerva uses when it builds a reference list for a note — APA, MLA, Chicago, and a few others come ready to use, and you can add more if you need them. The style you pick here is used whenever you run <b>Refactor → Insert/Update Bibliography</b>. Adding sources to cite is a separate step, covered in <a href="left-sidebar-sources.html#adding">Left sidebar → Sources</a>.</p>
+
+    <h2 id="settings">What you can set</h2>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Citation style</div>
+        <div class="v">Pick the style your references are written in. APA is the default, and you can also choose MLA, Chicago (author–date), Chicago (notes &amp; bibliography), IEEE, or Vancouver — plus any style you've added yourself. Each project keeps its own choice, so different collections of notes can follow different style guides.</div>
+      </div>
+      <div class="row">
+        <div class="k">Add a style</div>
+        <div class="v">Need a style that isn't in the list? Use <b>Import style…</b> to add one, and it appears in the Citation style menu right away. Styles you've added are listed here, each with a <b>Remove</b> button.</div>
+      </div>
+      <div class="row">
+        <div class="k">Add a language</div>
+        <div class="v">By default, references are written using English wording — the small words citation styles add, like "and", "ed.", or "no date". If you want your references written in another language, use <b>Import language…</b> to add it. Added languages are listed here, each with a <b>Remove</b> button.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/settings-bibliography.png" alt="The Bibliography tab: a menu for choosing your citation style with APA selected, a section for adding your own styles, and a section below it for adding other languages." loading="lazy" />
+      <figcaption>Screenshot — the Bibliography settings</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">This tab formats your references — it doesn't create them</span>
+      <p>Choosing a style here doesn't add a citation to a note. You cite a source or quote a saved excerpt using a link in your note, then run <b>Refactor → Insert/Update Bibliography</b> to gather those citations into a tidy References section written in the style you picked here. You can run it again any time you add more citations — it simply refreshes the same References section and leaves the rest of your writing untouched.</p>
+    </div>

--- a/website/docs/_content/settings-clipper.html
+++ b/website/docs/_content/settings-clipper.html
@@ -1,0 +1,24 @@
+---
+title: Minerva — Docs — Settings: Clipper
+description: The Clipper tab of Settings: turn on the browser clipper and pair it with your browser so you can save web pages straight into Minerva.
+---
+
+    <h1>Clipper</h1>
+    <p class="lede">The clipper lets you save the web page you're reading straight into Minerva as a source, using a small companion add-on for your browser. This tab turns that on and shows the one-time code that links your browser to Minerva.</p>
+
+    <h2 id="enable">Turn on the clipper</h2>
+    <p>Check <b>Enable browser clipper</b> to switch the feature on, and uncheck it to switch it off. That's all it takes — the change happens as soon as you click, and nothing is left listening for your browser when the box is unchecked.</p>
+
+    <h2 id="pairing">The pairing code</h2>
+    <p>Once the clipper is on, a pairing code appears. It's hidden by default; <b>Reveal</b> shows it and <b>Copy</b> puts it on your clipboard. Paste it into the browser add-on once, and from then on your browser can send pages to Minerva. You only need to do this a single time.</p>
+
+    <figure class="shot-img">
+      <img src="img/settings-clipper.png" alt="The Clipper tab with the clipper switched on: the pairing code is revealed, with buttons to hide it again or copy it, and a Regenerate code button below for starting fresh." loading="lazy" />
+      <figcaption>Screenshot — the Clipper tab with the pairing code shown</figcaption>
+    </figure>
+
+    <h2 id="regenerate">Regenerate the code</h2>
+    <p><b>Regenerate code</b> creates a brand-new pairing code and retires the old one. Any browser you'd already paired will stop working until you copy the new code and paste it in again. Use this if you want to re-pair from scratch.</p>
+
+    <h2 id="no-project">Open a thoughtbase first</h2>
+    <p>The clipper needs somewhere to file the pages you save, so it only runs while a thoughtbase is open. If you turn it on before opening one, you'll see a reminder to open a thoughtbase, and the pairing code appears once you do. Your choice to enable the clipper is remembered in the meantime.</p>

--- a/website/docs/_content/settings-compute.html
+++ b/website/docs/_content/settings-compute.html
@@ -1,0 +1,47 @@
+---
+title: Minerva — Docs — Settings: Compute
+description: The Compute settings tab: choose which Python Minerva uses to run the code cells in your notes.
+---
+
+    <h1>Compute</h1>
+    <p class="lede">Minerva can run Python code cells right inside your notes. The Compute tab does one thing: it lets you choose which Python on your computer does that work. If you're happy with the Python Minerva already finds, you never need to open this tab. To learn how to write and run code cells, see <a href="notes-code.html">Code &amp; compute cells</a>.</p>
+
+    <h2 id="interpreter">Choosing your Python</h2>
+    <p>By default, Minerva looks for Python on your computer automatically. If you'd rather point it at a specific one — say, a setup you've prepared with the packages you use — you can name it here. Your choice applies to every thoughtbase you open on this computer.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Python location</div>
+        <div class="v">Where your chosen Python lives. Leave it empty to let Minerva find one for you.</div>
+      </div>
+      <div class="row">
+        <div class="k">Browse…</div>
+        <div class="v">Pick your Python from a file chooser instead of typing its location. Minerva checks it right away so you know it works.</div>
+      </div>
+      <div class="row">
+        <div class="k">Check</div>
+        <div class="v">Test the current choice without saving it. Minerva tells you which version it found, or explains what went wrong if it couldn't run it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Save</div>
+        <div class="v">Keep your choice. Available once you've made a change.</div>
+      </div>
+      <div class="row">
+        <div class="k">Save &amp; restart</div>
+        <div class="v">Save your choice and switch to it straight away, so your next code cell uses it. Anything earlier cells had set up — variables, imported packages — starts fresh, just as if you'd reopened Minerva.</div>
+      </div>
+      <div class="row">
+        <div class="k">Clear</div>
+        <div class="v">Forget your saved choice and let Minerva find a Python for you again. Appears only after you've saved one.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/settings-compute.png" alt="The Compute panel: a field naming which Python to use with Browse and Check beside it, a line beneath confirming the version that was found, and the Save, Save &amp; restart, and Clear buttons below." loading="lazy" />
+      <figcaption>Screenshot — the Compute tab</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">Running code is your call</span>
+      <p>Minerva won't run Python in a thoughtbase until you say it's okay. The first time you run a code cell there, it asks for a quick confirmation, then remembers your answer for the rest of that thoughtbase. That's a one-time prompt at the moment you run a cell, not a switch on this tab. For the full picture, see <a href="notes-code.html#trust">Code &amp; compute cells</a>.</p>
+    </div>

--- a/website/docs/_content/settings-editor.html
+++ b/website/docs/_content/settings-editor.html
@@ -1,0 +1,39 @@
+---
+title: Minerva — Docs — Settings: Editor
+description: The Editor tab in Settings — tab size, word wrap, line numbers, whitespace, collapsing note properties, and numbered section headings.
+---
+
+    <h1>Editor</h1>
+    <p class="lede">These are the few preferences that fine-tune how it feels to write in Minerva. Most people never need to open this tab — the defaults are sensible — but if you like your editor set up a certain way, here's where to do it.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Tab size</div>
+        <div class="v">How far a tab or automatic indent moves the text. Default <b>2</b>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Word wrap</div>
+        <div class="v">Default <b>on</b>. Long lines wrap to fit the width of the editor instead of running off the right edge.</div>
+      </div>
+      <div class="row">
+        <div class="k">Show line numbers</div>
+        <div class="v">Default <b>on</b>. Shows numbers down the left edge of the editor.</div>
+      </div>
+      <div class="row">
+        <div class="k">Show whitespace</div>
+        <div class="v">Default <b>off</b>. Marks spaces and tabs with faint dots and arrows — handy when you want to see exactly how a line is indented.</div>
+      </div>
+      <div class="row">
+        <div class="k">Always collapse properties</div>
+        <div class="v">Default <b>off</b>. Automatically folds the <a href="notes-frontmatter.html">properties</a> block at the top of a note when you open it, so you land straight in the writing. Click to unfold it any time.</div>
+      </div>
+      <div class="row">
+        <div class="k">Numbered section headings</div>
+        <div class="v">Default <b>off</b>. Adds a section number in front of each second-level heading when you read a note — nice for long essays, distracting for journals and lists. It's just a reading touch; your headings aren't changed, and turning it off removes the numbers again.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/settings-editor.png" alt="The Editor tab, showing the tab size field and the toggles for word wrap, line numbers, whitespace, collapsing properties, and numbered section headings." loading="lazy" />
+      <figcaption>The Editor settings</figcaption>
+    </figure>

--- a/website/docs/_content/settings-formatter.html
+++ b/website/docs/_content/settings-formatter.html
@@ -1,0 +1,57 @@
+---
+title: Minerva — Docs — Settings: Formatter
+description: The Formatter tab in Settings — tidy your notes to a consistent style, with a safe house style on by default and more opinionated rules you can opt into.
+---
+
+    <h1>Formatter</h1>
+    <p class="lede">The Formatter tidies your notes to a consistent style — cleaning up stray spaces, straightening list markers, tidying footnotes, and more. You choose which touch-ups you want here on the <b>Formatter</b> tab, then run them whenever you like from <b>Refactor ▸ Format</b>. Nothing changes your notes until you run it.</p>
+
+    <h2 id="model">A safe default, plus opt-in polish</h2>
+    <p>Each touch-up is a checkbox with a plain-language description. They come in two flavors. The <b>house style</b> is a set of gentle, uncontroversial clean-ups that are <b>on by default</b> — they tidy spacing, list markers, and links without ever changing your wording, your headings, or the meaning of what you wrote. Everything else is more opinionated — things like rewording heading capitalization or auto-correcting spelling — so it's <b>off by default</b> and stays off until you turn it on.</p>
+
+    <p>Your choices are remembered for the notebook you're working in, so they stay with it wherever you open it.</p>
+
+    <div class="box">
+      <span class="label">Restore house style</span>
+      <p>The <b>Restore house style</b> button puts every setting back to its starting point in one click — the safe clean-ups on, everything else off. If you'd adjusted how a particular rule behaves, that returns to its default too. It's greyed out when you're already at the house style, and it won't ask you to confirm, because your notes aren't touched until you next run Format.</p>
+    </div>
+
+    <h2 id="categories">What it can tidy</h2>
+    <p>The touch-ups are grouped by what they affect. A few examples from each group:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Properties</div>
+        <div class="v">Tidies the properties block at the top of a note — trimming stray blank lines and removing duplicate values from a list. You can also opt in to sorting the property names into a consistent order.</div>
+      </div>
+      <div class="row">
+        <div class="k">Headings</div>
+        <div class="v">Optional clean-ups for heading structure: gently fix a heading level that jumps out of order, or apply a consistent capitalization style (title case, sentence case, or lowercase) while preserving names you list.</div>
+      </div>
+      <div class="row">
+        <div class="k">Content</div>
+        <div class="v">Optional polish for prose: turn three dots into a proper ellipsis (…), tidy up bare web links, and auto-correct a small, careful list of common misspellings.</div>
+      </div>
+      <div class="row">
+        <div class="k">Footnotes</div>
+        <div class="v">Optional footnote conventions: move a footnote marker to sit after sentence-ending punctuation, and gather all your footnote definitions into a single block at the end of the note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Spacing</div>
+        <div class="v">Safe, on-by-default clean-ups: remove stray spaces at the ends of lines, and cap long runs of blank lines. Code, math, and the properties block are left untouched.</div>
+      </div>
+      <div class="row">
+        <div class="k">Links and headings in Minerva</div>
+        <div class="v">Keeps a consistent style for your <code>[[wiki links]]</code>, and if two headings in a note share the same name, gives them distinct anchors so links can point to the right one — updating any links that referred to them.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/settings-formatter.png" alt="The Formatter tab, with a short intro about the house style, a Restore house style button, and each group of touch-ups shown as a checklist — every item a checkbox with a title and description, with the safe defaults already checked." loading="lazy" />
+      <figcaption>The Formatter tab</figcaption>
+    </figure>
+
+    <h2 id="exempt">Leaving one note alone</h2>
+    <p>These touch-ups apply to whatever you run Format over. When one note should be left exactly as you wrote it — a verbatim quote, something you hand-format, or a rough scratch pad — you can mark it to be skipped. Add a property named <b>format</b> set to <b>false</b>, and Format will pass that note by while tidying the rest.</p>
+
+    <p>You can set this a few ways: type <code>format: false</code> into the note's properties block, use <b>Add Property…</b> from the editor or the file list, or add it in the <b>Properties</b> panel in the right sidebar. In each case, set the value type to a true/false toggle and switch it off.</p>

--- a/website/docs/_content/settings-inspections.html
+++ b/website/docs/_content/settings-inspections.html
@@ -1,0 +1,30 @@
+---
+title: Minerva — Docs — Inspections settings
+description: Choose which health checks run over your thoughtbase, and how long "stale" and "unresolved" mean for you.
+---
+
+    <h1>Inspections</h1>
+    <p class="lede">Which standing checks Minerva runs over your thoughtbase, and what "stale" means for the way you work. Findings show up in the <a href="right-sidebar-inspections.html">Inspections panel</a> in the right sidebar; this page is about deciding what gets pointed out in the first place.</p>
+
+    <h2 id="choosing">Choosing which checks run</h2>
+    <p>Each check has a switch and a line saying what it looks for, grouped by what it's about: <b>Notes</b>, <b>Links</b>, and <b>Sources</b>. Everything is on to begin with. Switch off anything that isn't telling you something you'd act on — a thoughtbase of daily journal entries doesn't need to hear that its notes are old, and a set of working drafts doesn't need every unfinished link flagged.</p>
+    <p><b>Enable all</b> and <b>Disable all</b> are there for the two moments you want them: setting up, and starting over.</p>
+    <p>A check you switch off isn't quietly filtered out of the results — it doesn't run at all. Several read your whole knowledge graph, so switching off the ones you don't want makes a run over a large thoughtbase noticeably quicker. That applies to the automatic runs too, not just the ones you ask for.</p>
+    <p>Changes take effect on the next run — which is usually a couple of seconds after your next save. Press <b>Run</b> in the Inspections panel if you want the list to catch up immediately.</p>
+
+    <h2 id="thresholds">How long is "a while"?</h2>
+    <p>Two checks measure time, and neither has a right answer that suits everybody:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Call a note stale after</div>
+        <div class="v">Days without an edit before a note is flagged. A reference thoughtbase you revise twice a year wants a much longer window than a set of live project notes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Flag an unresolved stub after</div>
+        <div class="v">Days a source stub can sit unfilled before it's worth a nudge.</div>
+      </div>
+    </div>
+    <p>Each field appears only when its check is on — a dial for something that never runs is just clutter. Values are kept between 1 day and about ten years.</p>
+
+    <h2 id="scope">These settings follow you, not the thoughtbase</h2>
+    <p>Inspection preferences are stored per machine, alongside your other app settings, rather than inside a thoughtbase. They're a statement about how much you want to be nagged, not a property of the notes — so they apply to every thoughtbase you open here, and opening the same thoughtbase on another computer uses that computer's settings.</p>

--- a/website/docs/_content/settings-notes.html
+++ b/website/docs/_content/settings-notes.html
@@ -1,0 +1,67 @@
+---
+title: Minerva — Docs — Settings: Notes
+description: The Notes tab in Settings — where notes you split off and excerpt notes land, how they're named, and the templates that shape them.
+---
+
+    <h1>Notes</h1>
+    <p class="lede">Minerva has commands that turn one note into several — pulling a selection into its own note, or splitting a long note apart. The <b>Notes</b> settings tab decides where those new notes go and how they're named, plus what gets left behind in the note you split from.</p>
+
+    <h2 id="refactoring">Splitting notes</h2>
+    <p>These settings apply whenever you extract a selection into a new note or split a note into pieces. They're personal preferences for this computer, so they apply to every knowledge base you open here.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Where new notes go</div>
+        <div class="v">Choose to file each new note in the <b>same folder as the note you split from</b> (the default), at the <b>top of your knowledge base</b>, or in a <b>folder you name</b>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Custom folder</div>
+        <div class="v">Shown when you choose to name your own folder. Type the folder path, optionally using the placeholders below to sort notes by date — for example, into a folder for the current year and month. Left blank, new notes land at the top of your knowledge base.</div>
+      </div>
+      <div class="row">
+        <div class="k">Filename start</div>
+        <div class="v">Text you'd like added to the front of every new note's name. You can use the date placeholders below — for instance, to start each filename with a timestamp.</div>
+      </div>
+      <div class="row">
+        <div class="k">Tidy up heading levels</div>
+        <div class="v">When on, if the extracted text starts at a lower heading level, its headings are lifted so the note begins with a top-level heading. Only the new note is adjusted; the note you split from is untouched.</div>
+      </div>
+      <div class="row">
+        <div class="k">Embed instead of link</div>
+        <div class="v">When on, the note you split from shows the extracted content inline rather than just a link to it. If you set a link template below, that takes over and this option turns off.</div>
+      </div>
+      <div class="row">
+        <div class="k">Link template</div>
+        <div class="v">What to leave in the original note in place of the extracted text. Leave it blank for a plain link (or an inline embed if the option above is on). If you fill it in, it always wins.</div>
+      </div>
+      <div class="row">
+        <div class="k">New note template</div>
+        <div class="v">A wrapper for the body of every new note these commands create — handy for adding standard properties or a heading. Leave it blank to use the extracted text as-is.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/settings-notes.png" alt="The settings for splitting notes: where new notes go, the filename start, the tidy-headings and embed options, and the two template boxes for the link left behind and the new note's wrapper." loading="lazy" />
+      <figcaption>Screenshot — the Notes settings tab</figcaption>
+    </figure>
+
+    <h3 id="tokens">Placeholders</h3>
+    <p>In any of these template fields you can drop in placeholders that Minerva fills in automatically. Write each one inside double braces:</p>
+
+    <pre><code>{{date}}               Today's date
+{{date:FORMAT}}        A date in a format you choose (using YYYY, MM, DD, HH, mm, ss)
+{{title}}              The title of the note you split from
+{{new_note_title}}     The title of the new note
+{{new_note_content}}   The extracted text — for the new note template</code></pre>
+
+    <p>Use whichever placeholders fit the field. The extracted-text placeholder only belongs in the <b>New note template</b>, and it's the important one: if you set that template but leave the placeholder out, the new note is built from your template alone and the text you just extracted has nowhere to go. A placeholder Minerva doesn't recognize simply fills in as nothing.</p>
+
+    <h2 id="excerpt-notes">Excerpt notes</h2>
+    <p>When you turn a highlighted passage into its own note, this setting picks where it lands. Unlike the settings above, it belongs to the knowledge base itself, so everyone working in that knowledge base shares it.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Destination folder</div>
+        <div class="v">The folder where new excerpt notes go. Leave it blank and they land at the top of your knowledge base. The folder is created for you the first time it's needed.</div>
+      </div>
+    </div>

--- a/website/docs/_content/settings-object-types.html
+++ b/website/docs/_content/settings-object-types.html
@@ -1,0 +1,113 @@
+---
+title: Minerva — Docs — Settings: Object Types
+description: The Object Types tab in Settings — define what kinds of notes your project has, and adjust the built-in ones.
+---
+
+    <h1>Object Types</h1>
+    <p class="lede">An object type describes a kind of note — what fields it has, what icon it wears, how it looks in a gallery. This is where you see the types your project has and change them. Minerva ships a handful to start with, you can add your own, and you can adjust the built-in ones to suit how you actually work.</p>
+
+    <h2 id="list">What you'll see</h2>
+    <p>Every type in your project, one per row: its icon, its name, how many fields it declares, and how many notes are currently of that kind. A label on each row tells you where it came from:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">stock</div>
+        <div class="v">One of the types Minerva ships with — Book, Person, Meeting, Project, Idea, Article — exactly as it comes.</div>
+      </div>
+      <div class="row">
+        <div class="k">customized</div>
+        <div class="v">A stock type you've changed. Your version lives in this project and is what's actually used; the original is kept so you can go back to it.</div>
+      </div>
+      <div class="row">
+        <div class="k">user</div>
+        <div class="v">A type you created yourself, either here or from a note.</div>
+      </div>
+    </div>
+
+    <h2 id="editing">Changing a type</h2>
+    <p><strong>Edit</strong> opens the type's definition. Everything about it is here in one dialog:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Name</div>
+        <div class="v">What this kind of thing is called, wherever it's shown.</div>
+      </div>
+      <div class="row">
+        <div class="k">Icon</div>
+        <div class="v">The character that marks notes of this type in every list. On macOS the ☺ button opens the system emoji picker; you can also paste or type one.</div>
+      </div>
+      <div class="row">
+        <div class="k">Colour</div>
+        <div class="v">Tints the icon. Pick from the swatches beside the field, use the colour well for anything else, or type a hex value. The × clears it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Fields</div>
+        <div class="v">The properties notes of this type are expected to have. Each one has a name and a kind — text, number, date, a fixed list of choices, or a link to a note of another type. Add, remove, and reorder them; the order is the order they appear in on a note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Card</div>
+        <div class="v">Tick a field to include it when the note is shown as a card rather than a row.</div>
+      </div>
+      <div class="row">
+        <div class="k">Cover</div>
+        <div class="v">Which field holds an image, for the gallery view.</div>
+      </div>
+      <div class="row">
+        <div class="k">Parent type</div>
+        <div class="v">A more general type this one is a kind of. It inherits the parent's fields, and counts as one of the parent wherever they're gathered.</div>
+      </div>
+    </div>
+
+    <h2 id="customizing-stock">Adjusting a built-in type</h2>
+    <p>The stock types are a starting point, not a fixed set. If Book should track which shelf it's on, edit Book and add the field — no need to build your own near-copy.</p>
+
+    <p>Saving keeps a customized copy of that type in this project, which then shadows the built-in one. Your existing notes are unaffected: they're still Books, still found by everything that looks for Books. Only the definition changed.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Revert</div>
+        <div class="v">Appears on a customized type and puts the built-in definition back, discarding your changes to it. The notes using the type are left alone — the type still exists, it's just standard again.</div>
+      </div>
+      <div class="row">
+        <div class="k">The name stays fixed</div>
+        <div class="v">A built-in type keeps its name, even once customized. If you want a differently-named kind of thing, duplicate it — that gives you a type of your own that you can name freely.</div>
+      </div>
+    </div>
+
+    <h2 id="creating">Adding your own</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">New type</div>
+        <div class="v">Starts an empty definition. A name is all it needs; fields, icon, and the rest are optional and can be added later.</div>
+      </div>
+      <div class="row">
+        <div class="k">Duplicate</div>
+        <div class="v">Copies any type, built-in or not, as a new one of your own named "… copy". A quick way to start from something close to what you want.</div>
+      </div>
+      <div class="row">
+        <div class="k">From a note</div>
+        <div class="v"><strong>File → Save Note as Object Type</strong> builds a type out of a note you've already written, taking its properties as the fields.</div>
+      </div>
+    </div>
+
+    <h2 id="renaming-deleting">Renaming and deleting</h2>
+    <p>Your own types can also be renamed and deleted. Both take care of the notes that use them:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Rename</div>
+        <div class="v">Updates every note of that type to match, so nothing is left pointing at a name that no longer exists. If some notes can't be updated, the old type is kept rather than leaving them orphaned, and you're told.</div>
+      </div>
+      <div class="row">
+        <div class="k">Delete</div>
+        <div class="v">Tells you how many notes still use the type, then offers to remove the <code>type:</code> line from them as well. Decline and they keep it — it simply won't resolve to anything, which is easy to undo either way.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Types travel with the project</span>
+      <p>Your types and your customizations are stored inside the project itself, not on your machine. Open the same project elsewhere and they come with it; a different project has its own vocabulary.</p>
+    </div>
+
+    <h2 id="related">Using them</h2>
+    <p>A note takes on a type through its properties — see <a href="notes-typed-notes.html">Typed notes</a>. To browse your project by type, use the <a href="left-sidebar-objects.html">Objects panel</a>. To fill in a typed note's fields, use the <a href="right-sidebar-properties.html">Properties panel</a>.</p>

--- a/website/docs/_content/settings-skills.html
+++ b/website/docs/_content/settings-skills.html
@@ -1,0 +1,26 @@
+---
+title: Minerva — Docs — Settings: Skills
+description: The Skills tab in Settings — add your own thinking tools and choose which AI model each one uses.
+---
+
+    <h1>Skills</h1>
+    <p class="lede">Skills are the ready-made thinking tools that appear in Minerva's Learning, Research, and Analysis menus. The <b>Skills</b> tab in Settings lets you add your own and choose which AI model each one uses. Turning skills on or off, moving them between menus, and reordering them are covered at <a href="thinking-tools-managing-authoring.html">Thinking tools → Managing &amp; authoring</a>.</p>
+
+    <h2 id="import">Adding your own skill</h2>
+    <p>Click <b>Add skill…</b> and pick your skill file. Minerva checks that it's a valid, complete skill and adds it to your collection. If something's wrong — a missing detail, or a name that clashes with one you already have — it tells you exactly what to fix right below the button, and nothing is added until the file checks out.</p>
+    <p>Once a skill is added, it appears right away in its menu, ready to use. Two more buttons sit alongside: <b>Open skills folder</b> opens the place your skills are kept, and <b>Reload</b> refreshes the list after you've edited or dropped in a skill by hand.</p>
+
+    <figure class="shot-img">
+      <img src="img/settings-skills.png" alt="The Skills tab: the Import skill / Reveal skills folder / Reload buttons across the top, a Skill models section with a provider picker and a Reset to Default button, and below them the list of skills, each with a switch to turn it on, a menu it belongs to, and a picker to choose its AI model." loading="lazy" />
+      <figcaption>Screenshot — the Skills settings panel</figcaption>
+    </figure>
+
+    <h2 id="model-overrides">Choosing a skill's AI model</h2>
+    <p>Each skill has a model picker. Leave it on the default and the skill uses the model it's meant to run on. Pick a specific model instead to pin that one skill to your choice — handy when you want a heavier model for careful analysis, or a faster one for quick tasks. The default option always names the model it would actually use, so there's no guesswork. Your choices apply everywhere you use Minerva on this computer.</p>
+
+    <h2 id="reset-models">Resetting every skill to its default</h2>
+    <p>Each skill's author picked a model for it — the heavier thinking skills get a frontier model, the lighter ones a cheaper sibling — and those choices are written in Anthropic's models. If you work through OpenAI or Google, that's the wrong vocabulary, and re-picking a model on fifty-odd rows by hand is nobody's idea of an evening.</p>
+    <p>Choose a provider next to <b>Reset to Default…</b> and every skill goes back to its author's choice, expressed in that provider's models: the heavy skills land on the frontier model, the light ones on the cheap one. Resetting onto the provider the skills were written for simply clears your pins, so every row reads "Default" again.</p>
+    <p>Only the model pins change. Which skills are switched on, which menu each one sits in, and their order are left exactly as you have them.</p>
+
+    <p>To turn a skill on or off, move it to a different menu, or change its order, see <a href="thinking-tools-managing-authoring.html">Thinking tools → Managing &amp; authoring</a>.</p>

--- a/website/docs/_content/settings-sources.html
+++ b/website/docs/_content/settings-sources.html
@@ -1,0 +1,48 @@
+---
+title: Minerva — Docs — Settings: Sources
+description: The Sources settings tab: bringing in subject tags when you add a source by identifier, and logging in to sites so Minerva can reach articles behind a paywall.
+---
+
+    <h1>Sources</h1>
+    <p class="lede">A source is a paper, article, or document you've brought into your project to read and cite. The <b>Sources</b> tab in Settings holds two conveniences for getting sources in: automatically picking up subject tags when you add one by its identifier, and logging in to sites so Minerva can reach articles you have access to. To learn what sources are and the different ways to add one, see <a href="left-sidebar-sources.html">Left sidebar → Sources</a>.</p>
+
+    <h2 id="ingest">Subject tags on new sources</h2>
+    <p>When you add a source by its identifier — a DOI, arXiv id, or PubMed id — the catalog you're pulling it from often already knows what subject areas the work belongs to. Minerva can bring those subjects along as ready-made tags on the new source, so it's filed under the right topics automatically.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Import subject tags on new sources</div>
+        <div class="v">On by default. When it's on, adding a source by identifier tags it with the subject areas the catalog lists for that work — grouped by where they came from, so a paper might arrive tagged something like <code>crossref/sociology</code>, <code>arxiv/cs-lg</code>, or <code>mesh/genetics</code>. Turning it off only affects sources you add from then on; tags already on existing sources stay put. To remove these tags from a source later, right-click it and choose "Strip upstream tags."</div>
+      </div>
+    </div>
+
+    <p>These tags only come from sources you add by identifier — adding one by web address or from a file won't produce them, since only a catalog lookup knows the work's subject areas.</p>
+
+    <h2 id="privileged-sites">Sites you're logged in to</h2>
+    <p>Some articles are only fully available once you've signed in — through an institution or a paid subscription. If you list a site here and log in to it, Minerva will use that login whenever it fetches from that site, so a paywalled article comes in complete instead of blocked.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Add site</div>
+        <div class="v">Enter the site's address (for example <code>arxiv.org</code>) and an optional name, then <b>Add</b>. Each site you add keeps its own separate, private login — signing in to one never affects another.</div>
+      </div>
+      <div class="row">
+        <div class="k">Login</div>
+        <div class="v">Opens a browser window on the site so you can sign in the way you normally would. Close the window when you're done, and Minerva remembers the login for future fetches.</div>
+      </div>
+      <div class="row">
+        <div class="k">Logout</div>
+        <div class="v">Signs you out of that site and forgets the login. The site stays in your list — you'd just log in again next time you need it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Remove</div>
+        <div class="v">Signs you out and takes the site off the list entirely.</div>
+      </div>
+    </div>
+
+    <p>Being listed here only means Minerva uses your login when it fetches from that site. It doesn't change anything else, and nothing gets brought in without your say-so.</p>
+
+    <figure class="shot-img">
+      <img src="img/settings-sources.png" alt="The subject-tags option with its on/off switch at the top, and below it the list of sites you're logged in to — each showing its name, address, when you last signed in, and buttons to log in, log out, or remove it, with a form to add a new site." loading="lazy" />
+      <figcaption>The Sources settings tab</figcaption>
+    </figure>

--- a/website/docs/_content/settings-versioning.html
+++ b/website/docs/_content/settings-versioning.html
@@ -1,0 +1,43 @@
+---
+title: Minerva — Docs — Versioning
+description: Settings for how long Minerva keeps each note's saved versions, how many it keeps per note, and how big a file can get before it stops being recorded.
+---
+
+    <h1>Versioning</h1>
+    <p class="lede">Minerva keeps a copy of every version of every note you save, so you can read them and put one back from the <a href="right-sidebar-history.html">History panel</a>. That costs disk, and these three settings decide how much: how long a version lives, how many pile up for one note, and how big a file has to get before it stops being recorded.</p>
+
+    <figure class="shot-img">
+      <img src="img/settings-versioning.png" alt="The Versioning panel in Settings, showing the three limits: keep versions for 30 days, 500 versions per note, and a 1024 KB maximum file size." loading="lazy" />
+      <figcaption>Screenshot — Settings → Versioning</figcaption>
+    </figure>
+
+    <h2 id="limits">The three limits</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Keep versions for</div>
+        <div class="v">How many days an unnamed version lives before it's dropped. Default: <b>30</b>. Raise it if you want a longer memory; lower it if history is using more disk than it's worth to you.</div>
+      </div>
+      <div class="row">
+        <div class="k">Versions per note</div>
+        <div class="v">How many unnamed versions to keep for a single note, newest first. Default: <b>500</b>. This is the backstop for a long editing session, which can otherwise produce hundreds of versions of one note in an afternoon.</div>
+      </div>
+      <div class="row">
+        <div class="k">Maximum file size</div>
+        <div class="v">Files bigger than this get no history at all. Default: <b>1024 KB</b> — far above any note you'd write by hand, and low enough that a large generated <code>.csv</code> isn't copied on every save. Set it to <code>0</code> if you'd rather have history on everything and have the disk for it.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Two versions are never dropped</span>
+      <p>Neither limit touches a version you've <a href="right-sidebar-history.html#naming">named</a>, or a note's <b>initial version</b>. A name is a deliberate "keep this", and the initial version is what "undo everything" gets you back to — losing either to a retention rule would defeat the point of keeping history at all. Neither is what fills a disk.</p>
+    </div>
+
+    <h2 id="lowering">What happens when you lower a limit</h2>
+    <p>The open thoughtbase is re-pruned as soon as you change a setting, so tightening a limit frees the disk immediately rather than gradually as you happen to edit each note. Other thoughtbases on this machine catch up the next time each of their notes is saved.</p>
+    <p>Pruning removes stored versions permanently. If there's a state of a note you want to survive a shorter retention window, name it first.</p>
+
+    <h2 id="per-machine">Per-machine, not per-thoughtbase</h2>
+    <p>These limits are stored for this computer and apply to every thoughtbase you open on it — what they're budgeting is this machine's disk, and the same thoughtbase on a roomier machine can reasonably keep more. The history itself is per-thoughtbase: it lives in the <code>.minerva</code> folder beside the notes, so a thoughtbase carries its own past with it if you move it.</p>
+
+    <h2 id="what-is-recorded">What gets recorded</h2>
+    <p>Every save of every note — markdown and the <code>.csv</code>, <code>.ttl</code> and <code>.py</code> notes alike — whether the save came from you, from a <a href="thinking-tools.html">thinking tool</a>, or from restoring an earlier version. Attachments and images aren't notes and aren't recorded. Neither is anything inside <code>.minerva</code> itself.</p>

--- a/website/docs/_content/settings-web.html
+++ b/website/docs/_content/settings-web.html
@@ -1,0 +1,34 @@
+---
+title: Minerva — Docs — Settings: Web
+description: The Web tab in Settings: turn web access on or off for conversations, and choose which sites the assistant may draw from.
+---
+
+    <h1>Web</h1>
+    <p class="lede">When you chat with the assistant, it can reach out to the web to answer questions that go beyond your own notes. This tab decides whether it may do that, and which sites it's allowed to draw from. To see how web results appear in a conversation, visit <a href="conversations-chatting.html">Chatting with the AI</a>.</p>
+
+    <h2 id="controls">The settings</h2>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Enable web access for conversations</div>
+        <div class="v">The main switch. When it's on, the assistant can look things up on the web whenever a question needs information beyond your notes. When it's off, it works only from what's already in your thoughtbase. On by default.</div>
+      </div>
+      <div class="row">
+        <div class="k">Allowed sites</div>
+        <div class="v">List trusted sites here, one per line (for example, <code>arxiv.org</code>), and the assistant will search and read only those. Leave it blank to let it search the whole web.</div>
+      </div>
+      <div class="row">
+        <div class="k">Blocked sites</div>
+        <div class="v">List sites here, one per line, to keep them out of web results. This applies only when the allowed-sites list is empty.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Good to know</span>
+      <p>If you fill in the allowed-sites list, it takes over completely and your blocked-sites list is ignored — the assistant sticks to your trusted sites and nothing else. So if web results seem to be leaving out sources you expected, check whether you've added anything to the allowed-sites list.</p>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/settings-web.png" alt="A switch to turn web access on or off for conversations, followed by two boxes: one for sites the assistant may draw from, and one for sites to keep out." loading="lazy" />
+      <figcaption>The Web tab in Settings</figcaption>
+    </figure>

--- a/website/docs/_content/settings.html
+++ b/website/docs/_content/settings.html
@@ -1,0 +1,146 @@
+---
+title: Minerva — Docs — Settings
+description: The twelve places to adjust how Minerva looks and behaves: Editor, Appearance, Behaviors, Notes, Formatter, Bibliography, Web, Sources, Clipper, Compute, AI, and Skills.
+---
+
+    <h1>Settings</h1>
+    <p class="lede">Settings is where you shape how Minerva looks and works. Thirteen tabs cover different corners of the app — the writing experience, the AI, where new notes are filed, what the app is allowed to fetch. Most changes take effect right away, so you can try something and see the result.</p>
+
+    <h2 id="glance">The thirteen tabs</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k"><a href="settings-editor.html">Editor</a></div>
+        <div class="v">Tab size, wrapping, line numbers, and other editing preferences.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-appearance.html">Appearance</a></div>
+        <div class="v">Choose a theme and the font your notes are shown in.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-behaviors.html">Behaviors</a></div>
+        <div class="v">App-wide toggles, and a way to bring back any dialog you told to stop asking.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-notes.html">Notes</a></div>
+        <div class="v">Where new notes are filed when you split a note or save an excerpt.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-versioning.html">Versioning</a></div>
+        <div class="v">How long each note's saved versions are kept, and how much disk they may use.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-formatter.html">Formatter</a></div>
+        <div class="v">Turn each tidy-up rule for your writing on or off.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-object-types.html">Object Types</a></div>
+        <div class="v">The kinds of note your project knows about, and the fields each one expects.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-bibliography.html">Bibliography</a></div>
+        <div class="v">Pick a citation style and language, and add more of each.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-web.html">Web</a></div>
+        <div class="v">Decide whether the AI can search and read the web, and which sites it may visit.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-sources.html">Sources</a></div>
+        <div class="v">Bring in tags from your sources and choose which sites can be fetched.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-clipper.html">Clipper</a></div>
+        <div class="v">Connect the browser tool that sends web pages into Minerva.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-compute.html">Compute</a></div>
+        <div class="v">Choose which Python setup runs the calculations in your notes.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-ai.html">AI</a></div>
+        <div class="v">Set the default model, how hard it thinks, your access key, and voice dictation.</div>
+      </div>
+      <div class="row">
+        <div class="k"><a href="settings-skills.html">Skills</a></div>
+        <div class="v">Import skills and set per-skill model overrides.</div>
+      </div>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="settings-editor.html">
+        <span class="em">📃</span>
+        <h3>Editor</h3>
+        <p>Tab size, wrapping, line numbers, and other editing preferences.</p>
+      </a>
+      <a class="doc-card" href="settings-appearance.html">
+        <span class="em">🪞</span>
+        <h3>Appearance</h3>
+        <p>Choose a theme and the font your notes are shown in.</p>
+      </a>
+      <a class="doc-card" href="settings-behaviors.html">
+        <span class="em">🧩</span>
+        <h3>Behaviors</h3>
+        <p>App-wide toggles, and a way to bring back dialogs you silenced.</p>
+      </a>
+      <a class="doc-card" href="settings-notes.html">
+        <span class="em">🗒️</span>
+        <h3>Notes</h3>
+        <p>Where new notes are filed when you split a note or save an excerpt.</p>
+      </a>
+      <a class="doc-card" href="settings-versioning.html">
+        <span class="em">🕰️</span>
+        <h3>Versioning</h3>
+        <p>How long each note's saved versions are kept, and how much disk they may use.</p>
+      </a>
+      <a class="doc-card" href="settings-formatter.html">
+        <span class="em">🧹</span>
+        <h3>Formatter</h3>
+        <p>Turn each tidy-up rule for your writing on or off.</p>
+      </a>
+      <a class="doc-card" href="settings-object-types.html">
+        <span class="em">🧩</span>
+        <h3>Object Types</h3>
+        <p>Define what kinds of note your project has.</p>
+      </a>
+      <a class="doc-card" href="settings-inspections.html">
+        <span class="em">🩺</span>
+        <h3>Inspections</h3>
+        <p>Which health checks run, and what counts as stale.</p>
+      </a>
+      <a class="doc-card" href="settings-bibliography.html">
+        <span class="em">📜</span>
+        <h3>Bibliography</h3>
+        <p>Pick a citation style and language, and add more of each.</p>
+      </a>
+      <a class="doc-card" href="settings-web.html">
+        <span class="em">🌍</span>
+        <h3>Web</h3>
+        <p>Decide whether the AI can search and read the web, and which sites.</p>
+      </a>
+      <a class="doc-card" href="settings-sources.html">
+        <span class="em">🎫</span>
+        <h3>Sources</h3>
+        <p>Bring in tags from your sources and choose which sites can be fetched.</p>
+      </a>
+      <a class="doc-card" href="settings-clipper.html">
+        <span class="em">✂️</span>
+        <h3>Clipper</h3>
+        <p>Connect the browser tool that sends web pages into Minerva.</p>
+      </a>
+      <a class="doc-card" href="settings-compute.html">
+        <span class="em">🐍</span>
+        <h3>Compute</h3>
+        <p>Choose which Python setup runs the calculations in your notes.</p>
+      </a>
+      <a class="doc-card" href="settings-ai.html">
+        <span class="em">🤖</span>
+        <h3>AI</h3>
+        <p>Set the default model, effort, access key, and voice dictation.</p>
+      </a>
+      <a class="doc-card" href="settings-skills.html">
+        <span class="em">🎚️</span>
+        <h3>Skills</h3>
+        <p>Import skills and set per-skill model overrides.</p>
+      </a>
+    </div>

--- a/website/docs/_content/thinking-tools-analysis.html
+++ b/website/docs/_content/thinking-tools-analysis.html
@@ -1,0 +1,95 @@
+---
+title: Minerva — Docs — Analysis Operations
+description: The skills in Minerva's Analysis menu: generation, disagreement, diagnostics, semantics, pattern-finding, motivation, planning, data analysis, and organization — 27 skills for working a claim or argument over.
+---
+
+    <h1>Analysis Operations</h1>
+    <p class="lede">The <b>Analysis</b> menu is the largest — skills for working over a claim, argument, or plan you already have: generating opposition and synthesis, exposing assumptions, mapping a decision's dimensions, finding patterns, stress-testing plans, and analyzing your data. Its skills fall into <a href="thinking-tools-three-menus.html#grouping">themed groups</a>, and every one hands back a <a href="thinking-tools-running-a-skill.html">suggestion you review</a>.</p>
+
+    <h2 id="generation">Generation</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Antithesize</div><div class="v">Generate a standalone opposition — a complete rival worldview.</div></div>
+      <div class="row"><div class="k">Synthesize</div><div class="v">Compress thesis + antithesis into a unified frame.</div></div>
+      <div class="row"><div class="k">Metaphorize</div><div class="v">High-coverage source→target domain mapping.</div></div>
+      <div class="row"><div class="k">Fill Out Note</div><div class="v">Expand a sparse or dictated note into a fuller draft, reviewed as a diff.</div></div>
+    </div>
+
+    <h2 id="disagreement">Disagreement</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Steelman</div><div class="v">Construct the strongest version of an opposing argument.</div></div>
+      <div class="row"><div class="k">Double Crux</div><div class="v">Find the shared crux that would resolve a disagreement.</div></div>
+      <div class="row"><div class="k">Find Tensions</div><div class="v">Surface where this note and another conflict.</div></div>
+    </div>
+
+    <h2 id="diagnostic">Diagnostic</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Excavate</div><div class="v">Surface hidden assumptions underlying arguments.</div></div>
+      <div class="row"><div class="k">Rhetoricize</div><div class="v">Map the rhetorical "spin-space" — where could the argument pivot?</div></div>
+    </div>
+
+    <h2 id="semantic">Semantic</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Dimensionalize</div><div class="v">Reduce a decision to 3–7 measurable dimensions.</div></div>
+      <div class="row"><div class="k">Handlize</div><div class="v">Extract operational "handles" — short phrases you can grab and use.</div></div>
+      <div class="row"><div class="k">Taboo</div><div class="v">Semantic decomposition by banning a contested term.</div></div>
+    </div>
+
+    <h2 id="pattern">Pattern</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Inductify</div><div class="v">Cross-example pattern extraction — what underlies these cases?</div></div>
+      <div class="row"><div class="k">Rhyme</div><div class="v">Fast structural-similarity recognition — what does this echo?</div></div>
+      <div class="row"><div class="k">Negspace</div><div class="v">Detect what is conspicuously absent.</div></div>
+      <div class="row"><div class="k">Noticing</div><div class="v">Surface the felt sense the prose isn't saying out loud.</div></div>
+    </div>
+
+    <h2 id="motivation">Motivation</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Goal Factor</div><div class="v">Decompose a goal into the underlying needs it serves.</div></div>
+      <div class="row"><div class="k">Aversion Factor</div><div class="v">Decompose a stated objection into the underlying aversions.</div></div>
+      <div class="row"><div class="k">Inner Loop</div><div class="v">Sim the plan from the inside — what would actually happen?</div></div>
+    </div>
+
+    <h2 id="planning">Planning</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Hamming Question</div><div class="v">Surface the most-important problem you are not working on.</div></div>
+      <div class="row"><div class="k">Murphyjitsu</div><div class="v">Pre-mortem failure analysis for plans and decisions.</div></div>
+      <div class="row"><div class="k">Reference Class</div><div class="v">Forecast via base rates from the right outside view.</div></div>
+    </div>
+
+    <h2 id="data">Data</h2>
+    <p>These three work over the <a href="data.html">tabular data</a> in your thoughtbase and return a reviewable note:</p>
+    <div class="deflist">
+      <div class="row"><div class="k">Find Correlations</div><div class="v">Surface the strongest correlations across the thoughtbase's tabular data.</div></div>
+      <div class="row"><div class="k">Find Outliers</div><div class="v">Flag the anomalous values in the thoughtbase's tabular data.</div></div>
+      <div class="row"><div class="k">Generate Visualizations</div><div class="v">Propose the right <a href="notes-charts.html">charts</a> for the thoughtbase's tabular data.</div></div>
+    </div>
+
+    <h2 id="organization">Organization</h2>
+    <div class="deflist">
+      <div class="row"><div class="k">Reorganize by Topic</div><div class="v">Propose moving loose notes into topic folders, reviewed as one plan.</div></div>
+      <div class="row"><div class="k">Tidy Filenames</div><div class="v">Propose <a href="refactoring.html">renaming</a> notes toward a consistent filename convention.</div></div>
+    </div>
+
+    <div class="box">
+      <span class="label">These are the stock skills</span>
+      <p>This is what ships in the Analysis menu. Turn skills on and off, move them between menus, reorder them, or write your own — see <a href="thinking-tools-managing-authoring.html">Managing &amp; authoring</a>.</p>
+    </div>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="thinking-tools-learning.html">
+        <span class="em">🎓</span>
+        <h3>Learning Operations</h3>
+        <p>The Learning menu — understand what's in front of you.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-research.html">
+        <span class="em">🔬</span>
+        <h3>Research Operations</h3>
+        <p>The Research menu — gather, verify, and decompose.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-managing-authoring.html">
+        <span class="em">🛠️</span>
+        <h3>Managing &amp; authoring</h3>
+        <p>Turn skills on/off, move them, or write your own.</p>
+      </a>
+    </div>

--- a/website/docs/_content/thinking-tools-learning.html
+++ b/website/docs/_content/thinking-tools-learning.html
@@ -1,0 +1,79 @@
+---
+title: Minerva — Docs — Learning Operations
+description: The skills in Minerva's Learning menu: explain, summarize, give examples and counterexamples, find prerequisites, build a learning journey and glossary, quiz yourself, and draft flashcards.
+---
+
+    <h1>Learning Operations</h1>
+    <p class="lede">The <b>Learning</b> menu holds skills for understanding something already in front of you — re-explaining it at your level, drawing out examples and prerequisites, building study material, and testing yourself. Each runs over the current note (or a selection) and hands back a suggestion you <a href="thinking-tools-running-a-skill.html">review</a> before anything is kept.</p>
+
+    <h2 id="skills">The skills</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Explain Like I’m…</div>
+        <div class="v">Re-explain a topic at a chosen audience level.</div>
+      </div>
+      <div class="row">
+        <div class="k">Summarize</div>
+        <div class="v">Open a conversation that summarizes the active note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Give Examples</div>
+        <div class="v">Generate concrete examples illustrating the note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Find Counterexamples</div>
+        <div class="v">Where does this note’s argument break down?</div>
+      </div>
+      <div class="row">
+        <div class="k">Find Prerequisites</div>
+        <div class="v">List concepts to understand before tackling this note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Create Learning Journey</div>
+        <div class="v">Design an ordered learning path ending at mastery.</div>
+      </div>
+      <div class="row">
+        <div class="k">Generate Glossary</div>
+        <div class="v">Build a structured, graph-typed glossary for a note or topic.</div>
+      </div>
+      <div class="row">
+        <div class="k">Add Term to Glossary</div>
+        <div class="v">Add one term to the existing glossary, matching its conventions.</div>
+      </div>
+      <div class="row">
+        <div class="k">Deep Dive on Term</div>
+        <div class="v">Expand a selected term into a fuller explanation.</div>
+      </div>
+      <div class="row">
+        <div class="k">Quiz Me</div>
+        <div class="v">Test your understanding of the note with graded questions.</div>
+      </div>
+      <div class="row">
+        <div class="k">Propose Flashcards</div>
+        <div class="v">Draft atomic <a href="notes-flashcards.html">spaced-repetition cards</a> from the note, for your review.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">These are the stock skills</span>
+      <p>This is what ships in the Learning menu. You can turn skills on and off, move them between menus, reorder them, or write your own — see <a href="thinking-tools-managing-authoring.html">Managing &amp; authoring</a>.</p>
+    </div>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="thinking-tools-research.html">
+        <span class="em">🔬</span>
+        <h3>Research Operations</h3>
+        <p>The Research menu — gather, verify, and decompose.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-analysis.html">
+        <span class="em">🧩</span>
+        <h3>Analysis Operations</h3>
+        <p>The Analysis menu — work a claim or argument over.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-three-menus.html">
+        <span class="em">🧠</span>
+        <h3>The three menus</h3>
+        <p>How Learning, Research, and Analysis divide the work.</p>
+      </a>
+    </div>

--- a/website/docs/_content/thinking-tools-managing-authoring.html
+++ b/website/docs/_content/thinking-tools-managing-authoring.html
@@ -1,0 +1,33 @@
+---
+title: Minerva — Docs — Managing &amp; Authoring Skills
+description: Turn skills on or off, move them between menus, and reorder them — all from Settings.
+---
+
+    <h1>Managing &amp; authoring</h1>
+    <p class="lede">Skills are the ready-made thinking tools in the Learning, Research, and Analysis menus. From <b>Settings → Skills</b> you can turn any of them off, move it to a different menu, or change its order. Your changes take effect right away.</p>
+
+    <h2 id="settings">Managing skills from Settings</h2>
+    <p>Open <b>Settings → Skills</b> and you'll see each menu — Learning, Research, and Analysis — listing its skills as rows. Every row has a simple set of controls, so tidying up your menus is a matter of clicking, not editing anything by hand.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Turn on or off</div>
+        <div class="v">Uncheck a skill to hide it everywhere it would otherwise appear. It isn't deleted — the row stays in Settings, dimmed, so you can switch it back on whenever you like.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move to a different menu</div>
+        <div class="v">Use the menu dropdown to send a skill to whichever of the three menus you prefer. Handy when a tool you reach for constantly lives in one menu but you'd rather find it in another.</div>
+      </div>
+      <div class="row">
+        <div class="k">Reorder</div>
+        <div class="v">The up and down arrows change where a skill sits in its menu. The order you set here is the order you'll see everywhere the skill appears.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/thinking-tools-managing-authoring.png" alt="The Learning, Research, and Analysis menus stacked together, each showing its skills as rows. Every row has an on/off checkbox, the skill's name, arrows to move it up or down, and a dropdown to send it to a different menu." loading="lazy" />
+      <figcaption>The Skills settings panel</figcaption>
+    </figure>
+
+    <h2 id="authoring">Writing your own</h2>
+    <p>Beyond rearranging the skills that come built in, you can write your own to capture a way of thinking you return to often. Authoring is a more advanced topic with its own dedicated guide — start there when you're ready.</p>

--- a/website/docs/_content/thinking-tools-research.html
+++ b/website/docs/_content/thinking-tools-research.html
@@ -1,0 +1,107 @@
+---
+title: Minerva — Docs — Research Operations
+description: The skills in Minerva's Research menu: find sources, mine and verify claims, weigh arguments, decompose notes into claims and linked notes, and draft summaries.
+---
+
+    <h1>Research Operations</h1>
+    <p class="lede">The <b>Research</b> menu holds skills that go out and gather new material and hold it to account — finding sources, mining and verifying claims, weighing the arguments for and against, and breaking a note down into its parts. Its skills are organized into <a href="thinking-tools-three-menus.html#grouping">themed groups</a>; several reach the web, and every one hands back a <a href="thinking-tools-running-a-skill.html">suggestion you review</a>.</p>
+
+    <h2 id="discovery">Discovery</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Find Sources</div>
+        <div class="v">Assemble a candidate reading list for a topic — you pick what to <a href="ingest.html">ingest</a>.</div>
+      </div>
+    </div>
+
+    <h2 id="mining">Mining</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Extract Key Claims</div>
+        <div class="v">Mine the central claims a source makes, each with a supporting excerpt.</div>
+      </div>
+    </div>
+
+    <h2 id="verification">Verification</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Check Facts</div>
+        <div class="v">Web-verify a claim — corroborated, contested, or unverifiable.</div>
+      </div>
+      <div class="row">
+        <div class="k">Date / Scope Check</div>
+        <div class="v">Is this still true now, and was it ever true as stated?</div>
+      </div>
+      <div class="row">
+        <div class="k">Find Primary Sources</div>
+        <div class="v">Trace a claim past the citation chain to the actual primary source.</div>
+      </div>
+      <div class="row">
+        <div class="k">Translate the Magnitude</div>
+        <div class="v">Re-ground a quantitative claim against its base rate and baseline.</div>
+      </div>
+    </div>
+
+    <h2 id="argumentation">Argumentation</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Find Supporting Arguments</div>
+        <div class="v">Surface the strongest cases in favour of a specific claim.</div>
+      </div>
+      <div class="row">
+        <div class="k">Find Opposing Arguments</div>
+        <div class="v">Surface the strongest cases against a specific claim.</div>
+      </div>
+      <div class="row">
+        <div class="k">Find Load-Bearing Claim</div>
+        <div class="v">Identify the single claim whose falsity would collapse the argument.</div>
+      </div>
+    </div>
+
+    <h2 id="decomposition">Decomposition</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Decompose into Claims</div>
+        <div class="v">Pull every distinct assertion out as its own typed claim.</div>
+      </div>
+      <div class="row">
+        <div class="k">Decompose into Linked Notes</div>
+        <div class="v">Split the note into a parent index + 2–7 focused children.</div>
+      </div>
+      <div class="row">
+        <div class="k">Crystallize as Components</div>
+        <div class="v">Extract thought components and file as a crystallization note.</div>
+      </div>
+    </div>
+
+    <h2 id="summarize">Summarize</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Propose Summary</div>
+        <div class="v">Draft an abstract + TL;DR for this source, for your review.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">These are the stock skills</span>
+      <p>This is what ships in the Research menu. Turn skills on and off, move them between menus, reorder them, or write your own — see <a href="thinking-tools-managing-authoring.html">Managing &amp; authoring</a>.</p>
+    </div>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="thinking-tools-learning.html">
+        <span class="em">🎓</span>
+        <h3>Learning Operations</h3>
+        <p>The Learning menu — understand what's in front of you.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-analysis.html">
+        <span class="em">🧩</span>
+        <h3>Analysis Operations</h3>
+        <p>The Analysis menu — work a claim or argument over.</p>
+      </a>
+      <a class="doc-card" href="ingest.html">
+        <span class="em">📥</span>
+        <h3>Ingest</h3>
+        <p>Bring the sources you find into the thoughtbase.</p>
+      </a>
+    </div>

--- a/website/docs/_content/thinking-tools-running-a-skill.html
+++ b/website/docs/_content/thinking-tools-running-a-skill.html
@@ -1,0 +1,53 @@
+---
+title: Minerva — Docs — Running a Skill
+description: How to run a thinking tool from the Learning, Research, or Analysis menu — and why its result almost always arrives as a proposal for you to review.
+---
+
+    <h1>Running a skill</h1>
+    <p class="lede">A skill is a ready-made thinking tool you launch on the note you're working in. Pick one from the Learning, Research, or Analysis menu (or the editor's right-click menu) and Minerva puts the relevant parts of your note to work for you. Almost every skill hands back its result as a <a href="conversations-propose-review-approve.html">proposal you review</a> — nothing changes in your notes without a keystroke from you.</p>
+
+    <h2 id="invoke">What happens when you run one</h2>
+    <p>You don't have to prepare anything. Launch a skill and it draws on whatever it needs from where you are — the note you're reading, a passage you've selected, a claim under your cursor, related notes, or the source you're viewing.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">1. It reads your context</div>
+        <div class="v">The skill picks up just the material it needs for the job — the whole note, the passage you've highlighted, or the claim at your cursor. It never reaches beyond that.</div>
+      </div>
+      <div class="row">
+        <div class="k">2. It may ask a quick question</div>
+        <div class="v">Some skills open a short form first — a dropdown or a text field. Excavate, for example, asks how deep to go: Quick, Standard, or Deep. Skills with nothing to ask start right away.</div>
+      </div>
+      <div class="row">
+        <div class="k">3. It works</div>
+        <div class="v">Most skills open a new <a href="conversations.html">conversation</a> already primed with your context, so you can watch it think and reply just like any chat. A few instead show their thinking in a compact panel at the bottom, with no back-and-forth.</div>
+      </div>
+      <div class="row">
+        <div class="k">4. It offers a proposal</div>
+        <div class="v">When a skill wants to change your notes — filing a claim, suggesting evidence, drafting a summary, rewriting a note — it hands you a proposal to review. Nothing is written until you approve it.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">You always have the final say</span>
+      <p>A skill is a helpful starting point, not a shortcut past your review. Whatever it opens follows the same rule as a conversation you began yourself: <b>the tool proposes, you confirm.</b> See <a href="conversations-propose-review-approve.html">The propose, review, approve loop</a> and <a href="left-sidebar-proposals.html">Proposals</a> for how to review what a skill hands you.</p>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/thinking-tools-running-a-skill.png" alt="Side by side: the Research menu open with a skill highlighted on the left, and the Proposals panel on the right showing the pending card it created, ready to expand and review." loading="lazy" />
+      <figcaption>Screenshot — Running a skill and reviewing its proposal</figcaption>
+    </figure>
+
+    <h2 id="output-modes">Where the result shows up</h2>
+    <p>Two things can happen after a skill runs, depending on how it was built:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">In a conversation</div>
+        <div class="v">The usual way. The skill opens a new conversation tied to your note, with its opening prompt already in place. You read along as the answer comes in, and if the skill wants to change your notes, its proposal appears as a pending card in the <a href="left-sidebar-proposals.html">Proposals panel</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k">In a panel at the bottom</div>
+        <div class="v">A few skills, such as Excavate, work in a small panel instead of a conversation: you see the thinking stream in, then the finished text with <b>Save as Note</b>, <b>Append to Current</b>, and <b>Copy</b>. Here your click on a button is the confirmation step.</div>
+      </div>
+    </div>

--- a/website/docs/_content/thinking-tools-three-menus.html
+++ b/website/docs/_content/thinking-tools-three-menus.html
@@ -1,0 +1,33 @@
+---
+title: Minerva — Docs — The Three Menus
+description: How thinking tools are split across the Learning, Research, and Analysis menus, and how larger menus tidy themselves into themed submenus.
+---
+
+    <h1>The three menus</h1>
+    <p class="lede">Your thinking tools live in three menus in the menu bar — <b>Learning</b>, <b>Research</b>, and <b>Analysis</b>. They aren't rigid categories, just a helpful division of labor: Learning helps you understand something already in front of you, Research goes out and gathers new material, and Analysis works on a claim or argument you already have. The order reads like a workflow — understand first, then gather, then examine.</p>
+
+    <h2 id="menus">What belongs where</h2>
+    <p>Here are a few of the built-in tools in each menu, to give you a feel for the split.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Learning</div>
+        <div class="v">Tools that work on something you already have open — explain it, expand it, or quiz you on it. <b>Deep Dive on Term</b> expands a word or phrase you've selected into a fuller explanation at the depth you choose, using the surrounding note for context. <b>Explain Like I'm…</b> and <b>Quiz Me</b> are the same shape: nothing new comes in from outside, the tool just changes how you engage with what's already there. See <a href="thinking-tools-learning.html">Learning Operations</a> for the full menu.</div>
+      </div>
+      <div class="row">
+        <div class="k">Research</div>
+        <div class="v">Tools that go get something — from the web, from your existing notes, or from a source you're reading — and hand it back as a draft for you to keep. <b>Find Sources</b> builds a candidate reading list; you decide which ones are worth actually adding. <b>Extract Key Claims</b> pulls the main claims out of a source, each linked back to the passage it came from. <b>Check Facts</b> tests a specific claim against outside evidence. See <a href="thinking-tools-research.html">Research Operations</a> for the full menu.</div>
+      </div>
+      <div class="row">
+        <div class="k">Analysis</div>
+        <div class="v">Tools that operate on a claim, argument, or note you already have — drawing out its structure, its tensions, or a stronger version of it. <b>Steelman</b> builds the strongest possible version of an opposing argument. <b>Find Tensions</b> compares two notes for where they disagree. <b>Doublecrux</b> and <b>Murphyjitsu</b> belong to the same family. This is by far the largest menu, which is why it's the one that benefits most from grouping. See <a href="thinking-tools-analysis.html">Analysis Operations</a> for the full menu.</div>
+      </div>
+    </div>
+
+    <h2 id="grouping">Themed groups within a menu</h2>
+    <p>When a menu holds a lot of tools, related ones are gathered into themed submenus — labels like <b>Disagreement</b>, <b>Verification</b>, or <b>Discovery</b> — so you're not scrolling one long list. For example, Steelman and Doublecrux sit together under Disagreement, while Check Facts and Find Primary Sources sit under Verification. Tools that don't belong to a theme simply stay in the menu alongside the submenus. Today the Research and Analysis menus use groups — Analysis, the largest, most heavily; the Learning menu stays a flat list.</p>
+
+    <figure class="shot-img">
+      <img src="img/thinking-tools-three-menus.png" alt="The Analysis menu is open, showing themed submenus like Disagreement and Verification alongside any standalone tools, with the Disagreement submenu expanded to reveal Steelman, Find Tensions, and Doublecrux." loading="lazy" />
+      <figcaption>The Analysis menu with a themed group open</figcaption>
+    </figure>

--- a/website/docs/_content/thinking-tools-what-they-are.html
+++ b/website/docs/_content/thinking-tools-what-they-are.html
@@ -1,0 +1,33 @@
+---
+title: Minerva — Docs — What Thinking Tools Are
+description: Thinking tools are skills: ready-made prompts that live in the Learning, Research, and Analysis menus, which you can use as-is or write your own.
+---
+
+    <h1>What thinking tools are</h1>
+    <p class="lede">Thinking tools are ready-made ways to put AI to work on your notes. Each one lives in the <b>Learning</b>, <b>Research</b>, or <b>Analysis</b> menu, and behind every entry is a <b>skill</b>: a saved instruction for the AI, together with a name and a home menu. Pick one and it runs against whatever you have open or selected.</p>
+
+    <h2 id="what-is-a-skill">A skill is a reusable instruction</h2>
+    <p>Think of a skill as a small, purpose-built assistant. It knows one job — add a term to your glossary, steelman an argument, find tensions in a note — and it carries the instructions for doing that job well. When you choose a skill, Minerva hands the AI those instructions along with the right context (the note you're in, or the text you've selected) and starts a conversation.</p>
+
+    <p>Because each skill is a single, plain file, they're easy to browse, tweak, and share. Nothing about a skill is locked inside the app — you can write your own, adjust one you like, or turn one off entirely.</p>
+
+    <h2 id="stock-vs-user">Built-in skills and your own</h2>
+    <p>Skills come from two places:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Built-in skills</div>
+        <div class="v">Minerva ships with a full set of skills covering the default Learning, Research, and Analysis menus — enough to be useful the moment you open the app.</div>
+      </div>
+      <div class="row">
+        <div class="k">Your own skills</div>
+        <div class="v">You can add skills of your own. They appear alongside the built-in ones and are available in every thoughtbase you open on that computer. After you add or change one by hand, use <b>Reload</b> in Settings → Skills to pick up the change.</div>
+      </div>
+    </div>
+
+    <p>Your skills add to the built-in set rather than replacing it. If you'd rather a built-in skill worked differently, turn it off in Settings → Skills and write your own version — starting from a copy of the one you liked is the easiest way to do this.</p>
+
+    <figure class="shot-img">
+      <img src="img/thinking-tools-what-they-are.png" alt="The Analysis menu open, listing skills such as Steelman, Find Tensions, Murphyjitsu, Doublecrux, and Antithesize, each with a short description beneath its name." loading="lazy" />
+      <figcaption>A thinking-tools menu open</figcaption>
+    </figure>

--- a/website/docs/_content/thinking-tools.html
+++ b/website/docs/_content/thinking-tools.html
@@ -1,0 +1,75 @@
+---
+title: Minerva — Docs — Thinking Tools
+description: The Learning, Research, and Analysis skills: what they are, running one, the three menus, and making them your own.
+---
+
+    <h1>Thinking tools</h1>
+    <p class="lede">The Learning, Research, and Analysis menus are ready-made thinking moves you run over the note you're looking at — steelman an argument, pull out its claims, quiz yourself on it, check a fact. Each one is a <b>skill</b>, and the set is yours to turn on and off, rearrange, or add to.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="thinking-tools-what-they-are.html"><b>What thinking tools are</b></a> — the skills that come with Minerva, and ones you can add.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="thinking-tools-running-a-skill.html"><b>Running a skill</b></a> — pick one from a menu; it works and hands back a suggestion to review.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="thinking-tools-three-menus.html"><b>The three menus</b></a> — Learning, Research, Analysis, and how skills group within each.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v">The full catalogs — <a href="thinking-tools-learning.html"><b>Learning</b></a>, <a href="thinking-tools-research.html"><b>Research</b></a>, and <a href="thinking-tools-analysis.html"><b>Analysis</b> Operations</a> — every stock skill in each menu, with what it does.</div>
+      </div>
+      <div class="row">
+        <div class="k">—</div>
+        <div class="v"><a href="thinking-tools-managing-authoring.html"><b>Making them your own</b></a> — turn skills on and off, move and reorder them, or write your own.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">You stay in control</span>
+      <p>A skill's result is a suggestion, never a silent change. Anything a skill wants to add or edit comes back for you to approve or reject first — see <a href="conversations-propose-review-approve.html">The propose → review → approve loop</a>.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="thinking-tools-what-they-are.html">
+        <span class="em">📄</span>
+        <h3>What thinking tools are</h3>
+        <p>The skills that come with Minerva, and ones you add, sitting side by side.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-running-a-skill.html">
+        <span class="em">▶️</span>
+        <h3>Running a skill</h3>
+        <p>Pick one from a menu; it works and hands back a suggestion to review.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-three-menus.html">
+        <span class="em">🗂️</span>
+        <h3>The three menus</h3>
+        <p>Learning, Research, Analysis — and how skills group within each.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-learning.html">
+        <span class="em">🎓</span>
+        <h3>Learning Operations</h3>
+        <p>Every skill in the Learning menu — understand what's in front of you.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-research.html">
+        <span class="em">🔬</span>
+        <h3>Research Operations</h3>
+        <p>Every skill in the Research menu — gather, verify, and decompose.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-analysis.html">
+        <span class="em">🧩</span>
+        <h3>Analysis Operations</h3>
+        <p>Every skill in the Analysis menu — work a claim or argument over.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools-managing-authoring.html">
+        <span class="em">🛠️</span>
+        <h3>Making them your own</h3>
+        <p>Turn skills on and off, move and reorder them — and how to write your own.</p>
+      </a>
+    </div>

--- a/website/docs/_content/thoughtbase-operations.html
+++ b/website/docs/_content/thoughtbase-operations.html
@@ -1,0 +1,94 @@
+---
+title: Minerva — Docs — Thoughtbase operations
+description: The File-menu commands for handling thoughtbases in Minerva: create a new thoughtbase, open one, switch between recents, close, and edit the thoughtbase guide.
+---
+
+    <h1>Thoughtbase operations</h1>
+    <p class="lede">A <a href="thoughtbase.html">thoughtbase</a> is a folder on your disk, and the commands for handling one live at the top of the <b>File</b> menu — grouped there first because the natural first move is "open my thoughtbase" before doing anything in it. Each window holds one open thoughtbase at a time.</p>
+
+    <h2 id="creating">Creating and opening</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">New Thoughtbase…</div>
+        <div class="v"><b>File → New Thoughtbase…</b> Choose a location and name; Minerva creates the folder and sets up an empty thoughtbase, ready for your first note.</div>
+      </div>
+      <div class="row">
+        <div class="k">Open Thoughtbase…</div>
+        <div class="v"><b>File → Open Thoughtbase…</b> (<kbd>⌘</kbd><kbd>O</kbd>). Pick an existing thoughtbase folder to open it in the current window. Opening any folder of markdown notes works — Minerva builds the graph for it the first time.</div>
+      </div>
+    </div>
+
+    <h2 id="switching">Switching between thoughtbases</h2>
+    <p>Keep a thoughtbase per subject and move between them however suits you:</p>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Recent Thoughtbases</div>
+        <div class="v"><b>File → Recent Thoughtbases</b> lists the ones you've opened lately — pick one to jump straight back in.</div>
+      </div>
+      <div class="row">
+        <div class="k">Clear Recent Thoughtbases</div>
+        <div class="v"><b>File → Recent Thoughtbases → Clear Recent Thoughtbases</b> empties that list. It only tidies the list of recently opened thoughtbases — none of your notes are touched.</div>
+      </div>
+      <div class="row">
+        <div class="k">New Window</div>
+        <div class="v"><b>File → New Window</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd>) opens a second window. Because each window holds one thoughtbase, this is how you keep two open side by side — open one thoughtbase in each.</div>
+      </div>
+    </div>
+
+    <h2 id="closing">Closing</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Close Thoughtbase</div>
+        <div class="v"><b>File → Close Thoughtbase</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>W</kbd>) closes the current thoughtbase and returns the window to an empty state, ready to open another. Your files are saved as you go, so nothing is lost.</div>
+      </div>
+    </div>
+
+    <h2 id="guide">The thoughtbase guide</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Edit Thoughtbase Guide…</div>
+        <div class="v"><b>File → Edit Thoughtbase Guide…</b> opens <code>thoughtbase.md</code>, a plain-English guide to this thoughtbase — its structure, intent, and conventions — that Minerva shows the assistant at the start of every conversation. It's created from a template the first time you open it. Keeping it up to date is the simplest way to make the AI's help fit how <em>this</em> thoughtbase is organized.</div>
+      </div>
+    </div>
+
+    <h2 id="properties">Thoughtbase properties</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Thoughtbase Properties…</div>
+        <div class="v"><b>File → Thoughtbase Properties…</b> opens a small dialog for the two things a thoughtbase itself carries: what it's called, and — tucked under <b>Advanced</b> — the base address its knowledge graph uses.</div>
+      </div>
+    </div>
+
+    <p>The <b>Name</b> is a display label, kept separately from the folder on disk. Set it to whatever reads best and the folder keeps its own name; leave it blank and Minerva falls back to the folder's name. This is the friendly way to fix a thoughtbase called <code>notes-final-v2</code> without renaming anything on your file system.</p>
+
+    <div class="box">
+      <span class="label">Advanced: the graph base IRI</span>
+      <p>Every fact in your <a href="notes-rdf.html">knowledge graph</a> is identified by an address built on a common prefix — the base IRI. You'd change it if you're publishing your graph and want its identifiers to live under a domain you control.</p>
+      <p>Saving a new base rebuilds every index so all those identifiers regenerate. It has to be an absolute <code>http://</code> or <code>https://</code> address ending in a slash; anything else is refused with the reason shown in the dialog. Your <a href="left-sidebar-proposals.html">proposals</a> are carried over automatically, and <a href="navigation-wiki-links.html">wiki-links</a> between notes aren't affected — they don't use the base at all. What does break is anything outside Minerva that referred to the old addresses: exports you've already published, and any identifiers you'd copied elsewhere by hand.</p>
+      <p>Most thoughtbases never need this. If you're not publishing the graph, the default is fine.</p>
+    </div>
+
+    <h2 id="rename-delete">Renaming, moving, or deleting a thoughtbase</h2>
+    <p>There are two different things you might mean by renaming a thoughtbase. To change what it's <em>called</em> in Minerva, set its Name in <a href="#properties">Thoughtbase Properties</a> — that's instant and touches nothing on disk. To change the <em>folder</em>, do it in Finder or your file manager like any other folder, then open it again from its new location.</p>
+
+    <p>Deleting works the same way: a thoughtbase is an ordinary folder, so removing the folder removes the thoughtbase. There's no command inside Minerva for it. (Renaming, moving, and deleting individual <a href="notes.html#lifecycle">notes</a> <em>is</em> handled inside Minerva, from the sidebar.)</p>
+
+    <h2 id="related">Related</h2>
+    <p>Once a thoughtbase is open, these cover what you do next:</p>
+    <div class="doc-cards">
+      <a class="doc-card" href="ingest.html">
+        <span class="em">📥</span>
+        <h3>Ingest</h3>
+        <p>Bring web pages, PDFs, and references in as sources.</p>
+      </a>
+      <a class="doc-card" href="export.html">
+        <span class="em">📤</span>
+        <h3>Export &amp; publish</h3>
+        <p>Publish a thoughtbase to the web, or export notes as documents and citations.</p>
+      </a>
+      <a class="doc-card" href="maintenance.html">
+        <span class="em">🛠️</span>
+        <h3>Maintenance</h3>
+        <p>Rebuild indexes and keep the graph and search in sync.</p>
+      </a>
+    </div>

--- a/website/docs/_content/thoughtbase.html
+++ b/website/docs/_content/thoughtbase.html
@@ -1,0 +1,96 @@
+---
+title: Minerva — Docs — What is a thoughtbase?
+description: What a thoughtbase is in Minerva, the kinds of work people build one for, and a map of everything a thoughtbase holds — notes, links, sources, data, the knowledge graph, and AI conversations.
+---
+
+    <h1>What is a thoughtbase?</h1>
+    <p class="lede">A <b>thoughtbase</b> is where your thinking on a subject lives and grows. Instead of scattered documents and lost chat threads, you gather what you're working through as <a href="notes.html">notes</a> — and notes link to each other, so ideas connect the way they do in your head. Some you write yourself; some you draft side by side with the AI. Over time a thoughtbase becomes a living map of what you know, not a folder of dead files.</p>
+
+    <p>Each thoughtbase is self-contained: one folder of plain files, with its own <a href="data.html">knowledge graph</a> built automatically from what's inside. You can keep several — one per subject — and open whichever you're working in. Everything is stored locally, in plain text, and stays yours.</p>
+
+    <h2 id="what-for">What you might build one of</h2>
+    <p>A thoughtbase suits any subject you return to and want to build up over time rather than finish and forget. A few shapes it commonly takes:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">A research project</div>
+        <div class="v">A literature review, a thesis, or an ongoing investigation — papers and web pages brought in as <a href="ingest.html">sources</a>, key claims extracted, and your own synthesis linking them together.</div>
+      </div>
+      <div class="row">
+        <div class="k">A writing project</div>
+        <div class="v">A book, a report, or a long essay — the manuscript alongside the background notes, characters, arguments, and references that feed it.</div>
+      </div>
+      <div class="row">
+        <div class="k">A subject you're learning</div>
+        <div class="v">A course or a field you're getting to grips with — explanations in your own words, <a href="notes-flashcards.html">flashcards</a>, and worked examples that build on each other.</div>
+      </div>
+      <div class="row">
+        <div class="k">A decision or investigation</div>
+        <div class="v">Options, evidence, and arguments laid out and connected — support, rebut, and depends-on <a href="notes-links.html">links</a> making the structure of the reasoning visible.</div>
+      </div>
+      <div class="row">
+        <div class="k">A domain you're mapping</div>
+        <div class="v">A product area, a system's architecture, a body of law, a company's history — a reference map of what's true and how the parts relate.</div>
+      </div>
+      <div class="row">
+        <div class="k">A data analysis</div>
+        <div class="v">A question you're answering with data — <a href="notes-tables.html">CSV tables</a> you query with SQL, notes that <a href="notes-code.html">compute</a>, and <a href="notes-charts.html">charts</a> that render live against the numbers.</div>
+      </div>
+      <div class="row">
+        <div class="k">A personal knowledge base</div>
+        <div class="v">A durable place for what you know and keep coming back to — a "second brain" you can actually query, not just search.</div>
+      </div>
+    </div>
+
+    <h2 id="contents">What's inside a thoughtbase</h2>
+    <p>A thoughtbase collects several kinds of thing. Most of it is notes; the rest is the connective tissue and structure that turns a pile of notes into something you can query and build on.</p>
+
+    <div class="doc-cards">
+      <a class="doc-card" href="notes.html">
+        <span class="em">🧵</span>
+        <h3>Notes</h3>
+        <p>The main content — prose, tables, images, math, diagrams, and more. One note per idea, page, or piece.</p>
+      </a>
+      <a class="doc-card" href="notes-links.html">
+        <span class="em">🔗</span>
+        <h3>Links</h3>
+        <p>Connections between notes — plain wiki-links plus typed links like supports, rebuts, and depends-on.</p>
+      </a>
+      <a class="doc-card" href="ingest.html">
+        <span class="em">📥</span>
+        <h3>Sources</h3>
+        <p>Outside material brought in — web pages, PDFs, and references you cite and mine for claims.</p>
+      </a>
+      <a class="doc-card" href="notes-frontmatter.html">
+        <span class="em">🏷️</span>
+        <h3>Properties &amp; tags</h3>
+        <p>Structured details on a note — tags, status, and other metadata that the graph reads.</p>
+      </a>
+      <a class="doc-card" href="notes-tables.html">
+        <span class="em">📋</span>
+        <h3>Data &amp; tables</h3>
+        <p>CSV files as typed tables, and tables inside notes — queryable data that charts and cells read.</p>
+      </a>
+      <a class="doc-card" href="data.html">
+        <span class="em">🕸️</span>
+        <h3>The knowledge graph</h3>
+        <p>A precise map of titles, tags, links, and facts, built automatically on every save — queryable with SPARQL and SQL.</p>
+      </a>
+      <a class="doc-card" href="conversations.html">
+        <span class="em">💬</span>
+        <h3>Conversations &amp; proposals</h3>
+        <p>Your threads with the AI, and the changes it proposes — filed as notes and claims only after you approve them.</p>
+      </a>
+      <a class="doc-card" href="thinking-tools.html">
+        <span class="em">🧠</span>
+        <h3>Thinking-tool output</h3>
+        <p>Results of the Learning, Research, and Analysis skills — each returned as a note you review and keep or discard.</p>
+      </a>
+    </div>
+
+    <h2 id="where">Where a thoughtbase lives</h2>
+    <p>A thoughtbase is just a folder on your disk. Your notes are ordinary markdown files inside it, organized into subfolders however you like — readable and portable, with or without Minerva. Alongside them, a hidden <code>.minerva</code> folder holds the knowledge graph and other generated data, rebuilt from your files as you work.</p>
+    <p>Because it's local-first and plain-text, a thoughtbase is yours: back it up, sync it, or put it under version control like any other folder. Nothing lives in a proprietary database you can't get out of. When you're ready to share, you can <a href="export.html">publish or export</a> a thoughtbase without giving up the original.</p>
+
+    <h2 id="managing">Creating and managing thoughtbases</h2>
+    <p>You create, open, switch between, and close thoughtbases from the <b>File</b> menu. See <a href="thoughtbase-operations.html">Thoughtbase operations</a> for each command and its keyboard shortcut.</p>

--- a/website/docs/_content/viewing-options-font-size-zoom.html
+++ b/website/docs/_content/viewing-options-font-size-zoom.html
@@ -1,0 +1,29 @@
+---
+title: Minerva — Docs — Font Size &amp; Zoom
+description: Two ways to make things bigger or smaller in Minerva — the editor's own text size, and zoom for the whole window — and how they work together.
+---
+
+    <h1>Font size &amp; zoom</h1>
+    <p class="lede">Minerva gives you two ways to make things bigger or smaller, and they do different jobs. <b>Editor font size</b> changes only the text you're writing in. <b>Zoom</b> scales the whole window at once — sidebars, menus, dialogs, and your writing together. Reach for whichever fits: bump the editor text when you just want more comfortable writing, or zoom the window when everything feels too small.</p>
+
+    <h2 id="mechanisms">The two controls</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Editor font size</div>
+        <div class="v">Changes only the size of the text in the <a href="editor.html">editor</a> — the rest of the window stays put. Press <kbd>⌘</kbd><kbd>⇧</kbd><kbd>=</kbd> / <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>=</kbd> to make it larger and <kbd>⌘</kbd><kbd>⇧</kbd><kbd>-</kbd> / <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>-</kbd> to make it smaller, a step at a time. You'll also find these under View, along with a command to reset to the default size. Your choice is remembered the next time you open Minerva.</div>
+      </div>
+      <div class="row">
+        <div class="k">Zoom</div>
+        <div class="v">Scales everything in the window together, not just the editor. Press <kbd>⌘</kbd><kbd>+</kbd> / <kbd>Ctrl</kbd><kbd>+</kbd> to zoom in, <kbd>⌘</kbd><kbd>-</kbd> / <kbd>Ctrl</kbd><kbd>-</kbd> to zoom out, and <kbd>⌘</kbd><kbd>0</kbd> / <kbd>Ctrl</kbd><kbd>0</kbd> to return to normal size. The same commands live under View.</div>
+      </div>
+    </div>
+
+    <figure class="shot-img">
+      <img src="img/viewing-options-font-size-zoom.png" alt="The View menu open to its lower section, showing the zoom commands (zoom in, zoom out, and back to normal size) grouped just above the separate commands for making the editor text larger, smaller, or reset to default." loading="lazy" />
+      <figcaption>The zoom and font size commands in the View menu</figcaption>
+    </figure>
+
+    <div class="box">
+      <span class="label">The two stack together</span>
+      <p>Because zoom scales the whole window, it also scales whatever editor text size you've set. If you've already made the editor text larger and then zoom in as well, the text grows twice. If things look bigger than expected, check both controls — neither one resets the other.</p>
+    </div>

--- a/website/docs/_content/viewing-options-operations.html
+++ b/website/docs/_content/viewing-options-operations.html
@@ -1,0 +1,92 @@
+---
+title: Minerva — Docs — View operations
+description: The View menu commands in Minerva: toggle the sidebars and conversations, cycle preview mode, split the editor, switch theme, and adjust zoom and editor font size.
+---
+
+    <h1>View operations</h1>
+    <p class="lede">The <b>View</b> menu controls what's on screen — which panels are showing, how a note is displayed, the split layout, the theme, and text size. Almost every command has a keyboard shortcut, so you rarely need the menu itself once they're in your fingers.</p>
+
+    <h2 id="panels">Showing and hiding panels</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Toggle Left Sidebar</div>
+        <div class="v"><b>View → Toggle Left Sidebar</b> (<kbd>⌘</kbd><kbd>B</kbd>) shows or hides the <a href="left-sidebar.html">left rail</a> — the Notes tree, Sources, Tags, and more.</div>
+      </div>
+      <div class="row">
+        <div class="k">Toggle Right Sidebar</div>
+        <div class="v"><b>View → Toggle Right Sidebar</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>B</kbd>) shows or hides the <a href="right-sidebar.html">right rail</a> — backlinks, outline, properties, and the rest.</div>
+      </div>
+      <div class="row">
+        <div class="k">Toggle Conversations</div>
+        <div class="v"><b>View → Toggle Conversations</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>K</kbd>) shows or hides the <a href="conversations.html">Conversations</a> panel.</div>
+      </div>
+      <div class="row">
+        <div class="k">Cycle Preview Mode</div>
+        <div class="v"><b>View → Cycle Preview Mode</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd>) steps the current pane through Source, Preview, and side-by-side. See <a href="viewing-options-view-modes.html">View modes</a>.</div>
+      </div>
+    </div>
+
+    <h2 id="splits">Splitting the editor</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Split Editor Right / Down</div>
+        <div class="v"><b>View → Split Editor Right</b> (<kbd>⌘</kbd><kbd>\</kbd>) and <b>Split Editor Down</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>\</kbd>) divide the window into panes so you can see two notes at once. See <a href="viewing-options-split-panes-windows.html">Split panes &amp; windows</a>.</div>
+      </div>
+      <div class="row">
+        <div class="k">Focus Next / Previous Group</div>
+        <div class="v"><b>View → Focus Next Group</b> (<kbd>⌘</kbd><kbd>⌥</kbd><kbd>→</kbd>) and <b>Focus Previous Group</b> (<kbd>⌘</kbd><kbd>⌥</kbd><kbd>←</kbd>) move the cursor between panes.</div>
+      </div>
+      <div class="row">
+        <div class="k">Close Group</div>
+        <div class="v"><b>View → Close Group</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>W</kbd>) closes the focused pane.</div>
+      </div>
+    </div>
+
+    <h2 id="theme">Theme</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Theme</div>
+        <div class="v"><b>View → Theme</b> picks a look directly — Dark, Light, High Contrast, or System.</div>
+      </div>
+      <div class="row">
+        <div class="k">Cycle Theme</div>
+        <div class="v"><b>View → Cycle Theme</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd>) steps through them without opening the menu. See <a href="viewing-options-themes.html">Themes</a>.</div>
+      </div>
+    </div>
+
+    <h2 id="zoom">Zoom and font size</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Actual Size · Zoom In · Zoom Out</div>
+        <div class="v"><b>View → Zoom In / Zoom Out</b> scales the whole window; <b>Actual Size</b> resets it.</div>
+      </div>
+      <div class="row">
+        <div class="k">Editor Font Size</div>
+        <div class="v"><b>View → Increase / Decrease Editor Font Size</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>=</kbd> / <kbd>⌘</kbd><kbd>⇧</kbd><kbd>-</kbd>) resizes the editor text only, and <b>Reset Editor Font Size</b> restores it. Zoom and font size are independent and compound — see <a href="viewing-options-font-size-zoom.html">Font size &amp; zoom</a>.</div>
+      </div>
+    </div>
+    <p>The View menu also offers full-screen and developer tools at the bottom.</p>
+
+    <div class="box">
+      <span class="label">Windows / Linux</span>
+      <p>Every shortcut above uses <kbd>Ctrl</kbd> in place of <kbd>⌘</kbd>.</p>
+    </div>
+
+    <h2 id="related">Related</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="viewing-options-view-modes.html">
+        <span class="em">🔄</span>
+        <h3>View modes</h3>
+        <p>Source, Preview, and side-by-side, per pane.</p>
+      </a>
+      <a class="doc-card" href="viewing-options-split-panes-windows.html">
+        <span class="em">🪟</span>
+        <h3>Split panes &amp; windows</h3>
+        <p>Two notes at once — in one window or several.</p>
+      </a>
+      <a class="doc-card" href="viewing-options-themes.html">
+        <span class="em">🎨</span>
+        <h3>Themes</h3>
+        <p>Dark, Light, High Contrast, and System.</p>
+      </a>
+    </div>

--- a/website/docs/_content/viewing-options-split-panes-windows.html
+++ b/website/docs/_content/viewing-options-split-panes-windows.html
@@ -1,0 +1,74 @@
+---
+title: Minerva — Docs — Split Panes &amp; Windows
+description: Splitting the editor into multiple panes — each with its own tabs and view mode — moving tabs between them, and when to open a whole new window instead.
+---
+
+    <h1>Split panes &amp; windows</h1>
+    <p class="lede">Sometimes you want to see two notes at once — a source next to the claim it supports, or an outline next to the section you're drafting. Minerva gives you two ways to do that: split the current window into side-by-side <b>panes</b>, each with its own tabs and <a href="viewing-options-view-modes.html">view mode</a>, or open a separate <b>window</b>.</p>
+
+    <h2 id="panes">Splitting into panes</h2>
+    <p>A pane is a section of the window with its own tabs and its own view. You can split any pane into two, and split again from there, arranging your notes into as many side-by-side and stacked panes as you like. Drag the divider between two panes to resize them.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Split right</div>
+        <div class="v"><kbd>⌘</kbd><kbd>\</kbd> (<kbd>Ctrl</kbd><kbd>\</kbd> on Windows/Linux), the split button in a pane's toolbar, or <b>View → Split Editor Right</b>. Adds a new pane to the right of the current one.</div>
+      </div>
+      <div class="row">
+        <div class="k">Split down</div>
+        <div class="v"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>\</kbd> (<kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>\</kbd>), the split-down button, or <b>View → Split Editor Down</b>. Stacks a new pane below the current one.</div>
+      </div>
+      <div class="row">
+        <div class="k">Drag a tab to an edge</div>
+        <div class="v">Drag a tab toward the left, right, top, or bottom edge of a pane; a preview shows where it'll land. Dropping there splits the pane and moves the tab into the new one.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move between panes</div>
+        <div class="v"><kbd>⌘</kbd><kbd>⌥</kbd><kbd>→</kbd> / <kbd>⌘</kbd><kbd>⌥</kbd><kbd>←</kbd> (<kbd>Ctrl</kbd><kbd>Alt</kbd>), or <b>View → Focus Next/Previous Group</b>, moves your focus from one pane to the next.</div>
+      </div>
+      <div class="row">
+        <div class="k">Close a pane</div>
+        <div class="v"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>W</kbd> or <b>View → Close Group</b> closes the focused pane and gives its space back to the panes beside it.</div>
+      </div>
+    </div>
+
+    <h2 id="moving-tabs">Moving notes between panes</h2>
+    <p>With more than one pane open, you can move a tab from one to another in two ways:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Drag it over</div>
+        <div class="v">Drag a tab and drop it in the middle of another pane, or onto its tab bar, to move it there without creating a new split.</div>
+      </div>
+      <div class="row">
+        <div class="k">Move to Other Group</div>
+        <div class="v">Right-click a tab and choose <b>Move to Other Group</b>. When several panes are open, this becomes a short list so you can pick where it goes.</div>
+      </div>
+    </div>
+
+    <p>A note can only be open in one pane at a time. If you try to open something that's already open elsewhere, Minerva simply brings that pane into focus.</p>
+
+    <h2 id="view-mode">Each pane keeps its own view</h2>
+    <p>Each pane remembers its own view mode — <a href="viewing-options-view-modes.html">Source, Preview, or Editor + Preview</a> — so you can, for example, edit a note in one pane while reading its finished form in another. A new pane starts in the same mode as the one it split from, but you can change either one at any time.</p>
+
+    <figure class="shot-img">
+      <img src="img/viewing-options-split-panes-windows.png" alt="The window is split into two side-by-side panes. The left pane shows a note you're editing; the right pane shows a different note fully rendered for reading. Each pane has its own tabs and toolbar." loading="lazy" />
+      <figcaption>Two panes, two views</figcaption>
+    </figure>
+
+    <h2 id="windows">Opening a new window</h2>
+    <p><b>File → New Window</b> (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd>) opens a fresh, empty Minerva window. You then open a thoughtbase into it, either the same one you already have open or a different one entirely. Changes you save in one window show up in the other automatically.</p>
+
+    <h2 id="which">Split pane or new window?</h2>
+    <p>Both let you see two things at once — here's how to choose:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Use a split</div>
+        <div class="v">You want two views side by side on one screen within the same thoughtbase — a source next to the note citing it, or the same note being edited and read at once.</div>
+      </div>
+      <div class="row">
+        <div class="k">Use a new window</div>
+        <div class="v">You want a second window you can move and resize on its own — handy across two monitors — or you want two different thoughtbases open at the same time.</div>
+      </div>
+    </div>

--- a/website/docs/_content/viewing-options-themes.html
+++ b/website/docs/_content/viewing-options-themes.html
@@ -1,0 +1,53 @@
+---
+title: Minerva — Docs — Themes
+description: Choose how Minerva looks: Dark, Light, or High Contrast, plus a System option that follows your computer. Switch instantly from Settings, the status bar, or a shortcut.
+---
+
+    <h1>Themes</h1>
+    <p class="lede">A theme sets how the whole app looks. Minerva offers three — Dark, Light, and High Contrast — plus a System option that follows your computer's own light-or-dark setting. Switching is instant and applies everywhere; there's no per-note override.</p>
+
+    <h2 id="themes">The themes</h2>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Dark <span style="color:var(--text-faint);font-weight:400;">(default)</span></div>
+        <div class="v">A warm, dark look: deep ink backgrounds, soft warm-white text, and a honeyed amber accent.</div>
+      </div>
+      <div class="row">
+        <div class="k">Light</div>
+        <div class="v">The same warm palette on a pale paper background, with darker text — the daytime twin of the dark theme rather than a plain white mode.</div>
+      </div>
+      <div class="row">
+        <div class="k">High Contrast</div>
+        <div class="v">A stark, high-legibility black-on-white look with strong, clearly separated colors. Built for readability first.</div>
+      </div>
+      <div class="row">
+        <div class="k">System</div>
+        <div class="v">Follows your computer's light or dark setting, and updates on its own if you change that setting while Minerva is open. This is what you start with on a fresh install.</div>
+      </div>
+    </div>
+
+    <h2 id="switching">Switching themes</h2>
+    <p>Change the theme any of three ways — the change takes effect right away:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Settings → Appearance</div>
+        <div class="v">Open Settings, go to the <b>Appearance</b> tab, and pick a theme from the <b>Theme</b> menu. It applies as you choose — there's no confirm step.</div>
+      </div>
+      <div class="row">
+        <div class="k">Status bar</div>
+        <div class="v">Click the theme name at the bottom of the window to open a quick picker, then click the one you want.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd></div>
+        <div class="v">Cycles through Dark, Light, High Contrast, and System without opening a menu.</div>
+      </div>
+    </div>
+
+    <p>Your theme choice is remembered on this computer. It's a personal appearance setting, so it isn't part of your notes and won't follow them to another device.</p>
+
+    <figure class="shot-img">
+      <img src="img/viewing-options-themes.png" alt="The Appearance tab in Settings, with the Theme menu open on its four choices: Dark, Light, High Contrast, and System." loading="lazy" />
+      <figcaption>Screenshot — Theme picker in Settings</figcaption>
+    </figure>

--- a/website/docs/_content/viewing-options-view-modes.html
+++ b/website/docs/_content/viewing-options-view-modes.html
@@ -1,0 +1,46 @@
+---
+title: Minerva — Docs — View Modes
+description: The three ways to look at a note in Minerva — Source, Preview, and Side by side — and how to switch between them.
+---
+
+    <h1>View modes</h1>
+    <p class="lede">You can look at a note three ways: as the plain text you type, as the finished, formatted page, or with both side by side. Each pane sets its own mode, so you can be editing one note while reading another in the same window. Switching modes never changes your note — it's just a different way to look at the same content.</p>
+
+    <h2 id="modes">The three modes</h2>
+    <p>The mode belongs to the pane, not the note. Reopen a note later and it appears in whatever mode that pane was last set to.</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Source</div>
+        <div class="v">The plain text you type, ready to edit. This is where you'll want to be for hands-on work: fixing a link, adjusting a note's properties, or writing inside a cell.</div>
+      </div>
+      <div class="row">
+        <div class="k">Preview</div>
+        <div class="v">The finished, read-only page, with everything formatted the way it will look — headings, callouts, math, diagrams, charts, and embedded media all shown live.</div>
+      </div>
+      <div class="row">
+        <div class="k">Side by side</div>
+        <div class="v">Your text on the left and the formatted page on the right, in the same pane, so you can write and see the result at once.</div>
+      </div>
+    </div>
+
+    <p>A plain-text file has nothing to format, so it only shows Source — the toggle doesn't appear.</p>
+
+    <figure class="shot-img">
+      <img src="img/viewing-options-view-modes.png" alt="A note in Side by side mode: your text on the left and the same content formatted on the right, split by a thin divider. Above the note, the Source / Side by side / Preview buttons show Side by side as the active choice." loading="lazy" />
+      <figcaption>Screenshot — Side by side mode</figcaption>
+    </figure>
+
+    <h2 id="switching">Switching modes</h2>
+    <p>There are two ways to change a pane's mode:</p>
+
+    <div class="deflist">
+      <div class="row">
+        <div class="k">Toolbar buttons</div>
+        <div class="v">Three buttons above the note — <b>Source</b>, <b>Side by side</b>, <b>Preview</b> — jump straight to that mode from wherever you are, so you can go from editing to the finished page in one click.</div>
+      </div>
+      <div class="row">
+        <div class="k">Cycle shortcut — <kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd></div>
+        <div class="v">Steps the active pane through the three modes in order: <b>Source → Preview → Side by side → Source</b>. The same command is in the View menu as <b>Cycle Preview Mode</b>.</div>
+      </div>
+    </div>

--- a/website/docs/_content/viewing-options.html
+++ b/website/docs/_content/viewing-options.html
@@ -1,0 +1,65 @@
+---
+title: Minerva — Docs — Viewing Options
+description: How you view a note in Minerva: the three view modes, appearance themes, font size and zoom, and splitting panes or opening new windows.
+---
+
+    <h1>Viewing options</h1>
+    <p class="lede">How a note looks on screen is separate from what's in it. Four independent controls shape that: how a pane displays a note, which color theme the app wears, how large the text is, and how many notes you can see side by side. None of these change your notes — they just change how you're looking at them.</p>
+
+    <h2 id="glance">At a glance</h2>
+    <div class="deflist">
+      <div class="row">
+        <div class="k">View menu</div>
+        <div class="v"><a href="viewing-options-operations.html"><b>View operations</b></a> — the View menu at a glance: panels, splits, theme, zoom, and font size.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>P</kbd></div>
+        <div class="v"><a href="viewing-options-view-modes.html"><b>View modes</b></a> — cycle a pane through Source, Preview, and side-by-side.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>⇧</kbd><kbd>T</kbd></div>
+        <div class="v"><a href="viewing-options-themes.html"><b>Themes</b></a> — cycle Dark, Light, High Contrast, and System.</div>
+      </div>
+      <div class="row">
+        <div class="k">several</div>
+        <div class="v"><a href="viewing-options-font-size-zoom.html"><b>Font size &amp; zoom</b></a> — resize editor text and the whole window independently — they compound.</div>
+      </div>
+      <div class="row">
+        <div class="k"><kbd>⌘</kbd><kbd>\</kbd> / <kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd></div>
+        <div class="v"><a href="viewing-options-split-panes-windows.html"><b>Split panes &amp; windows</b></a> — split the current window, or open a new one entirely.</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <span class="label">Windows / Linux</span>
+      <p>Every shortcut above uses <kbd>Ctrl</kbd> in place of <kbd>⌘</kbd>.</p>
+    </div>
+
+    <h2 id="learn-more">In depth</h2>
+    <div class="doc-cards">
+      <a class="doc-card" href="viewing-options-operations.html">
+        <span class="em">🖥️</span>
+        <h3>View operations</h3>
+        <p>The View menu commands, grouped and explained.</p>
+      </a>
+      <a class="doc-card" href="viewing-options-view-modes.html">
+        <span class="em">🔄</span>
+        <h3>View modes</h3>
+        <p>Source, Preview, or both side by side — a per-pane setting.</p>
+      </a>
+      <a class="doc-card" href="viewing-options-themes.html">
+        <span class="em">🎨</span>
+        <h3>Themes</h3>
+        <p>Dark, Light, High Contrast, or follow the OS — switches instantly.</p>
+      </a>
+      <a class="doc-card" href="viewing-options-font-size-zoom.html">
+        <span class="em">🔠</span>
+        <h3>Font size &amp; zoom</h3>
+        <p>Two separate controls for bigger text, and they compound.</p>
+      </a>
+      <a class="doc-card" href="viewing-options-split-panes-windows.html">
+        <span class="em">🪟</span>
+        <h3>Split panes &amp; windows</h3>
+        <p>See two notes at once — split the window, or open a new one.</p>
+      </a>
+    </div>

--- a/website/docs/_layout.html
+++ b/website/docs/_layout.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>{{title}}</title>
+<meta name="description" content="{{description}}" />
+<link rel="stylesheet" href="../minerva.css" />
+<link rel="stylesheet" href="docs.css" />
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Minerva">
+        <defs>
+          <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1b2452"/><stop offset="45%" stop-color="#232a5e"/><stop offset="100%" stop-color="#3a2d6b"/></linearGradient>
+          <linearGradient id="plum" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e9b96a"/><stop offset="55%" stop-color="#cf9646"/><stop offset="100%" stop-color="#a9742f"/></linearGradient>
+          <linearGradient id="fc" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#f6e2b8"/><stop offset="100%" stop-color="#e3c489"/></linearGradient>
+          <radialGradient id="eg" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fff7e6"/><stop offset="60%" stop-color="#ffd97a"/><stop offset="100%" stop-color="#d99a3a"/></radialGradient>
+        </defs>
+        <rect width="1024" height="1024" rx="220" fill="url(#sky)"/>
+        <path d="M512 880 C 360 880, 300 760, 300 620 C 300 470, 380 380, 512 380 C 644 380, 724 470, 724 620 C 724 760, 664 880, 512 880 Z" fill="url(#plum)"/>
+        <ellipse cx="512" cy="455" rx="232" ry="200" fill="url(#plum)"/>
+        <path d="M512 290 C 408 290, 350 360, 350 460 C 350 560, 420 630, 512 630 C 604 630, 674 560, 674 460 C 674 360, 616 290, 512 290 Z" fill="url(#fc)"/>
+        <circle cx="438" cy="450" r="92" fill="#3a2a18"/><circle cx="586" cy="450" r="92" fill="#3a2a18"/>
+        <circle cx="438" cy="450" r="74" fill="url(#eg)"/><circle cx="586" cy="450" r="74" fill="url(#eg)"/>
+        <circle cx="438" cy="450" r="34" fill="#241608"/><circle cx="586" cy="450" r="34" fill="#241608"/>
+        <circle cx="452" cy="436" r="12" fill="#fffdf5"/><circle cx="600" cy="436" r="12" fill="#fffdf5"/>
+        <path d="M512 470 L490 540 C 490 562, 534 562, 534 540 Z" fill="#caa24a"/>
+      </svg>
+      <span>Minerva</span>
+    </a>
+    <div class="links">
+      <a href="../features.html" class="hide-sm">Features</a>
+      <a href="../getting-started.html" class="hide-sm">Getting Started</a>
+      <a href="index.html" class="active hide-sm">Docs</a>
+      <a href="../about.html" class="hide-sm">About</a>
+      <a href="../privacy.html" class="hide-sm">Privacy</a>
+      <a href="../getting-started.html" class="navcta">Download</a>
+    </div>
+  </div>
+</nav>
+
+<div class="docs">
+
+  <!-- ===== Left navigation (shared across all docs pages) ===== -->
+  <aside class="docs-nav">
+{{sidebar}}
+  </aside>
+
+  <!-- ===== Content ===== -->
+  <main class="docs-content">
+{{content}}
+  </main>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>
+      <div class="brand" style="display:flex;align-items:center;gap:10px;font-weight:650;color:var(--text);margin-bottom:10px;"><span>Minerva</span></div>
+      <div class="note">A local-first desktop workspace for thinking with AI.</div>
+    </div>
+    <div class="cols">
+      <div class="col"><h4>Product</h4><a href="../features.html">Features</a><a href="../getting-started.html">Getting Started</a><a href="../getting-started.html">Download</a></div>
+      <div class="col"><h4>Learn</h4><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="index.html">Docs</a><a href="https://davegriffith.substack.com/">Dancing with Robots</a></div>
+      <div class="col"><h4>Source</h4><a href="https://github.com/dgriffith/ide-for-thought">GitHub</a><a href="https://github.com/dgriffith/ide-for-thought/releases">Releases</a><a href="https://github.com/dgriffith/ide-for-thought/blob/main/LICENSE">License</a></div>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/website/docs/_nav.json
+++ b/website/docs/_nav.json
@@ -1,0 +1,532 @@
+{
+  "sections": [
+    {
+      "label": "Introduction",
+      "items": [
+        {
+          "href": "index.html",
+          "label": "Overview"
+        },
+        {
+          "href": "thoughtbase.html",
+          "label": "What is a thoughtbase?",
+          "children": [
+            {
+              "href": "thoughtbase-operations.html",
+              "label": "Thoughtbase operations"
+            }
+          ]
+        },
+        {
+          "href": "../getting-started.html",
+          "label": "Getting started"
+        }
+      ]
+    },
+    {
+      "label": "Using Minerva",
+      "items": [
+        {
+          "href": "notes.html",
+          "label": "Notes",
+          "children": [
+            {
+              "href": "notes-links.html",
+              "label": "Links"
+            },
+            {
+              "href": "notes-frontmatter.html",
+              "label": "Properties"
+            },
+            {
+              "href": "notes-typed-notes.html",
+              "label": "Typed notes"
+            },
+            {
+              "href": "notes-highlights.html",
+              "label": "Highlights"
+            },
+            {
+              "href": "notes-tasks.html",
+              "label": "Task lists"
+            },
+            {
+              "href": "notes-callouts.html",
+              "label": "Callouts"
+            },
+            {
+              "href": "notes-images.html",
+              "label": "Images"
+            },
+            {
+              "href": "notes-tables.html",
+              "label": "Tables &amp; CSV"
+            },
+            {
+              "href": "notes-footnotes.html",
+              "label": "Footnotes"
+            },
+            {
+              "href": "notes-flashcards.html",
+              "label": "Flashcards"
+            },
+            {
+              "href": "notes-media.html",
+              "label": "Media"
+            },
+            {
+              "href": "notes-math.html",
+              "label": "Math"
+            },
+            {
+              "href": "notes-diagrams.html",
+              "label": "Diagrams"
+            },
+            {
+              "href": "notes-charts.html",
+              "label": "Charts"
+            },
+            {
+              "href": "notes-code.html",
+              "label": "Code &amp; compute cells"
+            },
+            {
+              "href": "notes-query.html",
+              "label": "Query cells"
+            },
+            {
+              "href": "notes-search.html",
+              "label": "Search cells"
+            },
+            {
+              "href": "notes-rdf.html",
+              "label": "Turtle / RDF"
+            }
+          ]
+        },
+        {
+          "href": "navigation.html",
+          "label": "Navigation",
+          "children": [
+            {
+              "href": "navigation-command-palette.html",
+              "label": "Command palette"
+            },
+            {
+              "href": "navigation-quick-switch.html",
+              "label": "Quick switch"
+            },
+            {
+              "href": "navigation-wiki-links.html",
+              "label": "Wiki-links"
+            },
+            {
+              "href": "navigation-search.html",
+              "label": "Search"
+            },
+            {
+              "href": "navigation-breadcrumbs.html",
+              "label": "Breadcrumbs"
+            },
+            {
+              "href": "navigation-back-forward.html",
+              "label": "Back / forward"
+            }
+          ]
+        },
+        {
+          "href": "viewing-options.html",
+          "label": "Viewing options",
+          "children": [
+            {
+              "href": "viewing-options-operations.html",
+              "label": "View operations"
+            },
+            {
+              "href": "viewing-options-view-modes.html",
+              "label": "View modes"
+            },
+            {
+              "href": "viewing-options-themes.html",
+              "label": "Themes"
+            },
+            {
+              "href": "viewing-options-font-size-zoom.html",
+              "label": "Font size &amp; zoom"
+            },
+            {
+              "href": "viewing-options-split-panes-windows.html",
+              "label": "Split panes &amp; windows"
+            }
+          ]
+        },
+        {
+          "href": "editor.html",
+          "label": "Editor",
+          "children": [
+            {
+              "href": "editor-operations.html",
+              "label": "Editor operations"
+            },
+            {
+              "href": "editor-writing-surface.html",
+              "label": "The writing surface"
+            },
+            {
+              "href": "editor-markdown-formatting.html",
+              "label": "Markdown formatting"
+            },
+            {
+              "href": "editor-keyboard-shortcuts.html",
+              "label": "Keyboard shortcuts"
+            },
+            {
+              "href": "editor-link-autocomplete.html",
+              "label": "Link autocomplete"
+            },
+            {
+              "href": "editor-voice-dictation.html",
+              "label": "Voice dictation"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "The workspace",
+      "items": [
+        {
+          "href": "left-sidebar.html",
+          "label": "Left sidebar",
+          "children": [
+            {
+              "href": "left-sidebar-notes-tree.html",
+              "label": "Notes tree"
+            },
+            {
+              "href": "left-sidebar-sources.html",
+              "label": "Sources"
+            },
+            {
+              "href": "left-sidebar-tags.html",
+              "label": "Tags"
+            },
+            {
+              "href": "left-sidebar-tables.html",
+              "label": "Tables"
+            },
+            {
+              "href": "left-sidebar-objects.html",
+              "label": "Objects"
+            },
+            {
+              "href": "left-sidebar-bookmarks.html",
+              "label": "Bookmarks"
+            },
+            {
+              "href": "left-sidebar-proposals.html",
+              "label": "Proposals"
+            }
+          ]
+        },
+        {
+          "href": "right-sidebar.html",
+          "label": "Right sidebar",
+          "children": [
+            {
+              "href": "right-sidebar-backlinks.html",
+              "label": "Backlinks"
+            },
+            {
+              "href": "right-sidebar-outgoing-links.html",
+              "label": "Outgoing links"
+            },
+            {
+              "href": "right-sidebar-outline.html",
+              "label": "Outline"
+            },
+            {
+              "href": "right-sidebar-properties.html",
+              "label": "Properties"
+            },
+            {
+              "href": "right-sidebar-citations.html",
+              "label": "Citations"
+            },
+            {
+              "href": "right-sidebar-tags.html",
+              "label": "Tags"
+            },
+            {
+              "href": "right-sidebar-related.html",
+              "label": "Related"
+            },
+            {
+              "href": "right-sidebar-footnotes.html",
+              "label": "Footnotes"
+            },
+            {
+              "href": "right-sidebar-history.html",
+              "label": "History"
+            },
+            {
+              "href": "right-sidebar-tables.html",
+              "label": "Tables"
+            },
+            {
+              "href": "right-sidebar-heading-graph.html",
+              "label": "Heading graph"
+            },
+            {
+              "href": "right-sidebar-bookmarks.html",
+              "label": "Bookmarks"
+            },
+            {
+              "href": "right-sidebar-inspections.html",
+              "label": "Inspections"
+            }
+          ]
+        },
+        {
+          "href": "conversations.html",
+          "label": "Conversations",
+          "children": [
+            {
+              "href": "conversations-chatting.html",
+              "label": "Chatting with the AI"
+            },
+            {
+              "href": "conversations-slash-commands.html",
+              "label": "Slash commands"
+            },
+            {
+              "href": "conversations-drafts.html",
+              "label": "Drafts"
+            },
+            {
+              "href": "conversations-propose-review-approve.html",
+              "label": "The propose → review → approve loop",
+              "crumb": "Propose, review, approve"
+            }
+          ]
+        },
+        {
+          "href": "settings.html",
+          "label": "Settings",
+          "children": [
+            {
+              "href": "settings-editor.html",
+              "label": "Editor"
+            },
+            {
+              "href": "settings-appearance.html",
+              "label": "Appearance"
+            },
+            {
+              "href": "settings-behaviors.html",
+              "label": "Behaviors"
+            },
+            {
+              "href": "settings-notes.html",
+              "label": "Notes"
+            },
+            {
+              "href": "settings-versioning.html",
+              "label": "Versioning"
+            },
+            {
+              "href": "settings-formatter.html",
+              "label": "Formatter"
+            },
+            {
+              "href": "settings-object-types.html",
+              "label": "Object Types"
+            },
+            {
+              "href": "settings-inspections.html",
+              "label": "Inspections"
+            },
+            {
+              "href": "settings-bibliography.html",
+              "label": "Bibliography"
+            },
+            {
+              "href": "settings-web.html",
+              "label": "Web"
+            },
+            {
+              "href": "settings-sources.html",
+              "label": "Sources"
+            },
+            {
+              "href": "settings-clipper.html",
+              "label": "Clipper"
+            },
+            {
+              "href": "settings-compute.html",
+              "label": "Compute"
+            },
+            {
+              "href": "settings-ai.html",
+              "label": "AI"
+            },
+            {
+              "href": "settings-skills.html",
+              "label": "Skills"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Data &amp; workflows",
+      "items": [
+        {
+          "href": "refactoring.html",
+          "label": "Refactoring",
+          "children": [
+            {
+              "href": "refactoring-operations.html",
+              "label": "Refactoring operations"
+            },
+            {
+              "href": "refactoring-manual.html",
+              "label": "Manual rename, move &amp; delete"
+            },
+            {
+              "href": "refactoring-safe-delete.html",
+              "label": "Safe delete &amp; dangling links"
+            },
+            {
+              "href": "refactoring-ai-assisted.html",
+              "label": "AI-assisted refactors"
+            }
+          ]
+        },
+        {
+          "href": "thinking-tools.html",
+          "label": "Thinking tools",
+          "children": [
+            {
+              "href": "thinking-tools-what-they-are.html",
+              "label": "What thinking tools are"
+            },
+            {
+              "href": "thinking-tools-running-a-skill.html",
+              "label": "Running a skill"
+            },
+            {
+              "href": "thinking-tools-three-menus.html",
+              "label": "The three menus"
+            },
+            {
+              "href": "thinking-tools-learning.html",
+              "label": "Learning Operations"
+            },
+            {
+              "href": "thinking-tools-research.html",
+              "label": "Research Operations"
+            },
+            {
+              "href": "thinking-tools-analysis.html",
+              "label": "Analysis Operations"
+            },
+            {
+              "href": "thinking-tools-managing-authoring.html",
+              "label": "Managing &amp; authoring"
+            }
+          ]
+        },
+        {
+          "href": "data.html",
+          "label": "Data",
+          "title": "Working with data",
+          "children": [
+            {
+              "href": "data-operations.html",
+              "label": "Data operations"
+            },
+            {
+              "href": "query-menu-panel.html",
+              "label": "Query menu &amp; panel"
+            },
+            {
+              "href": "query-runnable-cells.html",
+              "label": "Runnable cells"
+            },
+            {
+              "href": "query-result-blocks.html",
+              "label": "Result blocks"
+            }
+          ]
+        },
+        {
+          "href": "ingest.html",
+          "label": "Ingest",
+          "children": [
+            {
+              "href": "ingest-adding-sources.html",
+              "label": "Adding sources"
+            },
+            {
+              "href": "ingest-pdf.html",
+              "label": "PDF ingest"
+            },
+            {
+              "href": "ingest-clipper.html",
+              "label": "Browser clipper"
+            },
+            {
+              "href": "ingest-citing-duplicates.html",
+              "label": "Citing &amp; duplicates"
+            }
+          ]
+        },
+        {
+          "href": "export.html",
+          "label": "Export",
+          "children": [
+            {
+              "href": "export-documents.html",
+              "label": "Document exports"
+            },
+            {
+              "href": "export-publishing.html",
+              "label": "Publishing"
+            },
+            {
+              "href": "export-bibliography.html",
+              "label": "Bibliography &amp; citations"
+            },
+            {
+              "href": "export-flashcards.html",
+              "label": "Flashcards"
+            },
+            {
+              "href": "export-scopes-privacy.html",
+              "label": "Scopes &amp; privacy"
+            }
+          ]
+        },
+        {
+          "href": "connecting.html",
+          "label": "Connecting to Minerva",
+          "children": [
+            {
+              "href": "connecting-cli.html",
+              "label": "CLI use"
+            },
+            {
+              "href": "connecting-mcp.html",
+              "label": "MCP use"
+            }
+          ]
+        },
+        {
+          "href": "maintenance.html",
+          "label": "Maintenance"
+        }
+      ]
+    }
+  ]
+}

--- a/website/docs/conversations-propose-review-approve.html
+++ b/website/docs/conversations-propose-review-approve.html
@@ -117,7 +117,6 @@
     <h2 id="decide">Approving and rejecting</h2>
     <p>Once you've read a proposal, the decision is one keystroke: <kbd>y</kbd> to approve, <kbd>n</kbd> to reject. Approving applies the change; rejecting throws it away. Either way the proposal stays on record, so you always have a history of what was suggested and what you decided. See <a href="left-sidebar-proposals.html">Proposals</a> for the full set of shortcuts and ways to filter what you're looking at.</p>
 
-
     <div class="pager">
       <a class="prev" href="conversations-drafts.html">
         <span class="dir">Previous</span>

--- a/website/docs/conversations.html
+++ b/website/docs/conversations.html
@@ -135,9 +135,9 @@
     </div>
 
     <div class="pager">
-      <a class="prev" href="right-sidebar-bookmarks.html">
+      <a class="prev" href="right-sidebar-inspections.html">
         <span class="dir">Previous</span>
-        <span class="ttl">← Bookmarks</span>
+        <span class="ttl">← Inspections</span>
       </a>
       <a class="next" href="conversations-chatting.html">
         <span class="dir">Next</span>

--- a/website/docs/left-sidebar-bookmarks.html
+++ b/website/docs/left-sidebar-bookmarks.html
@@ -129,11 +129,11 @@
     <div class="pager">
       <a class="prev" href="left-sidebar-objects.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Objects</span>
+        <span class="ttl">← Objects</span>
       </a>
       <a class="next" href="left-sidebar-proposals.html">
         <span class="dir">Next</span>
-        <span class="ttl">Proposals &rarr;</span>
+        <span class="ttl">Proposals →</span>
       </a>
     </div>
   </main>

--- a/website/docs/left-sidebar-objects.html
+++ b/website/docs/left-sidebar-objects.html
@@ -130,11 +130,11 @@
     <div class="pager">
       <a class="prev" href="left-sidebar-tables.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Tables</span>
+        <span class="ttl">← Tables</span>
       </a>
       <a class="next" href="left-sidebar-bookmarks.html">
         <span class="dir">Next</span>
-        <span class="ttl">Bookmarks &rarr;</span>
+        <span class="ttl">Bookmarks →</span>
       </a>
     </div>
   </main>

--- a/website/docs/left-sidebar-proposals.html
+++ b/website/docs/left-sidebar-proposals.html
@@ -67,7 +67,7 @@
     <a href="left-sidebar-objects.html" class="sub">Objects</a>
     <a href="left-sidebar-bookmarks.html" class="sub">Bookmarks</a>
     <a href="left-sidebar-proposals.html" class="sub active">Proposals</a>
-    <a href="left-sidebar.html">Left sidebar</a>
+    <a href="right-sidebar.html">Right sidebar</a>
     <a href="conversations.html">Conversations</a>
     <a href="settings.html">Settings</a>
 
@@ -139,11 +139,11 @@
     <div class="pager">
       <a class="prev" href="left-sidebar-bookmarks.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Bookmarks</span>
+        <span class="ttl">← Bookmarks</span>
       </a>
       <a class="next" href="right-sidebar.html">
         <span class="dir">Next</span>
-        <span class="ttl">Right sidebar &rarr;</span>
+        <span class="ttl">Right sidebar →</span>
       </a>
     </div>
   </main>

--- a/website/docs/left-sidebar-tables.html
+++ b/website/docs/left-sidebar-tables.html
@@ -163,7 +163,7 @@
       </a>
       <a class="next" href="left-sidebar-objects.html">
         <span class="dir">Next</span>
-        <span class="ttl">Objects &rarr;</span>
+        <span class="ttl">Objects →</span>
       </a>
     </div>
   </main>

--- a/website/docs/notes-footnotes.html
+++ b/website/docs/notes-footnotes.html
@@ -156,6 +156,7 @@ effect size.[^size]
       <div class="k">Screenshot — Footnotes panel</div>
       <div class="d">The right-sidebar Footnotes panel showing several footnotes with their labels and previews, including one flagged as never used and one flagged as not yet written.</div>
     </div>
+
     <div class="pager">
       <a class="prev" href="notes-tables.html">
         <span class="dir">Previous</span>

--- a/website/docs/notes-frontmatter.html
+++ b/website/docs/notes-frontmatter.html
@@ -159,6 +159,7 @@ The body of the note starts here.</code></pre>
       <img src="img/notes-frontmatter.png" alt="The Properties panel in the right sidebar, open on a note. It shows a title, a row of tags as removable chips, a created date with a date picker, a linked &quot;about&quot; note as a clickable chip, and a custom &quot;status&quot; field — with an &quot;Add property&quot; row at the bottom for adding more." loading="lazy" />
       <figcaption>The Properties panel</figcaption>
     </figure>
+
     <div class="pager">
       <a class="prev" href="notes-links.html">
         <span class="dir">Previous</span>
@@ -166,7 +167,7 @@ The body of the note starts here.</code></pre>
       </a>
       <a class="next" href="notes-typed-notes.html">
         <span class="dir">Next</span>
-        <span class="ttl">Typed notes &rarr;</span>
+        <span class="ttl">Typed notes →</span>
       </a>
     </div>
   </main>

--- a/website/docs/notes-highlights.html
+++ b/website/docs/notes-highlights.html
@@ -134,7 +134,7 @@ Flagged for review: ==orange:re-check this once the rebuild finishes==.</code></
     <div class="pager">
       <a class="prev" href="notes-typed-notes.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Typed notes</span>
+        <span class="ttl">← Typed notes</span>
       </a>
       <a class="next" href="notes-tasks.html">
         <span class="dir">Next</span>

--- a/website/docs/notes-typed-notes.html
+++ b/website/docs/notes-typed-notes.html
@@ -187,11 +187,11 @@
     <div class="pager">
       <a class="prev" href="notes-frontmatter.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Properties</span>
+        <span class="ttl">← Properties</span>
       </a>
       <a class="next" href="notes-highlights.html">
         <span class="dir">Next</span>
-        <span class="ttl">Highlights &rarr;</span>
+        <span class="ttl">Highlights →</span>
       </a>
     </div>
   </main>

--- a/website/docs/right-sidebar-backlinks.html
+++ b/website/docs/right-sidebar-backlinks.html
@@ -127,6 +127,7 @@
 
     <h2 id="empty">When nothing links here</h2>
     <p>If no note links to the one you're viewing, the panel says <i>"No backlinks found."</i> That's normal for a brand-new note or one you simply haven't linked to yet. If backlinks do exist but your search doesn't match any of them, it says <i>"No matches"</i> instead, so you can tell whether the panel is empty because nothing links here or because your search is too narrow.</p>
+
     <div class="pager">
       <a class="prev" href="right-sidebar.html">
         <span class="dir">Previous</span>

--- a/website/docs/right-sidebar-bookmarks.html
+++ b/website/docs/right-sidebar-bookmarks.html
@@ -73,6 +73,7 @@
     <a href="right-sidebar-tables.html" class="sub">Tables</a>
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub active">Bookmarks</a>
+    <a href="right-sidebar-inspections.html" class="sub">Inspections</a>
     <a href="conversations.html">Conversations</a>
     <a href="settings.html">Settings</a>
 
@@ -122,6 +123,7 @@
     <p>Click a row to jump to what it marks: a section bookmark scrolls you to that heading, and a spot bookmark takes you to that place in the text. Hover a row to reveal its delete button, which removes the bookmark everywhere.</p>
     <p>To make a new bookmark, right-click in your note or on its tab and choose <b>Bookmark This Note</b>, <b>Bookmark Section</b>, or <b>Bookmark Line</b>. To rename bookmarks or sort them into folders, use the <a href="left-sidebar-bookmarks.html">Bookmarks panel on the left</a>.</p>
     
+
     <div class="pager">
       <a class="prev" href="right-sidebar-heading-graph.html">
         <span class="dir">Previous</span>

--- a/website/docs/right-sidebar-citations.html
+++ b/website/docs/right-sidebar-citations.html
@@ -124,10 +124,11 @@
       <img src="img/right-sidebar-citations.png" alt="The Citations panel listing several sources by title, each with its author and year and a count of cites and quotes; one row is opened to show two quoted passages beneath it, each with a page number." loading="lazy" />
       <figcaption>Screenshot — Citations panel with an expanded source</figcaption>
     </figure>
+
     <div class="pager">
       <a class="prev" href="right-sidebar-properties.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Properties</span>
+        <span class="ttl">← Properties</span>
       </a>
       <a class="next" href="right-sidebar-tags.html">
         <span class="dir">Next</span>

--- a/website/docs/right-sidebar-inspections.html
+++ b/website/docs/right-sidebar-inspections.html
@@ -190,11 +190,11 @@
     <div class="pager">
       <a class="prev" href="right-sidebar-bookmarks.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Bookmarks</span>
+        <span class="ttl">← Bookmarks</span>
       </a>
       <a class="next" href="conversations.html">
         <span class="dir">Next</span>
-        <span class="ttl">Conversations &rarr;</span>
+        <span class="ttl">Conversations →</span>
       </a>
     </div>
   </main>

--- a/website/docs/right-sidebar-properties.html
+++ b/website/docs/right-sidebar-properties.html
@@ -181,7 +181,7 @@
       </a>
       <a class="next" href="right-sidebar-citations.html">
         <span class="dir">Next</span>
-        <span class="ttl">Citations &rarr;</span>
+        <span class="ttl">Citations →</span>
       </a>
     </div>
   </main>

--- a/website/docs/right-sidebar-tables.html
+++ b/website/docs/right-sidebar-tables.html
@@ -69,6 +69,7 @@
     <a href="right-sidebar-tags.html" class="sub">Tags</a>
     <a href="right-sidebar-related.html" class="sub">Related</a>
     <a href="right-sidebar-footnotes.html" class="sub">Footnotes</a>
+    <a href="right-sidebar-history.html" class="sub">History</a>
     <a href="right-sidebar-tables.html" class="sub active">Tables</a>
     <a href="right-sidebar-heading-graph.html" class="sub">Heading graph</a>
     <a href="right-sidebar-bookmarks.html" class="sub">Bookmarks</a>

--- a/website/docs/right-sidebar.html
+++ b/website/docs/right-sidebar.html
@@ -223,7 +223,7 @@
     <div class="pager">
       <a class="prev" href="left-sidebar-proposals.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Proposals</span>
+        <span class="ttl">← Proposals</span>
       </a>
       <a class="next" href="right-sidebar-backlinks.html">
         <span class="dir">Next</span>

--- a/website/docs/settings-bibliography.html
+++ b/website/docs/settings-bibliography.html
@@ -126,7 +126,7 @@
     <div class="pager">
       <a class="prev" href="settings-inspections.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Inspections</span>
+        <span class="ttl">← Inspections</span>
       </a>
       <a class="next" href="settings-web.html">
         <span class="dir">Next</span>

--- a/website/docs/settings-compute.html
+++ b/website/docs/settings-compute.html
@@ -135,6 +135,7 @@
       <span class="label">Running code is your call</span>
       <p>Minerva won't run Python in a thoughtbase until you say it's okay. The first time you run a code cell there, it asks for a quick confirmation, then remembers your answer for the rest of that thoughtbase. That's a one-time prompt at the moment you run a cell, not a switch on this tab. For the full picture, see <a href="notes-code.html#trust">Code &amp; compute cells</a>.</p>
     </div>
+
     <div class="pager">
       <a class="prev" href="settings-clipper.html">
         <span class="dir">Previous</span>

--- a/website/docs/settings-formatter.html
+++ b/website/docs/settings-formatter.html
@@ -153,7 +153,7 @@
       </a>
       <a class="next" href="settings-object-types.html">
         <span class="dir">Next</span>
-        <span class="ttl">Object Types &rarr;</span>
+        <span class="ttl">Object Types →</span>
       </a>
     </div>
   </main>

--- a/website/docs/settings-inspections.html
+++ b/website/docs/settings-inspections.html
@@ -122,11 +122,11 @@
     <div class="pager">
       <a class="prev" href="settings-object-types.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Object Types</span>
+        <span class="ttl">← Object Types</span>
       </a>
       <a class="next" href="settings-bibliography.html">
         <span class="dir">Next</span>
-        <span class="ttl">Bibliography &rarr;</span>
+        <span class="ttl">Bibliography →</span>
       </a>
     </div>
   </main>

--- a/website/docs/settings-object-types.html
+++ b/website/docs/settings-object-types.html
@@ -70,6 +70,7 @@
     <a href="settings-versioning.html" class="sub">Versioning</a>
     <a href="settings-formatter.html" class="sub">Formatter</a>
     <a href="settings-object-types.html" class="sub active">Object Types</a>
+    <a href="settings-inspections.html" class="sub">Inspections</a>
     <a href="settings-bibliography.html" class="sub">Bibliography</a>
     <a href="settings-web.html" class="sub">Web</a>
     <a href="settings-sources.html" class="sub">Sources</a>
@@ -204,11 +205,11 @@
     <div class="pager">
       <a class="prev" href="settings-formatter.html">
         <span class="dir">Previous</span>
-        <span class="ttl">&larr; Formatter</span>
+        <span class="ttl">← Formatter</span>
       </a>
       <a class="next" href="settings-inspections.html">
         <span class="dir">Next</span>
-        <span class="ttl">Inspections &rarr;</span>
+        <span class="ttl">Inspections →</span>
       </a>
     </div>
   </main>

--- a/website/docs/settings-web.html
+++ b/website/docs/settings-web.html
@@ -122,6 +122,7 @@
       <img src="img/settings-web.png" alt="A switch to turn web access on or off for conversations, followed by two boxes: one for sites the assistant may draw from, and one for sites to keep out." loading="lazy" />
       <figcaption>The Web tab in Settings</figcaption>
     </figure>
+
     <div class="pager">
       <a class="prev" href="settings-bibliography.html">
         <span class="dir">Previous</span>

--- a/website/screenshots/swap-shots.mjs
+++ b/website/screenshots/swap-shots.mjs
@@ -1,15 +1,20 @@
 // Swap the `.shot wide` placeholder for a real captured <figure><img> on every
 // docs page that has a matching image in website/docs/img/<page>.png.
 //
+// Edits the docs CONTENT FRAGMENTS (`website/docs/_content/*.html`), not the
+// generated pages — `website/docs/*.html` is output, and a write there would be
+// undone by the next `pnpm build:docs` (#1842).
+//
 // Convention: the captured image id === the page basename (notes-callouts.png ↔
 // notes-callouts.html). Idempotent — pages already swapped, or without an image,
-// are left untouched. Run after a capture pass:
-//   node website/screenshots/swap-shots.mjs
+// are left untouched. Run after a capture pass, then regenerate:
+//   node website/screenshots/swap-shots.mjs && pnpm build:docs
 import fs from 'node:fs';
 import path from 'node:path';
 
 const DOCS = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', 'docs');
 const IMG = path.join(DOCS, 'img');
+const CONTENT = path.join(DOCS, '_content');
 const esc = (s) => s.replace(/"/g, '&quot;');
 
 // The first `.shot wide` placeholder block, capturing .k (caption, optional) and
@@ -20,11 +25,11 @@ const only = process.argv.slice(2); // optional page-basename allowlist
 let swapped = 0;
 const skipped = [];
 
-for (const file of fs.readdirSync(DOCS).filter((f) => f.endsWith('.html'))) {
+for (const file of fs.readdirSync(CONTENT).filter((f) => f.endsWith('.html'))) {
   const id = file.replace(/\.html$/, '');
   if (only.length && !only.includes(id)) continue;
   if (!fs.existsSync(path.join(IMG, `${id}.png`))) continue; // no image yet
-  const p = path.join(DOCS, file);
+  const p = path.join(CONTENT, file);
   let html = fs.readFileSync(p, 'utf8');
   const m = html.match(RE);
   if (!m) { skipped.push(`${id} (no .shot wide placeholder)`); continue; }
@@ -38,4 +43,8 @@ for (const file of fs.readdirSync(DOCS).filter((f) => f.endsWith('.html'))) {
   fs.writeFileSync(p, html.replace(RE, figure));
   swapped++;
 }
-console.log(`Swapped ${swapped} page(s).` + (skipped.length ? ` Note: ${skipped.join('; ')}` : ''));
+console.log(
+  `Swapped ${swapped} page(s).` +
+  (skipped.length ? ` Note: ${skipped.join('; ')}` : '') +
+  (swapped ? ' Run `pnpm build:docs` to regenerate website/docs/*.html.' : ''),
+);


### PR DESCRIPTION
Closes #1842. The last of the twelve architecture-review findings.

`website/docs/` was 118 hand-maintained HTML pages, ~36% of whose lines were byte-identical copy-pasted chrome. Adding a page meant a scripted edit across all 118 to insert its sidebar entry, plus hand-fixing its neighbours' pagers. And it isn't just a marketing-site concern: `build-help-corpus.mjs` chunks these pages into `resources/help-docs/corpus.json`, which ships inside the app.

Every page is now generated from three inputs:

```
website/docs/_layout.html      shared chrome, four placeholders
website/docs/_nav.json         the nav tree — drives every sidebar,
                               breadcrumb trail and prev/next pager
website/docs/_content/*.html   one fragment per page: title/description
                               front-matter plus the body
```

**Hand-maintained surface: 20,650 → 7,775 lines.** Adding a docs page is now one nav entry plus one fragment.

### The model

I worked this out before the build and it held: the nav block and footer are byte-identical across all 118; the head differs only in title and description; the sidebar is a function of (nav tree, active page); crumbs and the pager are derivable — the pager from the **depth-first** order of the whole tree, which reproduces 117 of 118 exactly.

Two corrections came back from implementation, both real:

- **20 distinct sidebars, not ~16** — four were stale (see below).
- **Crumb label ≠ pager label ≠ nav label.** `data.html` is *Data* in the sidebar but *Working with data* in crumbs and pagers. Hence three registers in `_nav.json`: `label` / `title` / `crumb`.

### Five hand-maintenance bugs the generator fixes by construction

I verified these independently by stripping tags and comparing rendered text on all 119 files — these five are the **only** pages whose text changes, and every change is a correction:

| Page | Was |
| --- | --- |
| `conversations.html` | pager `prev` pointed at Bookmarks; depth-first says Inspections |
| `left-sidebar-proposals.html` | a duplicated `Left sidebar` link where `Right sidebar` belonged — a **broken top-level nav link** |
| `right-sidebar-bookmarks.html` | sidebar missing *Inspections* |
| `right-sidebar-tables.html` | sidebar missing *History* |
| `settings-object-types.html` | sidebar missing *Inspections* |

The `right-sidebar-tables` one is mine. When I added the History page I ran a script inserting the nav entry before each page's Tables link — and on the Tables page itself that link reads `class="sub active"`, which my pattern didn't match. So the one page guaranteed to be read by someone looking at Tables was the one missing the new entry. That is exactly the failure mode this issue exists to remove.

### Verification

- `node scripts/build-docs.mjs` on the committed tree → **no diff**. The generator reproduces every byte it claims to own.
- Hand-editing a generated page fails `tests/scripts/docs-generated.test.ts` (118 byte-identity assertions plus an orphan check) — verified by doing it.
- Rendered-text comparison across all pages: only the five above differ, all additive.
- Help-corpus snapshot **unchanged, no `-u`** — chunk ids survive the move to fragments, with a new test asserting `extractFragmentChunks(body) === extractPageChunks(renderedPage)`.

### Two bugs caught mid-flight, both worth knowing

1. **`$$` corruption.** `String.replace(str, str)` treats `$$` in the *replacement* as an escaped `$`, so the first run silently turned every `$$\int…$$` in `notes-math.html` into `$…$` — in the body *and* the meta description. Only the byte-diff gate caught it. Now a function replacer, with a regression test. I re-checked the file by hand; it's intact.
2. **`website/screenshots/swap-shots.mjs` writes into `docs/*.html`** — which the next `build:docs` would silently clobber. Repointed at the fragments.

### Deviations from the brief

The agent normalised two cosmetic classes rather than carrying per-page fidelity flags: 15 pages had `&larr;`/`&rarr;` where 103 already used `←`/`→`, and 8 had an inconsistent blank line before the pager. Zero rendered change. I'd have made the same call — 15 encoding flags to preserve a typo is a worse artefact than the diff.

Not done, deliberately: `check:docs` isn't in CI (the vitest gate covers it), and `scripts/` has no coverage floor since the coverage config only includes `src/**`.

`pnpm lint` clean; full suite **6,745 passing** (621 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyjTVGXb7DtU5BvCzUgRQy