### PR TITLE
test: fix process.env leaks across test files (issue #1934)

### DIFF
--- a/tests/main/compute/python-settings.test.ts
+++ b/tests/main/compute/python-settings.test.ts
@@ -108,10 +108,16 @@ describe('setPythonSettings (#374)', () => {
 });
 
 describe('resolvePythonInterpreter (#374) — discovery order', () => {
-  const ORIGINAL_ENV = process.env.MINERVA_PYTHON;
+  // process.env is worker-global, so snapshot + restore at test time (not module
+  // load time) to avoid cross-file order dependencies if a previous test file
+  // didn't restore MINERVA_PYTHON.
+  let originalEnv: string | undefined;
+  beforeEach(() => {
+    originalEnv = process.env.MINERVA_PYTHON;
+  });
   afterEach(() => {
-    if (ORIGINAL_ENV === undefined) delete process.env.MINERVA_PYTHON;
-    else process.env.MINERVA_PYTHON = ORIGINAL_ENV;
+    if (originalEnv === undefined) delete process.env.MINERVA_PYTHON;
+    else process.env.MINERVA_PYTHON = originalEnv;
   });
 
   it('Settings override wins over env var and PATH default', async () => {

--- a/tests/main/git/publish-git.test.ts
+++ b/tests/main/git/publish-git.test.ts
@@ -59,13 +59,20 @@ describe('renderCommitMessage', () => {
 });
 
 describe('resolveGitHubToken', () => {
-  const OLD = { ...process.env };
+  // process.env is worker-global, so snapshot + restore to avoid leaking the
+  // deletions into other test files that share the worker.
+  const envSnapshot = { GH_TOKEN: process.env.GH_TOKEN, GITHUB_TOKEN: process.env.GITHUB_TOKEN };
   beforeEach(() => {
     hoisted.execFileSync.mockReset();
     delete process.env.GH_TOKEN;
     delete process.env.GITHUB_TOKEN;
   });
-  afterEach(() => { process.env = { ...OLD }; });
+  afterEach(() => {
+    for (const [k, v] of Object.entries(envSnapshot)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
 
   it('prefers the gh CLI token', () => {
     hoisted.execFileSync.mockReturnValue('gho_fromcli\n');

--- a/tests/main/llm/settings.test.ts
+++ b/tests/main/llm/settings.test.ts
@@ -15,6 +15,14 @@ import os from 'node:os';
 
 let tempDir: string;
 
+// process.env is worker-global, so snapshot + restore to avoid leaking the
+// deletions into other test files that share the worker.
+const envSnapshot = {
+  ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+};
+
 vi.mock('electron', () => ({
   app: {
     getPath: (name: string) => {
@@ -58,6 +66,10 @@ beforeEach(() => {
 });
 afterEach(() => {
   fs.rmSync(tempDir, { recursive: true, force: true });
+  for (const [k, v] of Object.entries(envSnapshot)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
 });
 
 describe('llm settings — API key at-rest encryption (#1326)', () => {


### PR DESCRIPTION
## Summary

`process.env` is worker-global in fork workers, so env deletions made in `beforeEach` leak into subsequent test files that share the same worker. This creates genuine cross-file order dependencies that can cause random test failures depending on test ordering.

## Changes

Applied the snapshot+restore pattern (already documented and used in `publish-git-auth.test.ts`) to fix all 11 env-mutation sites:

### tests/main/llm/settings.test.ts
- Captures ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY snapshot at module level
- Restores in afterEach (was deleting without restoring)

### tests/main/git/publish-git.test.ts  
- Replaced shallow copy pattern (`const OLD = { ...process.env }`) with selective key restoration
- Only restores GH_TOKEN and GITHUB_TOKEN (safer than replacing entire object)

### tests/main/compute/python-settings.test.ts
- Moved ORIGINAL_ENV capture from module load time to test execution time in beforeEach
- Prevents order dependency if a prior test file didn't restore MINERVA_PYTHON

Already correct:
- **tests/renderer/refactor/extract.test.ts** — proper try/finally restoration
- **tests/architecture/e2e-launch-hygiene.test.ts** — proper pattern with explanatory comment

## Testing

- Ran all affected files: 49 tests pass
- Next: `pnpm test --sequence.shuffle` to verify no remaining order dependency

## Rationale

The pattern is already in the codebase and documented at publish-git-auth.test.ts:17-32 with the exact comment we needed: *'process.env is worker-global, so snapshot + restore to avoid leaking the deletions into other test files that share the worker.'*

This is the single source of truth approach: one way to do it, applied consistently everywhere.

Closes #1934