### PR TITLE
fix: three tests assert their stated outcome, not just not.toThrow()

### DIFF
--- a/tests/renderer/markdown/vega-renderer.test.ts
+++ b/tests/renderer/markdown/vega-renderer.test.ts
@@ -89,9 +89,9 @@ describe('findUrlRefs (vega remote-data guardrail)', () => {
   it('does not blow the stack / loop forever on deep nesting', () => {
     let deep: Record<string, unknown> = { url: 'https://leaf.test/x.json' };
     for (let i = 0; i < 200; i++) deep = { nested: deep };
-    // Depth guard caps recursion at 64; a url below that is simply not reached.
-    // The point is it returns without throwing.
-    expect(() => urls(deep)).not.toThrow();
+    // Depth guard caps recursion at 64; the leaf url sits well below that,
+    // so it must not be reached.
+    expect(urls(deep)).toEqual([]);
   });
 });
 

--- a/tests/renderer/preview/hydrate.test.ts
+++ b/tests/renderer/preview/hydrate.test.ts
@@ -104,7 +104,9 @@ describe('highlightCodeBlocks', () => {
 
   it('returns early when there are no un-highlighted code blocks', () => {
     const root = div('<p>no code here</p>');
-    expect(() => highlightCodeBlocks(makeCtx(root))).not.toThrow();
+    const before = root.innerHTML;
+    highlightCodeBlocks(makeCtx(root));
+    expect(root.innerHTML).toBe(before);
   });
 
   it('highlights a known-language block synchronously and marks it data-hl', () => {

--- a/tests/shared/sql-format.test.ts
+++ b/tests/shared/sql-format.test.ts
@@ -37,11 +37,9 @@ DESCRIBE YOUR_TABLE;`,
   });
 
   it('falls back to the original text on a parser error', () => {
-    // sql-formatter is forgiving, but if it ever throws the helper
+    // sql-formatter throws on this deeply malformed string; the helper
     // must surface the original so a half-typed query isn't destroyed.
-    // Probe with a deeply malformed string that sql-formatter either
-    // handles or throws on — either way the contract holds.
     const input = 'SELECT (((';
-    expect(() => formatSql(input)).not.toThrow();
+    expect(formatSql(input)).toBe(input);
   });
 });


### PR DESCRIPTION
## Summary
Three tests only asserted `not.toThrow()` where their name/comment states a stronger expectation that wasn't actually being checked:

- `tests/shared/sql-format.test.ts` — "falls back to the original text on a parser error" now asserts `formatSql(input)` equals the original input, not just that it doesn't throw.
- `tests/renderer/markdown/vega-renderer.test.ts` — the depth-guard test now asserts the result is `[]`. Verified this fails if the depth guard is weakened (a network-egress guard).
- `tests/renderer/preview/hydrate.test.ts` — "returns early when there are no un-highlighted code blocks" now asserts the DOM's innerHTML is unchanged.

Fixes #1937

## Test plan
- [x] All three tests pass: `pnpm test tests/shared/sql-format.test.ts tests/renderer/markdown/vega-renderer.test.ts tests/renderer/preview/hydrate.test.ts`
- [x] Manually verified the vega-renderer test fails when the depth guard is weakened (temporarily bumped the cap, confirmed red, reverted)
- [x] `pnpm lint` passes (verified via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)