### PR TITLE
test: reset shared beforeAll fixtures per test, clear bookmarks persist timer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,31 @@ Note what it can't tell you: it doesn't distinguish a real store from a
 passthrough, and it says nothing about whether a mutating channel ships a change
 event (a main-side question).
 
+#### Testing a store: mock the module, don't add a reset API (#1944)
+
+Store singletons under `stores/*.svelte.ts` deliberately do **not** get a
+generic `reset()`/`clear()` export. Decision, not an oversight:
+
+- **Default: `vi.mock` the whole store module.** Most components/ops tests
+  don't need the store's real logic — they need it to hand back
+  controllable state. Mocking the module (see
+  `right-sidebar/BookmarksPanel.test.ts`) is fully isolated between tests
+  with zero store-specific cleanup code, and is the pattern to reach for
+  first.
+- **Testing the store's own logic is the exception.** A test that imports
+  the real module (`stores/bookmarks.test.ts` exercises
+  `retargetSectionAnchor`) owns its own scoped reset for exactly the state
+  it touches, rather than the store exporting a generic one nothing else
+  needs. A blanket `reset()` API would mostly serve this one call site while
+  adding a public surface every other consumer has to know is test-only.
+- **Cancel any real timers a mutation arms.** A debounced-persist store
+  (`bookmarks.svelte.ts`'s 500ms `schedulePersist`, mirroring
+  `search/index.ts`'s pattern) can leave a live `setTimeout` armed past the
+  end of whatever test triggered it, firing mid-run of a later one. Export a
+  narrow `_clearPendingPersistForTests()`-style escape hatch (test-only,
+  underscore-prefixed, same convention as `_setPersistDebounceMsForTests` in
+  `search/index.ts`) and call it in `afterEach` — not a general reset.
+
 ### UI & UX Philosophy
 This is a **professional tool**. Design accordingly:
 

--- a/src/renderer/lib/stores/bookmarks.svelte.ts
+++ b/src/renderer/lib/stores/bookmarks.svelte.ts
@@ -17,6 +17,13 @@ function schedulePersist() {
   }, 500);
 }
 
+/** Test-only: cancel a pending debounced persist without saving, so a real
+ *  500ms timer armed by one test can't fire mid-run of a later one (#1944). */
+export function _clearPendingPersistForTests(): void {
+  if (persistTimer) clearTimeout(persistTimer);
+  persistTimer = null;
+}
+
 export function getBookmarksStore() {
   async function load() {
     tree = await api.bookmarks.load();

--- a/tests/main/sources/tables-markdown.test.ts
+++ b/tests/main/sources/tables-markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,10 +7,12 @@ import {
   disposeProject,
   runQuery,
   registerCsv,
+  unregisterCsv,
   registerMarkdownTable,
   unregisterNoteTables,
   reregisterNoteTables,
   onCsvTableCollision,
+  listTables,
 } from '../../../src/main/sources/tables';
 import { projectContext } from '../../../src/main/project-context-types';
 import type { ParsedTable } from '../../../src/main/graph/parser';
@@ -27,6 +29,20 @@ beforeAll(async () => {
 afterAll(async () => {
   disposeProject(ctx);
   await fs.rm(rootPath, { recursive: true, force: true });
+});
+
+// The DuckDB instance is shared across every test in this file (a fresh one
+// per test would re-pay initTablesDb's startup cost for no benefit here), so
+// nothing stops one test's tables from colliding with the next's. Drop
+// everything through the real unregister paths after each test — that
+// exercises the same cleanup production code relies on, rather than
+// depending on every test picking a disjoint name forever (#1944).
+afterEach(async () => {
+  const tables = await listTables(ctx);
+  const notePaths = new Set(tables.filter((t) => t.source === 'note').map((t) => t.relativePath));
+  const csvPaths = new Set(tables.filter((t) => t.source === 'csv').map((t) => t.relativePath));
+  for (const notePath of notePaths) await unregisterNoteTables(ctx, notePath);
+  for (const csvPath of csvPaths) await unregisterCsv(ctx, csvPath);
 });
 
 function table(caption: string, headers: string[], rows: string[][]): ParsedTable {

--- a/tests/main/sources/tables.test.ts
+++ b/tests/main/sources/tables.test.ts
@@ -99,6 +99,10 @@ describe('tables module — DuckDB lifecycle + runQuery (#232)', () => {
       expect(inSecond.ok).toBe(false);
     } finally {
       disposeProject(otherCtx);
+      // `ctx`'s DuckDB connection is shared with every other test in this
+      // file (#1944) — drop the ad-hoc table rather than leaving it behind
+      // for whatever test runs next to collide with.
+      await runQuery(ctx, `DROP TABLE IF EXISTS scratch`);
     }
   });
 });

--- a/tests/renderer/stores/bookmarks.test.ts
+++ b/tests/renderer/stores/bookmarks.test.ts
@@ -4,13 +4,13 @@
  * bookmarks and other notes' bookmarks alone. IPC persistence is mocked.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../../src/renderer/lib/ipc/client', () => ({
   api: { bookmarks: { save: vi.fn(), load: vi.fn() } },
 }));
 
-import { getBookmarksStore } from '../../../src/renderer/lib/stores/bookmarks.svelte';
+import { getBookmarksStore, _clearPendingPersistForTests } from '../../../src/renderer/lib/stores/bookmarks.svelte';
 
 const store = getBookmarksStore();
 
@@ -21,6 +21,11 @@ function reset() {
 }
 
 beforeEach(reset);
+// Every mutation above arms a real 500ms debounced-persist timer with no
+// per-test reset (#1944) — left alone, it fires mid-run of whatever test
+// happens to be executing 500ms later. Cancel it once this test's mutations
+// are done instead of letting it survive past the test that armed it.
+afterEach(_clearPendingPersistForTests);
 
 function bm(name: string) {
   return store.tree.find((n) => n.type === 'bookmark' && n.name === name);


### PR DESCRIPTION
## Summary

- **`tests/main/sources/tables-markdown.test.ts`** — added an `afterEach` that drops every registered note/CSV table through the real `unregisterNoteTables`/`unregisterCsv` paths, so the single shared DuckDB instance is actually reset between tests instead of relying on every test picking a disjoint table name forever. The `onCsvTableCollision` handler was already correctly unsubscribed via `unsub()` at both call sites in the current file — that specific claim in the issue no longer applies (verified by checking git history: the file hasn't changed since it was first added).
- **`tests/main/sources/tables.test.ts`** — the one ad-hoc `scratch` table (created outside the tracked registration API, so `listTables()` can't see it) is now dropped in the test's own `finally` block.
- **`src/renderer/lib/stores/bookmarks.svelte.ts`** — exported `_clearPendingPersistForTests()` to cancel the debounced-persist timer without saving. Every store mutation arms a real 500ms `setTimeout` with no per-test reset, so it could fire mid-run of whatever test happens to be executing 500ms later. `bookmarks.test.ts` (the one test file that imports the real store rather than mocking it) now cancels it in `afterEach`.
- **`CLAUDE.md`** — recorded the decision on renderer store reset APIs: no generic `reset()` export; default to mocking the whole store module in tests (`BookmarksPanel.test.ts`'s existing pattern), and a test that needs the real store's logic owns its own scoped reset plus cancels any real timers via a narrow, underscore-prefixed test-only export (the same convention as `_setPersistDebounceMsForTests` in `search/index.ts`).

Fixes #1944

## Test plan
- [x] `pnpm test tests/main/sources/tables-markdown.test.ts tests/main/sources/tables.test.ts tests/renderer/stores/bookmarks.test.ts` passes
- [x] Full unit suite (`pnpm test`) passes — 625 files, 6831 passed
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)