### PR TITLE
test(ipc): test helpers.ts directly instead of asserting against its mock (#1926)

### DIFF
--- a/tests/main/ipc/helpers.test.ts
+++ b/tests/main/ipc/helpers.test.ts
@@ -1,0 +1,373 @@
+/**
+ * `src/main/ipc/helpers.ts`, tested directly (#1926).
+ *
+ * This module owns the whole #1631 no-project convention — `withRootPath` vs
+ * `withRootPathOr` vs `withRootPathWin` — which `vitest.config.mts` names as the
+ * reason the `src/main/ipc/**` branch floor exists ("this layer owns the
+ * `withRootPath` vs `withRootPathOr` decision, so a #1631 no-project conflation
+ * now regresses into a test failure instead of passing in silence"). It also
+ * owns `reindexFile`, the graph+search+vectors fan-out whose duplicated copies
+ * caused the stale-embeddings drift in #1892.
+ *
+ * It had no test of its own. Sixteen registrar tests `vi.mock` it, so the glob
+ * floor was satisfied by the registrars while the module implementing the policy
+ * measured 6.55% statements / **0% branches**. One of those mocks
+ * (`no-project-contract.test.ts`) re-implements the wrappers' semantics inside
+ * the mock and asserts against the re-implementation — so a bug in the real
+ * `rootPathFromEvent` → `winFromEvent` → `getRootPath(win.id)` chain was
+ * invisible to every one of them.
+ *
+ * So: the real module, with only the process edges mocked (`electron`'s
+ * `BrowserWindow`, `window-manager`'s window registry, and the three index
+ * backends). `listIndexableFiles` runs against a real temp tree, because its
+ * whole job is walking one.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+/** The project a window has open. `null` models "no project" / "Settings". */
+let openProject: string | null = '/vault';
+
+const { win, otherWin, registry, index } = vi.hoisted(() => {
+  const mkWin = (id: number) => ({ id, webContents: { send: vi.fn() } });
+  return {
+    win: mkWin(1),
+    otherWin: mkWin(2),
+    /** What `windowsForProject` reports; a test sets it per case. */
+    registry: { windows: [] as Array<{ id: number; webContents: { send: ReturnType<typeof vi.fn> } }> },
+    index: {
+      graphIndexNote: vi.fn(),
+      graphRemoveNote: vi.fn(),
+      searchIndexNote: vi.fn(),
+      searchRemoveNote: vi.fn(),
+      searchPersist: vi.fn(),
+      vectorsIndexNote: vi.fn(),
+      vectorsRemoveNote: vi.fn(),
+      readFile: vi.fn(),
+      markPathHandled: vi.fn(),
+    },
+  };
+});
+
+vi.mock('electron', () => ({
+  // The real chain is `BrowserWindow.fromWebContents(e.sender)` — keyed off the
+  // event so a test can hand in a window that isn't in the registry.
+  BrowserWindow: { fromWebContents: (sender: unknown) => (sender as { win?: unknown })?.win ?? win },
+  dialog: {},
+}));
+
+vi.mock('../../../src/main/window-manager', () => ({
+  getRootPath: (id: number) => (id === win.id ? openProject : null),
+  markPathHandled: index.markPathHandled,
+  windowsForProject: () => registry.windows,
+}));
+
+vi.mock('../../../src/main/graph/index', () => ({
+  indexNote: index.graphIndexNote,
+  removeNote: index.graphRemoveNote,
+}));
+vi.mock('../../../src/main/search/index', () => ({
+  indexNote: index.searchIndexNote,
+  removeNote: index.searchRemoveNote,
+  persist: index.searchPersist,
+}));
+vi.mock('../../../src/main/embeddings/vector-store', () => ({
+  indexNote: index.vectorsIndexNote,
+  removeNote: index.vectorsRemoveNote,
+}));
+vi.mock('../../../src/main/notebase/fs', () => ({ readFile: index.readFile }));
+
+import {
+  winFromEvent,
+  rootPathFromEvent,
+  withRootPath,
+  withRootPathOr,
+  withRootPathWin,
+  reindexFile,
+  removeFromIndexes,
+  listIndexableFiles,
+  persistIndexes,
+  broadcastRewritten,
+  broadcastHeadingRename,
+  broadcastProposalsChanged,
+  broadcastHistoryChanged,
+  broadcastInspectionsChanged,
+  hooks,
+  readJsonFileOr,
+} from '../../../src/main/ipc/helpers';
+import { Channels } from '../../../src/shared/channels';
+
+/** An IpcMainInvokeEvent, as far as these helpers are concerned. */
+const evt = (w: unknown = win) => ({ sender: { win: w } }) as unknown as Electron.IpcMainInvokeEvent;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  openProject = '/vault';
+  registry.windows = [];
+});
+
+describe('winFromEvent / rootPathFromEvent', () => {
+  it('resolves the window from the event sender', () => {
+    expect(winFromEvent(evt())).toBe(win);
+  });
+
+  it('resolves the open project via the window id', () => {
+    expect(rootPathFromEvent(evt())).toBe('/vault');
+  });
+
+  it('reports null for a window with no project open', () => {
+    // A real second window (Settings, or a window whose project was released) —
+    // not the same thing as `openProject = null`.
+    expect(rootPathFromEvent(evt(otherWin))).toBeNull();
+  });
+});
+
+describe('withRootPath — "there must be a project"', () => {
+  it('hands the resolved rootPath to the handler, ahead of its own args', () => {
+    const fn = vi.fn((root: string, a: string, b: number) => `${root}:${a}:${b}`);
+    expect(withRootPath(fn)(evt(), 'x', 2)).toBe('/vault:x:2');
+    expect(fn).toHaveBeenCalledWith('/vault', 'x', 2);
+  });
+
+  it('throws when no project is open, without calling the handler', () => {
+    openProject = null;
+    const fn = vi.fn();
+    expect(() => withRootPath(fn)(evt())).toThrow('No project open');
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  // The guard runs before the handler body, so a throw is synchronous even for
+  // an async handler. `ipcMain.handle` turns that into a rejected renderer
+  // promise either way — but the timing is what a caller sees under test.
+  it('throws synchronously even when the handler is async', () => {
+    openProject = null;
+    expect(() => withRootPath(async () => 'never')(evt())).toThrow('No project open');
+  });
+});
+
+describe('withRootPathOr — a legitimate project-less value', () => {
+  it('runs the handler when a project is open', () => {
+    const fn = vi.fn((root: string, n: number) => root.length + n);
+    expect(withRootPathOr(-1, fn)(evt(), 1)).toBe(7);
+  });
+
+  it('returns the fallback, not the handler, when no project is open', () => {
+    openProject = null;
+    const fn = vi.fn();
+    expect(withRootPathOr([], fn)(evt())).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('returns the fallback synchronously — it does not wrap it in a promise', () => {
+    openProject = null;
+    // Callers written as `expect(...).resolves` would silently pass on any
+    // value; the fallback arm never enters the async handler at all.
+    expect(withRootPathOr(false, async () => true)(evt())).toBe(false);
+  });
+
+  it('hands back the caller\'s own fallback identity', () => {
+    openProject = null;
+    const sentinel = { ok: false as const };
+    expect(withRootPathOr(sentinel, () => ({ ok: true as const }))(evt())).toBe(sentinel);
+  });
+});
+
+describe('withRootPathWin — project + window', () => {
+  it('hands the handler both the rootPath and the window', () => {
+    const fn = vi.fn((root: string, w: unknown, a: string) => ({ root, w, a }));
+    expect(withRootPathWin(fn)(evt(), 'arg')).toEqual({ root: '/vault', w: win, a: 'arg' });
+  });
+
+  it('throws when no project is open', () => {
+    openProject = null;
+    const fn = vi.fn();
+    expect(() => withRootPathWin(fn)(evt())).toThrow('No project open');
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe('reindexFile — the graph/search/vectors fan-out', () => {
+  it('sends a markdown note to all three indexes', async () => {
+    index.readFile.mockResolvedValue('# hello');
+    await reindexFile('/vault', 'notes/a.md');
+
+    expect(index.readFile).toHaveBeenCalledWith('/vault', 'notes/a.md');
+    expect(index.graphIndexNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md', '# hello');
+    expect(index.searchIndexNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md', '# hello');
+    expect(index.vectorsIndexNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md', '# hello');
+  });
+
+  // The asymmetry is deliberate — full-text and embeddings are markdown-only —
+  // and it is the reason three hand-copied fan-outs drifted apart (#1892).
+  it.each(['data/t.ttl', 'data/t.csv', 'scripts/t.py'])(
+    'sends a non-markdown note (%s) to the graph only',
+    async (rel) => {
+      index.readFile.mockResolvedValue('content');
+      await reindexFile('/vault', rel);
+
+      expect(index.graphIndexNote).toHaveBeenCalled();
+      expect(index.searchIndexNote).not.toHaveBeenCalled();
+      expect(index.vectorsIndexNote).not.toHaveBeenCalled();
+    },
+  );
+
+  it('skips a non-indexable file without even reading it', async () => {
+    await reindexFile('/vault', 'assets/img.png');
+    expect(index.readFile).not.toHaveBeenCalled();
+    expect(index.graphIndexNote).not.toHaveBeenCalled();
+  });
+
+  // thoughtbase.md feeds the conversation system prompt, not the graph.
+  it('skips the thoughtbase guide even though it is markdown', async () => {
+    await reindexFile('/vault', 'thoughtbase.md');
+    expect(index.readFile).not.toHaveBeenCalled();
+    expect(index.graphIndexNote).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeFromIndexes — the mirror of the fan-out', () => {
+  it('removes a markdown note from all three indexes', () => {
+    removeFromIndexes('/vault', 'notes/a.md');
+    expect(index.searchRemoveNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md');
+    expect(index.graphRemoveNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md');
+    expect(index.vectorsRemoveNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md');
+  });
+
+  // Note the shape difference from reindexFile: removal is unconditional across
+  // all three, because removing a key that was never indexed is a no-op.
+  it('removes a non-markdown note from all three as well', () => {
+    removeFromIndexes('/vault', 'data/t.ttl');
+    expect(index.graphRemoveNote).toHaveBeenCalled();
+    expect(index.searchRemoveNote).toHaveBeenCalled();
+    expect(index.vectorsRemoveNote).toHaveBeenCalled();
+  });
+
+  it('skips a non-indexable file', () => {
+    removeFromIndexes('/vault', 'assets/img.png');
+    expect(index.graphRemoveNote).not.toHaveBeenCalled();
+  });
+});
+
+describe('listIndexableFiles — walks a real tree', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-ipc-helpers-'));
+    fs.mkdirSync(path.join(root, 'notes', 'deep'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.hidden'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'notes', 'a.md'), '');
+    fs.writeFileSync(path.join(root, 'notes', 'data.csv'), '');
+    fs.writeFileSync(path.join(root, 'notes', 'img.png'), '');
+    fs.writeFileSync(path.join(root, 'notes', '.secret.md'), '');
+    fs.writeFileSync(path.join(root, 'notes', 'deep', 'b.md'), '');
+    fs.writeFileSync(path.join(root, '.hidden', 'c.md'), '');
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('recurses, keeps indexable files, and drops the rest', async () => {
+    expect((await listIndexableFiles(root, 'notes')).sort()).toEqual([
+      'notes/a.md',
+      'notes/data.csv',
+      'notes/deep/b.md',
+    ]);
+  });
+
+  it('skips dotted entries at every level', async () => {
+    const all = await listIndexableFiles(root, '');
+    expect(all).not.toContain('.hidden/c.md');
+    expect(all).toContain('notes/a.md');
+  });
+
+  it('joins paths without a leading slash when relDir is empty', async () => {
+    expect(await listIndexableFiles(root, '')).toContain('notes/a.md');
+  });
+
+  // The `catch` exists so a caller can ask about a directory that was just
+  // deleted; an empty list is the honest answer, not a crash.
+  it('returns an empty list for a directory that does not exist', async () => {
+    await expect(listIndexableFiles(root, 'nope/not/here')).resolves.toEqual([]);
+  });
+});
+
+describe('persistIndexes', () => {
+  // graph.ttl is a cold snapshot (#348) — it flushes on project release, not here.
+  it('persists the search index only', async () => {
+    await persistIndexes('/vault');
+    expect(index.searchPersist).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('broadcasts — fan out to every window on the project', () => {
+  beforeEach(() => { registry.windows = [win, otherWin]; });
+
+  it('broadcastRewritten reaches both windows', () => {
+    broadcastRewritten('/vault', ['notes/a.md']);
+    for (const w of [win, otherWin]) {
+      expect(w.webContents.send).toHaveBeenCalledWith(Channels.NOTEBASE_REWRITTEN, ['notes/a.md']);
+    }
+  });
+
+  it('broadcastRewritten sends nothing for an empty path list', () => {
+    broadcastRewritten('/vault', []);
+    expect(win.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('broadcastHeadingRename carries the candidate', () => {
+    const candidate = { relativePath: 'notes/a.md', from: 'Old', to: 'New' };
+    broadcastHeadingRename('/vault', candidate as never);
+    expect(win.webContents.send)
+      .toHaveBeenCalledWith(Channels.NOTEBASE_HEADING_RENAME_SUGGESTED, candidate);
+  });
+
+  it('broadcastProposalsChanged is a bare signal', () => {
+    broadcastProposalsChanged('/vault');
+    expect(win.webContents.send).toHaveBeenCalledWith(Channels.PROPOSALS_CHANGED);
+  });
+
+  it('broadcastHistoryChanged carries the note path', () => {
+    broadcastHistoryChanged('/vault', 'notes/a.md');
+    expect(win.webContents.send).toHaveBeenCalledWith(Channels.HISTORY_CHANGED, 'notes/a.md');
+  });
+
+  it('broadcastHistoryChanged carries null for a project-wide change', () => {
+    broadcastHistoryChanged('/vault', null);
+    expect(win.webContents.send).toHaveBeenCalledWith(Channels.HISTORY_CHANGED, null);
+  });
+
+  it('broadcastInspectionsChanged is a bare signal', () => {
+    broadcastInspectionsChanged('/vault');
+    expect(win.webContents.send).toHaveBeenCalledWith(Channels.INSPECTIONS_CHANGED);
+  });
+
+  it('a project with no open windows is a silent no-op, not a crash', () => {
+    registry.windows = [];
+    expect(() => {
+      broadcastRewritten('/vault', ['notes/a.md']);
+      broadcastProposalsChanged('/vault');
+      broadcastInspectionsChanged('/vault');
+    }).not.toThrow();
+  });
+});
+
+describe('the write-pipeline hooks bundle', () => {
+  it('exposes the real broadcast + markPathHandled implementations', () => {
+    expect(hooks.markPathHandled).toBe(index.markPathHandled);
+    expect(hooks.broadcastRewritten).toBe(broadcastRewritten);
+    expect(hooks.broadcastHeadingRename).toBe(broadcastHeadingRename);
+  });
+});
+
+describe('readJsonFileOr re-export', () => {
+  // Re-exported through the helpers barrel so callers (and CLAUDE.md's IPC
+  // section) can reach it here; the implementation is a leaf module.
+  it('is the read-json leaf, reachable from the barrel', async () => {
+    const leaf = await import('../../../src/main/ipc/read-json');
+    expect(readJsonFileOr).toBe(leaf.readJsonFileOr);
+  });
+});

--- a/tests/main/ipc/no-project-contract.test.ts
+++ b/tests/main/ipc/no-project-contract.test.ts
@@ -12,10 +12,16 @@
  *   - the thing isn't there  → `null` (its ONE remaining meaning)
  *   - a real IO/parse error  → rejects (never a sentinel, never defaults)
  *
- * Style follows register-bookmarks.test.ts: only electron + the project-scoping
- * helpers are mocked, and the mocked `withRootPath` / `withRootPathOr` reproduce
- * the real wrappers' semantics — so a handler that regressed back to
- * `withRootPathOr(null, …)` would resolve `null` here and fail the assertion.
+ * The project-scoping wrappers run for real. They used to be `vi.mock`ed with a
+ * hand-written copy of their semantics, which meant this file asserted against
+ * the copy: a bug in the real `rootPathFromEvent` → `winFromEvent` →
+ * `getRootPath(win.id)` chain was invisible here and in the fifteen other
+ * registrar tests that mock the module the same way (#1926). Steering now
+ * happens one layer lower — `window-manager.getRootPath` reports `state.root` —
+ * so `src/main/ipc/helpers.ts` itself is on the path under test.
+ *
+ * `tests/main/ipc/helpers.test.ts` covers those wrappers directly; this file
+ * covers what the *handlers* do with them.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs/promises';
@@ -38,40 +44,12 @@ vi.mock('electron', () => ({
   ipcMain: { handle: (channel: string, fn: Handler) => { handlers.set(channel, fn); } },
   dialog: { showOpenDialog: vi.fn(), showSaveDialog: vi.fn() },
   Notification: Object.assign(vi.fn(), { isSupported: () => false }),
-  BrowserWindow: { fromWebContents: () => null },
+  // The real `winFromEvent` → `getRootPath(win.id)` chain runs now, so this has
+  // to be a window-shaped object rather than null.
+  BrowserWindow: { fromWebContents: () => ({ id: 1, webContents: { send: vi.fn() } }) },
   app: { getPath: () => os.tmpdir() },
   shell: {},
 }));
-
-// Keep the REAL readJsonFileOr (it's what FORMATTER_LOAD_SETTINGS now leans on);
-// only the project-scoping wrappers are stubbed, with the real semantics, so we
-// can steer/clear the open project.
-vi.mock('../../../src/main/ipc/helpers', async () => {
-  const { readJsonFileOr } = await import('../../../src/main/ipc/read-json');
-  return {
-    readJsonFileOr,
-    rootPathFromEvent: () => state.root,
-    withRootPath:
-      <A extends unknown[], R>(fn: (rootPath: string, ...a: A) => R) =>
-      (_e: unknown, ...args: A) => {
-        if (!state.root) throw new Error('No project open');
-        return fn(state.root, ...args);
-      },
-    withRootPathOr:
-      <A extends unknown[], R>(fallback: R, fn: (rootPath: string, ...a: A) => R) =>
-      (_e: unknown, ...args: A) => (state.root ? fn(state.root, ...args) : fallback),
-    withRootPathWin:
-      <A extends unknown[], R>(fn: (rootPath: string, win: unknown, ...a: A) => R) =>
-      (_e: unknown, ...args: A) => {
-        if (!state.root) throw new Error('No project open');
-        return fn(state.root, null, ...args);
-      },
-    winFromEvent: () => null,
-    persistIndexes: vi.fn(),
-    broadcastRewritten: vi.fn(),
-    hooks: {},
-  };
-});
 
 // Domain modules the handlers delegate to — stubbed so the test exercises the
 // project-scoping contract, not the graph/approval engines.
@@ -86,7 +64,12 @@ vi.mock('../../../src/main/graph/index', () => ({
   getAliasEntries: vi.fn(),
   getAllFrontmatterKeys: vi.fn(),
 }));
-vi.mock('../../../src/main/search/index', () => ({ indexAllNotes: vi.fn() }));
+vi.mock('../../../src/main/search/index', () => ({
+  indexAllNotes: vi.fn(), indexNote: vi.fn(), removeNote: vi.fn(), persist: vi.fn(),
+}));
+vi.mock('../../../src/main/embeddings/vector-store', () => ({
+  indexNote: vi.fn(), removeNote: vi.fn(),
+}));
 vi.mock('../../../src/main/sources/tables', () => ({
   runQuery: vi.fn(), listTables: vi.fn(), registerAllCsvs: vi.fn(), registerAllNoteTables: vi.fn(),
 }));
@@ -116,7 +99,14 @@ vi.mock('../../../src/main/notebase/templates', () => ({
 // register-refactor's LLM / formatter / write-pipeline neighbours.
 vi.mock('../../../src/main/notebase/write-pipeline', () => ({ writeAndReindex: vi.fn() }));
 vi.mock('../../../src/main/history', () => ({ runWithHistorySource: vi.fn() }));
-vi.mock('../../../src/main/window-manager', () => ({ markPathHandled: vi.fn() }));
+// The single steering point for "is a project open?" now that the real helpers
+// are on the path. `windowsForProject` returns nothing, so the real broadcast
+// helpers are silent no-ops here.
+vi.mock('../../../src/main/window-manager', () => ({
+  getRootPath: () => state.root,
+  markPathHandled: vi.fn(),
+  windowsForProject: () => [],
+}));
 vi.mock('../../../src/main/llm/auto-tag', () => ({ runAutoTag: vi.fn(), applyAutoTag: vi.fn() }));
 vi.mock('../../../src/main/llm/auto-link', () => ({
   suggestLinksTo: vi.fn(), fileAutoLinkOutbound: vi.fn(),

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -148,18 +148,34 @@ export default defineConfig({
           statements: 64,
           branches: 51,
         },
+        // Two per-file floors below, for the same reason twice: the glob above
+        // is an aggregate, and an aggregate cannot fail on account of one file.
+        // Both of these were comfortably carried by their neighbours while
+        // sitting at 0% branches themselves.
+        //
         // `PROPOSAL_APPROVE` is the single channel through which a human
-        // confirms an LLM write — the Trust Principle's enforcement point — so
-        // it gets its own floor rather than hiding inside the aggregate above.
-        // It has to: the glob floor was comfortably met by the other 23
-        // registrars while this file sat at 25% statements / 0% branches, its
-        // only test reference being the shared no-project contract (#1924).
-        // An aggregate cannot fail for one file, which is the whole reason the
-        // gap survived. Now 100% across the board via
+        // confirms an LLM write — the Trust Principle's enforcement point. The
+        // glob was met by the other 23 registrars while this file sat at 25%
+        // statements / 0% branches, its only test reference being the shared
+        // no-project contract (#1924). Now 100% across the board via
         // `tests/main/ipc/register-proposals.test.ts`; floors sit just under so
         // a new defensive branch won't flap, but the approve/reject arms cannot
         // quietly go untested again.
         'src/main/ipc/register-proposals.ts': {
+          lines: 95,
+          functions: 95,
+          statements: 95,
+          branches: 90,
+        },
+        // `helpers.ts` is the sharper case: sixteen registrar tests `vi.mock`
+        // this module, so the aggregate was satisfied by the very tests that
+        // mocked it out, while the module that *implements* the `withRootPath`
+        // vs `withRootPathOr` policy sat at 6.55% statements / 0% branches —
+        // the exact conflation the glob's own comment says the branch floor
+        // exists to catch (#1926). It also owns `reindexFile`, whose
+        // graph/search/vectors fan-out is the one that drifted in #1892. Now
+        // 100% across the board via `tests/main/ipc/helpers.test.ts`.
+        'src/main/ipc/helpers.ts': {
           lines: 95,
           functions: 95,
           statements: 95,


### PR DESCRIPTION
Closes #1926.

Rebased onto `main` after #1949 and #1950 merged. The `vitest.config.mts` conflict was the expected one — both PRs added a per-file floor at the same insertion point — resolved by keeping both entries under a shared comment, since they are the same lesson twice.

## Why

`src/main/ipc/helpers.ts` owns the whole #1631 no-project convention — `withRootPath` vs `withRootPathOr` vs `withRootPathWin`. `vitest.config.mts` names exactly this when explaining why the `src/main/ipc/**` branch floor exists:

> this layer owns the `withRootPath` vs `withRootPathOr` decision, so a #1631 no-project conflation now regresses into a test failure instead of passing in silence

It also owns `reindexFile`, the graph+search+vectors fan-out whose hand-copied duplicates drifted apart in #1892.

It had **no test of its own**. Sixteen registrar tests `vi.mock` it, so the glob floor was comfortably satisfied by the registrars while the module implementing the policy measured **6.55% statements / 0% branches**.

## What

**`tests/main/ipc/helpers.test.ts`** — 36 tests against the real module. Only the process edges are mocked: `electron`'s `BrowserWindow`, `window-manager`'s registry, and the three index backends. `listIndexableFiles` runs against a real temp tree, since walking one is its entire job.

**6.55% S / 0% B → 100% S / 100% B / 100% F / 100% L.**

The fan-out tests pin the asymmetry that caused #1892:

| Input | graph | search | vectors |
|---|---|---|---|
| `notes/a.md` | ✓ | ✓ | ✓ |
| `.ttl` / `.csv` / `.py` | ✓ | — | — |
| `assets/img.png` | — | — | — (not even read) |
| `thoughtbase.md` | — | — | — |

…and the mirror: removal *is* unconditional across all three, because removing a key that was never indexed is a no-op. That difference is the kind of thing three hand-copied fan-outs get wrong.

## The part that matters most: removing the re-implementation

`no-project-contract.test.ts` mocked this module with a hand-written copy of the wrappers' semantics and asserted against **the copy**. Its own header was candid that the mock "reproduce[s] the real wrappers' semantics" — but that means a bug in the real `rootPathFromEvent` → `winFromEvent` → `getRootPath(win.id)` chain was invisible to it, and to the fifteen other registrar tests that mock the same way.

Steering now happens one layer lower: `window-manager.getRootPath` reports `state.root`, so the real helpers are on the path under test. The `vi.mock` of `ipc/helpers` is gone.

**This is load-bearing, not cosmetic.** Mutating `rootPathFromEvent` to ignore the window registry:

| File | Result under the mutation |
|---|---|
| `no-project-contract.test.ts` — **main's version** | **16/16 pass** (blind) |
| `no-project-contract.test.ts` — this PR | **9/16 fail** |
| `helpers.test.ts` (new) | **11/36 fail** |

All 16 of its existing assertions still pass unchanged against the real wrappers, so the conversion didn't weaken what it was already checking.

## Coverage floor

`src/main/ipc/helpers.ts` gets its own per-file floor (95/95/95/90). The glob demonstrably could not protect it — the aggregate is met by the very tests that mock it out.

## Gate (re-run post-rebase, against the merged #1949 + #1950)

- `pnpm lint` — tsc, svelte-check, eslint all clean
- `pnpm coverage` — exit 0, **624 files / 6811 tests passing**, all floors met
- Verified from lcov: `helpers.ts` and `register-proposals.ts` both at 100% lines / branches / functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mqvJTEVXfw6fDuKGYtXR8