### PR TITLE
refactor(editor): extract keymap and completion into build-keymap-and-completion.ts (issue #1903)

### DIFF
--- a/reports/quality-review-entire-project-2026-08-23-193321.md
+++ b/reports/quality-review-entire-project-2026-08-23-193321.md
@@ -1,0 +1,898 @@
+# Quality Assurance Review Plan
+Generated: 2026-08-23 19:33:21
+Scope: /Users/davegriffith/minerva (entire project)
+
+## Executive Summary
+
+Minerva's *quantity* of testing is not in question: 621 vitest files / 6,745 tests, all
+passing, in 70 seconds; six architecture fitness functions; a Playwright Electron suite; a
+benchmark regression gate; a blocking supply-chain audit. The refactoring review an hour
+ago already catalogued the structural debt. This review looked at what a refactoring lens
+and a coverage percentage both miss — whether the tests that exist can actually fail,
+whether the gates that exist actually run, and whether the layers claimed to cover
+something do.
+
+Four findings drive everything below.
+
+**1. There is a hole in the middle of the pyramid, and the documentation papers over it.**
+`docs/development.md:184-186` states that "some surfaces (notably `App.svelte`, the
+composition root) are covered by the Playwright e2e journeys rather than unit tests." That
+is not what the e2e journeys do. `tests/e2e/journeys.spec.ts:4-6` and
+`tests/e2e/happy-paths.spec.ts:26` both say plainly that they drive `window.api` inside
+`win.evaluate(...)` *instead of* clicking the UI, "rather than simulating CodeMirror
+keystrokes / panel clicks, which are brittle and just re-test the component suite." So the
+6 journey/happy-path tests exercise the preload bridge and the main-process pipeline —
+genuinely valuable — and touch zero App.svelte code paths. Measured: App.svelte is **0%**
+(593 executable lines), and **66 of 125 Svelte components (3,418 of 8,760 executable
+component lines) are at 0%**. Unit tests cover the *extracted* `lib/app/*-ops` factories;
+e2e covers the *bridge below* the UI; nothing covers the UI itself except a11y/focus-trap
+clicking a file and opening two panels. `UnlinkedMentions` (#1899) is not an anomaly — it
+is the one place the gap became visible, because someone happened to write a test for a
+component wired to nothing. The rest of that layer has no test at all, so nothing can
+reveal it.
+
+**2. The first e2e test boots against the developer's real Electron profile, and its core
+assertion is false on any machine that has used the app.** `tests/e2e/smoke.spec.ts:70`
+launches with `args: [projectRoot]` and **no `--user-data-dir`** — the only one of the six
+specs' nine launch sites that omits it (the second test in the same file, `:167`, does it
+correctly). So it inherits `~/Library/Application Support/Minerva/`, `src/main/session.ts:13`
+restores the saved window, and the assertion at `:111` — `expect(getByRole('button', { name:
+'Open Thoughtbase' })).toBeVisible()` — fails. Verified on this machine: that profile's
+`session.json` contains `rootPath: "/Users/davegriffith/philosophy_of_engineering"`. The
+file header at `:19-20` states the premise it depends on ("no project open by default — a
+fresh launch yields the 'Open Thoughtbase' shell"), which is true only on a clean CI runner.
+This is the exact inverse of the flake everyone worries about: **green in CI, red locally,
+and it mutates the developer's real profile while running.** One line fixes it.
+
+**3. Two gates are advertised but do not run where it counts.** `pnpm coverage` in CI never
+runs `fetch:model` (the fetch is hooked to `predev`/`prebuild`/`prebuild:e2e` only,
+`package.json:48-50`; there is no `pretest`), and `resources/models/**/*.onnx` is gitignored
+(`.gitignore:70`), so `haveModel` is false on every CI checkout and **12 tests across 4
+files silently skip in CI** — the entire real-inference embeddings surface plus help-docs
+semantic search. They report as *skipped*, not failed, and `src/main/embeddings/**` has no
+coverage floor of its own, so nothing notices. Separately, `pnpm lint:fonts` runs *only* in
+`.githooks/pre-push` and appears nowhere in `.github/workflows/` — a `--no-verify` push, a
+fork PR, or a checkout where `pnpm install` never set `core.hooksPath` bypasses it entirely.
+
+**4. The coverage floors have drifted into 10–30 points of dead slack, and the slackest one
+guards the trust path.** The floors were set "~10 points below the measured-at-floor-time
+numbers" and never re-ratcheted as coverage improved. Measured today: `src/main/llm/**` —
+the approval engine, per CLAUDE.md the most important area in the system — sits at **85.1%
+lines against a floor of 55**, +30.1 points of headroom, and 70.5% branches against 45.
+`src/main/git/**` is +26.8. `src/shared/**` is +25.9 *and has no branch floor at all*
+despite measuring 86.1%. A large fraction of the trust-path suite could be deleted and every
+gate in the repo would stay green. Note the internal inconsistency: `pattern-ratchets` and
+`file-size-budgets` hold *exact* numbers and fail when the count moves in either direction —
+the strictly better design, already in this repo — while the coverage floors, which guard
+the more important thing, use one-directional soft floors.
+
+What is genuinely strong, stated so the above is read in proportion: the architecture
+fitness functions are the best-designed I have reviewed — every one carries an explicit
+anti-vacuity test ("a broken scan would pass vacuously",
+`ipc-registrar-coverage.test.ts:113`; `no-cycles.test.ts:72`; `pattern-ratchets.test.ts:186`)
+and self-documents its own blind spots in the header. The write guard is real, fatal under
+test, and covered by both a unit and a wired-integration file. The approval engine's tests
+assert rollback, not just success. Snapshot over-reliance does not exist (4 snapshots in
+12,837 assertions, all shape-drift). Zero literal `.skip`/`.only`/`.todo`, zero
+`test.concurrent`, zero `Math.random`, zero external network calls, zero fixed ports, and
+fake-timer restore hygiene is 12-for-12.
+
+---
+
+## Quality Metrics
+
+Every number below was produced by a command run during this review. Nothing is estimated.
+
+### Suite size and execution
+
+| Metric | Value | How measured |
+|---|---|---|
+| Vitest test files | 621 | `pnpm coverage` summary |
+| Vitest tests | 6,745 (all passed, 0 failed, 0 skipped **locally**) | same |
+| `pnpm test` wall time | **70.43 s** (`real 71.20`) | `/usr/bin/time -p pnpm test` |
+| `pnpm coverage` wall time | **105.10 s** | `/usr/bin/time -p pnpm coverage` |
+| Vitest CPU time | 479 s user / 91 s sys across workers | `time` output |
+| Playwright e2e specs / tests | 6 files / **15 tests** | `grep -c '^test(' tests/e2e/*.spec.ts` |
+| `it`/`test` blocks / `expect()` calls | 6,198 / 12,837 | brace-matching scan over `tests/` |
+| Test files by tree | main 301 · renderer 177 · shared 121 · scripts 6 · cli 6 · architecture 6 · preload 2 · clipper 2 | `find tests -name '*.test.ts' \| cut -d/ -f2 \| uniq -c` |
+| Test LOC / source LOC | 82,361 / 127,894 (0.64 : 1) | `find … -exec cat {} + \| wc -l` |
+| Benchmarks | 6 `*.bench.ts` | `find tests -name '*.bench.ts'` |
+| Vitest pool config | **defaults** — pool `forks`, `isolate: true`, `fileParallelism: true`, `testTimeout: 5000` | `vitest.config.mts` sets none of these |
+
+### Coverage — measured, whole repo
+
+`pnpm coverage` completed successfully (exit 0, all floors passed). v8 provider,
+`src/**/*.{ts,svelte}`:
+
+```
+Statements   : 69.01% ( 29719/43060 )
+Branches     : 61.80% ( 14247/23051 )
+Functions    : 61.59% (  5585/9068  )
+Lines        : 72.34% ( 24238/33503 )
+```
+
+Caveat on the local number: measured on a machine where `resources/models` and Python 3 are
+present, so it **includes** the 12 model-gated tests and the ~15 Python sandbox tests that
+CI skips. The CI figure is lower by an unmeasured amount (Finding C2). I did not reproduce
+a modelless run.
+
+### Coverage floors vs. measured — the slack table
+
+Computed by parsing `coverage/lcov.info` and aggregating `LF/LH`, `BRF/BRH`, `FNF/FNH` per
+glob, then differencing against `vitest.config.mts`. These are glob aggregates, **not** the
+v8 text report's per-directory rows — those exclude subdirectories and read misleadingly
+high (`src/main/graph` shows 96.99% as a directory row but 94.2% as the `src/main/graph/**`
+glob).
+
+| Glob | Lines % | floor | slack | Branch % | floor | slack | Funcs % | floor |
+|---|---|---|---|---|---|---|---|---|
+| `src/main/llm/**` | 85.1 | 55 | **+30.1** | 70.5 | 45 | **+25.5** | 86.4 | 58 |
+| `src/main/git/**` | 90.8 | 64 | **+26.8** | 80.7 | 66 | +14.7 | 81.1 | 62 |
+| `src/shared/**` | 95.9 | 70 | **+25.9** | 86.1 | *none* | — | 96.6 | 70 |
+| `src/renderer/**` | 57.8 | 42 | +15.8 | 46.8 | 34 | +12.8 | 50.6 | 40 |
+| `src/main/graph/**` | 94.2 | 80 | +14.2 | 75.9 | 62 | +13.9 | 93.2 | 80 |
+| `src/main/compute/**` | 87.9 | 75 | +12.9 | 73.9 | 60 | +13.9 | 86.2 | 74 |
+| `src/main/notebase/**` | 92.2 | 80 | +12.2 | 76.5 | 65 | +11.5 | 93.6 | 78 |
+| `src/main/publish/**` | 93.4 | 82 | +11.4 | 76.2 | 65 | +11.2 | 92.4 | 82 |
+| `src/main/history/**` | 93.3 | 82 | +11.3 | 88.1 | 75 | +13.1 | 100.0 | 88 |
+| `src/main/ipc/**` | 75.8 | 65 | +10.8 | 61.9 | 51 | +10.9 | 76.5 | 66 |
+| `src/main/sources/**` | 89.8 | 80 | +9.8 | 75.3 | 65 | +10.3 | 91.0 | 80 |
+
+The two best-ratcheted areas (`sources`, `ipc`, ~+10) are the two most recently touched.
+The rest have drifted.
+
+### The lowest-covered modules that matter
+
+From the v8 text report. Excluding files correctly untested by design —
+`src/preload/preload.ts` at 0.27% is deliberate, and `vitest.config.mts` explains why the
+full-surface snapshot contract test is its right gate rather than a line floor.
+
+| Module | Stmts | Branch | Note |
+|---|---|---|---|
+| `src/renderer/App.svelte` | **0** | 0 | 593 executable lines; the composition root |
+| `src/main/ipc/helpers.ts` | **6.55** | **0** | owns `withRootPath`/`withRootPathOr` + the reindex fan-out — C3 |
+| `src/main/window-manager.ts` | 6.45 | 5.14 | the watcher reindex path |
+| `src/main/llm/tools/set-properties.ts` | **1.85** | 0 | an LLM graph-write tool |
+| `src/main/llm/tools/propose-compute.ts` | 3.57 | 0 | |
+| `src/main/skills/register.ts` | 5.26 | 0 | |
+| `src/main/notebase/templates.ts` | 5.88 | 0 | |
+| `src/main/llm/tools/ask-user.ts` | 5.55 | 0 | |
+| `src/main/llm/tools/query-graph.ts` / `search-notes.ts` | 9.09 | 0 | |
+| `src/main/llm/tools/get-properties.ts` | 12.5 | 0 | |
+| `src/main/ipc/register-conversation-drafts.ts` | 21.22 | 16.10 | tracked as **#1900** |
+| `src/main/graph/queries/notes.ts` | 22.91 | 13.63 | |
+| `src/main/ipc/register-proposals.ts` | **25** | **0** | the approval-queue IPC — C1 |
+| `src/main/ipc/register-refactor.ts` | 26.78 | 33.33 | tracked as **#1901** |
+| `src/main/menu.ts` | 28.08 | 33.33 | the native menu, 983 lines |
+| `src/renderer/lib/voice/**` | 22.54 | 8.65 | |
+
+### Test-quality indicators
+
+| Indicator | Count | Command |
+|---|---|---|
+| Literal `it.skip` / `describe.skip` / `.only` / `.todo` / `.fails` | **0** | `rg -n "\b(it\|test\|describe)\.(skip\|only\|todo\|fails)\s*\("` |
+| Environment-gated `cond ? describe : describe.skip` | 12–13 sites | `rg -n "\?\s*describe\s*:\s*describe\.skip"` |
+| `test.concurrent` | **0** | `rg -n "\.concurrent\b" tests` |
+| `toMatchSnapshot` / `toMatchInlineSnapshot` | 4 / 0 | `rg -o "toMatchSnapshot("` |
+| Bare `toHaveBeenCalled()` vs `toHaveBeenCalledWith(` | 641 / 560 | `grep -ro` per form |
+| …in `tests/main/ipc` | 148 / 200 | scoped |
+| …in `tests/main/llm` | 11 / 6 | scoped |
+| `expect.assertions(n)` / `expect.hasAssertions()` | **0** | `grep -r` |
+| Test files using `vi.mock` | 122 of 621 (20%); 378 calls | `grep -rl "vi\.mock("` |
+| Svelte components with 0% coverage | **66 of 125** (3,418 / 8,760 exec lines) | lcov parse |
+| Component test files | 41 (for 125 components) | `ls tests/renderer/components/*.test.ts` |
+
+### Determinism indicators
+
+| Indicator | Count | Command |
+|---|---|---|
+| `Math.random` in tests | **1** — and it is a comment saying not to use it | `rg -n "Math\.random" tests` |
+| `crypto.randomUUID` in tests | **0** | `rg -n "randomUUID" tests` |
+| Fake-timer files not restoring real timers | **0 of 12** | `comm -23` on `useFakeTimers` / `useRealTimers` file lists |
+| Tests contacting an external host | **0** (all 9 `fetch` sites are loopback or non-network) | `rg -n "await fetch\(\|fetch\('http" tests` |
+| Tests binding a fixed port | **0** (all `port: 0`) | `rg -n "port:\s*[0-9]+" tests \| grep -v "port: 0"` |
+| Unit-test writes into the repo tree | **0** (one `beforeAll` runs a real `vite build`) | `rg` for `cwd()`/`__dirname` writers |
+| Tests reading the real `~/.minerva/` | **0** — all three production readers take the path as a parameter | `rg -n "os\.homedir" src tests` |
+| Real wall-clock sleeps | 16 sites; 6 in `watcher.test.ts`, 4 in `search/index.test.ts` | `rg -n "setTimeout" tests` |
+| `waitForTimeout` in e2e | 7, all unconditioned "let it settle" | `rg -n "waitForTimeout" tests/e2e` |
+| `vi.stubEnv` (auto-restoring) | **0** — all 11 env mutations are raw assignment | `rg -n "vi\.stubEnv" tests` |
+| `TZ` pinned anywhere | **no** | `grep -rn TZ vitest.config.mts package.json .github/workflows/ci.yml` |
+| Leaked temp dirs in `$TMPDIR` | **4,065** (3,358 from one file, 1,184 created today) | `ls -d $TMPDIR/minerva-* \| wc -l` |
+| Leaked unix sockets from **production** code | 319 | `ls $TMPDIR/minerva-rpc-*.sock \| wc -l` |
+
+---
+
+## Test Coverage Analysis
+
+**Shape, not just level.** Coverage is high where the code is pure and file-backed, and
+collapses where the code is glue:
+
+- `src/shared/**` at 95.9% lines / 86.1% branches — excellent; formatter rule trees 96–100%.
+- Main-process domain modules (graph, publish, history, notebase, sources) at 89–94% lines,
+  mostly through **real-filesystem integration tests**: 184 of 621 test files (29.4%) create
+  a temp project. That is the right shape for this app and it is the strongest part of the
+  suite.
+- The IPC registrar layer is at 75.8% lines / 61.9% branches, and its coverage is *wiring*
+  coverage — 16 test files `vi.mock` the helpers module (C3).
+- The renderer is at 57.8% lines, but that aggregate is carried by well-tested `lib/`
+  helpers (`sources` 98.5%, `refactor` 94.7%, `command-palette` 97.2%). The component layer
+  itself is 39.6% (3,465 / 8,760 exec lines), with 66 files at exactly zero.
+
+**Branch coverage is the weaker axis everywhere** — 61.8% repo-wide vs 72.3% lines. Every
+per-area floor except `git` sits 10–14 points below measured branches, and `src/shared/**`
+has no branch floor at all. Branches are where error paths live, so this is the axis that
+corresponds most directly to "did we test the failure case."
+
+**What the numbers do not tell you.** `src/main/graph/health-checks.ts` measures 93.25%
+statements and is genuinely well tested — by six *other* files. Its namesake test file is
+fake (C4). Coverage cannot distinguish those, which is the argument for the next section.
+
+---
+
+## Testing Pyramid — actual shape
+
+| Layer | Files | Tests | Assessment |
+|---|---|---|---|
+| Pure unit (`tests/shared`) | 121 | — | Strong. 95.9% lines on `src/shared`. |
+| Main-process integration (real temp fs) | 184 across the suite | — | Strong, and the right choice for a local-first file app. |
+| Main-process wiring (mocked IPC registrars) | 24 registrar tests, 16 mocking `helpers` | — | Verifies channel→module wiring, not the wiring's semantics (C3). |
+| Renderer store/ops | 177 files incl. 41 component | — | Ops factories well covered (`source-ops` 99.5%, `note-ops` 91.4%); components 39.6%. |
+| Renderer UI / composition | — | — | **Empty.** App.svelte 0%, 66 components 0%. |
+| E2E (Playwright + Electron) | 6 | **15** | Real app boot, real IPC, but deliberately **bypasses the UI** via `window.api`. |
+
+This is not a pyramid; it is an hourglass with the waist missing. The 450:1 vitest-to-e2e
+ratio is fine — but the layer e2e is supposed to backstop (the UI) is precisely the layer it
+declines to touch, and `docs/development.md` asserts otherwise.
+
+The three specs that *do* drive real UI are `a11y.spec.ts` (clicks a file, a source, a
+proposal), `focus-trap.spec.ts` (one command-palette Tab-trap test), and `smoke.spec.ts`
+(asserts the welcome heading). Between them they are the entire UI-level regression net for
+125 components.
+
+---
+
+## Test Quality Assessment
+
+I audited assertion strength directly and via a scan of all 6,198 `it`/`test` blocks and
+12,837 `expect()` calls. **The headline is that this suite is much better than the usual
+failure modes predict**, and that belongs on the record before the specific criticisms:
+
+- Zero-assertion tests: 15 candidates, **0 genuine** — all assert via `expect.fail()` (the
+  architecture ratchets) or via helper assertion functions (`expectNoA11yViolations` in
+  `tests/helpers/axe.ts`, `expectMirrorMatchesRebuild` at
+  `tests/main/graph/n3-mirror-incremental.test.ts:76`).
+- Conditional assertions: 48 candidates, **47 are TypeScript discriminated-union narrowing**
+  where the discriminant is asserted first (`tests/main/sources/tables.test.ts:34-37` is the
+  model). Exactly one is genuinely vacuous.
+- `not.toThrow()`: 33 sites, 30 paired with a positive `toThrow` sibling in the same
+  describe. `tests/main/graph/write-guard.test.ts` alternates silent/throws/silent
+  deliberately.
+- `toBeDefined()`: 67 uses, almost all TypeScript narrowing guards followed by hard
+  assertions.
+- Snapshots: 4 total, all shape-drift (preload surface, IPC channel set, docs chunk ids, CSL
+  output). **No behavioral concern rests on a snapshot alone.**
+
+The four areas CLAUDE.md flags as highest-risk are the *best*-tested parts of the suite.
+`tests/main/llm/approval.test.ts` asserts the write is absent until approval and that a
+mid-bundle failure rolls back to the pre-image (`:185`, `:252`, `:295`).
+`tests/main/graph/write-guard-wired.test.ts` proves the guard is wired into the real
+`parseIntoStore`/`removeMatchingTriples`, asserts the trusted-context exemption, and
+regex-matches the failure message. `tests/main/graph/n3-mirror-incremental.test.ts` compares
+the incremental mirror against an independent from-scratch rebuild — the opposite of
+tautological.
+
+The weaknesses are specific rather than systemic: C4 and M1–M4 below.
+
+One systemic softness worth naming: **zero `expect.assertions(n)` across 6,198 tests**,
+alongside 199 `waitFor(` sites. An assertion that silently never executes inside a `waitFor`
+callback or an unawaited promise branch is not currently detectable. Today's tests appear
+clean; this is the mechanism by which a *future* weak test would hide.
+
+---
+
+## Quality Gates — CI vs. local
+
+**Enforced on every PR** (`.github/workflows/ci.yml`, three parallel jobs):
+
+- `pnpm lint` — `tsc --noEmit` ∥ `svelte-check --threshold error` ∥ `eslint .` (parallel,
+  `scripts/lint.mjs`); eslint carries the renderer data-flow `no-restricted-syntax` rule.
+- `pnpm coverage` — full suite **plus** all per-glob thresholds. Hard gate.
+- `pnpm audit --prod --audit-level=high` — **blocking** since #1455.
+- `pnpm test:e2e` — `electron-forge package` + Playwright, separate job.
+- Implicitly: all 6 architecture fitness functions + `tests/shared/ipc-contract-ratchet.test.ts`,
+  since they are ordinary vitest files.
+
+**Not enforced in CI:**
+
+| Gate | Where it runs | Consequence |
+|---|---|---|
+| `pnpm lint:fonts` | `.githooks/pre-push` **only** | Bypassed by `--no-verify`, `SKIP_HOOKS=1`, fork PRs, or any checkout that never ran `pnpm install`. Zero CI coverage. |
+| `pnpm bench:check` | `bench.yml` — `workflow_dispatch` + weekly cron | Perf regressions land unnoticed for up to 7 days, then surface with no bisect signal. Tolerance is **2.0×** — a benchmark may get 99% slower and pass. |
+| `pnpm audit` (full tree) | CI, `continue-on-error: true` | Visibility only, by documented design. |
+| `pnpm check:docs` | Nowhere | Docs-generation drift is caught only indirectly by `tests/scripts/help-docs-corpus-staleness.test.ts`. |
+| `pnpm test` at its own 5 s timeout | Nowhere — CI runs only `pnpm coverage` (30 s) | See M7. |
+| Tests at all | Not in the pre-push hook | The hook runs lint only, so a red suite can be pushed. Deliberate, but worth restating: **the local gate does not run tests.** |
+
+**Ratchet gameability.** I probed whether the fitness functions can be trivially satisfied.
+Mostly they cannot, and the reason is that their authors already asked the question — every
+one carries a vacuity floor. What remains:
+
+- `pattern-ratchets.test.ts` is lexical and **self-documents** its blind spots
+  (`catch { const x = null; return x; }` is not counted). Fair.
+- `file-size-budgets.test.ts` measures `src/` only. Splitting a 700-line file into two
+  349-line files passes and is the *intended* outcome; but nothing budgets `tests/`, where 9
+  files already exceed 600 lines (largest: `conversations-store.test.ts` at 823).
+- `ipc-registrar-coverage.test.ts` passes on mere import — **already tracked as #1894**. Its
+  own header honestly says so.
+- `store-ownership.test.ts` cannot distinguish a real store from a passthrough — CLAUDE.md
+  already says so.
+
+The gap the ratchets genuinely leave: **CLAUDE.md lists five IPC anti-patterns and
+`pattern-ratchets.test.ts` covers two** (H2).
+
+---
+
+## Non-Functional Testing
+
+### Performance
+
+Real, and better than most projects this size: 6 `*.bench.ts` files (graph index/query, save
+pipeline, embedding pooling, N3 cache/cold-rebuild) with a **committed baseline**
+(`tests/main/bench-baseline.json`) and a diff gate (`scripts/bench-check.mjs`) supporting
+both a ratio tolerance and an optional absolute `budgetMs`. The desktop analogue of load
+testing — large-thoughtbase indexing — is directly benched: `indexAllNotes` at 500 / 2,000 /
+5,000 notes (1,181 ms at 5k).
+
+Two weaknesses, both stated honestly in the workflow's own comments and both real: the gate
+runs weekly/on-demand rather than per PR (deliberate — micro-benchmarks flap on shared
+runners), and the tolerance is **2.0×**, so a 1.9× slowdown in `indexAllNotes: 5000 notes`
+passes. Every `budgetMs` in the committed baseline is `null`, so the absolute-ceiling
+mechanism that would catch exactly that is built and unused.
+
+### Security testing
+
+Not a web service, so no DAST/penetration testing — the desktop analogues are present and
+mostly in good shape:
+
+- **Path-traversal sandbox** (`assertSafePath`): `src/main/notebase/**` at 92.2% lines, with
+  a dedicated `tests/main/notebase/assert-safe-path-coverage.test.ts` that documents why
+  `vi.spyOn` can't be used and why the traversal-rejection tests are equivalent.
+- **Electron trust boundary**: `security.ts` 100%, `security-helpers.ts` ~100%,
+  `privileged-sites.ts` 96.4% — each with its own per-file floor.
+- **Python compute sandbox**: `tests/main/compute/sandbox-integration.test.ts` runs real
+  Seatbelt profiles and asserts a sandboxed process cannot open a socket, cannot write
+  `~/mv_sandbox_evil.txt`, and cannot read `~/.ssh/`. Excellent tests — with two caveats
+  (H3 for the silent skip, M6 for the fact that they write into the developer's real
+  `$HOME`).
+- **The Trust Principle** is gated three ways: the fatal-under-test write guard, the
+  `findUnreviewedLLMWrites` integrity query asserted six ways in
+  `tests/main/graph/trust-integrity.test.ts`, and the approval-engine rollback tests.
+- **Supply chain**: Dependabot (grouped weekly) + blocking `audit:prod`.
+
+Gap: **secret handling is thinly tested.** `src/main/secret-storage.ts` is at 90.5%
+statements but `src/main/clipper/lifecycle.ts` is 13.6%, and `clipper-config`'s decrypt +
+lazy-secret-upgrade path is one of the three configs CLAUDE.md lists as still hand-rolled.
+
+### Accessibility
+
+Genuinely well handled and better than the norm. Two tiers: jsdom + axe in the unit suite
+(`tests/renderer/a11y/dialogs.test.ts`, `color-contrast` disabled since jsdom computes no
+layout), and **real-Chromium axe** in `tests/e2e/a11y.spec.ts` across four surfaces (welcome,
+workspace, source viewer, proposals panel) with color-contrast *enforced*. The theme is
+pinned deterministically before the scan, with a documented reason (`bootDarkTheme`,
+`:100-113`). Baselines are per-surface rule-id allowlists that fail on a NEW rule, and three
+of four allowlists are empty or hold only the known CodeMirror
+`scrollable-region-focusable` quirk. This is the discipline the coverage floors should copy.
+The one blemish: 6 unconditioned `waitForTimeout(400-500)` sleeps before the axe scans (M8).
+
+### Compatibility — the desktop analogue of a browser matrix
+
+**Not applicable as written.** No browser matrix: this ships one Chromium, the one bundled
+with its pinned Electron. The real analogues:
+
+- **Platform matrix: none.** Every CI job that runs the app is `macos-latest`, for
+  documented reasons (the chokidar watcher tests exercise macOS fsevents semantics; the e2e
+  job needs a darwin `.app`). Packaging is arm64-only — **tracked as #962**.
+- Windows/Linux are untested at every level, and the code knows it:
+  `tests/main/compute/python-kernel.test.ts:419` carries
+  `process.platform === 'win32' ? it.skip : it`, and `sandbox-integration.test.ts` is
+  darwin-only. Whether that is a gap depends on whether those platforms are targets; today
+  they are not.
+- **Electron/Chromium drift** is covered by the smoke test's stated purpose
+  ("Electron-major-bump shape changes, CSP regressions strict enough to block bootstrap")
+  and by `tests/e2e/bundle-budget.spec.ts`.
+
+### Load / throughput / concurrency
+
+**Not applicable.** Single-user desktop app; no request rate, no concurrency model beyond
+Electron's three processes, no server to saturate. The meaningful analogue — behaviour as a
+thoughtbase grows — is the `indexAllNotes` bench series, which is the right substitute and
+exists.
+
+---
+
+## Flakiness and Determinism
+
+**Measured stability:** two consecutive full local runs (`pnpm coverage` then `pnpm test`)
+both reported 621/621 files and 6,745/6,745 tests passing, identically. Weak evidence — two
+runs, one machine — but it is the evidence there is.
+
+**The structural picture is unusually disciplined.** Cross-*file* isolation is sound:
+vitest's default `forks` pool with `isolate: true` gives every file a fresh module registry,
+so the renderer's module-level store singletons cannot leak between files. `test.concurrent`
+is unused, so within a file everything is sequential. Randomness, network, ports, and
+repo-tree writes are all clean (see the determinism table above).
+
+The real exposure is in five places:
+
+**1. Process-level state survives `isolate`.** `tests/main/llm/settings.test.ts:53-56`
+deletes `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` and `GEMINI_API_KEY` in `beforeEach`; its
+`afterEach` (`:59-61`) removes the temp dir and **never restores them**. Fork workers are
+reused across files, so every subsequent file on that worker sees them unset. The codebase
+already knows this hazard and documents it — `tests/main/publish-git-auth.test.ts:17-32`
+snapshots and restores with the comment *"process.env is worker-global, so snapshot +
+restore to avoid leaking the deletions into other test files that share the worker."*
+`vi.stubEnv` (which auto-restores) is used **zero** times; all 11 env mutations are raw
+assignment.
+
+**2. Fixed wall-clock sleeps on a real filesystem watcher.**
+`tests/main/notebase/watcher.test.ts` is the only test driving real chokidar
+(no `usePolling`, no `awaitWriteFinish`), has 19 tests, **no timeout override**, and burns
+real time three ways: a 50 ms `afterEach` sleep (`:68`) × 19; fixed negative-assertion
+sleeps at `:203` (400 ms), `:242` (300 ms), `:451` (400 ms); and a *positive* 200 ms
+dependency on a production buffer expiring at `:270`. Its polling helper (`:39-50`,
+`waitFor(pred, 4000)`) is the right pattern and the file header at `:11` explicitly
+documents that fixed sleeps flaked under parallel load in #344 — but the 4,000 ms default
+sits inside vitest's 5,000 ms test timeout, so the test dies before the helper produces its
+diagnostic.
+
+**3. Negative assertions after a real sleep — the false-red shape.**
+`tests/main/search/index.test.ts:91-92` does `await sleep(DEBOUNCE_MS / 2)` then
+`expect(fs.existsSync(indexFilePath(root))).toBe(false)`. If the sleep overshoots the 200 ms
+debounce on a loaded runner, the write has landed and the test fails. Same shape twice more
+at `:103-109`. (The `:129-130` variant fails safe.)
+
+**4. Wall-clock dates with no TZ pin.** `tests/renderer/source-display.test.ts:20-26`
+computes `isoDaysFromNow()` from `new Date()` at setup and `:63` asserts
+`isOverdue(isoDaysFromNow(0)) === false`, where `isOverdue` reads the clock again at assert
+time — a run straddling local midnight goes red. `:72-76` drives a "omit the year for a
+current-year date" assertion off `new Date().getFullYear()` — same class at new year. There
+is **no `TZ` pin** in `vitest.config.mts`, `package.json`, or `ci.yml`; only
+`tests/renderer/refactor/extract.test.ts:17-27` forces a zone, and it does so correctly.
+Only 3 files use `vi.setSystemTime` — the codebase's own good pattern, just not applied
+here.
+
+**5. Shared mutable `beforeAll` fixtures.** 25 files have `beforeAll` with no `beforeEach`.
+The sharpest is `tests/main/sources/tables-markdown.test.ts`: one DuckDB instance created at
+`:20-24` and mutated by every test (`registerMarkdownTable`, `reregisterNoteTables` ×5,
+`unregisterNoteTables`, `registerCsv`), plus a module-global `onCsvTableCollision` handler
+registered inside the `:91` test and **never unregistered**, so it stays live for `:115` and
+anything added later. Table names happen to be disjoint today; nothing enforces that.
+
+**Flake handling is asymmetric and untracked.** Playwright retries twice in CI
+(`playwright.config.ts`, `retries: process.env.CI ? 2 : 0`) with the honest rationale that
+"Electron boot is inherently flaky," and relies on `reporter: 'list'` printing "retry #N"
+lines for visibility — but nothing aggregates them, sets a budget, or fails on repeated
+retries. An e2e test could retry on every PR indefinitely and no signal would escape the
+log. Vitest has no retry at all — the right default, but the two suites now have opposite
+flake policies and neither is measured.
+
+---
+
+## Developer Feedback Loop
+
+A genuine strength; preserve it. 6,745 tests in **70 seconds** is an excellent inner loop
+for 128 kLOC, and `pnpm test:watch` on it is interactive. `pnpm lint` runs its three checks
+in parallel (`scripts/lint.mjs`). The pre-push hook catches the slow-to-discover class
+(type/template drift) locally before burning a macOS runner.
+
+Two asymmetries: the local gate runs lint but not tests (M7), and `pnpm test` / `pnpm
+coverage` enforce different timeouts while CI runs only the latter (M7).
+
+---
+
+## Findings
+
+Grouped by severity. Items already filed by the earlier refactoring review are
+cross-referenced by issue number and **not** re-filed.
+
+### Critical
+
+- [ ] **C1 — `register-proposals.ts`: the approval gate's own IPC surface is 25% covered
+      with 0% branches.** `src/main/ipc/register-proposals.ts` (52 lines: `PROPOSAL_LIST`,
+      `_DETAIL`, `_APPROVE`, `_REJECT`, `_EXPIRE`, `_NOTIFY_ARRIVAL`) is imported by exactly
+      one test file — `tests/main/ipc/no-project-contract.test.ts:131` — which asserts only
+      its no-project behaviour. There is **no test that exercises the approve path through
+      the IPC handler**. `PROPOSAL_APPROVE` is the single channel through which a human
+      confirms an LLM write; it is the enforcement point of the Trust Principle, and
+      `ipc-registrar-coverage.test.ts` reports it as "covered." CLAUDE.md's checklist asks
+      "Are there tests that verify the approval gate cannot be skipped?" — the engine has
+      them (`tests/main/llm/approval.test.ts`), the channel does not. *(Distinct from #1900,
+      which covers the six conversation-draft channels in `register-conversation-drafts.ts`.)*
+
+- [ ] **C2 — 12 tests silently skip in CI because the embedding model is never fetched.**
+      `resources/models/**/*.onnx` is gitignored (`.gitignore:70`); `fetch:model` is hooked
+      only to `predev`/`prebuild`/`prebuild:e2e` (`package.json:48-50`) and **there is no
+      `pretest`**; the CI `lint-and-test` job runs `pnpm install` → `pnpm lint` → `pnpm
+      coverage`, none of which trigger it. So `haveModel` is false on every CI checkout and
+      these skip silently: `tests/main/embeddings/wasm-embedder.test.ts` (4 tests, whole
+      file), `tests/main/embeddings/wordpiece.test.ts` (3),
+      `tests/main/help-docs/search.test.ts` (3),
+      `tests/main/embeddings/vector-store.test.ts:228` (2, the `realDescribe` block). They
+      report *skipped*, not failed. `src/main/embeddings/**` has no coverage floor of its
+      own, so it falls under the 45% global backstop and nothing notices. Fix: add a
+      `pretest`/`precoverage` hook or a CI step, **and** assert that the gated suites
+      actually ran — the anti-vacuity pattern the architecture tests already use.
+
+- [ ] **C3 — `src/main/ipc/helpers.ts` is 6.55% statements / 0% branches; 16 test files mock
+      it and one reimplements its semantics.** This module owns `withRootPath` /
+      `withRootPathOr` / `withRootPathWin` — the entire #1631 no-project convention that
+      `vitest.config.mts` says the `src/main/ipc/**` branch floor exists to protect ("this
+      layer owns the `withRootPath` vs `withRootPathOr` decision, so a #1631 no-project
+      conflation now regresses into a test failure instead of passing in silence"). It also
+      owns `reindexFile` (`:80`), the graph+search+vectors fan-out whose duplication caused
+      the stale-embeddings drift the refactoring review found. The aggregate floor is met by
+      the *registrars*; the module implementing the policy has zero branch coverage.
+      `tests/main/ipc/no-project-contract.test.ts:49-72` mocks the module and re-implements
+      `withRootPath`/`withRootPathOr` inside the mock, then asserts against that
+      re-implementation — so a bug in the real `rootPathFromEvent` → `winFromEvent` →
+      `getRootPath(win.id)` chain is invisible to all 24 registrar tests. Fix: a direct unit
+      test of the real wrappers and `reindexFile`, which needs no Electron beyond a fake
+      event object.
+
+- [ ] **C4 — `tests/main/graph/health-checks.test.ts` is a fake test file.** All 41 lines, 3
+      tests, **zero imports**. It declares array and object literals and asserts on them:
+      `const severities = ['info','warning','concern']; expect(severities).toContain('info')`
+      and `expect(inspection.id).toBeDefined()` on an object literal declared two lines up.
+      It cannot fail. It carries the exact filename of a real production module
+      (`src/main/graph/health-checks.ts`, 572+ lines) so it reads as that module's test in
+      every listing and every review. *No coverage is lost* — health-checks.ts is at 93.25%
+      via six other files — which is precisely why this matters: **no gate in this repo can
+      detect it.** Not the coverage floors, not the ratchets, not `ipc-registrar-coverage`.
+      Delete it or rewrite it against the module.
+
+- [ ] **C5 — The first e2e test boots against the developer's real Electron profile.**
+      `tests/e2e/smoke.spec.ts:70` launches with `args: [projectRoot]` and **no
+      `--user-data-dir`** — the only one of the six specs' nine launch sites that omits it
+      (the second test in the same file, `:167`, does it correctly, as do all five other
+      specs, which `mkdtempSync` a userData dir, seed `session.json`, and `rmSync` in a
+      `finally`). Consequences, all verified: (a) `src/main/session.ts:13` restores the real
+      saved window, so the assertion at `:111` that the "Open Thoughtbase" button is visible
+      **fails on any machine that has used the app** — this machine's profile has
+      `rootPath: "/Users/davegriffith/philosophy_of_engineering"`; (b) the run **mutates the
+      developer's real profile** (`Preferences`, `DIPS`, `Session Storage/` all carry
+      today's timestamp); (c) it is green in CI, so nothing surfaces it. The file header at
+      `:19-20` states the premise it depends on ("a fresh launch yields the 'Open
+      Thoughtbase' shell") — true only on a clean runner. One line fixes it. Related but
+      lower-severity: all six specs pass `env: { ...process.env }`, handing the developer's
+      real `ANTHROPIC_API_KEY` / `GH_TOKEN` to the app under test.
+
+### High
+
+- [ ] **H1 — `docs/development.md:184-186` claims a coverage that does not exist.** It says
+      "some surfaces (notably `App.svelte`, the composition root) are covered by the
+      Playwright e2e journeys rather than unit tests." The journeys explicitly do the
+      opposite: `tests/e2e/journeys.spec.ts:4-6` and `happy-paths.spec.ts:26` state they
+      drive `window.api` through `win.evaluate` *instead of* the UI. Measured: App.svelte
+      **0% / 593 exec lines**; **66 of 125 components at 0%** (3,418 exec lines), including
+      `Sidebar.svelte` (225), `QueryPanel.svelte` (140), `ExportDialog.svelte` (128),
+      `TagsPanel.svelte` (103), `Composer.svelte` (79), `RightSidebar.svelte` (69). Two
+      actions: correct the doc so the gap is visible, and add 3–5 real UI journeys (open
+      note → edit → save; open a proposal → approve; run a skill from the menu) that drive
+      the actual DOM rather than the bridge. #1899 is the one instance of this class that
+      surfaced; the doc is why it was the only one.
+
+- [ ] **H2 — `pattern-ratchets.test.ts` covers 2 of the 5 anti-patterns CLAUDE.md lists, and
+      the uncovered ones are growing.** Ratcheted: swallowed `catch → empty` (38 files) and
+      `withRootPathOr(null, …)` (1). **Not ratcheted:** the boolean/sentinel overload, the
+      in-band `error?`, and the vestigial `success` field. Measured today across `src/main`:
+      `withRootPathOr` fallbacks are `[]` ×22 (legitimate), plus **`false` ×3**
+      (`register-notebase.ts:412`, `register-proposals.ts:24`, `:28`), **`0` ×1**
+      (`register-proposals.ts:30` — "no project" and "expired zero proposals" are the same
+      answer), **`''` ×1** (`register-sources.ts:174`), **`{}` ×2** (`register-graph.ts:74`,
+      `register-types.ts:51`). CLAUDE.md names the `false` case in its backlog; seven
+      instances of the same shape have no executable gate, so the list can grow exactly the
+      way the prose backlog did before #1848. The machinery exists — it needs one more regex
+      and baseline.
+
+- [ ] **H3 — Environment-gated suites disappear silently, and nothing asserts they ran.**
+      12–13 sites use `cond ? describe : describe.skip`. Two are security tests:
+      `tests/main/compute/sandbox-integration.test.ts:40` (`canRun()` — darwin +
+      `sandbox-exec` + python3; 10 tests of OS-level sandbox enforcement, including the
+      socket / `~/.ssh` / home-write escape probes) and
+      `tests/main/compute/network-guard.test.ts:38` (5 network-egress tests). They run today
+      on `macos-latest`; they are one runner-image change or one missing Python from
+      vanishing without a sound. Combined with C2 the root cause is the same: **a skip is
+      indistinguishable from a pass in every report this project produces.** The fix is the
+      pattern the repo already invented — assert the gated population is non-empty, exactly
+      like `ipc-registrar-coverage.test.ts:113` ("a broken scan would pass vacuously").
+
+- [ ] **H4 — Re-ratchet the coverage floors; three areas carry 25–30 points of dead slack.**
+      Per the slack table: `src/main/llm/**` is **+30.1** lines / **+25.5** branches over its
+      floor, `src/main/git/**` **+26.8**, `src/shared/**` **+25.9 with no branch floor at
+      all** despite measuring 86.1%. The trust path — CLAUDE.md's stated top priority — has
+      the loosest gate in the repo relative to what it achieves. Set floors 3–5 points under
+      measured (the flap margin the config already reasons about), add the missing
+      `src/shared/**` branch floor, and consider adopting the *exact-number,
+      fails-in-both-directions* discipline that `pattern-ratchets` and `file-size-budgets`
+      already use — it is the strictly better ratchet and it lives in the same repo.
+
+- [ ] **H5 — 4,065 leaked temp directories, one file responsible for 3,358 of them.**
+      `tests/main/publish/publish-to-git.test.ts:63-64` creates a `minerva-pubroot-` temp dir
+      in `beforeEach` and has **no `afterEach` and no `rm` of any kind** (verified: zero
+      matches for `afterEach|rmSync|\.rm\(` in the file). 16 tests × ~210 recorded runs.
+      **1,184 of those directories were created today.** Five `*.bench.ts` files leak the
+      same way at lower volume (`n3-cache.bench.ts:26`, `graph-index.bench.ts:27`,
+      `full-index.bench.ts:31`, `n3-cold-rebuild.bench.ts:38`,
+      `write-pipeline.bench.ts:39`). Separately, **production** code leaks 319 unix sockets:
+      `src/main/compute/rpc-server.ts:219` creates `minerva-rpc-<pid>-<rand>.sock` in
+      `os.tmpdir()` and never unlinks it on close — collision-safe, but it pollutes the
+      shared namespace indefinitely and is a real-app resource leak that the tests merely
+      amplify. Note this is an *adoption* problem, not a design one:
+      `tests/helpers/temp-project.ts` hardens teardown correctly via `afterEach` (broader
+      adoption is **#1902**).
+
+- [ ] **H6 — `process.env` deletions leak across test files in a reused fork worker.**
+      `tests/main/llm/settings.test.ts:53-56` deletes `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`
+      and `GEMINI_API_KEY` in `beforeEach`; `afterEach` (`:59-61`) only removes the temp dir.
+      `isolate: true` resets the module registry, not the process, and fork workers are
+      reused — so every file scheduled after it on that worker sees those unset. This is a
+      genuine cross-file order dependency, and the codebase already documented the fix:
+      `tests/main/publish-git-auth.test.ts:17-32` snapshots and restores with the comment
+      *"process.env is worker-global, so snapshot + restore to avoid leaking the deletions
+      into other test files that share the worker."* `vi.stubEnv` (which auto-restores) is
+      used **zero** times across all 11 env-mutation sites.
+
+- [ ] **H7 — `src/main/llm/tools/`: seven LLM tool modules are effectively untested.**
+      `set-properties.ts` **1.85%**, `propose-compute.ts` 3.57%, `ask-user.ts` 5.55%,
+      `query-graph.ts` 9.09%, `search-notes.ts` 9.09%, `get-properties.ts` 12.5%,
+      `describe-graph-schema.ts` 33.3% — all at 0% branches. These are the callable surface
+      the model reaches for. `set-properties.ts` in particular is an LLM-originated graph
+      write, and the write guard is only fatal on paths that actually execute under test — an
+      untested apply path is a guard that never fires. The sibling tools are well covered
+      (`propose-notes` 89%, `propose-claims` 87%, `propose-note-body` 98%), so this is a
+      handful of gaps rather than a systemic one.
+
+### Medium
+
+- [ ] **M1 — `tests/main/notebase/fs.test.ts:109-116` — the one genuinely vacuous
+      conditional, on the sandbox path.** `if (firstFile >= 0 && lastDir >= 0) {
+      expect(lastDir).toBeLessThan(firstFile); }` with nothing asserting the guard holds. If
+      `listFiles` regressed to returning only directories, only files, or an empty array, the
+      "sorts directories before files" test stays green. Two lines fix it.
+
+- [ ] **M2 — Three tests whose assertion under-delivers their name.**
+      (a) `tests/shared/sql-format.test.ts:39-46` — titled "falls back to the original text
+      on a parser error," asserts only `not.toThrow()`; the stated risk ("a half-typed query
+      isn't destroyed") would still pass if the query *were* destroyed. Should be
+      `expect(formatSql(input)).toBe(input)`.
+      (b) `tests/renderer/markdown/vega-renderer.test.ts:89-94` — the comment states the
+      expected result (`[]`, leaf URL below the depth cap) but asserts `not.toThrow()`;
+      removing the depth guard entirely leaves this green. It guards a network-egress path.
+      `toEqual([])` is the fix.
+      (c) `tests/renderer/preview/hydrate.test.ts:105-108` — "returns early when there are no
+      un-highlighted code blocks" asserts only `not.toThrow()`; nothing checks the DOM was
+      left alone.
+
+- [ ] **M3 — Two literal tautologies.** `tests/shared/flashcards/guid.test.ts:90-92` —
+      `expect(guidsOf(persisted)).toEqual(guidsOf(persisted))`, identical expression on both
+      sides; determinism is already covered at `:20` and the meaningful version (guid
+      stability across an edit) exists at `:97`. And
+      `tests/main/graph/health-checks.test.ts:20` — `expect(types).toHaveLength(5)` counting
+      the test's own array literal (subsumed by C4).
+
+- [ ] **M4 — "No-op" asserted only as "didn't crash," on trust surfaces.**
+      `tests/main/ipc/register-compute.test.ts:307-309`: "revoking a thoughtbase that was
+      never trusted is a no-op, not an error" asserts only `not.toThrow()`. A handler that
+      wiped *all* consent records on an unknown root would pass — a compute-consent failure.
+      Same shape at `tests/main/notebase/watcher.test.ts:456`,
+      `tests/main/search/minisearch-provider.test.ts:102`,
+      `tests/main/compute/python-kernel.test.ts:214`. The good version already exists two
+      hundred lines away at `register-compute.test.ts:448`, which follows `not.toThrow` with
+      `expect(h.showItemInFolder).toHaveBeenCalled()`.
+
+- [ ] **M5 — Add `pnpm lint:fonts` to CI.** It exists only in `.githooks/pre-push` and
+      appears nowhere in `.github/workflows/`. Any `--no-verify` push, `SKIP_HOOKS=1`, fork
+      PR, or checkout that never ran `pnpm install` bypasses it. It is a one-line grep;
+      adding it to the lint job costs nothing.
+
+- [ ] **M6 — The sandbox-escape test writes into the developer's real `$HOME` and `~/.ssh`.**
+      `tests/main/compute/sandbox-integration.test.ts:106-110` does
+      `mkdirSync(path.join(os.homedir(), '.ssh'), {recursive:true})` then writes
+      `~/.ssh/mv_sandbox_probe` containing `'SECRET'` — cleaned in a `finally`, but it
+      **creates `~/.ssh` if the developer doesn't have one**. Lines `:99` and `:120` attempt
+      writes to `$HOME/mv_sandbox_evil.txt` and `$HOME/mv_sandbox_child_evil.txt` with **no
+      cleanup on either path** — and the entire premise of the test is that the sandbox might
+      be broken, in which case it litters real `$HOME`. The test is valuable and should stay;
+      it should target a temp `HOME` rather than the real one.
+
+- [ ] **M7 — `pnpm test` and `pnpm coverage` enforce different timeouts, and CI runs only
+      one.** `package.json:32` `"test": "vitest run"` (vitest default 5,000 ms);
+      `package.json:39` `"coverage": "vitest run --coverage --test-timeout=30000"`;
+      `ci.yml:69` runs only `pnpm coverage`. So **CI never validates the 5 s budget**, and a
+      test in the 5–30 s band is green on every PR and red the moment a developer types
+      `pnpm test`. The most likely candidate is `tests/main/notebase/watcher.test.ts` — 19
+      real-chokidar tests with a `waitFor(…, 4000)` helper and no overrides, inside a 5,000 ms
+      default. Fix: set `test.testTimeout` in `vitest.config.mts` and drop
+      `--test-timeout=30000` from `coverage` so both enforce one contract. Separately,
+      consider adding `pnpm test` to the pre-push hook — 70 s is proportionate for pre-push,
+      and the hook currently lets a red suite reach CI.
+
+- [ ] **M8 — Timing-sensitive tests that can fail red.** (a)
+      `tests/main/search/index.test.ts:91-92` and `:103-109` — `await sleep(DEBOUNCE_MS/2)`
+      then `expect(existsSync(...)).toBe(false)`; an overshoot past the 200 ms debounce on a
+      loaded runner turns this red. (b) `tests/renderer/source-display.test.ts:20-26,63` —
+      `isoDaysFromNow()` reads the clock at setup, `isOverdue` reads it again at assert time;
+      a run straddling local midnight fails, and `:72-76` fails at new year. There is **no
+      `TZ` pin** anywhere (`vitest.config.mts`, `package.json`, `ci.yml`), so every local-time
+      assertion inherits the runner's zone. The repo's own good pattern (`vi.setSystemTime`,
+      used in 3 files; `TZ` forced-and-restored in
+      `tests/renderer/refactor/extract.test.ts:17-27`) just needs applying here. (c) 7
+      unconditioned `waitForTimeout(400-500)` sleeps before axe scans in
+      `tests/e2e/a11y.spec.ts:142,154,201,205,249,254` and `smoke.spec.ts:114` — a slow runner
+      yields either a spurious violation or a spuriously clean scan.
+
+- [ ] **M9 — Shared mutable `beforeAll` fixtures with no reset.** 25 files have `beforeAll`
+      and no `beforeEach`. Sharpest: `tests/main/sources/tables-markdown.test.ts:20-24` — one
+      DuckDB instance mutated by every test, plus a module-global `onCsvTableCollision`
+      handler registered at `:91` and never unregistered, so it stays live for `:115` and
+      anything added later. Table names are disjoint today; nothing enforces it. Milder at
+      `tests/main/sources/tables.test.ts:8-13,92`. Related: the renderer store singletons
+      (`src/renderer/lib/stores/*.svelte.ts`) export no reset API, so each test file
+      hand-rolls one — `tests/renderer/stores/bookmarks.test.ts:17-23` walks only the top
+      level, while `right-sidebar/BookmarksPanel.test.ts:15-24` sidesteps it by mocking the
+      module (the better pattern). `bookmarks.svelte.ts:12-18` also arms an uncancelled real
+      500 ms `setTimeout` per mutation, which fires after the file's tests have finished.
+
+- [ ] **M10 — Tighten the bench gate, or use the mechanism already built.** Tolerance is
+      **2.0×** — a 99% slowdown passes — and every `budgetMs` in
+      `tests/main/bench-baseline.json` is `null`, so the absolute-ceiling check that
+      `scripts/bench-check.mjs` implements is never exercised. Set `budgetMs` on the scale
+      benches (`indexAllNotes: 5000 notes` is 1,181 ms at ±<1% per the baseline comment — an
+      1,800 ms ceiling would be generous and meaningful) and consider tightening tolerance to
+      ~1.3× for the low-variance benches while leaving the noisy ones at 2.0×.
+
+- [ ] **M11 — No flake budget on either suite.** Playwright retries twice in CI with nothing
+      aggregating the "retry #N" lines its config relies on for visibility; vitest has no
+      retry and no flake detection. A cheap first step: fail the e2e job when any test needed
+      a retry, or record retries so the rate is at least visible.
+
+- [ ] **M12 — Zero `expect.assertions(n)` across 6,198 tests, with 199 `waitFor(` sites.** No
+      systemic problem today (the assertion audit came back clean), but this is the mechanism
+      by which an assertion inside an unexecuted async branch would pass silently. Worth
+      adopting in the async component tests specifically, not repo-wide.
+
+- [ ] **M13 — `ipc-registrar-coverage.test.ts`'s header is stale.** It says "four of the
+      eleven currently-covered ones are reached only by the shared no-project contract test,"
+      written when 11 of 24 were covered. All 24 now are, and the honest caveat it makes is
+      more important, not less — it is exactly the C1 failure mode. One-line doc fix.
+
+### Already tracked — cross-references, not new findings
+
+These surfaced again and are correctly described by the existing issues: **#1900** (six
+approve-and-apply LLM draft channels untested — corroborated:
+`register-conversation-drafts.ts` measures 21.22% stmts / 16.10% branches), **#1901**
+(`register-refactor.ts` — corroborated at 26.78% / 33.33%), **#1902** (175 files hand-rolling
+`mkdtempSync` vs 6 importing the helper — see H5 for the measured consequence), **#1899**
+(`UnlinkedMentions` test against an unwired component — see H1 for why it is a symptom of a
+layer-wide gap), **#1894** (`ipc-registrar-coverage` passes on import — see C1 for the
+concrete consequence), **#1919** (duplicate editor-store test files), **#962** (arm64-only
+packaging — the compatibility-matrix analogue).
+
+---
+
+## Sections deliberately not filled
+
+Kept as headings because the template asks for them, with an honest statement rather than a
+fabricated number.
+
+- **Defect density per KLOC / escaped defects per release / MTTR / customer issues per
+  month.** Not measured and not meaningfully measurable here. This is a single-developer app
+  at `2.0.0-alpha.1` with no issue taxonomy separating "escaped defect" from "feature
+  request," no release cadence to normalise against, and no incident timeline. The closest
+  honest proxies from `git log --since="90 days ago"`: **739 commits, 84 `fix(…)` commits
+  (11.4%), 11 mentioning revert, 62 `test(…)` commits.** Those are raw counts, not a defect
+  rate — a `fix:` commit here often means "the UX was wrong," not "a shipped bug."
+- **Browser / device matrix.** Not applicable — one bundled Chromium. The desktop analogue
+  (platform + arch matrix) is under *Compatibility*: macOS arm64 only, tracked as #962.
+- **DAST / penetration testing / OWASP scan.** Not applicable — no server, no network attack
+  surface beyond outbound API calls. The analogues that *do* apply (path-traversal sandbox,
+  Electron trust boundary, Python sandbox escape probes, supply-chain audit) are under
+  *Security testing* and are largely in good shape.
+- **Load / stress / throughput (req/sec).** Not applicable — single-user desktop. The
+  analogue is large-thoughtbase indexing, which is benched (500/2k/5k notes) and gated, with
+  the caveats in M10.
+- **Customer satisfaction / NPS / support-ticket metrics.** No user base to measure.
+- **Test-case management, QA sign-off, release-readiness checklists, CODEOWNERS, PR
+  templates.** None exist (`.github/` has only `ISSUE_TEMPLATE`, `dependabot.yml`,
+  `workflows/`). For a single-developer project this is correct, not a gap — the executable
+  gates in `tests/architecture/` do the work a process checklist would do on a team, and do
+  it better. I am not recommending process ceremony.
+- **Mutation testing.** Not present. It is the tool that would have caught C4, M1, M2 and M4
+  automatically. Worth *considering* on `src/main/llm` and `src/main/notebase` only — but
+  6,745 tests × a mutation runner is a very different feedback loop from 70 seconds, so this
+  is a "run it once, act on the report, don't wire it into CI" suggestion, not a gate
+  recommendation.
+
+---
+
+### Method and limitations
+
+**What I actually ran** (darwin arm64, this working tree, `main` at `83e35f28`, clean except
+the untracked prior report):
+
+- `pnpm coverage` — full suite + v8 instrumentation + all thresholds. Exit 0. 621 files,
+  6,745 tests, 105.10 s. Source of every coverage number here.
+- `pnpm test` — full suite, no instrumentation. Exit 0. 621/6,745, 70.43 s.
+- A Python parse of `coverage/lcov.info` aggregating `LF/LH`, `BRF/BRH`, `FNF/FNH` per glob —
+  the slack table and the component zero-coverage counts. I used lcov rather than the v8 text
+  report because the text report's directory rows exclude subdirectories and read
+  misleadingly high.
+- A regex scan of `src/main` for `withRootPathOr` fallback shapes (H2).
+- A brace-matching scan over all 6,198 `it`/`test` blocks for zero-assertion and
+  single-weak-assertion bodies.
+- Direct verification on disk of the five most severe claims: read
+  `~/Library/Application Support/Minerva/session.json` (C5), counted
+  `ls -d $TMPDIR/minerva-* | wc -l` → 4,065 and `minerva-pubroot-*` → 3,358 and
+  `minerva-rpc-*.sock` → 319 (H5), grepped `publish-to-git.test.ts` for any cleanup → none
+  (H5), read `settings.test.ts:50-62` against `publish-git-auth.test.ts:15-33` (H6), read
+  `health-checks.test.ts` in full (C4).
+- Roughly 90 `grep`/`rg`/`wc` counts, each command stated inline next to its number.
+- `git log --since="90 days ago"` with `--grep` filters.
+- Read in full: `CLAUDE.md`, `vitest.config.mts`, all three `.github/workflows/*.yml`,
+  `.github/dependabot.yml`, `.githooks/pre-push`, `playwright.config.ts`, `scripts/lint.mjs`,
+  `scripts/bench-check.mjs` (gate logic), all six `tests/architecture/*.test.ts`,
+  `tests/shared/ipc-contract-ratchet.test.ts`, `src/main/graph/write-guard.ts`,
+  `src/main/ipc/helpers.ts`, `src/main/ipc/register-proposals.ts`,
+  `tests/main/graph/health-checks.test.ts`,
+  `tests/e2e/{smoke,journeys,a11y,focus-trap}.spec.ts` (headers + assertion lines),
+  `docs/development.md` §Tests, and the earlier refactoring review's summary and metrics.
+- I did **not** modify any file except this report. No git state was changed.
+
+**What I did not measure, and why:**
+
+- **CI-environment coverage.** Every coverage number is from a machine with
+  `resources/models` and Python 3 present. The CI figure is lower by the 12 model-gated tests
+  (C2). I did not reproduce a modelless run — it would have meant moving or deleting
+  `resources/models`, a working-tree modification.
+- **Whether CI is actually green.** I did not query `gh run list`. All statements about CI
+  are read from the workflow YAML, not from run history.
+- **Real flakiness rate.** Two consecutive local runs is not a flake study. The
+  timing-sensitive tests are flagged on structural grounds, not observed failures — I saw
+  none. I did not attempt to reproduce C5's local failure by running `pnpm test:e2e`, which
+  would have taken an `electron-forge package` build; the claim rests on reading the launch
+  args, the session-restore code path, and the real `session.json` contents.
+- **`src/main/menu.ts` (28% covered, 983 lines).** A large untested surface I flagged in the
+  metrics table but did not investigate. Plausibly a legitimate "hard to unit test, covered
+  by the e2e boot" case, or plausibly a real gap; I do not know which.
+- **Mutation score.** Not run — far outside this review's budget.
+- **The 24 files touching `Date.now`/`new Date`.** I counted them and examined the two
+  flagged in M8; I did not audit each for load-bearing clock dependence.
+
+**Claims I am less than fully confident in:**
+
+- **The exact CI-skipped test count (12).** Derived by counting `it(` blocks inside the
+  `describe.skip`-gated regions of four files (2 + 4 + 3 + 3). A parallel scan produced ~28
+  by counting all `it` blocks in those files including ungated ones; I used the narrower,
+  more defensible number. The *mechanism* (C2) is certain — `.gitignore:70` plus the absence
+  of any `pretest` in `package.json` is unambiguous — but treat "12" as approximate.
+- **"App.svelte is covered by nothing."** Precisely: 0% under v8 in the vitest run, and the
+  e2e journeys drive `window.api` rather than the DOM. But `smoke`, `a11y` and `focus-trap`
+  *do* boot the real app and click real UI, so some App.svelte code executes there —
+  Playwright coverage is not instrumented, so I cannot say how much. The claim I stand behind
+  is narrower: **no automated assertion exists about App.svelte's behaviour beyond "the
+  welcome screen renders and four surfaces have no new axe violations."**
+- **C5's local-failure claim** is an inference from three verified facts (no
+  `--user-data-dir`; `session.ts:13` reads `userData/session.json`; that file contains a
+  `rootPath`) rather than an observed red run. The *profile-mutation* half is directly
+  observed (timestamps on `Preferences`/`DIPS`/`Session Storage/`).
+- **The `bare toHaveBeenCalled()` concern is weaker than it first appears** and I
+  down-weighted it accordingly — repo-wide 641 bare vs 560 with-args, and in `tests/main/ipc`
+  the with-args form actually *dominates* (200 vs 148). Only `tests/main/llm` inverts (11 vs
+  6), on a small base. Not filed as a finding; reported in the metrics table as context.
+- **M2(b), M2(c) and M9** are judgement calls about what a test *ought* to assert or how much
+  shared-fixture coupling is acceptable. All the tests involved pass and guard something
+  real; reasonable people could call them adequate.
+- Everything in *Sections deliberately not filled* reflects my reading of Minerva as a
+  single-developer local-first desktop app. If it is heading toward a team or a user base,
+  several become applicable and the answers change.

--- a/reports/refactoring-review-entire-project-2026-08-23-182453.md
+++ b/reports/refactoring-review-entire-project-2026-08-23-182453.md
@@ -1,0 +1,653 @@
+# Refactoring Review Plan
+Generated: 2026-08-23 18:24:53
+Scope: /Users/davegriffith/minerva (entire project)
+
+## Executive Summary
+
+Minerva is, by a wide margin, the best-governed codebase I have reviewed against its own
+conventions. Six architecture fitness functions in `tests/architecture/` are green
+(verified: `npx vitest run tests/architecture` → 6 files / 18 tests passed), and they cover
+the failure modes most codebases discover only in a review like this one: file-size
+derivatives (`file-size-budgets.test.ts`), swallowed errors and `withRootPathOr(null, …)`
+(`pattern-ratchets.test.ts`), import cycles (`no-cycles.test.ts`), store ownership of
+mutations (`store-ownership.test.ts`), IPC-registrar test coverage
+(`ipc-registrar-coverage.test.ts` — `KNOWN_UNTESTED` is now **empty**), and config-root
+documentation (`config-roots-doc.test.ts`). The typed-IPC migration is complete
+(`UNMIGRATED_DOMAINS = new Set([])` in `tests/shared/ipc-contract-ratchet.test.ts:43`).
+The classic review findings — magic numbers, deep nesting, `any` leakage, dead `TODO`s —
+are essentially absent: 2 TODO/FIXME markers, 5 `eslint-disable`, 6 `: any`, 2 `as any`,
+7 `@ts-expect-error` across 768 source files.
+
+So this review deliberately goes after what the ratchets **cannot** see. Three themes:
+
+1. **Abstractions that exist but were never adopted.** `src/renderer/lib/components/ui/Dialog.svelte`
+   is a complete, documented 165-line dialog primitive with **zero importers**, while 30
+   components hand-roll its scaffolding. `tests/helpers/temp-project.ts` was written
+   because "~90 main-process test files repeat the same boilerplate" — 175 test files
+   still hand-roll `mkdtempSync` and 6 import the helper. `discardFrom` was extracted in
+   the conversations store; its mirror `approve*Draft` family (9 near-identical bodies)
+   was not. These are the highest-yield, lowest-risk items in the report because the
+   design decision is already made and reviewed. The sharpest case is
+   `UnlinkedMentions.svelte`: 163 lines wired to nothing, kept green by a 105-line test that
+   renders it directly, beside a test comment still describing an embedding that no longer
+   exists.
+
+2. **Duplicated policy that has already caused defects.** Three copies of the
+   graph/search/vectors re-index fan-out disagree — the watcher path
+   (`src/main/window-manager.ts:399-401`) omits `vectors.indexNote` that
+   `src/main/ipc/helpers.ts:87` performs, so watcher-driven note edits leave stale
+   embeddings. Two writers own `.minerva/config.json`, and one of them
+   (`src/main/graph/index.ts:100-110`) writes `{ baseUri }` wholesale over the other's
+   fields. Four copies of `IGNORED_DIRS` plus fifteen inline hidden-file skips implement
+   the ignore policy CLAUDE.md documents once. The project's own history names this cost
+   precisely: commit `de45b7bc` (#1818) says "Thirty components had each hand-rolled the
+   same two lines, drifting into four different opacities on the way, which meant 'make it
+   lighter' was a thirty-file edit."
+
+3. **Type-surface drift the compiler can't catch because the type is the thing that's
+   wrong.** `src/renderer/lib/ipc/client.ts` declares 83 of its 90 `on*` subscription
+   methods as returning `void`, while `src/preload/preload.ts` returns an unsubscribe
+   function from all 98 `subscribe(...)` calls. Consequently **zero** of the 103
+   subscription sites in `stores/` and `lib/app/` capture an unsubscriber — TypeScript
+   tells them there is nothing to capture.
+
+Two cross-references, so this report does not re-discover tracked debt: CLAUDE.md's
+IPC-error migration backlog entries for `GRAPH_QUERY`'s in-band `error?`
+(`src/shared/ipc-contract.ts:240`) and the proposals `APPROVE`/`REJECT` boolean overload
+(`src/main/ipc/register-proposals.ts:24,28`) are both still live and correctly described;
+they are listed here only as Low priority with adjacent, *unlisted* instances noted. All
+27 files over 600 lines are already budgeted, so "this file is big" is not itself a
+finding — only "this file has a seam" is.
+
+---
+
+## Code Quality Metrics
+
+Every number below states how it was derived. Nothing is estimated.
+
+| Metric | Value | Derivation |
+|---|---|---|
+| Source files (`.ts` + `.svelte` under `src/`) | 768 | `find src -type f \( -name '*.ts' -o -name '*.svelte' \) \| wc -l` |
+| Total source lines | 127,894 | same `find` piped to `wc -l`, `total` row |
+| Lines by layer | main 47,183 · renderer 63,953 · shared 14,297 · preload 645 | per-directory `find … -exec wc -l {} +` tail |
+| Files over 600 lines | 27 | `awk '$1>600 && $2!="total"'` over the `wc -l` output |
+| …of which budgeted | 27 / 27 | every path in the table matches `BUDGETS` in `tests/architecture/file-size-budgets.test.ts:57-84`; the suite passes, so measured == budget |
+| Svelte components | 125 | `find src/renderer -name '*.svelte' \| wc -l` |
+| Renderer stores | 27 | `ls src/renderer/lib/stores/*.svelte.ts` |
+| IPC registrars | 24 `register-*.ts` (3,667 lines in `src/main/ipc/`) | `wc -l src/main/ipc/*.ts` |
+| Test files / lines | 621 `.test.ts` / 83,986 lines under `tests/` | `find tests -name '*.test.ts' \| wc -l`; `find tests -type f -name '*.ts' -exec wc -l {} +` |
+| Test-to-source line ratio | 0.66 : 1 | 83,986 / 127,894 |
+| TODO / FIXME / HACK in `src/` | 2 | `grep -rn 'TODO\|FIXME\|HACK' src --include='*.ts' --include='*.svelte' \| wc -l` |
+| `eslint-disable` in `src/` | 5 | same grep shape |
+| `: any` / `as any` / `@ts-expect-error` | 6 / 2 / 7 | same grep shape |
+| `console.*` calls in `src/` | 199 (main 107, renderer 88, shared 2, preload 2) | `grep -rn 'console\.' <dir>` per layer |
+| …with a `[tag]` prefix | ~105 across 30 distinct ad-hoc tags | `grep -rhoE "console\.(log\|warn\|error)\('\[[a-z-]+\]"` piped to `sort \| uniq -c` |
+| Architecture tests | 6 files / 18 tests, all passing | `npx vitest run tests/architecture` |
+| `.svelte` lines inside `<style>` | 14,930 of 40,368 (36%) | Python scan tracking `<style>`…`</style>` spans over all `src/renderer/**/*.svelte` |
+| `.svelte` lines inside `<script>` | 15,227 of 40,368 (37%) | same scan |
+| Components with >250 lines of scoped CSS | 12 | same scan, filtered |
+| Cross-file duplicate 12-line windows | 634 groups | Python rolling-hash over whitespace-normalised lines of all `src/**/*.{ts,svelte}`, windows of 12 with ≥11 non-comment lines, reported only when the group spans >1 file |
+| Test files calling `mkdtempSync` | 175 files / 211 call sites (103 also call `initGraph`) | `grep -rl 'mkdtempSync' tests` and `\| xargs grep -l initGraph` |
+| Test files importing `tests/helpers/temp-project` | 6 (excluding the helper itself) | `grep -rl 'temp-project' tests --include='*.ts'` |
+
+**Longest top-level functions** (Python brace-depth scan over `src/**/*.ts`, top of list):
+
+| Lines | Location |
+|---|---|
+| 1017 | `src/renderer/lib/stores/editor.svelte.ts:167` `getEditorStore` |
+| 767 | `src/renderer/lib/app/refactor-ops.svelte.ts:61` `createRefactorOps` |
+| 641 | `src/renderer/lib/app/note-ops.ts:47` `createNoteOps` |
+| 497 | `src/main/ipc/register-conversation-drafts.ts:105` `registerConversationDrafts` |
+| 402 | `src/renderer/lib/preview/markdown-config.ts:69` `createPreviewMarkdown` |
+| 382 | `src/main/ipc/register-notebase.ts:56` `registerNotebase` |
+| 268 | `src/main/window-manager.ts:249` `openProjectInWindow` |
+| 223 | `src/main/menu.ts:231` `buildFileMenu` |
+
+Caveat, stated because the number is otherwise misleading: most of the top entries are
+**factory/registrar** functions whose length is the sum of independent closures or handler
+registrations, not a 500-line procedure. `openProjectInWindow` and `buildFileMenu` are the
+genuine long-procedure cases. `getEditorStore` at 1017 lines is a genuine god-object.
+
+**Script / template / style split of the largest components** (same span scan):
+
+| Component | Total | `<script>` | template | `<style>` |
+|---|---|---|---|---|
+| `App.svelte` | 2081 | 1020 | 750 | 311 |
+| `Preview.svelte` | 1532 | 1106 | 125 | 301 |
+| `SourceDetail.svelte` | 1338 | 413 | 349 | 576 |
+| `SourcesPanel.svelte` | 1298 | 620 | 294 | 384 |
+| `Editor.svelte` | 1209 | 1054 | 49 | 106 |
+| `PropertiesPanel.svelte` | 1157 | 459 | 251 | 447 |
+| `Sidebar.svelte` | 991 | 530 | 182 | 279 |
+
+`Editor.svelte` and `Preview.svelte` are TypeScript modules wearing a `.svelte` costume
+(87% and 72% script, 4% and 8% template). `SourceDetail.svelte` and `PropertiesPanel.svelte`
+are the opposite problem — 43% and 39% scoped CSS.
+
+**Top cross-file clone clusters** (duplicate-window counts from the scan above):
+
+| Windows | Pair |
+|---|---|
+| 98 | `AddPropertyDialog.svelte` ↔ `PromptDialog.svelte` |
+| 75 | `right-sidebar/BacklinksPanel.svelte` ↔ `right-sidebar/OutgoingLinksPanel.svelte` |
+| 70 | `NewNoteDialog.svelte` ↔ `PromptDialog.svelte` |
+| 66 | `ConfirmDialog.svelte` ↔ `PromptDialog.svelte` |
+| 61 | `AddPropertyDialog.svelte` ↔ `ToolParamsDialog.svelte` |
+| 56 | `MineReferencesDialog.svelte` ↔ `ResolveStubDialog.svelte` |
+
+**Duplicated pure helpers** (`grep -rhoE '^(export )?function ([a-z]…)'` piped to
+`uniq -c`, then each verified by name): `escapeHtml` defined in **15** files,
+`slugify`-family in 11, `escapeAttr` in 8, `stripFrontmatter` in 6, `escapeRegex` in 4.
+
+---
+
+## Refactoring Opportunities
+
+### High Priority (Quick Wins)
+
+- [ ] **Adopt `ui/Dialog.svelte`, or delete it.** It has **zero** importers in `src/`
+      while 30 components duplicate its overlay/card scaffolding.
+      `src/renderer/lib/components/ui/Dialog.svelte:1-165` (verified: `grep -rn "ui/Dialog" src/renderer` → no hits;
+      `grep -rl 'var(--scrim-blur)' src/renderer --include='*.svelte'` → 30 files).
+      Commit `de45b7bc` (#1818) documents the cost in the project's own words: the last
+      backdrop change was "a thirty-file edit" across "four different opacities". Start
+      with `PromptDialog.svelte` (124 of its 212 lines are `<style>`) and
+      `ConfirmDialog.svelte` (138 of 220).
+- [ ] **The rest of the design system is dead too — adopt or delete in the same PR.**
+      `Kbd.svelte`, `Stepper.svelte`, `Toggle.svelte` have 0 `src/` importers; `Eyebrow.svelte`
+      and `SegmentedControl.svelte` have 1 each; `Chip.svelte` has 2.
+      `src/renderer/lib/components/ui/` — 566 lines shipped in #545/#556 and never wired in.
+- [ ] **Fix the event-subscription return type: 83 methods declare `void` where preload
+      returns an unsubscriber.** `src/renderer/lib/ipc/client.ts:60` (`onRenamed(...): void`)
+      and 82 more (`grep -c '^\s*on[A-Z][A-Za-z]*(.*): void;'` → 83; only 7 declare
+      `() => void`), against `src/preload/preload.ts:16-20` where `subscribe()` returns
+      `() => { ipcRenderer.off(...) }` for all 98 sites. Result: **0 of 103**
+      `api.*.on*` calls in `stores/`+`lib/app/` capture the unsubscriber. Pure type change,
+      zero runtime effect; `tests/preload/preload-bridge.test.ts` pins the surface.
+- [ ] **`resolveBaseUri` clobbers the project config — a data-loss path.**
+      `src/main/graph/index.ts:100-110`: `writeConfig` does `JSON.stringify({ baseUri })`
+      wholesale over the same `.minerva/config.json` that `src/main/project-config.ts:141-146`
+      (`patchProjectConfig`) merges into. `readConfig` at `:94-98` is `catch { return null }`,
+      so a **corrupt** config is indistinguishable from a missing one and triggers the
+      overwrite — destroying `displayName`, `bibliography`, `onboarding`, `publishTargets`.
+      Extract one electron-free `.minerva/config.json` read/patch leaf used by both.
+- [ ] **Watcher-driven note edits never update the vector store.**
+      `src/main/window-manager.ts:399-401` (`onFileChanged`) and `:430-441` (`onFileCreated`)
+      call `graph.indexNote` + `search.indexNote` only, while `src/main/ipc/helpers.ts:87`
+      also calls `vectors.indexNote`. Sources and excerpts in the *same file* do get vectors
+      (`window-manager.ts:479, 486, 495, 502`), which is what makes this read as an oversight.
+      `src/main/embeddings/backfill.ts:121-128` skips notes that already have rows, so it
+      never self-heals. One `indexAllFor(ctx, rel, content)` in a non-electron module,
+      called from all three fan-out copies.
+- [ ] **`health-checks` `running` flag is module-global while its results are per-project.**
+      `src/main/graph/health-checks.ts:40-41` (`lastResultsByProject` Map vs `let running = false`)
+      and the guard at `:78`. A check running for project A makes a concurrent check for
+      project B return `[]` — indistinguishable from "clean". With `armAutoChecks` debouncing
+      off every graph write and a 5-minute periodic timer per project, concurrent runs across
+      windows are the normal case. Key `running` by `rootPath`.
+- [ ] **Four write handlers silently report success when no project is open.**
+      `src/main/ipc/register-refactor.ts:112` (`FORMATTER_SAVE_SETTINGS`),
+      `src/main/ipc/register-bookmarks.ts:15` (`BOOKMARKS_SAVE`) and `:25` (`TABS_SAVE`),
+      `src/main/ipc/register-graph.ts:125` (`GRAPH_EXPORT`) all use
+      `withRootPathOr(undefined, …)`. CLAUDE.md rule 2 restricts that fallback to a
+      *legitimate* project-less value. The precedent is already written down at
+      `src/main/ipc/register-notebase.ts:396-399`: "NOT `withRootPathOr` (#1862). This is a
+      write, and the old fallback said 'I replaced 0 occurrences' for a call that never ran."
+      Not caught by `pattern-ratchets.test.ts`, whose `NO_PROJECT_NULL` regex matches only
+      `withRootPathOr(null`.
+- [ ] **Extract `fileAndApprove()` in the drafts registrar — the other half of a prior
+      review item that was only half-done.** `src/main/ipc/register-conversation-drafts.ts`
+      lines 120-135, 149-158, 181-188, 219-228, 260-276, 334-340 repeat
+      `proposeWrite → if (proposal) approveProposal → return { proposalUri, applied: true }`.
+      `conversationProvenance()` (`:98`) shipped from the 2026-08-01 review;
+      `fileAndAutoApprove` did not. The helper also fixes a live bug: `applied: true` is
+      hardcoded at `:133, :158, :188, :228` even when `proposal` is `null` and nothing was
+      applied — the same shape as `GIT_COMMIT.success`, already on CLAUDE.md's vestigial list.
+- [ ] **Mirror `discardFrom` with an `approveFrom` in the conversations store.**
+      `src/renderer/lib/stores/conversations.svelte.ts:864` already collapses the 9 discard
+      functions to one-liners (`:871, :884, :898, :914, :930, :966, :990, :1013, :1036`).
+      The 9 `approve*Draft` bodies at `:830, :873, :886, :900, :916, :932, :968, :992, :1015`
+      still repeat `findTab → plainSnapshot → applyDraft(() => api.conversations.fileXDraft(…)) →
+      tab.xDrafts.filter(...)` verbatim, differing only in the API method and the array field.
+- [ ] **Consolidate the ignore policy: 4 copies plus 15 inline variants.**
+      Identical `const IGNORED_DIRS = new Set(['.git','node_modules','.minerva','.obsidian'])`
+      at `src/main/notebase/fs.ts:10`, `src/main/notebase/search-in-notes.ts:15`,
+      `src/main/llm/auto-link.ts:26`, `src/main/formatter/orchestrator.ts:16`. A *different*
+      inline policy at `src/main/graph/indexers.ts:942` and `:961`,
+      `src/main/sources/tables.ts:553` and `:601`, `src/main/search/index.ts:81`,
+      `src/main/embeddings/backfill.ts:196`, `src/main/llm/tools/list-notes.ts:22`,
+      `src/main/publish/exporters/annotated-reading/index.ts:98`, and 6 more. Highest
+      duplication count in `src/main`, and CLAUDE.md states this policy exactly once.
+- [ ] **Delete four verified-dead exports.** `disposeSharedEmbedder`
+      (`src/main/embeddings/shared-embedder.ts:29` — the *only* cleanup path for the
+      process-wide embedder worker, never called: wire it into quit or drop it),
+      `getWindowById` (`src/main/window-manager.ts:536`), `KNOWN_FILTERS`
+      (`src/main/skills/template.ts:83`), `_isOpen` (`src/main/sources/tables.ts:663`,
+      whose comment claims "Exposed for tests" but no test uses it). Each verified by
+      `grep -rn '\bNAME\b' src tests` returning only the definition line.
+- [ ] **An entire feature is unreachable, and a green test hides it.**
+      `src/renderer/lib/components/right-sidebar/UnlinkedMentions.svelte` (163 lines) is
+      imported by **no** source file — `RightSidebar.svelte:2-14` wires 13 panels and this
+      is not among them, and `RelatedPanel.svelte` does not import it either. Its store
+      `src/renderer/lib/stores/link-suggestions.svelte.ts` (21 lines) has exactly one
+      consumer: the dead component. Yet `tests/renderer/components/UnlinkedMentions.test.ts`
+      (105 lines) renders it and passes, and `tests/renderer/components/right-sidebar/RelatedPanel.test.ts:20`
+      carries a now-false comment describing "Embedded UnlinkedMentions (#1074)". ~184
+      source lines plus a 105-line test that proves nothing about the shipped app.
+      Decide: re-wire it into `RightSidebar` or delete all three, and fix the stale comment
+      either way.
+
+### Medium Priority (Structural Improvements)
+
+- [ ] **Six approve-and-apply draft channels have no test reference anywhere.**
+      `CONVERSATION_FILE_PROPERTY_DRAFT`, `CONVERSATION_FILE_CLAIMS_DRAFT`,
+      `CONVERSATION_FILE_REFACTOR_DRAFT`, `CONVERSATION_FILE_REORG_DRAFT`,
+      `CONVERSATION_FILE_NOTE_BODY_DRAFT`, `CONVERSATION_RUN_COMPUTE_DRAFT` /
+      `CONVERSATION_INSERT_COMPUTE_DRAFT` return zero hits from
+      `grep -rl "<CHANNEL>" tests`. Each files a proposal **and auto-approves it** —
+      exactly the path CLAUDE.md's LLM review checklist asks about. `register-conversation-drafts.ts`
+      has no dedicated test file; it is reached only via `tests/main/ipc/register-conversation.test.ts:119`,
+      which exercises 2 of its 11 handlers (`:268`, `:311`).
+- [ ] **`register-refactor.ts`: 10 of its 12 channels are untested, including the LLM apply
+      paths.** Only `FORMATTER_LOAD_SETTINGS` (via `no-project-contract.test.ts`) and
+      `REFACTOR_AUTO_LINK_APPLY` (via `write-pipeline.test.ts`) appear in `tests/`.
+      `REFACTOR_AUTO_TAG_APPLY` and `REFACTOR_AUTO_LINK_INBOUND_APPLY` — named in CLAUDE.md's
+      Write Guard section as paths that must wrap themselves in `withLLMContext` — have no
+      handler-level test. `ipc-registrar-coverage.test.ts` passes because the registrar is
+      *imported*; its own docstring is candid that this "does NOT claim the registrar is
+      thoroughly tested". `register-proposals` and `register-templates` are in the same
+      import-only position.
+- [ ] **Adopt `tests/helpers/temp-project.ts`.** The fixture (#678) exists and its docstring
+      says "~90 main-process test files repeat the same boilerplate … at this many
+      repetitions the threshold is crossed". Measured today: **175** test files call
+      `mkdtempSync` (211 sites), **103** of those also call `initGraph` — the exact shape
+      `useGraphProject()` collapses — and **6** files import the helper. This is the
+      "refactor later" moment the project's own recorded guidance describes, not premature
+      fixture-building.
+- [ ] **Extract the remaining CodeMirror assembly out of `Editor.svelte`.** 1054 of its
+      1209 lines are `<script>` against 49 lines of template
+      (`src/renderer/lib/components/Editor.svelte`). The destination convention is fully
+      established — `src/renderer/lib/editor/` already holds 36 modules / 4,699 lines. The
+      residual context/gutter-menu state block at `:206-431` and the completion/extension
+      blocks at `:645-996` are the seams. Coverage floor exists (`vitest.config.mts`,
+      per-file `Editor.svelte` block), so extraction requires retuning it in the same PR.
+- [ ] **Same for `Preview.svelte`:** 1106 script / 125 template lines, with
+      `src/renderer/lib/preview/` already holding 13 modules (2,150 lines).
+- [ ] **Split the frontmatter→RDF converter out of `graph/indexers.ts`.**
+      `src/main/graph/indexers.ts:133-401` is one cohesive value-mapping concern that never
+      touches orchestration: `recoverYamlEatenWikiLink` (`:133`), `isFrontmatterMap` (`:146`),
+      `emitFrontmatterValue` (`:174`), `resolveFrontmatterPredicate` (`:230`),
+      `declaredPropertyPredicate` (`:251`), the ISO/wikilink regexes (`:258-264`),
+      `resolveWholeWikiLink` (`:277`), `frontmatterValueToEdge` (`:321`), `coerceDeclared` (`:364`).
+      ~285 lines → `indexers/frontmatter.ts`; the `indexers/` directory already exists with
+      4 modules and `indexers.ts:46-49` already imports from it. The split is half-done.
+      Tests already isolate this behaviour (`tests/main/graph/frontmatter-indexing.test.ts`,
+      `frontmatter-backlinks.test.ts`, `frontmatter-link-parity.test.ts`).
+- [ ] **Move the accelerator utilities out of `menu.ts`.** `src/main/menu.ts:1023-1071`
+      (`formatAccelerator`, `collectAcceleratorsByMenu`, `walkInto`) are pure and
+      Electron-free — the doc comment at `:1038-1043` says so. The proof they're in the
+      wrong file is in the test: `tests/main/menu-accelerators.test.ts:11-15` explains it
+      must "mock the entire Electron + project-state surface that `menu.ts` pulls in" to
+      reach them. ~50 lines off a budgeted file *and* a test with no mocks.
+- [ ] **Extract `createWatchHandlers()` from `openProjectInWindow`.**
+      `src/main/window-manager.ts:249-516` is a 268-line procedure whose `:296-506` region is
+      a closure factory over `(rootPath, projectCtx, win)`. `onFileChanged` (`:372-412`) and
+      `onFileCreated` (`:413-442`) are near-identical — same CSV branch, same
+      `.csv.schema.yaml` early return, same read→index→reregister→persist block, differing
+      only in a comment. Extraction leaves ~60 lines of lifecycle and makes the handlers
+      testable without a `BrowserWindow`.
+- [ ] **Follow the existing `install*` convention in `markdown-config.ts`.**
+      `src/renderer/lib/preview/markdown-config.ts:69` (`createPreviewMarkdown`, 402 lines)
+      already delegates 7 concerns to `installMath` / `installCallouts` / `installDoiAutolink` /
+      `installHighlight` / `installWikiLinks` / `installNoteTags` / `installTransclusions`
+      (imports at `:21-25`), but keeps the heading/paragraph/list-item/image rules (`:104-256`)
+      and six fence renderers (`:258-368`) plus the dispatcher (`:369-460`) inline.
+      `installFences(md, deps)` and `installAnchors(md)` finish the job. Well covered by
+      `tests/renderer/preview/markdown-config.test.ts` and `hydrate.test.ts`.
+- [ ] **Collapse `BacklinksPanel` and `OutgoingLinksPanel` into one direction-parameterised
+      component.** `src/renderer/lib/components/right-sidebar/BacklinksPanel.svelte` (219)
+      and `OutgoingLinksPanel.svelte` (230) produce an 84-line whitespace-normalised diff,
+      and **83** of their style-block lines are byte-identical (`comm -12` over the sorted
+      `:136-219` / `:138-230` spans). The script diff is only: `Backlink` vs `OutgoingLink`,
+      `b.backlinks` vs `b.outgoing`, and `source`/`sourceTitle` vs `target`/`targetTitle`.
+- [ ] **Promote the repeated component chrome into a utility layer, not just tokens.**
+      Measured across `src/renderer/**/*.svelte`: a `.context-menu {` rule in **10**
+      components (`Editor`, `EditorContextMenu`, `PdfViewer`, `SourcesPanel`,
+      `BookmarksPanel`, `Sidebar`, `TabBar`, `FileTree`, `TablesPanel`,
+      `right-sidebar/HistoryPanel`); a `.field {` rule in **19**; `background: var(--accent)`
+      (the primary-button surface) in **49**. 36% of all `.svelte` lines (14,930 of 40,368)
+      live inside `<style>`, and 12 components carry more than 250 lines of scoped CSS
+      each — `SourceDetail.svelte` is 576 of 1,338 (43%) and `PropertiesPanel.svelte` 447 of
+      1,157 (39%). Tokens in `global.css` already solve *values*; what is missing is a
+      shared class layer for the three or four recurring *shapes*. Note the positive
+      counter-example: menu positioning was correctly factored into
+      `src/renderer/lib/utils/menuClamp.ts` and is imported by 10 files — that is the model.
+- [ ] **Give the draft-kind family one parameterised channel pair.** Nine draft kinds are
+      spelled out longhand across five layers: 21 constants in `src/shared/channels.ts:528-568`,
+      matching `ChannelMap` entries, ~19 methods in `src/preload/preload.ts:285-323`, the
+      client interface, 11 handlers in `register-conversation-drafts.ts`, and 9 approve +
+      9 discard functions in the conversations store. A shared base already exists
+      (`src/shared/conversation-draft-base.ts`), so the discriminant is half-built. Adding a
+      tenth kind is currently a seven-file change.
+- [ ] **`src/shared/types.ts` (732) is a residual dump, not an honest catalog.** `src/shared/`
+      has already been split into ~30 domain modules (`conversation-claims-drafts.ts`,
+      `conversation-note-body-drafts.ts`, `conversation-refactor-drafts.ts`, `history.ts`,
+      `proposals.ts`, …) — yet every conversation *core* type is still here: `ContextBundle`
+      (`:552`), `TurnUsage` (`:581`), `ConversationMessage` (`:588`), `ConversationStatus`
+      (`:631`), `Conversation` (`:675`). The tell that it's a dump rather than a barrel:
+      `PrivilegedSite` (`:615-630`) — per-machine cookie-partition state — sits *inside* the
+      `// ── Conversations ──` section. `shared/conversation.ts` is the missing module.
+      (By contrast `channels.ts` and `ipc-contract.ts` genuinely are catalogs; leave them.)
+- [ ] **Six more hand-rolled config loaders that CLAUDE.md's "still hand-rolled" list omits.**
+      CLAUDE.md names `clipper-config`, `llm/settings`, `menu-config-store` (both confirmed:
+      `src/main/clipper/clipper-config.ts:41`, `src/main/llm/settings.ts:106`). Also unmigrated,
+      all with the corruption-swallowing `catch`: `src/main/recent-projects.ts:17-24`,
+      `src/main/session.ts:15-22`, `src/main/privileged-sites.ts:26-35`,
+      `src/main/publish/exporters/static-site/site-config.ts:51-62` (whose comment explicitly
+      conflates "missing / malformed"), `src/main/llm/conversation.ts:302-315` (a hand-rolled
+      `typeof` ladder where `asBool`/`asString`/`asFiniteNumber` exist), and
+      `src/main/graph/index.ts:94-98`. `config-roots-doc.test.ts` passes because it checks
+      *location*, not *loader* — update CLAUDE.md's list as part of this.
+- [ ] **`session.ts:13` resolves `app.getPath('userData')` at module load** — the exact
+      anti-pattern `src/main/recent-projects.ts:7-14` writes a nine-line comment warning
+      against ("made merely IMPORTING this file a side effect — which broke every test suite
+      that reaches it transitively"). `privileged-sites.ts:20-24` uses the safe lazy form.
+      `session.ts` is the odd one out and, unlike its two neighbours, has no test.
+- [ ] **`readJsonFileOr` has no write counterpart, and none of the four writers is atomic.**
+      `src/main/ipc/read-json.ts:16-25` gets ENOENT-vs-corrupt right for reads. The write half
+      (`mkdir recursive` + `writeFile(JSON.stringify(x, null, 2))`) is copy-pasted at
+      `src/main/ipc/register-bookmarks.ts:16-18` and `:26-28`,
+      `src/main/ipc/register-refactor.ts:113-115`, `src/main/llm/conversation.ts:317-319`.
+      No temp-file + rename, so a crash mid-write produces exactly the corruption
+      `readJsonFileOr` will then correctly refuse to swallow.
+- [ ] **`register-sources.ts` broadcasts change events to the invoking window only.**
+      `broadcast(win, Channels.SOURCES_CHANGED)` at `:78, :89, :187, :228, :234, :240, :246,
+      :252, :258` (+ `COLLECTIONS_CHANGED` at `:271`) all target `win`, while the established
+      pattern in `src/main/ipc/helpers.ts:125-168` (`broadcastRewritten`,
+      `broadcastProposalsChanged`, `broadcastHistoryChanged`) fans out via
+      `windowsForProject(rootPath)`. Two windows on one thoughtbase: window B's Sources panel
+      goes stale. `:225-260` is six handlers of byte-identical shape — a `withSourceMutation(fn)`
+      wrapper deletes ~24 lines and fixes the fan-out in one edit.
+- [ ] **Hoist the duplicated pure helpers into `src/shared/`.** `escapeHtml` is defined in 15
+      files (`src/renderer/lib/preview/text.ts:8` already exports one; the other 14 include
+      `markdown/youtube-embed.ts:55`, `markdown/mermaid-renderer.ts:184`,
+      `markdown/vega-renderer.ts:382`, `shared/markdown/math-plugin.ts:52`, and 8 publish
+      exporters). `stripFrontmatter` in 6, `escapeRegex` in 4, `slugify`-family in 11
+      (`src/shared/slug.ts:16` is the canonical one; `src/main/types/write.ts:29`,
+      `types/parse.ts:27`, `skills/parse.ts:37` and 3 publish exporters each redefine it).
+      Check semantics before merging the slug variants — some are deliberately different.
+- [ ] **There is no logging seam.** 199 `console.*` calls, ~105 carrying a bracket tag across
+      30 ad-hoc names (`[settings]` 21, `[minerva]` 20, `[conv]` 12, `[conv-panel]` 10, then a
+      long tail of singletons like `[quit]`, `[tabs]`, `[tool]`). No level control, no way to
+      silence a subsystem, no consistent prefix. A 30-line `logger(tag)` leaf and a codemod
+      would make the output greppable and the noise tunable.
+- [ ] **Extract session persistence out of the editor store.**
+      `src/renderer/lib/stores/editor.svelte.ts:167` (`getEditorStore`, 1,017 lines) is the
+      largest single function in the codebase. The tab/layout serialisation block is the
+      clean seam — it is pure data mapping over `EditorGroup`/`TabState` with no editor
+      behaviour in it. Separately, `getEditorStore()` is **not memoised** and is called at
+      18 sites (`grep -rn 'getEditorStore()' src/renderer \| wc -l`); every call rebuilds
+      the full closure set over the same module-level `$state`. The state is shared so
+      behaviour is correct, but the shape invites the assumption that it is a singleton.
+      Well covered (`tests/renderer/stores/editor-store.test.ts` 740 lines +
+      `tests/renderer/editor-store.test.ts` 668 lines — themselves worth merging; the
+      duplicate-ish names are a navigation hazard).
+- [ ] **Nothing links `client.ts` to `ChannelMap` at compile time.**
+      `src/renderer/lib/ipc/client.ts` (1,239 lines) hand-restates every signature that
+      `src/shared/ipc-contract.ts` already declares and `src/preload/preload.ts` already
+      implements — three declarations of one contract, with only the preload↔contract pair
+      structurally enforced (via the typed `invoke` wrapper). The 83-method `void`-vs-`() => void`
+      drift above is precisely what that missing third link would have caught. A
+      `type _Check = Assert<Extends<NotebaseApi, ClientOf<ChannelMap>>>` would make the
+      client a derived view rather than a parallel transcript.
+- [ ] **`Editor.svelte`'s 196-line `extensions` array literal.**
+      `src/renderer/lib/components/Editor.svelte:441-637` is a single array expression mixing
+      a11y attributes, markdown/plaintext branching, the frontmatter fold, and ~30 imported
+      extensions. It is the natural first extraction toward `lib/editor/build-extensions.ts`
+      and would take the component below its coverage floor's blind spot.
+- [ ] **`Sidebar.svelte` takes ~40 props.** `src/renderer/lib/components/Sidebar.svelte`
+      — the longest parameter list in the renderer, and the reason `App.svelte`'s template
+      half (750 lines) is as large as it is. Grouping into 2-3 cohesive prop objects, or
+      reading directly from `sidebar-selection`/`notebase` stores where the data already
+      lives, is the smaller change.
+- [ ] **Turn `health-checks.ts`'s hand-paired dispatch into a registry.**
+      `src/main/graph/health-checks.ts:85-98` pairs each check with its inspection type ids,
+      then post-filters at `:101` to undo the multi-type checks it just ran — and the same
+      pairing exists again in `src/shared/inspections.ts`'s catalog. A
+      `CHECKS: Array<{ types: string[]; run(ctx, settings) }>` collapses `:85-101` to a
+      filter + `Promise.all` and makes "did we forget to gate the new check?" structurally
+      impossible. Inside it, `checkDuplicateSources` (`:396-456`) is two near-identical
+      blocks (`:400-425` DOI, `:428-453` URI) differing only in predicate, key, type and
+      message.
+
+### Low Priority (Nice-to-Have)
+
+- [ ] **The swallow ratchet misses the expression form.**
+      `tests/architecture/pattern-ratchets.test.ts:105` `SWALLOW` matches only block-form
+      `catch { return X }`, and only under `src/main`. There are **18** `.catch(() => <empty>)`
+      sites tracked by nothing — including the one CLAUDE.md already names,
+      `src/main/ipc/register-links.ts:117` (`.catch(() => '')`), plus two fresh ones at
+      `src/main/ipc/register-bibliography.ts:117` and `:122`, and
+      `src/main/git/publish-git.ts:163, :164, :183`. Adding a second regex is a ~5-line change.
+      Extending the scan to `src/renderer` + `src/shared` costs little: only 3 block-form
+      sites exist there today (`ComputeDraftCard.svelte` ×1, `src/shared` ×2), so the
+      baseline is nearly free to establish now and expensive to establish later.
+- [ ] **Two `ok`-shaped returns that are neither a real union nor a plain value, and are not
+      on CLAUDE.md's backlog.** `src/shared/ipc-contract.ts:248`
+      (`graph:attachExcerptEvidence` → `{ ok: boolean; error?: string; proposalUri?: string }`)
+      is both halves of the anti-pattern at once — an undiscriminated `ok: boolean` *and* an
+      in-band `error?`. `src/shared/ipc-contract.ts:504` (`sources:applyStubResolution` →
+      `{ ok: boolean }`) carries no failure information at all. The backlog correctly lists
+      `GRAPH_QUERY` (`:240`) and the proposals booleans
+      (`src/main/ipc/register-proposals.ts:24, :28`); these two are adjacent and unlisted.
+      `PROPOSAL_EXPIRE` (`:30`, `withRootPathOr(0, …)`) is a third — "expired 0" and "no
+      project" are the same answer today.
+- [ ] **90 inline `import('…')` type annotations in `client.ts`.**
+      `src/renderer/lib/ipc/client.ts` has a top-level import block at `:1-8` and then reaches
+      for inline dynamic-import types 90 times (e.g. `:206, :624, :639`). Preload does this
+      twice. Purely a readability inconsistency, but it makes the file harder to scan than
+      its 1,239 lines already do.
+- [ ] **`DAY_MS` defined twice.** `src/main/graph/queries/sources.ts:180`
+      (`export const DAY_MS = 86_400_000`, re-exported through `graph/queries.ts:46` and used
+      by `llm/approval.ts` and `health-checks.ts`) and `src/main/history/policy.ts:24`
+      (`const DAY_MS = 24 * 60 * 60 * 1000`). Import the shared one.
+- [ ] **Nine editor commands exported for one in-file consumer.**
+      `src/renderer/lib/editor/formatting.ts:583-592` exports `insertVegaLiteBar` …
+      `insertVegaLiteFromCell`, all of which are referenced only by the
+      `VEGA_LITE_CHART_ITEMS` table at `:598-606` in the same file. Drop the `export`.
+- [ ] **`package.json` triplicates a script string.** `predev`, `prebuild` and `prebuild:e2e`
+      are the same three-command chain written out three times. Name it once
+      (`"prep": "…"`) and have the three delegate.
+- [ ] **Unnamed magic numbers in `health-checks.ts`.** `LIMIT 20` (`:149`), `LIMIT 25`
+      (`:409`, `:437`), `LIMIT 1000` (`:521`), the `>= 50` soft cap (`:534`),
+      `5 * 60 * 1000` (`:761`). The file already knows the right idiom —
+      `DEFAULT_CHECK_DEBOUNCE_MS` at `:708`. Note that magic numbers are otherwise **not**
+      a problem in this codebase: only ~14 of 42 `setTimeout` sites use a bare literal, and
+      most timing constants are already named.
+- [ ] **Extract `buildKernelEnv()` from `spawnKernel`.**
+      `src/main/compute/python-kernel.ts:102-240` mixes launch planning (including a 36-line
+      `env` literal at `:113-158`), the JSON line-protocol handler (`:169-207`) and process
+      lifecycle (`:209-237`). `buildKernelEnv(rootPath, rpcSocket, allowNetwork)` is pure;
+      today PYTHONPATH ordering, `MPLBACKEND` and `MINERVA_ALLOW_NETWORK` gating can only be
+      verified by spawning a real interpreter.
+- [ ] **Generate `EventMap`'s menu block.** `src/shared/ipc-contract.ts:626-692` is ~65
+      hand-written zero-arg `'menu:*': () => void` entries, mechanically derivable from a
+      `MENU_COMMANDS` tuple. Also: `PublishTargetBase` / `GitPublishTarget` / `S3PublishTarget`
+      at `:703-720` are domain models in a file whose own header (`:26`) declares it a pure
+      IPC-signature module, and the comment at `:701-702` admits they're mirrored in
+      `project-config.ts:110`.
+- [ ] **Six stores contain no reactive state at all.** `link-suggestions.svelte.ts` (21),
+      `publish.svelte.ts` (22), `review.svelte.ts` (18), `saved-queries.svelte.ts` (36),
+      `settings.svelte.ts` (66), `source-data.svelte.ts` (58) declare zero `$state` /
+      `$derived` / `$effect` (verified by grep over `src/renderer/lib/stores/*.svelte.ts`).
+      They exist to satisfy the data-flow rule rather than to own state, which is exactly
+      the limitation `tests/architecture/store-ownership.test.ts:22-26` names about itself:
+      "It CANNOT tell a well-designed store from a one-line passthrough." Not a defect —
+      but worth deciding per store whether the `api` call belongs in an ops module instead,
+      and worth remembering when reading that test as a guarantee.
+- [ ] **A swallowed error in the renderer, in the same channel CLAUDE.md already flags.**
+      `src/renderer/lib/components/right-sidebar/CitationsPanel.svelte:55-57` —
+      `api.links.citationsForNote(...).catch(() => { groups = []; })` renders a failed
+      citation fetch as "no citations". The main-side half of this call
+      (`LINKS_CITATIONS_FOR_NOTE`'s `.catch(() => '')`) is already on CLAUDE.md's swallow
+      backlog; the renderer half is not, because no ratchet scans `src/renderer`. Fix both
+      together, and it makes the ratchet-scope extension above concrete.
+- [ ] **`SettingsDialog.svelte`'s last inline tab.** 8 of its 9 tabs are already separate
+      components; the `notes` tab body remains inline. Finishing the pattern drops the file
+      under its 779-line budget.
+- [ ] **No unused-export tooling.** `knip` / `ts-prune` are absent from `package.json`
+      (only `dependency-cruiser@^18.2.0`, used by `no-cycles.test.ts`). My heuristic scan of
+      1,604 exported symbols produced ~60 candidates, but most are false positives — same-file
+      table consumers and test-only helpers — which is exactly why this needs a real tool
+      rather than a grep. Given how well the other ratchets work here, a `knip` baseline in
+      the same ratcheted style would fit the codebase's existing idiom.
+- [ ] **Do not refactor `src/main/llm/apply-dispatch.ts`.** Recorded deliberately because it
+      is 499 lines and will keep showing up on size-sorted lists. `:30-58` is a typed
+      `PayloadHandler` registry with rollback-data inference, `:86-123` a clean
+      ordered-apply-with-reverse-rollback, `:137-464` ten self-contained handler literals.
+      Splitting into `payload-handlers/*.ts` would convert compile-time registration into
+      import-for-side-effect ordering — a downgrade.
+
+---
+
+## Risk Assessment
+
+### Safe Refactorings (Low Risk)
+
+Type-only, delete-only, or mechanically verified; the existing gates catch a mistake.
+
+| Item | Why it's safe | What catches a regression |
+|---|---|---|
+| `client.ts` `on*` → `() => void` | No runtime change; preload already returns the function | `tsc --noEmit` + `tests/preload/preload-bridge.test.ts` snapshot |
+| Delete the 4 dead exports | Zero references verified across `src/` + `tests/` | `tsc --noEmit`; `no-cycles` unaffected |
+| Drop `export` on the 9 `insertVegaLite*` | Single in-file consumer | `tsc --noEmit` |
+| `DAY_MS` de-dup, `package.json` script naming | Value-identical | existing suites |
+| `escapeHtml` / `escapeRegex` / `stripFrontmatter` hoist | Pure functions; diff each body before merging | `tests/renderer/preview/text.test.ts`, publish exporter suites (`csl.test.ts` 758 lines, `static-site.test.ts` 490) |
+| `fileAndApprove` / `approveFrom` extraction | Behaviour-preserving except the `applied: true` bug, which is the point | `tests/main/llm/conversation-drafts-flow.test.ts`, `tests/renderer/stores/conversations-store.test.ts` (823 lines) |
+| `menu/accelerators.ts` move | Pure, Electron-free | `tests/main/menu-accelerators.test.ts` (and it gets simpler) |
+| `temp-project.ts` adoption | Test-only; a wrong conversion fails immediately | the converted test itself |
+| `IGNORED_DIRS` consolidation | Set-equality is checkable by eye; the 15 inline variants need per-site confirmation that policies really match | `tests/main/notebase/*`, `graph/*`, `search/*` — but see Moderate below |
+| Ratchet-scope extensions (`.catch` regex, renderer/shared scan) | Adding a baseline can only fail loudly | the ratchet itself |
+| Delete or re-wire `UnlinkedMentions` + `link-suggestions` store | Zero source importers verified; only its own test references it | `tsc --noEmit`, `svelte-check`; deleting the test with it is the point |
+| `SettingsDialog` `notes` tab extraction | 8 of 9 sibling tabs already prove the pattern | `svelte-check` + the settings render tests |
+
+### Moderate Risk
+
+| Item | Risk | Mitigation |
+|---|---|---|
+| `resolveBaseUri` config fix | Touches project bootstrap; a wrong merge could leave `baseUri` unset and break every graph URI | Add a test asserting `displayName` survives a `baseUri` coin *and* a corrupt-config read; `tests/main/project-config.test.ts` covers the safe writer already |
+| `withRootPathOr(undefined) → withRootPath` on 4 writes | Callers now get a rejected promise where they got silent success; each renderer call site needs a `catch` | `tests/main/ipc/no-project-contract.test.ts` is the existing template for exactly this assertion (`:163`) |
+| `health-checks` `running` per-project | Concurrency semantics; a wrong key reintroduces the cross-project stomp instead of fixing it | `tests/main/graph/health-checks.test.ts` exists but is single-project — add a two-project case first |
+| `IGNORED_DIRS` unification across the 15 inline sites | The two policies are **not** identical: `IGNORED_DIRS` names four dirs, the inline form is `startsWith('.') || === 'node_modules'`. Merging naively changes what gets indexed | Land the shared constant first, then convert call sites one at a time, each with its own test |
+| `indexers/frontmatter.ts` split | Large move in a coverage-floored tree (`src/main/graph/**`: 80 L / 80 F / 78 S / 62 B) | Pure move with no logic edits; run `pnpm coverage` in the same PR |
+| `createWatchHandlers` extraction | Watcher paths are timing-sensitive and partly untested | `tests/main/notebase/watcher.test.ts` covers the watcher, not these handlers — write the handler test as part of the extraction, which is the payoff |
+| `withSourceMutation` + multi-window broadcast | Changes observable behaviour (more windows refresh) — that is the fix, but it is a behaviour change | `tests/main/ipc/register-sources.test.ts` (746 lines) |
+| `ui/Dialog.svelte` adoption | Visual regression across 30 dialogs if migrated in bulk | Migrate 2-3 per PR starting with `PromptDialog`/`ConfirmDialog`; `tests/renderer/a11y/` + the axe helpers exist; **do not** change any dialog's affordances — CLAUDE.md's UX philosophy (no danger styling, dismissable confirms, "Don't ask again") must survive unchanged |
+| `markdown-config.ts` `installFences` | Renderer output is snapshot-adjacent | `tests/renderer/preview/markdown-config.test.ts`, `hydrate.test.ts` (519 lines) |
+| Editor-store session-persistence extraction | 1,017-line function with 18 call sites; the `src/renderer/**` aggregate floor plus per-file floors apply | Two large suites already cover it (`editor-store.test.ts` ×2, 1,408 lines combined); merge those first so the safety net lives in one place |
+| CSS utility layer for `.context-menu` / `.field` / primary button | Svelte scoping means a global utility class behaves differently from a scoped rule; specificity shifts are easy to miss | Introduce the layer additively, migrate a handful of components per PR, keep `tests/renderer/a11y/` green |
+| `Sidebar.svelte` prop consolidation | ~40 props threaded from `App.svelte`; a mis-grouped object is a silent prop-name typo | Run `svelte-check`, not just `tsc` — CLAUDE.md is explicit that it is what catches script↔template drift |
+
+### High Risk
+
+| Item | Risk | Recommendation |
+|---|---|---|
+| Vector-store fan-out unification | Touches the graph + search + vectors write path from three call sites at once, including the LLM apply path (`apply-dispatch.ts:243-252, :262-271`). A mistake here is silent — stale embeddings look like ordinary "semantic search didn't find it" | Split into two PRs: (1) add `vectors.indexNote` to the watcher handlers with a test, (2) unify the three copies afterwards. Do **not** do both at once |
+| `Editor.svelte` / `Preview.svelte` script extraction | 1054 and 1106 lines of stateful CodeMirror/markdown-it wiring; per-file coverage floors in `vitest.config.mts` will move and must be retuned in the same PR; `svelte-check` is the only thing that catches script↔template drift | One concern per PR, budget + floor updated in the same diff, and `pnpm lint` (not just `tsc`) before every push |
+| Draft-kind channel parameterisation | Crosses all five layers and touches the approval engine's auto-approve path. The LLM write guard is fatal under test, which helps — but a mis-typed discriminant could route a payload to the wrong `operationType` | Do the six missing draft-channel tests **first**; they are the safety net this refactor needs and are valuable on their own |
+| `shared/types.ts` split | 732 lines with wide import fan-out; a careless move can create the import cycle `no-cycles.test.ts` exists to prevent | Move one cohesive group (`shared/conversation.ts`) with re-exports left behind, verify `no-cycles`, then remove the re-exports in a follow-up |
+
+---
+
+## Implementation Strategy
+
+**Phase 0 — extend the nets before moving anything (½ day).**
+The ratchets are this codebase's best asset; two cheap extensions make the rest of the work
+safer. Add the `.catch(() => <empty>)` regex to `pattern-ratchets.test.ts` and widen its
+scan to `src/renderer` + `src/shared` (3 sites today, so the baseline is nearly free).
+Establish the baseline *now*, before any refactor churns those files.
+
+**Phase 1 — correctness (2-3 days).**
+The four verified defects, smallest blast radius first, each with the test it was missing:
+`resolveBaseUri` config clobber → `health-checks` `running` key → the four
+`withRootPathOr(undefined)` writes → the vector fan-out (split into two PRs as noted).
+None of these is a refactor in the pure sense, but each one's *cause* is duplication, and
+fixing the cause is the refactor.
+
+**Phase 2 — adopt what already exists (3-4 days).**
+Nothing new gets designed in this phase, which is what makes it cheap. `ui/Dialog.svelte`
+(2-3 dialogs per PR), `temp-project.ts` (batch by directory: `tests/main/graph/` first,
+it has the most `initGraph` sites), `approveFrom` mirroring `discardFrom`, `fileAndApprove`
+finishing the 2026-08-01 review's item 5, and the `IGNORED_DIRS` constant. Delete the four
+dead exports, the `ui/` primitives that adoption does not reach, and — once someone decides
+whether the feature is wanted — `UnlinkedMentions` and its store.
+
+**Phase 3 — test the trust path (2-3 days).**
+The six untested approve-and-apply draft channels and `register-refactor`'s ten. Write
+`tests/main/ipc/register-conversation-drafts.test.ts` as a real file rather than leaning on
+`register-conversation.test.ts`. This phase is a prerequisite for Phase 5 and stands on its
+own merits against CLAUDE.md's LLM review checklist.
+
+**Phase 4 — seams in budgeted files (1 week).**
+One extraction per PR, budget lowered in the same diff (the ratchet requires it — a file
+that shrinks fails until the number is lowered). Order by payoff-per-risk:
+`menu/accelerators.ts` → `indexers/frontmatter.ts` → `installFences` in `markdown-config.ts`
+→ `createWatchHandlers` → `LinkListPanel` → `Preview.svelte` → `Editor.svelte`.
+
+**Phase 5 — structural (deferred; scope separately).**
+Draft-kind parameterisation, `shared/conversation.ts`, the logging seam, the six config
+loaders, the `readJsonFileOr` write counterpart. Each is a design decision, not a cleanup;
+each deserves an issue with a stated rationale rather than being folded into a
+refactoring sweep.
+
+**Standing rules for every PR here.** Branch first — never commit to `main`. Stage explicit
+paths, never `git add -A`. Run `pnpm lint` (the pre-push hook does, but `svelte-check` is
+what catches `.svelte` drift and it is easy to skip locally). Any `.svelte` file touched
+needs `svelte-check`; any `window.api` surface change needs
+`pnpm test tests/preload/preload-bridge.test.ts -u`; any budgeted file needs its `BUDGETS`
+entry updated in the same diff; any `website/docs/*.html` edit needs the help-corpus
+snapshot regenerated.
+
+---
+
+## Estimated Effort
+
+Ranges assume one engineer familiar with the codebase, and include writing the test that
+each item's risk row calls for. "Sessions" ≈ half-days.
+
+| Phase | Items | Effort | Notes |
+|---|---|---|---|
+| 0 — extend the ratchets | 2 | 1 session | Do this first; it is nearly free and it protects everything after |
+| 1 — correctness | 4 (5 PRs) | 4-6 sessions | Config clobber ~1 session incl. test; vector fan-out is 2 PRs |
+| 2 — adopt existing abstractions | 6 | 7-9 sessions | Dialog migration dominates (~10 PRs × ~½ session); `temp-project` conversion is mechanical but touches 175 files, so batch it; `UnlinkedMentions` is ~1 hour |
+| 3 — trust-path tests | 2 | 4-5 sessions | 16 untested channels; `register-conversation-drafts.test.ts` is the bulk |
+| 4 — seams in budgeted files | 11 | 12-15 sessions | `Editor.svelte` (component + extensions array) and the editor store are 2-3 each; coverage-floor retuning adds overhead to every one |
+| 5 — structural (deferred) | 7 | 15-20 sessions | Scope as separate issues; draft-kind parameterisation and the CSS utility layer are the largest |
+| Low-priority cleanups | 14 | 4-5 sessions | Mostly one-liners; batch several per PR |
+
+**Total for Phases 0-4: roughly 28-36 sessions (~3.5-4.5 engineer-weeks).**
+**Phase 5 + low-priority: a further 19-25 sessions, better tracked as issues than as a sweep.**
+
+Highest return per session, if only a few can be funded: Phase 0 (1 session, protects
+everything), the `client.ts` subscription-type fix (1 session, unlocks a capability that is
+currently unreachable at 103 call sites), the `resolveBaseUri` clobber (1 session, data
+loss), the six missing draft-channel tests (3 sessions, trust path), and the
+`UnlinkedMentions` decision (~1 hour — it removes a test that is currently lying to you).
+
+---
+
+### Method and limitations
+
+All metrics were produced by commands recorded in the Code Quality Metrics table; every
+`file:line` reference in the Opportunities sections points at a line actually opened during
+this review. The clone detector is a 12-line rolling hash over whitespace-normalised source,
+which finds *copied* code and does not find semantically-equivalent code written differently
+— it undercounts. The unused-export scan is a name-based grep heuristic and is reported only
+as a reason to adopt a real tool, except for the four cases individually verified. The
+longest-function scan is a brace-depth walk and is noted above to conflate factory closures
+with long procedures. A parallel deep-dive on `src/renderer/` was still running when this
+report was written; its findings were folded in only after independent re-verification,
+and two of its claims were **dropped** for failing that check — menu positioning is in fact
+already factored into a shared `src/renderer/lib/utils/menuClamp.ts` with 10 importers, and
+`adjustSubmenu` turned out to be a 3-line wrapper around it rather than duplicated logic.
+Every count in this report is the reviewer's own measurement, not a subagent's.

--- a/src/renderer/lib/components/Editor.svelte
+++ b/src/renderer/lib/components/Editor.svelte
@@ -3,16 +3,15 @@
   import EditorContextMenu from './EditorContextMenu.svelte';
   import QuickFixMenu, { type QuickFix } from './QuickFixMenu.svelte';
   import { installDismissOnClickOutside } from '../dismiss-menu';
-  import { EditorView, keymap } from '@codemirror/view';
-  import { EditorState, Prec, Compartment } from '@codemirror/state';
+  import { EditorView } from '@codemirror/view';
+  import { EditorState, Compartment } from '@codemirror/state';
   import { cmTheme, fontSizeTheme, hiddenLineNumbersTheme } from '../editor/editor-theme';
   import { getEditorSettings, saveEditorSettings, type EditorSettings } from '../editor/settings';
   import { indentUnit, foldEffect, unfoldEffect, foldedRanges } from '@codemirror/language';
   import { highlightWhitespace } from '@codemirror/view';
   import { openSearchPanel, setSearchQuery, SearchQuery } from '@codemirror/search';
-  import { autocompletion, acceptCompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
-  import { acceptCompletionEatTail, completionKeymapNoEnter } from '../editor/accept-completion-eat-tail';
-  import { historyField, indentWithTab } from '@codemirror/commands';
+  import { type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
+  import { historyField } from '@codemirror/commands';
   import { api } from '../ipc/client';
   import {
     uploadImage,
@@ -21,7 +20,6 @@
     type UploadResult,
   } from '../editor/image-upload';
   import { sortLines } from '../editor/commands';
-  import { resolveKeyBindings } from '../editor/command-registry';
   import { toggleEditorDictation } from '../editor/dictation';
   import { findLinkAt, type LinkRange } from '../editor/link-decorations';
   import { brokenNoteLinkAt } from '../editor/broken-link-decorations';
@@ -31,8 +29,6 @@
     resolveBookmarkOffsets,
     type BookmarkRef,
   } from '../editor/bookmark-gutter';
-  import { linkCompletionSource } from '../editor/link-autocomplete';
-  import { typeCreateCompletionSource } from '../editor/type-create-autocomplete';
   import type { TypeInfo } from '../../../shared/objects/type-def';
   import { planBlockLink } from '../editor/block-link';
   import { toHistorySnapshot, canRestoreHistory } from '../editor/history-snapshot';
@@ -42,6 +38,11 @@
   import { extractClaimUri } from '../../../shared/refactor/find-arguments';
   import type { EditorContextMenuState, EditorMenuOps } from '../editor/context-menu-ops';
   import { buildExtensions } from '../editor/build-extensions';
+  import { buildKeymapAndCompletion } from '../editor/build-keymap-and-completion';
+
+  import { getToolInfosByCategory } from '../tools/tool-registry';
+  import { isSourceScoped } from '../../../shared/tools/types';
+  import { groupToolsByGroup } from '../../../shared/tools/grouping';
 
   export interface CursorInfo {
     line: number;
@@ -49,10 +50,6 @@
     selectionLength: number;
     wordCount: number;
   }
-
-  import { getToolInfosByCategory } from '../tools/tool-registry';
-  import { isSourceScoped } from '../../../shared/tools/types';
-  import { groupToolsByGroup } from '../../../shared/tools/grouping';
 
   interface Props {
     /**
@@ -682,82 +679,23 @@
   }
 
   onMount(() => {
-    const resolved = resolveKeyBindings();
-    const appKeymap = Prec.highest(keymap.of([
-      { key: 'Mod-s', run: () => { onSave(); return true; } },
-      { key: 'Alt-Enter', run: openQuickFix },
-      // Tab accepts the active completion, else indents (Shift-Tab outdents).
-      // acceptCompletion returns false with no popup open, and same-key bindings
-      // run in array order, so the fall-through lands on indentWithTab. Both
-      // no-op while tab-focus mode is on (editor.toggleTabFocusMode, Ctrl-m),
-      // which is what still lets keyboard users move focus out of the editor.
-      { key: 'Tab', run: acceptCompletion },
-      indentWithTab,
-      // Enter accepts the active completion and eats the half-typed word tail
-      // (#206) — only word chars, so `[[No|te]]` → `[[Notebook]]` keeps its
-      // brackets. Returns false with no popup open, so Enter stays a newline /
-      // list-continuation. completionKeymapNoEnter restores arrow-nav and
-      // Escape that defaultKeymap:false (below) removes.
-      { key: 'Enter', run: acceptCompletionEatTail },
-      ...completionKeymapNoEnter,
-      ...resolved.map(({ key: k, command: run }) => ({ key: k, run })),
-    ]));
-
-    const updateListener = EditorView.updateListener.of((update) => {
-      if (update.docChanged && !ignoreNextUpdate) {
-        onContentChange(update.state.doc.toString());
-      }
-      ignoreNextUpdate = false;
-
-      if (update.selectionSet || update.docChanged) {
-        const { state } = update;
-        const pos = state.selection.main.head;
-        const line = state.doc.lineAt(pos);
-        const sel = state.selection.main;
-        const docText = state.doc.toString();
-        onCursorChange?.({
-          line: line.number,
-          column: pos - line.from + 1,
-          selectionLength: Math.abs(sel.to - sel.from),
-          wordCount: docText.trim() ? docText.trim().split(/\s+/).length : 0,
-        });
-      }
-    });
-
-    const linkCompletion = linkCompletionSource({
-      getNotePaths: () => getNotePaths?.() ?? [],
-      getSources: () => getSources?.() ?? [],
-      getAliases: () => getAliases?.() ?? [],
-      readNote: (p) => api.notebase.readFile(p),
-    });
-
-    // Inline `/book` typed creation (#1065). The apply removes the `/partial`,
-    // then the host prompt+create runs async and its target is linked at the
-    // same spot — type, template, and link in one gesture.
-    const typeCreateCompletion = typeCreateCompletionSource({
-      loadTypes: () => api.types.list().then((c) => c.types),
-      onPick: (type, view, from, to) => {
-        view.dispatch({ changes: { from, to, insert: '' } });
-        void resolveInlineTypeCreate?.(type).then((target) => {
-          if (!target || !view.dom.isConnected) return;
-          const link = `[[${target}]]`;
-          const at = Math.min(from, view.state.doc.length);
-          view.dispatch({ changes: { from: at, insert: link }, selection: { anchor: at + link.length } });
-        });
-      },
-    });
-
-    const completion = autocompletion({
-      override: [tagCompletion, linkCompletion, typeCreateCompletion],
-      activateOnTyping: true,
-      closeOnBlur: true,
-      // Our Enter binding (acceptCompletionEatTail) owns accept-on-Enter; the
-      // built-in one would win the tie otherwise (#206).
-      defaultKeymap: false,
+    const keymapAndCompletionExtensions = buildKeymapAndCompletion({
+      onSave,
+      openQuickFix,
+      onContentChange,
+      onCursorChange,
+      getNotePaths,
+      getSources,
+      getAliases,
+      tagCompletion,
+      resolveInlineTypeCreate,
+      plainText,
+      getIgnoreNextUpdate: () => ignoreNextUpdate,
+      setIgnoreNextUpdate: (value) => { ignoreNextUpdate = value; },
     });
 
     // Wiki-link / tag autocomplete is markdown-only (#1130).
-    const allExtensions = [...extensions, appKeymap, updateListener, ...(plainText ? [] : [completion])];
+    const allExtensions = [...extensions, ...keymapAndCompletionExtensions];
 
     // When the caller passes a history snapshot AND its serialised doc
     // still matches the current content, restore the undo/redo stacks

--- a/src/renderer/lib/editor/build-keymap-and-completion.ts
+++ b/src/renderer/lib/editor/build-keymap-and-completion.ts
@@ -1,0 +1,126 @@
+import { EditorView, keymap } from '@codemirror/view';
+import { Prec, type Extension } from '@codemirror/state';
+import { autocompletion, acceptCompletion, type CompletionContext, type CompletionResult } from '@codemirror/autocomplete';
+import { acceptCompletionEatTail, completionKeymapNoEnter } from './accept-completion-eat-tail';
+import { indentWithTab } from '@codemirror/commands';
+import { linkCompletionSource } from './link-autocomplete';
+import { typeCreateCompletionSource } from './type-create-autocomplete';
+import { resolveKeyBindings } from './command-registry';
+import { api } from '../ipc/client';
+import type { TypeInfo } from '../../../shared/objects/type-def';
+
+export interface CursorInfo {
+  line: number;
+  column: number;
+  selectionLength: number;
+  wordCount: number;
+}
+
+export interface BuildKeymapAndCompletionOptions {
+  onSave: () => void;
+  openQuickFix: (view: EditorView) => boolean;
+  onContentChange: (text: string) => void;
+  onCursorChange: ((info: CursorInfo) => void) | undefined;
+  getNotePaths: (() => string[]) | undefined;
+  getSources: (() => readonly import('../../../shared/types').SourceMetadata[]) | undefined;
+  getAliases: (() => readonly { alias: string; relativePath: string }[]) | undefined;
+  tagCompletion: (context: CompletionContext) => Promise<CompletionResult | null>;
+  resolveInlineTypeCreate: ((type: TypeInfo) => Promise<string | null>) | undefined;
+  plainText: boolean;
+  getIgnoreNextUpdate: () => boolean;
+  setIgnoreNextUpdate: (value: boolean) => void;
+}
+
+export function buildKeymapAndCompletion(opts: BuildKeymapAndCompletionOptions): Extension[] {
+  const {
+    onSave,
+    openQuickFix,
+    onContentChange,
+    onCursorChange,
+    getNotePaths,
+    getSources,
+    getAliases,
+    tagCompletion,
+    resolveInlineTypeCreate,
+    plainText,
+    getIgnoreNextUpdate,
+    setIgnoreNextUpdate,
+  } = opts;
+
+  const resolved = resolveKeyBindings();
+  const appKeymap = Prec.highest(keymap.of([
+    { key: 'Mod-s', run: () => { onSave(); return true; } },
+    { key: 'Alt-Enter', run: (view) => view ? openQuickFix(view) : false },
+    // Tab accepts the active completion, else indents (Shift-Tab outdents).
+    // acceptCompletion returns false with no popup open, and same-key bindings
+    // run in array order, so the fall-through lands on indentWithTab. Both
+    // no-op while tab-focus mode is on (editor.toggleTabFocusMode, Ctrl-m),
+    // which is what still lets keyboard users move focus out of the editor.
+    { key: 'Tab', run: acceptCompletion },
+    indentWithTab,
+    // Enter accepts the active completion and eats the half-typed word tail
+    // (#206) — only word chars, so `[[No|te]]` → `[[Notebook]]` keeps its
+    // brackets. Returns false with no popup open, so Enter stays a newline /
+    // list-continuation. completionKeymapNoEnter restores arrow-nav and
+    // Escape that defaultKeymap:false (below) removes.
+    { key: 'Enter', run: acceptCompletionEatTail },
+    ...completionKeymapNoEnter,
+    ...resolved.map(({ key: k, command: run }) => ({ key: k, run })),
+  ]));
+
+  const updateListener = EditorView.updateListener.of((update) => {
+    if (update.docChanged && !getIgnoreNextUpdate()) {
+      onContentChange(update.state.doc.toString());
+    }
+    setIgnoreNextUpdate(false);
+
+    if (update.selectionSet || update.docChanged) {
+      const { state } = update;
+      const pos = state.selection.main.head;
+      const line = state.doc.lineAt(pos);
+      const sel = state.selection.main;
+      const docText = state.doc.toString();
+      onCursorChange?.({
+        line: line.number,
+        column: pos - line.from + 1,
+        selectionLength: Math.abs(sel.to - sel.from),
+        wordCount: docText.trim() ? docText.trim().split(/\s+/).length : 0,
+      });
+    }
+  });
+
+  const linkCompletion = linkCompletionSource({
+    getNotePaths: () => getNotePaths?.() ?? [],
+    getSources: () => getSources?.() ?? [],
+    getAliases: () => getAliases?.() ?? [],
+    readNote: (p) => api.notebase.readFile(p),
+  });
+
+  // Inline `/book` typed creation (#1065). The apply removes the `/partial`,
+  // then the host prompt+create runs async and its target is linked at the
+  // same spot — type, template, and link in one gesture.
+  const typeCreateCompletion = typeCreateCompletionSource({
+    loadTypes: () => api.types.list().then((c) => c.types),
+    onPick: (type, view, from, to) => {
+      view.dispatch({ changes: { from, to, insert: '' } });
+      void resolveInlineTypeCreate?.(type).then((target) => {
+        if (!target || !view.dom.isConnected) return;
+        const link = `[[${target}]]`;
+        const at = Math.min(from, view.state.doc.length);
+        view.dispatch({ changes: { from: at, insert: link }, selection: { anchor: at + link.length } });
+      });
+    },
+  });
+
+  const completion = autocompletion({
+    override: [tagCompletion, linkCompletion, typeCreateCompletion],
+    activateOnTyping: true,
+    closeOnBlur: true,
+    // Our Enter binding (acceptCompletionEatTail) owns accept-on-Enter; the
+    // built-in one would win the tie otherwise (#206).
+    defaultKeymap: false,
+  });
+
+  // Wiki-link / tag autocomplete is markdown-only (#1130).
+  return [appKeymap, updateListener, ...(plainText ? [] : [completion])];
+}

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -60,7 +60,7 @@ const BUDGETS: Record<string, number> = {
   'src/renderer/lib/components/SourcesPanel.svelte': 1297,
   'src/renderer/lib/ipc/client.ts': 1239,
   'src/renderer/lib/stores/conversations.svelte.ts': 1212,
-  'src/renderer/lib/components/Editor.svelte': 1024,
+  'src/renderer/lib/components/Editor.svelte': 962,
   'src/renderer/lib/stores/editor.svelte.ts': 1183,
     'src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte': 1156,
   'src/main/menu.ts': 1072,


### PR DESCRIPTION
## Summary

Extracts the 75-line keymap, update listener, and completion source building logic from `Editor.svelte`'s `onMount` hook into a new pure function `buildKeymapAndCompletion()` in `src/renderer/lib/editor/build-keymap-and-completion.ts`. This is the second seam in the broader CodeMirror extraction effort (issue #1903).

## What Changed

**New file: `src/renderer/lib/editor/build-keymap-and-completion.ts`** (126 lines)
- Exports `buildKeymapAndCompletion(opts: BuildKeymapAndCompletionOptions): Extension[]`
- Pure function containing exactly the logic from Editor.svelte's onMount:
  - Keymap building with command-registry resolution (Mod-s/Alt-Enter/Tab/Enter handling)
  - Update listener for doc-change and cursor-position tracking
  - Completion source building (tag/link/type-create completion)
  - Autocompletion configuration
- Captures closure-dependent state through structured options interface:
  - Callbacks for app events (onSave, openQuickFix, onContentChange, onCursorChange)
  - Completion source config (getNotePaths, getSources, getAliases, resolveInlineTypeCreate)
  - Accessors for mutable state (getIgnoreNextUpdate, setIgnoreNextUpdate)
  - The tagCompletion function + plainText flag

**Modified: `src/renderer/lib/components/Editor.svelte`**
- Replaced 75-line inline keymap/completion/update-listener building with a single call to `buildKeymapAndCompletion({...})`
- Removed now-internal imports: keymap, Prec, autocompletion, acceptCompletion, CompletionContext, CompletionResult, acceptCompletionEatTail, completionKeymapNoEnter, indentWithTab, resolveKeyBindings, linkCompletionSource, typeCreateCompletionSource
- No behavior changes — keymap and completion built identically

## Extraction History

This is the second seam of issue #1903 (broader CodeMirror extraction):
- **#1921 (PR #1957)**: Extracted 196-line extensions array → Editor.svelte 1208 → 1024 (−184 lines)
- **#1903 Phase 1 (this PR)**: Extracted 75-line keymap/completion → Editor.svelte 1024 → 962 (−62 lines)
- **Total progress**: 1208 → 962 (−246 lines, 20.3% reduction from pre-#1921 baseline)

## Metrics

- **Editor.svelte**: 1024 → 962 lines (−62 lines, 6.0% reduction)
- **build-keymap-and-completion.ts**: 126 lines (created, under 600-line threshold)
- File-size budget updated in same diff
- All 625 test files pass (6827 tests)

## Verification

- ✅ `pnpm lint` passes (tsc, svelte-check, eslint)
- ✅ `pnpm test` passes (625 test files, 6827 tests)
- ✅ File-size budgets ratcheted down for Editor.svelte
- ✅ No behavior regression — keymap, update listener, and completion built identically
- ✅ Pre-push hooks pass

## Related Issues

- Closes one seam of #1903 (extracts keymap/completion)
- Builds on #1921 (extensions array extraction, PR #1957)
- Remaining seams for #1903: context menu operations block