### PR TITLE
fix: assert guard condition in path-sandbox test

### DIFF
--- a/tests/main/notebase/fs.test.ts
+++ b/tests/main/notebase/fs.test.ts
@@ -109,9 +109,9 @@ describe('listFiles', () => {
     const files = await listFiles(root);
     const firstFile = files.findIndex((f) => !f.isDirectory);
     const lastDir = files.findLastIndex((f) => f.isDirectory);
-    if (firstFile >= 0 && lastDir >= 0) {
-      expect(lastDir).toBeLessThan(firstFile);
-    }
+    expect(firstFile).toBeGreaterThanOrEqual(0);
+    expect(lastDir).toBeGreaterThanOrEqual(0);
+    expect(lastDir).toBeLessThan(firstFile);
   });
 
   it('ignores .minerva directory', async () => {


### PR DESCRIPTION
## Summary
- The "sorts directories before files" test in `tests/main/notebase/fs.test.ts` had a vacuous conditional assertion — if `listFiles` regressed to returning only directories, only files, or an empty array, the test stayed green.
- Now explicitly asserts both a file and a directory exist in the result before checking sort order, so the guard condition is asserted rather than assumed.

Fixes #1936

## Test plan
- [x] `pnpm test tests/main/notebase/fs.test.ts` passes
- [x] `pnpm lint` passes (verified via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)