### PR TITLE
test: assert unchanged state, not just not.toThrow(), on four no-op tests

### DIFF
--- a/tests/main/compute/python-kernel.test.ts
+++ b/tests/main/compute/python-kernel.test.ts
@@ -207,11 +207,23 @@ skipIfNoPython('python kernel (#241)', () => {
     }
   });
 
-  it('invalidate(): no-op when no kernel is running', () => {
-    // Should not throw. The function silently returns when the project
-    // has no live kernel — the watcher fires invalidate eagerly on
-    // every .py write regardless of whether a kernel has spawned yet.
-    expect(() => invalidate('/tmp/no-kernel-for-this-root-' + Date.now(), ['x.py'])).not.toThrow();
+  it('invalidate(): no-op when no kernel is running', async () => {
+    // The function silently returns when the project has no live kernel —
+    // the watcher fires invalidate eagerly on every .py write regardless of
+    // whether a kernel has spawned yet. A real kernel for another project
+    // must survive untouched.
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'minerva-py-invalidate-'));
+    try {
+      await runPython(projectRoot, 'noop.md', '1');
+      invalidate('/tmp/no-kernel-for-this-root-' + Date.now(), ['x.py']);
+      const after = await runPython(projectRoot, 'noop.md', '2 + 2');
+      expect(after.ok).toBe(true);
+      if (!after.ok || after.output.type !== 'json') return;
+      expect(after.output.value).toBe(4);
+    } finally {
+      await stopKernel(projectRoot);
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
   });
 
   it('invalidate(): walks submodules under a package prefix', async () => {

--- a/tests/main/ipc/register-compute.test.ts
+++ b/tests/main/ipc/register-compute.test.ts
@@ -305,7 +305,12 @@ describe('COMPUTE_CONSENT_STATUS / GRANT / LIST / REVOKE', () => {
   });
 
   it('revoking a thoughtbase that was never trusted is a no-op, not an error', () => {
-    expect(() => call(Channels.COMPUTE_REVOKE_CONSENT, '/never-seen')).not.toThrow();
+    call(Channels.COMPUTE_GRANT_CONSENT, 'python', 'print(1)', 'project');
+    call(Channels.COMPUTE_REVOKE_CONSENT, '/never-seen');
+    // The unrelated root's consent record must survive untouched.
+    expect(call(Channels.COMPUTE_LIST_CONSENT)).toEqual([
+      { rootPath: ROOT, blanket: true, cellCount: 0 },
+    ]);
   });
 
   it('hashes are stored, not the code itself', () => {

--- a/tests/main/notebase/watcher.test.ts
+++ b/tests/main/notebase/watcher.test.ts
@@ -452,8 +452,20 @@ describe('startWatching() (#345)', () => {
       expect(created).toEqual([]);
     });
 
-    it('stopWatching on an unknown id is a no-op (no throw)', () => {
-      expect(() => stopWatching(98765)).not.toThrow();
+    it('stopWatching on an unknown id is a no-op — other watchers keep running', async () => {
+      const created: string[] = [];
+      await startWatching(root, win as unknown as BrowserWindow, winId, {
+        onFileCreated: (p) => created.push(p),
+        onFileChanged: () => undefined,
+        onFileDeleted: () => undefined,
+      });
+
+      stopWatching(98765);
+
+      // The real watcher on `winId` must still be attached and firing.
+      await fsp.writeFile(path.join(root, 'still-watching.md'), 'x\n', 'utf-8');
+      await waitFor(() => created.length > 0);
+      expect(created).toEqual(['still-watching.md']);
     });
 
     it('startWatching twice on the same id replaces the previous watcher', async () => {

--- a/tests/main/search/minisearch-provider.test.ts
+++ b/tests/main/search/minisearch-provider.test.ts
@@ -97,9 +97,12 @@ describe('MiniSearchProvider', () => {
       expect(await p.search('Test')).toEqual([]);
     });
 
-    it('is a no-op for non-existent document', () => {
+    it('is a no-op for non-existent document', async () => {
       const p = createProvider();
-      expect(() => p.remove('nonexistent.md')).not.toThrow();
+      write(p, 'note.md', 'Test', 'Content');
+      p.remove('nonexistent.md');
+      // The real document must survive untouched.
+      expect(await p.search('Test')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## Summary
Four tests asserted a "no-op" invariant using only `not.toThrow()` — a handler that wiped unrelated state would still pass:

- `tests/main/ipc/register-compute.test.ts` — "revoking a thoughtbase that was never trusted is a no-op" now asserts another root's real consent record (blanket trust) survives untouched. This is the flagship case from the issue: a handler that wiped *all* consent records on an unknown root would have passed the old test — a compute-trust failure, not a cosmetic one.
- `tests/main/notebase/watcher.test.ts` — `stopWatching` on an unknown id now asserts the real watcher for a known id keeps firing `onFileCreated` afterward.
- `tests/main/search/minisearch-provider.test.ts` — `remove()` on a non-existent doc now asserts a real indexed document is still findable afterward.
- `tests/main/compute/python-kernel.test.ts` — `invalidate()` with no kernel running for that root now asserts a real kernel for a different project root keeps executing afterward.

Fixes #1939

## Test plan
- [x] All four files pass: `pnpm test tests/main/ipc/register-compute.test.ts tests/main/notebase/watcher.test.ts tests/main/search/minisearch-provider.test.ts tests/main/compute/python-kernel.test.ts` (101 tests)
- [x] `pnpm lint` passes (verified via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)