### PR TITLE
fix(hygiene): stop the temp-dir and rpc-socket leaks (#1933)

### DIFF
--- a/src/main/compute/rpc-server.ts
+++ b/src/main/compute/rpc-server.ts
@@ -21,6 +21,7 @@
  * every call.
  */
 
+import fs from 'node:fs';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
@@ -260,9 +261,57 @@ export async function startRpcServer(rootPath: string): Promise<RpcServer> {
         // (Errors ignored: the socket may have already been removed.)
       }).then(async () => {
         try {
-          const fs = await import('node:fs/promises');
-          await fs.unlink(socketPath);
+          await fs.promises.unlink(socketPath);
         } catch { /* nothing to do */ }
       }),
   };
+}
+
+const SOCKET_NAME_RE = /^minerva-rpc-(\d+)-[0-9a-f]+\.sock$/;
+
+/** True if `pid` names a process we could still signal (i.e. it's alive). */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // ESRCH: no such process — genuinely gone. EPERM: it exists but we lack
+    // permission to signal it — still alive, so leave its socket alone.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Remove `.sock` files a past Minerva process left behind without cleaning up
+ * after itself (#1933). `close()` above unlinks on every path this process
+ * controls — graceful stop, kernel crash, `before-quit` — but none of that
+ * runs if the *whole app* is killed harder than that (SIGKILL, an OS crash, a
+ * `pnpm dev` restart that doesn't wait for shutdown). A socket's PID is
+ * embedded in its own filename, so on the next boot "no process has that PID
+ * anymore" is an unambiguous, no-false-positive test for staleness — this
+ * process's own still-launching sockets can't yet exist to be swept.
+ *
+ * Best-effort throughout: a sweep is a startup nicety, not a correctness
+ * requirement, so any failure (unreadable tmpdir, a permissions error, a
+ * socket removed by a concurrent sweep) is swallowed rather than surfaced.
+ */
+export function sweepStaleRpcSockets(): void {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(os.tmpdir());
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    const match = SOCKET_NAME_RE.exec(name);
+    if (!match) continue;
+    const pid = Number(match[1]);
+    if (isProcessAlive(pid)) continue;
+    try {
+      fs.unlinkSync(path.join(os.tmpdir(), name));
+    } catch {
+      // Already gone, or a permissions error — either way, not this
+      // process's problem to solve right now.
+    }
+  }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import { registerBuiltinExporters } from './publish';
 import { installCsp, installMediaPermissions } from './security';
 import { flushAllProjects } from './project-context';
 import { shutdownAllKernels } from './compute/python-kernel';
+import { sweepStaleRpcSockets } from './compute/rpc-server';
 import { stopClipperServer } from './clipper/lifecycle';
 import { registerSkillsAtStartup } from './skills/register';
 import { initAutoUpdate, setUpdateStateListener } from './auto-update';
@@ -38,6 +39,10 @@ boot('main module loaded');
 
 void app.whenReady().then(async () => {
   boot('app ready');
+  // Sweep RPC sockets an earlier process left behind without cleaning up
+  // (#1933) — a hard kill or crash bypasses every in-process close() path.
+  // Synchronous and cheap (one tmpdir listing); fine to do inline at startup.
+  sweepStaleRpcSockets();
   // Break the menu.ts <-> window-manager.ts import cycle (#986): window-manager
   // triggers menu rebuilds through this injected callback rather than importing
   // `rebuildMenu` directly. Registered before any window is created so the

--- a/tests/helpers/bench-temp-dirs.ts
+++ b/tests/helpers/bench-temp-dirs.ts
@@ -1,0 +1,32 @@
+/**
+ * Temp-dir cleanup for `*.bench.ts` files (#1933).
+ *
+ * Benchmarks seed via a top-level `await`, ahead of any `describe`/`bench`
+ * call — vitest's benchmark runner doesn't reliably await an async
+ * `beforeAll` before a `bench`'s iterations *start* (perf #1109 finding, see
+ * the header comment in `n3-cold-rebuild.bench.ts`). Five bench files then
+ * generalized that into "no lifecycle hook is trustworthy here" and skipped
+ * `afterAll` too, `mkdtempSync`-ing a root and never removing it — leaving
+ * thousands of stale directories after repeated `pnpm bench` runs.
+ *
+ * That generalization doesn't hold. Verified empirically: `afterAll` fires
+ * reliably *after* every `bench` iteration in a file has completed — the
+ * #1109 finding was specifically that `beforeAll` isn't awaited before
+ * iterations begin, a setup-ordering problem with no bearing on teardown
+ * ordering. (`process.on('exit')` was tried first here and rejected for the
+ * same reason in reverse: vitest tears benchmark workers down without a
+ * process-level `'exit'`, so that hook silently never fired at all.)
+ */
+import { afterAll } from 'vitest';
+import fs from 'node:fs';
+
+/**
+ * Register a temp dir for removal once this bench file's iterations finish.
+ * Returns `dir` unchanged, so it composes with `mkdtempSync` inline.
+ */
+export function trackTempDir(dir: string): string {
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  return dir;
+}

--- a/tests/main/compute/rpc-server.test.ts
+++ b/tests/main/compute/rpc-server.test.ts
@@ -9,12 +9,13 @@
  * and a real `minerva` import).
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { dispatchMethod } from '../../../src/main/compute/rpc-server';
+import { spawnSync } from 'node:child_process';
+import { dispatchMethod, sweepStaleRpcSockets } from '../../../src/main/compute/rpc-server';
 import { initGraph, indexNote } from '../../../src/main/graph/index';
 import { initSearch, indexNote as searchIndex } from '../../../src/main/search/index';
 import { initTablesDb } from '../../../src/main/sources/tables';
@@ -132,5 +133,73 @@ describe('rpc server method dispatch (#242)', () => {
     if ('error' in r) {
       expect(r.error.code).toBe('TypeError');
     }
+  });
+});
+
+/**
+ * `sweepStaleRpcSockets` (#1933) — a startup-only complement to `close()`'s
+ * own unlink. `close()` covers every path this process controls; this covers
+ * the one it can't (a prior process killed harder than that). A dead process's
+ * PID is unambiguous, so the sweep is tested against a real dead PID rather
+ * than a mock — `spawnSync` returns only once the child has already exited,
+ * which is exactly the guarantee the sweep relies on.
+ */
+describe('sweepStaleRpcSockets (#1933)', () => {
+  const created: string[] = [];
+
+  function sockPath(name: string): string {
+    const p = path.join(os.tmpdir(), name);
+    created.push(p);
+    return p;
+  }
+
+  afterEach(() => {
+    for (const p of created.splice(0)) {
+      try { fs.unlinkSync(p); } catch { /* already removed, or never created */ }
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('removes a socket file whose PID no longer belongs to any process', () => {
+    const deadPid = spawnSync(process.execPath, ['-e', 'process.exit(0)']).pid;
+    const stale = sockPath(`minerva-rpc-${deadPid}-deadbeef.sock`);
+    fs.writeFileSync(stale, '');
+
+    sweepStaleRpcSockets();
+
+    expect(fs.existsSync(stale)).toBe(false);
+  });
+
+  it('leaves a socket file whose PID is this (live) process alone', () => {
+    // The suffix has to be valid hex to match SOCKET_NAME_RE at all — a
+    // near-miss here would make this test pass for the wrong reason (the
+    // sweep ignoring the file because the *name* didn't match, not because
+    // the *PID* was live).
+    const live = sockPath(`minerva-rpc-${process.pid}-a11ce000.sock`);
+    fs.writeFileSync(live, '');
+
+    sweepStaleRpcSockets();
+
+    expect(fs.existsSync(live)).toBe(true);
+  });
+
+  it('ignores files that are not shaped like a minerva-rpc socket', () => {
+    const unrelated = sockPath('minerva-rpc-not-a-pid-x.sock');
+    fs.writeFileSync(unrelated, '');
+    const otherApp = sockPath('some-other-app-123-abc.sock');
+    fs.writeFileSync(otherApp, '');
+
+    sweepStaleRpcSockets();
+
+    expect(fs.existsSync(unrelated)).toBe(true);
+    expect(fs.existsSync(otherApp)).toBe(true);
+  });
+
+  it('is a startup nicety, not a correctness requirement — an unreadable tmpdir does not throw', () => {
+    vi.spyOn(fs, 'readdirSync').mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    expect(() => sweepStaleRpcSockets()).not.toThrow();
   });
 });

--- a/tests/main/graph/full-index.bench.ts
+++ b/tests/main/graph/full-index.bench.ts
@@ -24,11 +24,12 @@ import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexAllNotes } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { trackTempDir } from '../../helpers/bench-temp-dirs';
 
 const SCALES = [500, 2000, 5000];
 
 for (const scale of SCALES) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-fullidx-'));
+  const root = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-fullidx-')));
   const ctx: ProjectContext = projectContext(root);
   await initGraph(ctx);
   for (let i = 0; i < scale; i++) {

--- a/tests/main/graph/graph-index.bench.ts
+++ b/tests/main/graph/graph-index.bench.ts
@@ -21,10 +21,11 @@ import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexNote } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { trackTempDir } from '../../helpers/bench-temp-dirs';
 
 const SEED_NOTES = 500;
 
-const root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-idxbench-'));
+const root = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-idxbench-')));
 const ctx: ProjectContext = projectContext(root);
 await initGraph(ctx);
 // Populate the store so indexNote runs against a non-trivial graph, not an

--- a/tests/main/graph/n3-cache.bench.ts
+++ b/tests/main/graph/n3-cache.bench.ts
@@ -22,8 +22,9 @@ import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexNote, queryGraph } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { trackTempDir } from '../../helpers/bench-temp-dirs';
 
-const root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-n3bench-'));
+const root = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-n3bench-')));
 const ctx: ProjectContext = projectContext(root);
 await initGraph(ctx);
 // Plant 500 synthetic notes — roughly the inflection point where the

--- a/tests/main/graph/n3-cold-rebuild.bench.ts
+++ b/tests/main/graph/n3-cold-rebuild.bench.ts
@@ -31,11 +31,12 @@ import path from 'node:path';
 import os from 'node:os';
 import { initGraph, indexAllNotes, queryGraph, indexNote } from '../../../src/main/graph/index';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { trackTempDir } from '../../helpers/bench-temp-dirs';
 
 const SCALES = [500, 2000, 5000];
 
 for (const scale of SCALES) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-n3cold-'));
+  const root = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-n3cold-')));
   const ctx: ProjectContext = projectContext(root);
   await initGraph(ctx);
   // Write files to disk, then one indexAllNotes pass — the bulk (O(n),

--- a/tests/main/notebase/write-pipeline.bench.ts
+++ b/tests/main/notebase/write-pipeline.bench.ts
@@ -13,9 +13,12 @@
  * to leave pending — the process exits once the bench run ends.)
  *
  * Seeding runs as a top-level `await` per scale (see the header comment in
- * `n3-cold-rebuild.bench.ts` for why: `beforeAll`/`afterAll` don't reliably
- * run around a `bench`'s iterations in this vitest version's benchmark
- * runner — confirmed empirically).
+ * `n3-cold-rebuild.bench.ts` for why: `beforeAll` doesn't reliably complete
+ * before a `bench`'s iterations start in this vitest version's benchmark
+ * runner — confirmed empirically). `afterAll` doesn't share that problem —
+ * it's a teardown-ordering guarantee, not a setup one — so temp-dir cleanup
+ * below goes through it via `trackTempDir` (#1933), also confirmed
+ * empirically.
  */
 
 import { describe, bench } from 'vitest';
@@ -26,6 +29,7 @@ import { initGraph, indexAllNotes } from '../../../src/main/graph/index';
 import { initSearch, indexAllNotes as searchIndexAllNotes } from '../../../src/main/search/index';
 import { writeAndReindex, type WritePipelineHooks } from '../../../src/main/notebase/write-pipeline';
 import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { trackTempDir } from '../../helpers/bench-temp-dirs';
 
 const SCALES = [500, 2000, 5000];
 
@@ -36,7 +40,7 @@ const noopHooks: WritePipelineHooks = {
 };
 
 for (const scale of SCALES) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-savepipeline-'));
+  const root = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-savepipeline-')));
   const ctx: ProjectContext = projectContext(root);
   await initGraph(ctx);
   await initSearch(ctx);

--- a/tests/main/publish/publish-to-git.test.ts
+++ b/tests/main/publish/publish-to-git.test.ts
@@ -7,9 +7,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mkdtempSync, readFileSync } from 'node:fs';
-import os from 'node:os';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { useTempDir } from '../../helpers/temp-project';
 
 type Target = {
   id: string; label: string; exporter: string; gitRemote: string;
@@ -59,9 +59,13 @@ vi.mock('../../../src/main/git/github-repo', async (orig) => {
 
 import { publishToGit } from '../../../src/main/publish/publish-to-git';
 
+// `useTempDir` registers its own beforeEach/afterEach, so the dir is always
+// removed even when a test throws — the prior mkdtempSync-with-no-cleanup
+// left ~3,300 stale dirs behind on one dev machine (#1933).
+const tmp = useTempDir('minerva-pubroot-');
 let root: string;
 beforeEach(() => {
-  root = mkdtempSync(path.join(os.tmpdir(), 'minerva-pubroot-'));
+  root = tmp.root;
   h.target = {
     id: 't', label: 'T', exporter: 'static-site',
     gitRemote: 'https://github.com/o/r.git', gitBranch: 'gh-pages',


### PR DESCRIPTION
Closes #1933.

## Four leaks, one issue

**`publish-to-git.test.ts` — 3,438 stale dirs.** Bare `mkdtempSync` in `beforeEach`, no `afterEach`, no `rm` anywhere. Switched to `useTempDir()` (`tests/helpers/temp-project.ts`, #678) — same fixture the issue points to for #1902, so this is also a small step on that adoption effort.

**Five `*.bench.ts` files — 59 stale dirs.** These can't use the same fixture: benches seed via a top-level `await`, ahead of any `describe`/`bench` call, because vitest's benchmark runner doesn't reliably await an async `beforeAll` before iterations *start* (the #1109 finding, already documented in their headers).

One file's comment had generalized that into "no lifecycle hook is trustworthy here" and skipped `afterAll` too. I didn't take that at face value — I probed it.

## What I verified before trusting either approach

I tried `process.on('exit', ...)` first, since it seemed like the obvious way to sidestep hook-ordering entirely. Wired it up, ran a bench, checked the directory on disk afterward: **still there.** Added debug output inside the handler, redirected straight to a file (to rule out pipe buffering eating it): **zero output, ever.** vitest tears benchmark workers down without emitting a process-level `'exit'` inside them — the mechanism silently never fires.

So I went the other direction and tested whether `afterAll` — the thing the existing comment said not to trust — actually works for *teardown*, as opposed to the *setup*-ordering problem #1109 documented. Wrote a throwaway probe bench with a directory + `afterAll(() => rmSync(...))` + explicit before/after `existsSync` checks in stderr. Result: **fires reliably, every time**, after every iteration completes. The #1109 finding is specifically about `beforeAll` not being awaited before iterations begin — a setup problem — and has no bearing on teardown ordering. The blanket "beforeAll/afterAll" comment in `write-pipeline.bench.ts` was wrong; I corrected it.

`tests/helpers/bench-temp-dirs.ts` wraps each `mkdtempSync` in `trackTempDir()`, which registers the `afterAll`. Verified against real fs counts (not just green tests) before/after running all five files, individually and combined: **0 dirs added, every time.**

## The production socket leak — also not quite what was filed

`rpc-server.ts`'s `close()` already unlinks its socket on every path this process controls: graceful stop, kernel crash (`proc.on('exit')` in `python-kernel.ts`), and app quit (`before-quit` → `shutdownAllKernels` → `terminate` → `close`). So "never unlinks it on close" didn't hold up under inspection.

What's actually missing is the one path no in-process handler can reach: the *whole app* killed harder than that — SIGKILL, an OS crash, a `pnpm dev` restart that doesn't wait for shutdown. **324 stale sockets had accumulated here from exactly that**, on a dev machine that restarts `pnpm dev` constantly.

Added `sweepStaleRpcSockets()`, called once at app startup. A socket's PID is embedded in its own filename (`minerva-rpc-<pid>-<rand>.sock`), so "no process has that PID anymore" is an unambiguous, no-false-positive staleness test. Failure mode under PID reuse is asymmetric in the safe direction: a race only produces a false *negative* (skip a stale file), never deletes a live server's socket, since `isProcessAlive` gates every unlink.

## Cleanup on this machine (success criterion 4)

Removed the two categories named in the issue: `minerva-pubroot-*` (3,438 → 0) and the five bench prefixes (59 → 0). The 324 stale sockets were already swept to 0 incidentally, by running the sweep function for real during testing. Left the ~344 other `minerva-*` entries in `$TMPDIR` alone — they belong to unrelated test files outside this issue's scope.

## Verified by mutation

On `sweepStaleRpcSockets`:

| Mutation | Result |
|---|---|
| Delete unconditionally, ignore liveness | 1 test fails |
| Never unlink anything | 1 test fails |
| Overly permissive name regex (`/(\d+)/`) | 1 test fails |

One catch worth naming: my first "delete unconditionally" mutation run showed **no failures** — which worried me more than a failure would have, since the whole point of this PR is not trusting a green run at face value. Turned out the "live PID" test fixture used a non-hex suffix (`alive000` — contains `l`, `i`, `v`) that never matched `SOCKET_NAME_RE` at all, so the assertion was vacuously true regardless of what the mutation did. Fixed the suffix to valid hex and reran — now genuinely caught, confirmed by the table above.

## Gate

- `pnpm lint` — tsc, svelte-check, eslint all clean
- `pnpm coverage` — exit 0, **624 files / 6815 tests passing**, all floors met

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mqvJTEVXfw6fDuKGYtXR8