### PR TITLE
test(e2e): isolate every Electron launch from the developer's profile (#1928)

### DIFF
--- a/tests/architecture/e2e-launch-hygiene.test.ts
+++ b/tests/architecture/e2e-launch-hygiene.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Every e2e spec boots Minerva through `tests/e2e/helpers/launch.ts` (#1928).
+ *
+ * The bug this ratchets against: `smoke.spec.ts`'s first test called
+ * `electron.launch` with `args: [projectRoot]` and no `--user-data-dir`, so it
+ * ran against the developer's real Electron profile — writing to `Preferences`
+ * and `Session Storage` on the way out, and turning its own "a fresh launch
+ * yields the Open Thoughtbase shell" premise into a race against session
+ * restore that it happened to win. Eight sibling launch sites got it right.
+ * The one that didn't was invisible: green in CI (empty profile) and green
+ * locally (the assertion lands before restore completes), so nothing anywhere
+ * reported the difference.
+ *
+ * A convention that eight of nine call sites follow is not a convention, it's a
+ * coincidence. `launchMinerva` makes `userDataDir` a required parameter so
+ * omitting it is a type error; this test closes the other route, where a new
+ * spec reaches for `electron.launch` directly and never learns the helper
+ * exists.
+ *
+ * Deliberately a whole-file scan rather than a lint rule: the rule is about
+ * *which* API a spec may reach for, which reads more clearly as one assertion
+ * naming the reason than as an `eslint` `no-restricted-syntax` entry.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const E2E_DIR = path.resolve(__dirname, '..', 'e2e');
+const HELPER = path.join(E2E_DIR, 'helpers', 'launch.ts');
+
+function specFiles(): string[] {
+  return fs.readdirSync(E2E_DIR)
+    .filter((f) => f.endsWith('.spec.ts'))
+    .map((f) => path.join(E2E_DIR, f));
+}
+
+describe('e2e launch hygiene (#1928)', () => {
+  // Guards the scan itself: a glob that silently matched nothing would make
+  // every assertion below pass vacuously.
+  it('finds the e2e specs', () => {
+    expect(specFiles().length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('no spec calls electron.launch directly — they go through launchMinerva', () => {
+    const offenders = specFiles().filter((file) => {
+      const src = fs.readFileSync(file, 'utf8');
+      // Ignore prose: only a real call, not the word in a comment.
+      return /(?<!\/\/[^\n]*)\belectron\s*\.\s*launch\s*\(/.test(
+        src.split('\n').filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('//')).join('\n'),
+      );
+    });
+
+    expect(
+      offenders.map((f) => path.basename(f)),
+      'These specs launch Electron directly instead of via tests/e2e/helpers/launch.ts.\n' +
+      'A direct launch can omit --user-data-dir, which means booting the developer\'s real\n' +
+      'profile: the app restores their last project and the run writes back to it. That is\n' +
+      'exactly how the smoke test came to assert the opposite of what it claimed (#1928).\n' +
+      'Use `launchMinerva({ userDataDir })` — it requires the profile and filters the env.',
+    ).toEqual([]);
+  });
+
+  it('the helper forces --user-data-dir onto every launch', () => {
+    const src = fs.readFileSync(HELPER, 'utf8');
+    // One construction site for the flag, unconditional — not a caller-supplied
+    // arg the packaged/dev branches could each forget.
+    expect(src).toMatch(/const userDataArg = `--user-data-dir=\$\{userDataDir\}`/);
+    expect(src.match(/userDataArg/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
+  });
+
+  it('the helper filters credentials out of the forwarded environment', async () => {
+    const { scrubbedEnv } = await import('../e2e/helpers/launch');
+    const before = { ...process.env };
+    try {
+      process.env.ANTHROPIC_API_KEY = 'sk-should-not-reach-the-app';
+      process.env.GH_TOKEN = 'ghp_should-not-reach-the-app';
+      process.env.AWS_ACCESS_KEY_ID = 'AKIA-should-not-reach-the-app';
+      process.env.PATH = before.PATH ?? '/usr/bin';
+
+      const env = scrubbedEnv();
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(env.GH_TOKEN).toBeUndefined();
+      expect(env.AWS_ACCESS_KEY_ID).toBeUndefined();
+      // …while still handing over what the app genuinely needs to boot.
+      expect(env.PATH).toBeDefined();
+    } finally {
+      // process.env is worker-global; restore so the deletions don't leak into
+      // other files sharing this worker.
+      for (const k of ['ANTHROPIC_API_KEY', 'GH_TOKEN', 'AWS_ACCESS_KEY_ID']) {
+        if (before[k] === undefined) delete process.env[k];
+        else process.env[k] = before[k];
+      }
+    }
+  });
+});

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -19,13 +19,13 @@
  * `pnpm build:e2e` first (the `pnpm test:e2e` script does that). Gates on
  * serious + critical impact; minor/moderate are reported, non-fatal.
  */
-import { test, expect, _electron as electron, type Page } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
+import { launchMinerva, projectRoot } from './helpers/launch';
 import { runAxe, formatViolations, seriousOrWorse, type AxeViolation } from '../helpers/axe-playwright';
 
-const projectRoot = path.resolve(__dirname, '..', '..');
 
 // Pre-existing serious/critical violations tolerated so the net can land
 // without a product-a11y sweep. NEW rule ids fail the test. Tracked for a
@@ -87,11 +87,9 @@ async function launchApp(seedProjectDir?: string, extraEnv?: Record<string, stri
       JSON.stringify([{ x: 80, y: 80, width: 1200, height: 800, rootPath: seedProjectDir }]),
     );
   }
-  const app = await electron.launch({
-    args: [projectRoot, `--user-data-dir=${userDataDir}`],
-    cwd: projectRoot,
-    timeout: 60_000,
-    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1', ...extraEnv },
+  const app = await launchMinerva({
+    userDataDir,
+    env: extraEnv,
   });
   return { app, userDataDir };
 }

--- a/tests/e2e/focus-trap.spec.ts
+++ b/tests/e2e/focus-trap.spec.ts
@@ -11,12 +11,12 @@
  * Boots the in-tree `.vite/build` app (like the other e2e specs), so it needs
  * `pnpm build:e2e` first.
  */
-import { test, expect, _electron as electron, type Page } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
+import { launchMinerva, projectRoot } from './helpers/launch';
 
-const projectRoot = path.resolve(__dirname, '..', '..');
 
 async function launch() {
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-e2e-focustrap-userdata-'));
@@ -26,11 +26,8 @@ async function launch() {
     path.join(userDataDir, 'session.json'),
     JSON.stringify([{ x: 80, y: 80, width: 1200, height: 800, rootPath: projectDir }]),
   );
-  const app = await electron.launch({
-    args: [projectRoot, `--user-data-dir=${userDataDir}`],
-    cwd: projectRoot,
-    timeout: 60_000,
-    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1' },
+  const app = await launchMinerva({
+    userDataDir,
   });
   return { app, userDataDir, projectDir };
 }

--- a/tests/e2e/happy-paths.spec.ts
+++ b/tests/e2e/happy-paths.spec.ts
@@ -16,12 +16,12 @@
  * Boots the in-tree `.vite/build` app (like smoke.spec.ts), so it needs
  * `pnpm build:e2e` first (the `pnpm test:e2e` script does that).
  */
-import { test, expect, _electron as electron, type Page } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
+import { launchMinerva, projectRoot } from './helpers/launch';
 
-const projectRoot = path.resolve(__dirname, '..', '..');
 
 // These flows call `window.api` (the preload bridge) inside `win.evaluate` —
 // the renderer's global typing isn't in this spec's scope, so `window` reads as
@@ -36,11 +36,9 @@ async function launchWithProject() {
     path.join(userDataDir, 'session.json'),
     JSON.stringify([{ x: 80, y: 80, width: 1200, height: 800, rootPath: projectDir }]),
   );
-  const app = await electron.launch({
-    args: [projectRoot, `--user-data-dir=${userDataDir}`],
-    cwd: projectRoot,
-    timeout: 60_000,
-    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1', MINERVA_E2E: '1' },
+  const app = await launchMinerva({
+    userDataDir,
+    env: { MINERVA_E2E: '1' },
   });
   return { app, userDataDir, projectDir };
 }

--- a/tests/e2e/helpers/launch.ts
+++ b/tests/e2e/helpers/launch.ts
@@ -1,0 +1,106 @@
+/**
+ * One way to boot Minerva under Playwright (#1928).
+ *
+ * Every e2e spec used to call `electron.launch` directly with a hand-assembled
+ * options object. Eight of the nine launch sites passed `--user-data-dir` and
+ * one did not — `smoke.spec.ts`'s first test — so that test booted the
+ * *developer's real Electron profile*. Two consequences, measured rather than
+ * assumed:
+ *
+ *  - It **wrote to the real profile**: `Preferences`, `DIPS-wal` and
+ *    `Session Storage/` all took the run's timestamp.
+ *  - Its premise ("a fresh launch yields the Open Thoughtbase shell") became a
+ *    *race* rather than a fact. With a project in the profile the welcome
+ *    screen is still on screen at `domcontentloaded` and the assertion lands
+ *    ~1.8s in; session restore replaces it around the 6s mark. So the test won
+ *    the race and stayed green — but it was asserting a transient state, and a
+ *    slower boot or a faster restore flips it red for reasons unrelated to the
+ *    regression it exists to catch.
+ *
+ * Two things are therefore not optional here:
+ *
+ *  - **`userDataDir` is a required parameter.** Omitting it is a type error,
+ *    not a silently-different test. `tests/architecture/e2e-launch-hygiene.test.ts`
+ *    holds the other half by failing if a spec calls `electron.launch` directly.
+ *  - **The environment is filtered.** Specs forwarded `...process.env` wholesale,
+ *    handing the app under test the developer's real `GH_TOKEN` / `GITHUB_TOKEN`
+ *    (both of which `src/main/git/` actually reads) along with any model API
+ *    keys. A test run should not be able to authenticate as the developer.
+ */
+
+import { _electron as electron, type ElectronApplication } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Playwright transpiles tests as CJS (no `"type": "module"` in package.json),
+// so `__dirname` is available — `import.meta.url` would force ESM and trip
+// Playwright's loader.
+export const projectRoot = path.resolve(__dirname, '..', '..', '..');
+
+/**
+ * Names that never reach the app under test. Suffix-matched rather than
+ * enumerated so a newly-exported credential is excluded by default — the
+ * failure mode worth guarding is the one nobody remembers to add to a list.
+ */
+const SECRET_PATTERN = /(_KEY|_TOKEN|_SECRET|_PASSWORD|_CREDENTIALS|_SESSION)$/i;
+const SECRET_PREFIX = /^(AWS_|AZURE_|GCP_|GOOGLE_)/i;
+
+/** `process.env` minus anything that looks like a credential. */
+export function scrubbedEnv(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v === undefined) continue;
+    if (SECRET_PATTERN.test(k) || SECRET_PREFIX.test(k)) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * A fresh, empty temp directory. Used for both the isolated userData profile
+ * and the throwaway project a spec operates on. The caller owns removing it.
+ */
+export function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/**
+ * Seed a session so the app restores `projectDir` on launch. Without this the
+ * app boots to the welcome screen — which is what the smoke test wants, and
+ * exactly what it was not getting.
+ */
+export function seedSession(userDataDir: string, projectDir: string): void {
+  fs.writeFileSync(
+    path.join(userDataDir, 'session.json'),
+    JSON.stringify([{ x: 80, y: 80, width: 1000, height: 700, rootPath: projectDir }]),
+  );
+}
+
+export interface LaunchOptions {
+  /** Required: the profile this run may read and write. */
+  userDataDir: string;
+  /** Packaged-binary path. Omit to boot the in-tree `.vite/build/main.js`. */
+  executablePath?: string;
+  /** Extra env on top of the scrubbed base (e.g. `MINERVA_E2E: '1'`). */
+  env?: Record<string, string>;
+  /** Defaults to 60s — local boot is ~3s; a cold CI runner needs the headroom. */
+  timeout?: number;
+}
+
+/**
+ * Boot Minerva against an isolated profile. `ELECTRON_ENABLE_LOGGING` is always
+ * on so a failing launch has main-process output to show for it.
+ */
+export async function launchMinerva(opts: LaunchOptions): Promise<ElectronApplication> {
+  const { userDataDir, executablePath, env = {}, timeout = 60_000 } = opts;
+  const userDataArg = `--user-data-dir=${userDataDir}`;
+
+  return electron.launch({
+    ...(executablePath
+      ? { executablePath, args: [userDataArg] }
+      : { args: [projectRoot, userDataArg], cwd: projectRoot }),
+    timeout,
+    env: { ...scrubbedEnv(), ELECTRON_ENABLE_LOGGING: '1', ...env },
+  });
+}

--- a/tests/e2e/journeys.spec.ts
+++ b/tests/e2e/journeys.spec.ts
@@ -26,12 +26,12 @@
  * Boots the in-tree `.vite/build` app (like happy-paths.spec.ts), so it needs
  * `pnpm build:e2e` first (the `pnpm test:e2e` script does that).
  */
-import { test, expect, _electron as electron, type Page } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
+import { launchMinerva, projectRoot } from './helpers/launch';
 
-const projectRoot = path.resolve(__dirname, '..', '..');
 
 // These flows call `window.api` (the preload bridge) inside `win.evaluate` — the
 // renderer's global typing isn't in this spec's scope, so `window` reads as
@@ -52,11 +52,9 @@ async function launchWithProject() {
     path.join(userDataDir, 'session.json'),
     JSON.stringify([{ x: 80, y: 80, width: 1200, height: 800, rootPath: projectDir }]),
   );
-  const app = await electron.launch({
-    args: [projectRoot, `--user-data-dir=${userDataDir}`],
-    cwd: projectRoot,
-    timeout: 60_000,
-    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1', MINERVA_E2E: '1' },
+  const app = await launchMinerva({
+    userDataDir,
+    env: { MINERVA_E2E: '1' },
   });
   return { app, userDataDir, projectDir };
 }

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -27,15 +27,15 @@
  *     regression of that shape actually slips through.
  */
 
-import { test, expect, _electron as electron, type ConsoleMessage, type Page } from '@playwright/test';
+import { test, expect, type ConsoleMessage, type Page } from '@playwright/test';
 import path from 'node:path';
 import fs from 'node:fs';
-import os from 'node:os';
-
-// Playwright transpiles tests as CJS (no `"type": "module"` in
-// package.json), so __dirname is available — using import.meta.url
-// would force ESM and trip Playwright's loader.
-const projectRoot = path.resolve(__dirname, '..', '..');
+import {
+  launchMinerva,
+  makeTempDir,
+  seedSession,
+  projectRoot,
+} from './helpers/launch';
 
 /** Path to the packaged app binary, or null if it hasn't been built. */
 function packagedBinary(): string | null {
@@ -67,22 +67,13 @@ test('app launches, renderer mounts, no thrown errors', async () => {
   const mainStderr: string[] = [];
   const mainStdout: string[] = [];
 
-  const app = await electron.launch({
-    // `args: ['.']` boots Electron against the package.json `main`
-    // entry — same as `electron .` in development.
-    args: [projectRoot],
-    cwd: projectRoot,
-    // 60s — local boot is ~3s. The 30s default was tight enough on CI
-    // that a slow runner cold-start could legitimately exceed it (#518).
-    timeout: 60_000,
-    env: {
-      ...process.env,
-      // Tell Electron to log boot/IPC/render activity to stderr — only
-      // matters when something goes wrong (we read the buffer below);
-      // otherwise it just adds noise to a passing run.
-      ELECTRON_ENABLE_LOGGING: '1',
-    },
-  });
+  // A fresh, empty profile. This test asserts the *welcome* screen, which
+  // only appears when no project is restored — so booting the developer's
+  // real profile made it assert the opposite of what it says (#1928). It was
+  // green in CI, where the profile is always empty, and red on any machine
+  // that had actually used the app.
+  const userDataDir = makeTempDir('minerva-e2e-smoke-userdata-');
+  const app = await launchMinerva({ userDataDir });
 
   // Tap streams immediately after launch so we capture everything from
   // the moment Electron starts producing output.
@@ -121,6 +112,7 @@ test('app launches, renderer mounts, no thrown errors', async () => {
     throw err;
   } finally {
     await app.close().catch(() => { /* already exited */ });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
   }
 
   // CSP / preload warnings the project intentionally suppresses don't
@@ -151,23 +143,15 @@ test('packaged app opens a DuckDB-backed project (native binding shipped)', asyn
   const appBinary = packagedBinary();
   test.skip(appBinary === null, 'packaged app not built — run `pnpm build:e2e` first');
 
-  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-e2e-userdata-'));
-  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-e2e-project-'));
+  const userDataDir = makeTempDir('minerva-e2e-userdata-');
+  const projectDir = makeTempDir('minerva-e2e-project-');
   // Copy the fixture (it has newData.csv → registerAllCsvs → DuckDB) so the
   // launch can't mutate the tracked fixture (search-index persist, etc.).
   fs.cpSync(path.join(projectRoot, 'tests', 'fixtures', 'sample-project'), projectDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(userDataDir, 'session.json'),
-    JSON.stringify([{ x: 80, y: 80, width: 1000, height: 700, rootPath: projectDir }]),
-  );
+  seedSession(userDataDir, projectDir);
 
   const mainOut: string[] = [];
-  const app = await electron.launch({
-    executablePath: appBinary as string,
-    args: [`--user-data-dir=${userDataDir}`],
-    timeout: 60_000,
-    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1' },
-  });
+  const app = await launchMinerva({ userDataDir, executablePath: appBinary as string });
   app.process().stderr?.on('data', (chunk: Buffer) => mainOut.push(chunk.toString()));
   app.process().stdout?.on('data', (chunk: Buffer) => mainOut.push(chunk.toString()));
 


### PR DESCRIPTION
Closes #1928.

## What was actually wrong — and one correction to the issue

`smoke.spec.ts`'s first test launched with `args: [projectRoot]` and **no `--user-data-dir`**, the only one of nine launch sites that omitted it. So it booted the developer's real Electron profile.

**Confirmed:** it writes to that profile. `Preferences`, `DIPS-wal` and `Session Storage/` all took the run's timestamp — observed directly, twice.

**Corrected:** the issue predicted the test would *fail* on any machine that had used the app. It does not. Verified against a fresh build with the real profile in place — the original test passes.

What's really there is a **race**, which I probed with a seeded profile pointing at a real project:

```
[probe] immediately after load: h1=1 openButton=1
[probe] after 6s:               h1=0 openButton=0
```

The welcome screen is still on screen at `domcontentloaded`; the assertion lands ~1.8s in; session restore replaces it around 6s. **The test won the race**, so it was green in CI *and* locally — which is why nothing ever reported the difference. But it was asserting a transient state, and a slower boot or a faster restore flips it red for reasons unrelated to the regression it exists to catch.

My first reproduction *did* show a red run, but that turned out to be a stale `.vite/build` predating recent commits, not the profile. Worth stating plainly rather than letting a convenient failure stand in as evidence.

So: the profile mutation is the concrete defect; the race is the latent one. Both are fixed by the same change.

## The fix

`tests/e2e/helpers/launch.ts` — one way to boot Minerva, with all nine launch sites routed through it.

- **`userDataDir` is a required parameter.** Omitting it is a type error, not a silently-different test.
- **The environment is filtered.** Specs forwarded `...process.env` wholesale, handing the app under test the developer's real `GH_TOKEN` / `GITHUB_TOKEN` — both of which `src/main/git/` actually reads — plus any model API keys. Secrets are suffix/prefix-matched (`*_KEY`, `*_TOKEN`, `AWS_*`, …) rather than enumerated, so a newly-exported credential is excluded by default.

`tests/architecture/e2e-launch-hygiene.test.ts` closes the other route: a new spec that reaches for `electron.launch` directly fails the build. Verified by mutation — pointing one spec back at `electron.launch` fails it with the offending filename.

A convention that eight of nine call sites follow is a coincidence, not a convention.

Net: **38 insertions, 63 deletions** across the five specs, since each hand-assembled options object collapses to `launchMinerva({ userDataDir })`.

## Verification

| Check | Result |
|---|---|
| `pnpm lint` | tsc, svelte-check, eslint all clean |
| `npx vitest run tests/architecture` | 7 files / 22 tests (was 6 / 18) |
| `npx playwright test` | 15/15 passing |
| Real profile after a full run | `session.json` byte-identical to the pre-run backup |

## Pre-existing flake, for the record

Full cold e2e runs are flaky on this machine, independent of this change. Two of three full runs had one 60s timeout; every affected test passes in isolation and a warm re-run went 15/15 in 24.7s.

I checked whether that was mine by running the full suite on unmodified `main`: it failed **two different** tests (`a11y.spec.ts:216`, `focus-trap.spec.ts:43`) while `happy-paths` passed. So the flake pre-dates this PR and moves around — which is #1943 (timing-sensitive tests, no `TZ` pin, unconditioned `waitForTimeout` before axe scans) and #1946 (no flake budget on either suite). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mqvJTEVXfw6fDuKGYtXR8