### PR TITLE
test: delete literal tautology in guid.test.ts

### DIFF
--- a/tests/shared/flashcards/guid.test.ts
+++ b/tests/shared/flashcards/guid.test.ts
@@ -87,10 +87,6 @@ describe('idempotency contract (the make-or-break)', () => {
     return collectCards(content, notePath).cards.map((c) => cardGuid(notePath, c.id!));
   }
 
-  it('re-exporting unchanged cards yields identical guids', () => {
-    expect(guidsOf(persisted)).toEqual(guidsOf(persisted));
-  });
-
   it('editing a card\'s text preserves its guid (Anki updates, keeps history)', () => {
     const edited = persisted.replace('hello', 'hello (greeting)');
     const before = guidsOf(persisted);


### PR DESCRIPTION
## Summary
- (a) `tests/shared/flashcards/guid.test.ts` — deleted "re-exporting unchanged cards yields identical guids", which asserted `guidsOf(persisted)` equals itself (identical expression on both sides, can never fail). Determinism is already covered by the `cardGuid` describe block, and the meaningful case (guid stability across an edit) is the very next test.
- (b) `tests/main/graph/health-checks.test.ts` tautology — already resolved by #1927's rewrite (merged in `ac832258`), which replaced the fake-test file with real assertions against `runAllChecks`. No further action needed here.

Fixes #1938

## Test plan
- [x] `pnpm test tests/shared/flashcards/guid.test.ts` passes (14 tests)
- [x] `pnpm lint` passes (verified via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)