### PR TITLE
test: remove timing- and timezone-sensitive flakiness across suites

### DIFF
--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -137,7 +137,10 @@ test('workspace (sidebar + editor): no NEW serious a11y violations (real-browser
     await bootDarkTheme(win);
     // Session restore replaces the welcome screen with the workspace.
     await expect(win.getByRole('button', { name: 'Open Thoughtbase' })).toHaveCount(0, { timeout: 25_000 });
-    await win.waitForTimeout(500); // let the sidebar tree + panels settle
+    // Wait for the sidebar tree to actually render, not a fixed guess at how
+    // long that takes — a loaded runner needs more real time, and a fixed
+    // sleep either scans too early (spurious violation) or wastes time.
+    await expect(win.locator('[data-relative-path]').first()).toBeVisible({ timeout: 10_000 });
 
     // Sidebar + shell.
     const shell = await runAxe(win);
@@ -149,7 +152,7 @@ test('workspace (sidebar + editor): no NEW serious a11y violations (real-browser
     const firstFile = win.locator('[data-relative-path$=".md"]').first();
     if (await firstFile.count()) {
       await firstFile.click();
-      await win.waitForTimeout(500);
+      await expect(win.locator('.cm-content')).toBeVisible({ timeout: 10_000 });
       const withEditor = await runAxe(win);
       reportKnown('workspace+editor', withEditor, KNOWN_WORKSPACE);
       const editorRegressions = unexpected(withEditor, KNOWN_WORKSPACE);
@@ -196,11 +199,13 @@ test('source viewer: no NEW serious a11y violations (real-browser, incl. color-c
     // Switch the left sidebar to Sources and open the first source into the
     // SourceDetail viewer (`.source-item` click → editor.openSource → tab).
     await win.getByTitle('Sources', { exact: true }).click();
-    await win.waitForTimeout(400);
     const firstSource = win.locator('.source-item').first();
+    await expect(firstSource).toBeVisible({ timeout: 10_000 });
     await firstSource.click();
     await expect(win.locator('.source-detail')).toBeVisible({ timeout: 10_000 });
-    await win.waitForTimeout(500); // let the excerpt list + preview settle
+    // Wait for the markdown body to actually render, not a fixed guess at
+    // how long the fetch + Preview render takes.
+    await expect(win.locator('.body-view')).toBeVisible({ timeout: 10_000 });
 
     const violations = await runAxe(win);
     reportKnown('source viewer', violations, KNOWN_SOURCE);
@@ -244,12 +249,12 @@ test('proposals panel: no NEW serious a11y violations (real-browser, incl. color
     // The left sidebar is already visible (we clicked a note in it above), so
     // no toggle is needed.
     await win.locator('.panel-tab[title="Proposals"]').first().click();
-    await win.waitForTimeout(400);
     // Expand the seeded proposal's review detail (payloads + Approve/Reject).
     const firstProposal = win.locator('.proposal-item').first();
+    await expect(firstProposal).toBeVisible({ timeout: 10_000 });
     if (await firstProposal.count()) {
       await firstProposal.click();
-      await win.waitForTimeout(400);
+      await expect(win.locator('.proposal-detail')).toBeVisible({ timeout: 10_000 });
     }
 
     const violations = await runAxe(win);

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -52,6 +52,35 @@ function packagedBinary(): string | null {
   return fs.existsSync(p) ? p : null;
 }
 
+/**
+ * Polls `count()` until it stops changing across `stableChecks` consecutive
+ * polls, or `timeoutMs` elapses. Used in place of a fixed
+ * `waitForTimeout` for "give async work a beat to surface a late error" —
+ * that has no positive UI condition to wait on, but "the error tally hasn't
+ * grown in a while" is a real quiescence signal, and a loaded runner
+ * naturally gets more real time to surface a late error instead of racing a
+ * guessed duration (#1943).
+ */
+async function waitForErrorCountToSettle(
+  count: () => number,
+  { timeoutMs = 2000, pollMs = 50, stableChecks = 4 }: { timeoutMs?: number; pollMs?: number; stableChecks?: number } = {},
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let last = count();
+  let stableStreak = 0;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => { setTimeout(resolve, pollMs); });
+    const current = count();
+    if (current === last) {
+      stableStreak++;
+      if (stableStreak >= stableChecks) return;
+    } else {
+      stableStreak = 0;
+      last = current;
+    }
+  }
+}
+
 test('app launches, renderer mounts, no thrown errors', async () => {
   // page.on('pageerror') captures synchronous renderer-side throws
   // (the most common runtime regression). app.process().on('exit', ...)
@@ -101,8 +130,11 @@ test('app launches, renderer mounts, no thrown errors', async () => {
     await expect(win.getByRole('heading', { name: 'Minerva' })).toBeVisible({ timeout: 10_000 });
     await expect(win.getByRole('button', { name: 'Open Thoughtbase' })).toBeVisible({ timeout: 10_000 });
 
-    // Give async effects another beat to surface late errors.
-    await win.waitForTimeout(500);
+    // Give async effects a beat to surface late errors — but wait on the
+    // actual condition (no new error in the last few polls) rather than a
+    // fixed sleep, so a loaded runner gets more real time instead of a
+    // spuriously clean scan, and a fast one doesn't wait longer than needed.
+    await waitForErrorCountToSettle(() => rendererErrors.length + consoleErrors.length);
   } catch (err) {
     // On hang/timeout, dump everything the main process said. The
     // Playwright failure message alone ("electron.launch: Timeout") is

--- a/tests/main/search/index.test.ts
+++ b/tests/main/search/index.test.ts
@@ -9,16 +9,21 @@
  * explicit `persist()` still forces an immediate write (the release/quit
  * paths keep calling that).
  *
- * Uses `_setPersistDebounceMsForTests` to shrink the real debounce window
- * rather than mocking time — `schedulePersist`'s timer callback does real
- * `fs` I/O, which doesn't resolve on vitest's fake-timer clock (it settles
- * via libuv's real thread pool), so faking `setTimeout` here would just trade
- * a slow test for a flaky one. To stay robust on a loaded CI runner (where a
- * `setTimeout` slips and the async write flushes late), the "did write"
- * assertions POLL for the file via `waitForIndex` rather than assuming a fixed
- * sleep landed it.
+ * Uses `_setPersistDebounceMsForTests` to shrink the real debounce window,
+ * plus vitest fake timers to make the "hasn't fired yet" assertions
+ * deterministic (issue #1943) — a real `sleep(DEBOUNCE_MS / 2)` races the
+ * runner's actual clock, so an overshoot on a loaded CI box lets the
+ * debounced write land early and turns a "hasn't written yet" assertion red.
+ * `vi.advanceTimersByTimeAsync` fires the timer at an exact fake-clock
+ * offset with no such race. Once a test needs to cross the deadline and
+ * confirm the write actually landed, it switches to real timers first —
+ * `schedulePersist`'s callback does real `fs` I/O that completes via the
+ * real event loop regardless of timer mode, but relying on fake-timer
+ * microtask draining to observe that completion is itself timing-sensitive
+ * (the exact number of promise hops isn't fixed), so `waitForWrite` polls on
+ * the real clock instead.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -38,27 +43,20 @@ function indexFilePath(root: string): string {
   return path.join(root, '.minerva', 'search-index.json');
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => { setTimeout(resolve, ms); });
-}
-
-/**
- * Poll until the debounced write has landed AND the file is fully written
- * (non-empty + parseable) — waits out both the timer firing and the async fs
- * flush, so a loaded runner can't race the assertion. Throws on timeout.
- */
-async function waitForIndex(root: string, timeoutMs = 5000): Promise<unknown> {
+/** Poll on the REAL clock for the debounced write to land. Call only after
+ *  `vi.useRealTimers()` — the fake clock never advances on its own. */
+async function waitForWrite(root: string, timeoutMs = 2000): Promise<string> {
   const p = indexFilePath(root);
   const start = Date.now();
   for (;;) {
     try {
       const raw = fs.readFileSync(p, 'utf-8');
-      if (raw) return JSON.parse(raw);
+      if (raw) return raw;
     } catch {
       // Not written yet, or caught mid-write — keep polling.
     }
     if (Date.now() - start > timeoutMs) throw new Error(`search index not written within ${timeoutMs}ms`);
-    await sleep(10);
+    await new Promise((resolve) => { setTimeout(resolve, 5); });
   }
 }
 
@@ -72,9 +70,11 @@ describe('search index persistence (perf #1107)', () => {
     ctx = projectContext(root);
     await initSearch(ctx);
     _setPersistDebounceMsForTests(DEBOUNCE_MS);
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     _setPersistDebounceMsForTests(3000);
     disposeProject(ctx);
     fs.rmSync(root, { recursive: true, force: true });
@@ -90,28 +90,37 @@ describe('search index persistence (perf #1107)', () => {
     indexNote(ctx, 'a.md', '# A\nbody');
     schedulePersist(ctx);
 
-    await sleep(DEBOUNCE_MS / 2);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS - 1);
     expect(fs.existsSync(indexFilePath(root))).toBe(false);
 
-    const written = await waitForIndex(root);
-    expect(JSON.stringify(written)).toContain('a.md');
+    // Cross the deadline to invoke the callback (kicks off the real fs
+    // write), then hand off to the real event loop so it can complete.
+    await vi.advanceTimersByTimeAsync(1);
+    vi.useRealTimers();
+    const written = await waitForWrite(root);
+    expect(written).toContain('a.md');
   });
 
   it('repeated schedulePersist calls within the window coalesce into one write', async () => {
     indexNote(ctx, 'a.md', '# A\nbody');
     schedulePersist(ctx);
-    await sleep(DEBOUNCE_MS / 2);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS / 2);
     // A second save comes in before the first would have fired — this
-    // should push the write out again rather than let the first fire.
+    // resets the timer to fire DEBOUNCE_MS from THIS call, not from the
+    // first, so the first would-have-fired deadline must pass with nothing
+    // written yet.
     indexNote(ctx, 'b.md', '# B\nbody');
     schedulePersist(ctx);
-    await sleep(DEBOUNCE_MS / 2);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS / 2 - 1);
     expect(fs.existsSync(indexFilePath(root))).toBe(false);
 
-    const written = await waitForIndex(root);
+    // The re-armed timer's deadline is DEBOUNCE_MS after the SECOND call.
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS / 2 + 1);
+    vi.useRealTimers();
+    const written = await waitForWrite(root);
     // Both notes made it into the single, coalesced write.
-    expect(JSON.stringify(written)).toContain('a.md');
-    expect(JSON.stringify(written)).toContain('b.md');
+    expect(written).toContain('a.md');
+    expect(written).toContain('b.md');
   });
 
   it('persist() forces an immediate write and cancels a pending scheduled one', async () => {
@@ -124,9 +133,9 @@ describe('search index persistence (perf #1107)', () => {
     const firstWrite = fs.statSync(indexFilePath(root)).mtimeMs;
 
     // The debounced timer that was pending before persist() ran should have
-    // been cancelled — waiting past its original deadline must not fire a
+    // been cancelled — advancing past its original deadline must not fire a
     // second, redundant write.
-    await sleep(DEBOUNCE_MS * 2);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS * 2);
     expect(fs.statSync(indexFilePath(root)).mtimeMs).toBe(firstWrite);
   });
 });

--- a/tests/renderer/source-display.test.ts
+++ b/tests/renderer/source-display.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   formatCreators,
   formatDueStamp,
@@ -8,15 +8,39 @@ import {
 } from '../../src/renderer/lib/sources/source-display';
 
 // Pure display helpers behind the SourceListItem split (#672). The date
-// helpers depend on "today", so those cases use offsets from the current date
-// rather than hard-coded strings.
+// helpers depend on "today" (#1943): the old version of this file read the
+// real clock via `isoDaysFromNow()` at setup and again inside
+// `isOverdue`/`formatDueStamp` at assert time, so a run straddling local
+// midnight or a year boundary could disagree with itself between those two
+// reads. Every case below instead pins the system clock (`vi.setSystemTime`)
+// and `TZ`, following the pattern in `refactor/extract.test.ts`, so "now" is
+// one fixed instant throughout a test regardless of when or where the suite
+// actually runs — the suite-wide `TZ` pin in `vitest.config.mts` covers tests
+// that don't touch the clock at all, but these do, so they pin their own.
+const atInstant = (tz: string, instant: string, assert: () => void): void => {
+  const prev = process.env.TZ;
+  process.env.TZ = tz;
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(instant));
+  try {
+    assert();
+  } finally {
+    vi.useRealTimers();
+    if (prev === undefined) delete process.env.TZ;
+    else process.env.TZ = prev;
+  }
+};
+
+// Arizona never observes DST, so this is a fixed, year-round UTC-7 offset —
+// exercising a non-UTC zone (so a `toISOString()` regression would surface)
+// without the offset itself varying by the calendar date under test.
+const TZ = 'America/Phoenix';
 
 // Formats the *local* calendar date, deliberately not `toISOString()`: that
 // serializes in UTC, so a local-midnight Date in any zone east of UTC renders
-// as the previous day (in UTC+2, `isoDaysFromNow(0)` yielded yesterday and the
-// "due today" case below asserted the opposite of what it meant to). The
-// helpers under test parse `${iso}T00:00:00` — local midnight — so the offsets
-// have to be local too.
+// as the previous day. The helpers under test parse `${iso}T00:00:00` — local
+// midnight — so the offsets have to be local too. Only valid while a fake
+// clock from `atInstant` is active.
 const isoDaysFromNow = (days: number): string => {
   const d = new Date();
   d.setHours(0, 0, 0, 0);
@@ -57,9 +81,21 @@ describe('isOverdue', () => {
   });
 
   it('is true strictly before today, false for today and the future', () => {
-    expect(isOverdue(isoDaysFromNow(-1))).toBe(true);
-    expect(isOverdue(isoDaysFromNow(0))).toBe(false); // due today is not overdue
-    expect(isOverdue(isoDaysFromNow(3))).toBe(false);
+    atInstant(TZ, '2026-06-15T18:00:00Z', () => {
+      expect(isOverdue(isoDaysFromNow(-1))).toBe(true);
+      expect(isOverdue(isoDaysFromNow(0))).toBe(false); // due today is not overdue
+      expect(isOverdue(isoDaysFromNow(3))).toBe(false);
+    });
+  });
+
+  it('a due-today date one second before local midnight is still not overdue', () => {
+    // The exact instant a real, unpinned clock read between computing
+    // "today" and calling isOverdue() could roll over to the next calendar
+    // day and flip this from false to true.
+    atInstant(TZ, '2026-06-15T06:59:59Z', () => { // 23:59:59 the previous day in UTC-7
+      expect(isOverdue(isoDaysFromNow(0))).toBe(false);
+      expect(isOverdue(isoDaysFromNow(-1))).toBe(true);
+    });
   });
 });
 
@@ -69,10 +105,25 @@ describe('formatDueStamp', () => {
   });
 
   it('omits the year for an in-current-year date, includes it otherwise', () => {
-    const thisYear = new Date().getFullYear();
-    const inYear = formatDueStamp(`${thisYear}-06-15`);
-    expect(inYear).not.toMatch(String(thisYear)); // "Jun 15", no year
-    const otherYear = formatDueStamp(`${thisYear + 2}-06-15`);
-    expect(otherYear).toMatch(String(thisYear + 2)); // "Jun 15 2027"
+    atInstant(TZ, '2026-06-15T18:00:00Z', () => {
+      const thisYear = new Date().getFullYear();
+      const inYear = formatDueStamp(`${thisYear}-06-15`);
+      expect(inYear).not.toMatch(String(thisYear)); // "Jun 15", no year
+      const otherYear = formatDueStamp(`${thisYear + 2}-06-15`);
+      expect(otherYear).toMatch(String(thisYear + 2)); // "Jun 15 2028"
+    });
+  });
+
+  it('holds across a New Year straddle', () => {
+    // One second before midnight on New Year's Eve: "now" is still the old
+    // year, so a date in the old year omits it and one in the new year
+    // (already elapsed in UTC, not yet locally) still counts as "not this
+    // year" and includes it.
+    atInstant(TZ, '2027-01-01T06:59:59Z', () => { // 23:59:59 Dec 31 2026 in UTC-7
+      const thisYear = new Date().getFullYear();
+      expect(thisYear).toBe(2026);
+      expect(formatDueStamp('2026-12-31')).not.toMatch('2026');
+      expect(formatDueStamp('2027-01-01')).toMatch('2027');
+    });
   });
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -23,6 +23,18 @@ export default defineConfig({
     // (e.g., watcher, chokidar waits, network probes) need >5s to avoid flakes;
     // 30s provides enough headroom without being overly lenient (#1942).
     testTimeout: 30000,
+    // Pin the ambient zone for the whole suite (#1943) — without this, any
+    // local-time assertion that doesn't explicitly pin its own clock/TZ
+    // inherits whatever zone the runner happens to be in, so the same test
+    // passes on a US laptop and fails in UTC CI (or vice versa). Phoenix
+    // never observes DST, so this is a fixed, year-round offset rather than
+    // a zone whose UTC delta shifts depending on which day the suite runs.
+    // Individual tests that specifically need to probe a *different* zone
+    // (e.g. a UTC-vs-local-date bug) still set and restore `process.env.TZ`
+    // themselves — see `refactor/extract.test.ts`.
+    env: {
+      TZ: 'America/Phoenix',
+    },
     coverage: {
       // v8 is the only provider we need; istanbul is slower and adds a
       // dep we don't have. text-summary lands in stdout for the baseline


### PR DESCRIPTION
## Summary

**(a) `tests/main/search/index.test.ts`** — replaced `sleep(DEBOUNCE_MS / 2)` + a negative `existsSync` check with `vi.useFakeTimers()`/`advanceTimersByTimeAsync`, so the "hasn't written yet" assertions fire at an exact fake-clock offset instead of racing the runner's real clock (an overshoot past the 200ms debounce used to turn this red). Once a test needs to confirm the debounced write actually landed, it switches to real timers and polls — `schedulePersist`'s real `fs.writeFile` completes via the real event loop regardless of timer mode, but relying on fake-timer microtask draining to observe that completion turned out to be itself timing-sensitive (verified empirically — the number of promise hops isn't fixed, so a fixed number of extra flush ticks was flaky).

**(b) `tests/renderer/source-display.test.ts`** — `isOverdue`/`formatDueStamp` read "now" at both setup and assert time, so a run straddling local midnight or a year boundary could disagree with itself. Every date-dependent case now pins `vi.setSystemTime` + `TZ` via an `atInstant()` helper (same pattern as `refactor/extract.test.ts`), plus two new regression tests pinned one second before local midnight and one second before New Year.

`vitest.config.mts` — pinned `TZ` to `America/Phoenix` (no DST) for the whole suite, so any local-time assertion that doesn't explicitly control its own clock stops depending on the runner's ambient zone.

**(c) `tests/e2e/a11y.spec.ts`** — replaced six unconditioned `waitForTimeout` sleeps before axe scans with condition-based waits on the actual DOM state being scanned (sidebar tree rendered, editor mounted, source body rendered, proposal detail expanded).

`tests/e2e/smoke.spec.ts` — replaced a "give async effects a beat" sleep with `waitForErrorCountToSettle()`, which polls until the renderer/console error tally stops growing for a few consecutive checks — a real quiescence signal for a wait that has no positive UI condition to check.

Fixes #1943

## Test plan
- [x] `pnpm test tests/main/search/index.test.ts tests/renderer/source-display.test.ts` — 13 tests, run 10× to confirm no flakiness
- [x] Full unit suite (`pnpm test`) passes with the global `TZ` pin active (625 files, 6831 passed)
- [x] `pnpm lint` passes
- [x] Verified the e2e `waitForTimeout` replacements against the packaged app (`pnpm build:e2e` + `playwright test tests/e2e/a11y.spec.ts tests/e2e/smoke.spec.ts`), run several times
- [x] Found a pre-existing, unrelated flake ("proposals panel" a11y test racing `seedProposal` against project-open state, and an unrelated "welcome screen" timeout) — confirmed it reproduces identically on unmodified `main`, so it's out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)