### PR TITLE
test: add boolean-overload ratchet for pattern-ratchets.test.ts (issue #1930)

### DIFF
--- a/tests/architecture/pattern-ratchets.test.ts
+++ b/tests/architecture/pattern-ratchets.test.ts
@@ -181,11 +181,34 @@ const NO_PROJECT_NULL_BASELINE: Record<string, number> = {
   'src/main/ipc/register-graph.ts': 1,
 };
 
+// ── Ratchet 3: boolean overloads ────────────────────────────────────────────
+
+/**
+ * `withRootPathOr(false, …)` or `withRootPathOr(0, …)` or `withRootPathOr(true, …)` —
+ * the handler answers a primitive (boolean/number) when no project is open, and its
+ * domain call answers the same type for a different reason (operation failed, no
+ * results, etc.), so the caller cannot tell them apart. CLAUDE.md rule 5: a sentinel
+ * marks exactly ONE expected absence.
+ *
+ * The pattern to catch: `withRootPathOr(false|true|0|1, ...)` — a primitive fallback
+ * that lacks semantic context (unlike { ok: false; error } which is a discriminated
+ * union). This regex skips over the optional generic type (which may have nested
+ * angle brackets) and finds the fallback value directly. It finds the common case
+ * but may miss variants written across multiple lines or using variables.
+ */
+const BOOLEAN_OVERLOAD = /withRootPathOr[^(]*\(\s*(?:false|true|0|1)\s*[,)]/g;
+
+const BOOLEAN_OVERLOAD_BASELINE: Record<string, number> = {
+  'src/main/ipc/register-notebase.ts': 1,
+  'src/main/ipc/register-proposals.ts': 3,
+};
+
 describe('known-bad pattern ratchets (#1848)', () => {
   it('the scanners still find things — a broken regex would pass vacuously', () => {
-    // The failure mode that would quietly turn both ratchets into decoration.
+    // The failure mode that would quietly turn all ratchets into decoration.
     expect(Object.keys(countPerFile('src/main', SWALLOW)).length).toBeGreaterThan(20);
     expect(Object.keys(countPerFile('src/main', NO_PROJECT_NULL)).length).toBeGreaterThan(0);
+    expect(Object.keys(countPerFile('src/main', BOOLEAN_OVERLOAD)).length).toBeGreaterThan(0);
   });
 
   it('swallowed errors: no new ones', () => {
@@ -208,6 +231,18 @@ describe('known-bad pattern ratchets (#1848)', () => {
       'Use `withRootPath` so "no project open" throws, leaving `null` to mean only "not found" ' +
       '(CLAUDE.md rules 2 and 5). `withRootPathOr` is for handlers whose project-less answer is a ' +
       'legitimate value — an empty list a UI renders as "nothing yet" — not a way to signal failure.',
+    );
+  });
+
+  it('boolean overloads: no new ones', () => {
+    assertRatchet(
+      'Boolean/numeric overloads (withRootPathOr(false|true|0|1, …))',
+      BOOLEAN_OVERLOAD_BASELINE,
+      countPerFile('src/main', BOOLEAN_OVERLOAD),
+      'A primitive fallback (false, true, 0, 1) when no project is open conflates "no project" ' +
+      'with operation failure/no results. Use a discriminated union ({ ok: false; error: "..." }) ' +
+      'instead, or a unique sentinel. See CLAUDE.md IPC error handling rule 3: discriminated `{ ok, … }` ' +
+      'unions for expected multi-outcome paths. Rule 5: a sentinel marks exactly one expected absence.',
     );
   });
 });


### PR DESCRIPTION
## Summary

Added Ratchet 3 (boolean overload) to pattern-ratchets.test.ts, completing the gate enforcement for the three most critical anti-patterns from CLAUDE.md's IPC error handling section. This prevents new boolean/numeric overloads in `withRootPathOr` fallbacks from landing without explicit decision.

## Pattern Caught

`withRootPathOr(false|true|0|1, ...)` — a primitive fallback that conflates 'no project' with operation failure or 'no results', making them indistinguishable to callers.

## Baseline

4 instances, all acknowledged in CLAUDE.md's migration backlog:

| File | Count | Channel |
|------|-------|---------|
| register-notebase.ts | 1 | NOTEBASE_GET_ONBOARDING_DISMISSED (false) |
| register-proposals.ts | 3 | PROPOSAL_APPROVE (false), PROPOSAL_REJECT (false), PROPOSAL_EXPIRE (0) |

## Implementation Notes

The regex `/withRootPathOr[^(]*\(\s*(?:false|true|0|1)\s*[,)]/g` skips over optional generic types (which can have nested angle brackets like `Promise<boolean>`) and matches the fallback value directly. It finds the common case but may miss variants written across multiple lines or using variables (acknowledged in the comment).

## Progression

This completes the ratchet coverage for confirmed patterns:
- **Ratchet 1** (Swallow): 38 files × ~1 instance each, baseline held since #1848
- **Ratchet 2** (no-project-null): 1 file, baseline held since #1841  
- **Ratchet 3** (boolean-overload): 2 files × 4 instances, NEW

## Why It Matters

The pattern-ratchets mechanism turns prose guidelines (CLAUDE.md's migration backlog) into executable gates — new instances fail CI unless explicitly baselined. Before this, new boolean overloads could land silently. Now they fail a test, forcing a deliberate decision in the diff.

## Testing

All 4 tests pass (swallow, no-project-null, boolean-overload, vacuity check).

Closes #1930