### PR TITLE
test(graph): replace the fake health-checks test with real coverage (#1927)

### DIFF
--- a/tests/main/graph/health-checks.test.ts
+++ b/tests/main/graph/health-checks.test.ts
@@ -1,43 +1,268 @@
-import { describe, it, expect } from 'vitest';
+/**
+ * `checkUnsupportedClaims`, `checkEvidenceGaps`, and `checkContradictions`
+ * (#1927).
+ *
+ * The file at this path used to be 41 lines with zero imports, asserting on
+ * array/object literals it declared itself two lines above each assertion —
+ * it could not fail, and it carried this module's exact filename, so it read
+ * as `health-checks.ts`'s test in every listing. `health-checks.ts` is at
+ * 93.25% line coverage via six other test files, which is exactly why nobody
+ * noticed: no coverage is lost by a test that runs nothing.
+ *
+ * What those six files leave genuinely untested is the *content* of these
+ * three checks specifically — `inspection-settings-skip.test.ts` counts how
+ * many SPARQL queries they fire (the "hidden argument-map checks" that always
+ * run), never what they return. This file closes that gap: real graph state
+ * via `applyTurtle`, `runAllChecks` over it, assertions on the inspection
+ * shape (type/severity/message/notePath) each check actually promises.
+ */
 
-// Test the inspection type structure and check naming conventions
-describe('health check inspection types', () => {
-  it('defines expected severity levels', () => {
-    const severities = ['info', 'warning', 'concern'];
-    expect(severities).toContain('info');
-    expect(severities).toContain('warning');
-    expect(severities).toContain('concern');
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { runAllChecks } from '../../../src/main/graph/health-checks';
+import { applyTurtle } from '../../../src/main/llm/proposal-persistence';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-health-checks-test-'));
+}
+
+describe('checkUnsupportedClaims', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
   });
 
-  it('defines expected check types', () => {
-    const types = [
-      'unsupported_claim',
-      'stale_note',
-      'missing_warrant',
-      'missing_backing',
-      'contradiction',
-    ];
-    expect(types).toHaveLength(5);
-    for (const t of types) {
-      expect(t).toMatch(/^[a-z_]+$/);
-    }
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
   });
 
-  it('inspection structure has required fields', () => {
-    const inspection = {
-      id: 'test-0',
+  it('flags a claim no grounds support', async () => {
+    await applyTurtle(ctx, `
+      <urn:claim:orphan> a thought:Claim ; thought:label "Orphan claim" .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    const unsupported = inspections.filter((i) => i.type === 'unsupported_claim');
+
+    expect(unsupported).toHaveLength(1);
+    expect(unsupported[0]).toMatchObject({
       type: 'unsupported_claim',
-      severity: 'warning' as const,
-      nodeUri: 'https://example.org/claim/1',
-      nodeLabel: 'Test claim',
-      message: 'Claim "Test claim" has no supporting evidence',
-      suggestedAction: 'Add grounds',
-    };
-    expect(inspection.id).toBeDefined();
-    expect(inspection.type).toBeDefined();
-    expect(inspection.severity).toBeDefined();
-    expect(inspection.nodeUri).toBeDefined();
-    expect(inspection.nodeLabel).toBeDefined();
-    expect(inspection.message).toBeDefined();
+      severity: 'warning',
+      nodeUri: 'urn:claim:orphan',
+      nodeLabel: 'Orphan claim',
+    });
+    expect(unsupported[0]!.message).toContain('Orphan claim');
+    expect(unsupported[0]!.message).toContain('no supporting evidence');
+  });
+
+  it('does not flag a claim that grounds already support', async () => {
+    await applyTurtle(ctx, `
+      <urn:claim:grounded> a thought:Claim ; thought:label "Grounded claim" .
+      <urn:grounds:g1> a thought:Grounds ; thought:supports <urn:claim:grounded> .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'unsupported_claim')).toBe(false);
+  });
+
+  it('carries the note path when the claim is anchored to one', async () => {
+    await indexNote(ctx, 'claims/orphan.md', '# Orphan claim\n');
+    await applyTurtle(ctx, `
+      <urn:claim:anchored> a thought:Claim ;
+        thought:label "Anchored claim" ;
+        minerva:relativePath "claims/orphan.md" .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    const found = inspections.find((i) => i.nodeUri === 'urn:claim:anchored');
+    expect(found?.notePath).toBe('claims/orphan.md');
+  });
+});
+
+describe('checkEvidenceGaps — missing_warrant / missing_backing', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('flags a claim with grounds but no warrant connecting them', async () => {
+    await applyTurtle(ctx, `
+      <urn:claim:c1> a thought:Claim ; thought:label "Needs a warrant" .
+      <urn:grounds:g1> a thought:Grounds ; thought:supports <urn:claim:c1> .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    const gaps = inspections.filter((i) => i.type === 'missing_warrant');
+
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]).toMatchObject({
+      severity: 'warning',
+      nodeUri: 'urn:claim:c1',
+      nodeLabel: 'Needs a warrant',
+    });
+    expect(gaps[0]!.message).toContain('grounds but no warrant');
+  });
+
+  it('does not flag a claim whose grounds are already connected by a warrant', async () => {
+    await applyTurtle(ctx, `
+      <urn:claim:c2> a thought:Claim ; thought:label "Fully warranted" .
+      <urn:grounds:g2> a thought:Grounds ; thought:supports <urn:claim:c2> .
+      <urn:warrant:w2> a thought:Warrant ; thought:supports <urn:claim:c2> .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'missing_warrant' && i.nodeUri === 'urn:claim:c2')).toBe(false);
+  });
+
+  it('does not flag a claim with no grounds at all — that is unsupported_claim\'s job, not this one\'s', async () => {
+    await applyTurtle(ctx, `
+      <urn:claim:c3> a thought:Claim ; thought:label "No grounds yet" .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'missing_warrant' && i.nodeUri === 'urn:claim:c3')).toBe(false);
+  });
+
+  it('flags a warrant with no backing', async () => {
+    await applyTurtle(ctx, `
+      <urn:warrant:w3> a thought:Warrant ; thought:label "Bare warrant" .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    const gaps = inspections.filter((i) => i.type === 'missing_backing');
+
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]).toMatchObject({
+      severity: 'info',
+      nodeUri: 'urn:warrant:w3',
+      nodeLabel: 'Bare warrant',
+    });
+    expect(gaps[0]!.message).toContain('no backing');
+  });
+
+  it('does not flag a warrant that already has backing', async () => {
+    await applyTurtle(ctx, `
+      <urn:warrant:w4> a thought:Warrant ; thought:label "Backed warrant" .
+      <urn:backing:b4> a thought:Backing ; thought:supports <urn:warrant:w4> .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'missing_backing' && i.nodeUri === 'urn:warrant:w4')).toBe(false);
+  });
+
+  it('reports both gaps independently on the same claim/warrant chain', async () => {
+    // A claim with grounds-but-no-warrant AND, separately, an unrelated
+    // warrant-with-no-backing — the two halves of checkEvidenceGaps run as
+    // independent queries, so this pins that neither shadows the other.
+    await applyTurtle(ctx, `
+      <urn:claim:c5> a thought:Claim ; thought:label "Half warranted" .
+      <urn:grounds:g5> a thought:Grounds ; thought:supports <urn:claim:c5> .
+      <urn:warrant:w5> a thought:Warrant ; thought:label "Separately bare" .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'missing_warrant' && i.nodeUri === 'urn:claim:c5')).toBe(true);
+    expect(inspections.some((i) => i.type === 'missing_backing' && i.nodeUri === 'urn:warrant:w5')).toBe(true);
+  });
+});
+
+describe('checkContradictions', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    root = mkTempProject();
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('flags two established claims that contradict each other', async () => {
+    await applyTurtle(ctx, `
+      <urn:claim:x> a thought:Claim ;
+        thought:label "The sky is blue" ;
+        thought:hasStatus thought:established ;
+        thought:contradicts <urn:claim:y> .
+      <urn:claim:y> a thought:Claim ;
+        thought:label "The sky is green" ;
+        thought:hasStatus thought:established .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    const contradictions = inspections.filter((i) => i.type === 'contradiction');
+
+    expect(contradictions).toHaveLength(1);
+    expect(contradictions[0]).toMatchObject({
+      severity: 'concern',
+      nodeUri: 'urn:claim:x',
+      nodeLabel: 'The sky is blue',
+    });
+    expect(contradictions[0]!.message).toContain('The sky is blue');
+    expect(contradictions[0]!.message).toContain('The sky is green');
+  });
+
+  it('does not flag a contradiction where one side is not established', async () => {
+    // thought:contradicts exists, but only one claim has been promoted to
+    // established — a still-pending claim contradicting an established one
+    // isn't a live inconsistency in the thoughtbase yet, just a marked tension.
+    await applyTurtle(ctx, `
+      <urn:claim:p> a thought:Claim ;
+        thought:label "Pending claim" ;
+        thought:contradicts <urn:claim:q> .
+      <urn:claim:q> a thought:Claim ;
+        thought:label "Established claim" ;
+        thought:hasStatus thought:established .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'contradiction')).toBe(false);
+  });
+
+  it('does not flag two established claims with no contradicts edge between them', async () => {
+    await applyTurtle(ctx, `
+      <urn:claim:m> a thought:Claim ; thought:label "M" ; thought:hasStatus thought:established .
+      <urn:claim:n> a thought:Claim ; thought:label "N" ; thought:hasStatus thought:established .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    expect(inspections.some((i) => i.type === 'contradiction')).toBe(false);
+  });
+
+  it('carries the note path when the contradicting claim is anchored to one', async () => {
+    await indexNote(ctx, 'claims/x.md', '# X\n');
+    await applyTurtle(ctx, `
+      <urn:claim:xa> a thought:Claim ;
+        thought:label "Anchored X" ;
+        thought:hasStatus thought:established ;
+        thought:contradicts <urn:claim:ya> ;
+        minerva:relativePath "claims/x.md" .
+      <urn:claim:ya> a thought:Claim ;
+        thought:label "Anchored Y" ;
+        thought:hasStatus thought:established .
+    `);
+
+    const inspections = await runAllChecks(ctx);
+    const found = inspections.find((i) => i.type === 'contradiction');
+    expect(found?.notePath).toBe('claims/x.md');
   });
 });


### PR DESCRIPTION
Closes #1927.

## What was there

`tests/main/graph/health-checks.test.ts` — 41 lines, zero imports from `src/`. It declared array/object literals and asserted on them directly:

```js
const severities = ['info', 'warning', 'concern'];
expect(severities).toContain('info');
```

It could not fail regardless of what the real code did, and it carried the exact filename of the 777-line production module, so it read as that module's test in every listing and every review.

## Why "no coverage is lost" undersold the actual gap

`health-checks.ts` sits at 93.25% line coverage via six other test files, which is exactly why nobody noticed. But I checked what those six actually exercise before assuming line coverage meant the module was well-tested.

`checkUnsupportedClaims`, `checkEvidenceGaps` (`missing_warrant`/`missing_backing`), and `checkContradictions` were reached only by `inspection-settings-skip.test.ts` — and that file counts *how many SPARQL queries fire* ("the hidden argument-map checks that always run"), never what they return. Real content coverage of those three checks' output shape — type, severity, message, notePath — didn't exist anywhere in the suite.

## What shipped

Real tests seeding graph state via `applyTurtle` (the same electron-free leaf `trust-integrity.test.ts` already uses) and running `runAllChecks` over it. 13 tests across the three checks, covering:
- the positive case (a claim/warrant with the gap → flagged)
- the negative case (the gap filled → not flagged)
- the boundary each check's own logic draws: grounds-without-warrant vs. no-grounds-at-all is a different check's job; established-vs-established contradiction vs. one side still pending are different outcomes
- `notePath` carried through when the component is anchored to a note

## Verified by mutation

| Mutation | Result |
|---|---|
| `checkUnsupportedClaims` short-circuited to `[]` | 2 tests fail |
| `missing_warrant` severity flipped `warning` → `info` | 1 test fails |
| Established-status filter dropped from the contradiction query | 1 test fails |

## Success criterion: spot-check the rest of `tests/main/graph/`

Had an Explore agent read all 58 test files for the same shape. Result: 3 files import nothing from `src/` (`excerpt-ontology`, `source-ontology`, `verification-ontology`.test.ts) — but each reads the real `ontology-thought.ttl` from disk via `fs.readFileSync` and asserts on its actual parsed triples. That content changes if someone edits the production ontology file; it isn't a value the test invented and then checked against itself. **`health-checks.test.ts` was an isolated case.**

## Success criterion: is a zero-import-test detector worth building?

**No — recorded here rather than built.** I tried the naive version first: grep every test file for "imports nothing from `src/`". That heuristic hit **~24 files**, and I read through the ones in question — `tests/architecture/no-cycles.test.ts` and `tests/cli/electron-free.test.ts` run dependency-cruiser / a real bundled build against `src/` without a static `import`; `tests/scripts/*` generate/validate docs; the three ontology tests above read the real `.ttl` file. All legitimate.

The property that actually made `health-checks.test.ts` fake wasn't "no `src/` import" — plenty of correctly-real tests share that property. It was "the assertions and the values they check are declared in the same fixture-free literal, so nothing external can make them fail." Telling a real `fs.readFileSync`-backed fixture apart from a self-referential one is a much fuzzier static check than something like `pattern-ratchets.test.ts` can cheaply express, and a ~24-false-positive baseline for one historical instance doesn't justify building it.

## Gate

- `pnpm lint` — tsc, svelte-check, eslint all clean
- `pnpm coverage` — exit 0, **624 files / 6825 tests passing**, all floors met

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mqvJTEVXfw6fDuKGYtXR8