### PR TITLE
ci: add pnpm lint:fonts to CI pipeline (issue #1940)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Lint (tsc + svelte-check + eslint)
         run: pnpm lint
 
+      - name: Lint fonts
+        run: pnpm lint:fonts
+
       # `pnpm coverage` runs the full suite with v8 instrumentation and enforces
       # the per-area thresholds in vitest.config (src/shared, src/main/llm,
       # src/main/notebase) — so the trust + security paths can't silently


### PR DESCRIPTION
## Summary

Adds the font linting step to the CI pipeline so hardcoded font references can't bypass the check via pre-push hook bypasses, fork PRs, or when git hooks aren't set up.

## What Changed

- Added `pnpm lint:fonts` step to lint-and-test job in .github/workflows/ci.yml
- Runs after main lint step, catches any hardcoded SF Mono/Fira Code/SFMono-Regular/Cascadia references
- Ensures consistent use of CSS font variables per appearance/settings.ts

## Issue

Previously `pnpm lint:fonts` only ran in pre-push hooks (.githooks/pre-push), leaving a gap for:
- `git push --no-verify` bypasses
- Fork PRs that don't run pre-push hooks
- Environments where git hooks aren't set up

Closes #1940