### PR TITLE
feat: per-benchmark tolerance + budgetMs on the scale benches

### DIFF
--- a/scripts/bench-check.mjs
+++ b/scripts/bench-check.mjs
@@ -15,7 +15,11 @@
  *     positive machine. Nightly baseline-diff catches real regressions without
  *     the flap.
  *   - Gates on the RATIO to a committed baseline (default 2×), not raw ms, so a
- *     slow cold runner shifts every number together and cancels out.
+ *     slow cold runner shifts every number together and cancels out. A
+ *     benchmark can override the default with its own `tolerance` — tighter
+ *     for a bench with demonstrated low run-to-run variance, so a real
+ *     regression can't hide inside slack sized for the noisiest bench in the
+ *     file (#1945).
  *   - An optional per-benchmark `budgetMs` adds a hard absolute ceiling for the
  *     few latencies we want a scale envelope on (e.g. graph query at 5k notes).
  *
@@ -27,9 +31,12 @@
  *                --update where it's the source to snapshot).
  *   --baseline   Committed baseline (default tests/main/bench-baseline.json).
  *   --tolerance  Regression factor (default: baseline.tolerance, else 2.0). Also
- *                overridable via BENCH_TOLERANCE. current/baseline > tolerance ⇒ fail.
+ *                overridable via BENCH_TOLERANCE. Overrides EVERY benchmark's own
+ *                `tolerance`, if set — it's a one-off operator request, not a
+ *                per-bench characteristic. current/baseline > tolerance ⇒ fail.
  *   --update     Refresh the baseline from --current (preserving tolerance +
- *                per-benchmark budgetMs) and exit 0. Run this to re-bless numbers.
+ *                per-benchmark budgetMs/tolerance) and exit 0. Run this to
+ *                re-bless numbers.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 
@@ -50,12 +57,18 @@ function parseArgs(argv) {
 }
 
 /** Flatten a vitest `--outputJson` report (files→groups→benchmarks) OR an
- *  already-flat baseline ({ benchmarks: [...] }) into name → {mean, hz, budgetMs}. */
+ *  already-flat baseline ({ benchmarks: [...] }) into name → {mean, hz, budgetMs, tolerance}. */
 function flatten(json) {
   const map = new Map();
   if (Array.isArray(json.benchmarks)) {
     for (const b of json.benchmarks) {
-      map.set(b.name, { mean: b.mean, hz: b.hz, budgetMs: b.budgetMs ?? null, gate: b.gate !== false });
+      map.set(b.name, {
+        mean: b.mean,
+        hz: b.hz,
+        budgetMs: b.budgetMs ?? null,
+        tolerance: b.tolerance ?? null,
+        gate: b.gate !== false,
+      });
     }
     return map;
   }
@@ -97,14 +110,17 @@ if (args.update) {
   } catch {
     /* first run — no baseline yet */
   }
-  // Preserve hand-set budgetMs / gate flags across a re-bless — only the
-  // measured mean/hz should move.
-  const prevMeta = new Map((prev.benchmarks ?? []).map((b) => [b.name, { budgetMs: b.budgetMs ?? null, gate: b.gate }]));
+  // Preserve hand-set budgetMs / tolerance / gate flags across a re-bless —
+  // only the measured mean/hz should move.
+  const prevMeta = new Map(
+    (prev.benchmarks ?? []).map((b) => [b.name, { budgetMs: b.budgetMs ?? null, tolerance: b.tolerance ?? null, gate: b.gate }]),
+  );
   const benchmarks = [...current.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([name, { mean, hz }]) => {
       const meta = prevMeta.get(name) ?? {};
       const entry = { name, mean: Number(mean.toFixed(6)), hz: Number(hz.toFixed(2)), budgetMs: meta.budgetMs ?? null };
+      if (meta.tolerance != null) entry.tolerance = meta.tolerance;
       if (meta.gate === false) entry.gate = false;
       return entry;
     });
@@ -112,7 +128,10 @@ if (args.update) {
     _comment:
       'Committed benchmark baseline (#1099). Regenerate on the macos-latest ' +
       'Bench runner with `pnpm bench:baseline` and commit the diff. `budgetMs` ' +
-      'is an optional hard ceiling (ms) — set it by hand for scale-envelope gates.',
+      'is an optional hard ceiling (ms) — set it by hand for scale-envelope gates. ' +
+      '`tolerance` optionally overrides the file-level ratio gate per benchmark — ' +
+      'tighten it for a demonstrated low-variance bench so its slack matches its ' +
+      'actual noise instead of the noisiest bench in the file (#1945).',
     tolerance: prev.tolerance ?? DEFAULT_TOLERANCE,
     benchmarks,
   };
@@ -124,11 +143,14 @@ if (args.update) {
 // ── compare current vs committed baseline ──
 const baselineJson = readJson(args.baseline);
 const baseline = flatten(baselineJson);
-const tolerance =
-  args.tolerance ??
-  (process.env.BENCH_TOLERANCE ? Number(process.env.BENCH_TOLERANCE) : undefined) ??
-  baselineJson.tolerance ??
-  DEFAULT_TOLERANCE;
+// An explicit CLI/env override applies to every benchmark, overriding even a
+// per-benchmark `tolerance` — it's a deliberate one-off operator request, not
+// a per-bench characteristic. Absent that, each benchmark falls back to its
+// own `tolerance` (if set) and only then to the file-level default.
+const explicitTolerance =
+  args.tolerance ?? (process.env.BENCH_TOLERANCE ? Number(process.env.BENCH_TOLERANCE) : undefined);
+const fileTolerance = baselineJson.tolerance ?? DEFAULT_TOLERANCE;
+const tolerance = explicitTolerance ?? fileTolerance;
 
 const regressions = [];
 const budgetBreaches = [];
@@ -143,20 +165,22 @@ for (const [name, base] of baseline) {
     continue;
   }
   const ratio = cur.mean / base.mean;
+  const benchTolerance = explicitTolerance ?? base.tolerance ?? fileTolerance;
   // Some benchmarks are inherently high-variance (e.g. building a 5k-note
   // rdflib graph from scratch is GC-dominated, ±200% run to run). Record them
   // for week-over-week diffing, but don't let their noise fail the gate.
   const gated = base.gate !== false;
-  const regressed = gated && ratio > tolerance;
+  const regressed = gated && ratio > benchTolerance;
   const overBudget = gated && base.budgetMs != null && cur.mean > base.budgetMs;
-  if (regressed) regressions.push({ name, ratio });
+  if (regressed) regressions.push({ name, ratio, tolerance: benchTolerance });
   if (overBudget) budgetBreaches.push({ name, mean: cur.mean, budgetMs: base.budgetMs });
   rows.push({
     name,
     base: base.mean,
     cur: cur.mean,
     ratio,
-    flag: !gated ? 'tracked' : regressed ? 'REGRESSED' : overBudget ? 'OVER BUDGET' : ratio < 1 / tolerance ? 'faster' : 'ok',
+    tolerance: benchTolerance,
+    flag: !gated ? 'tracked' : regressed ? 'REGRESSED' : overBudget ? 'OVER BUDGET' : ratio < 1 / benchTolerance ? 'faster' : 'ok',
   });
 }
 for (const name of current.keys()) {
@@ -164,12 +188,12 @@ for (const name of current.keys()) {
 }
 
 // ── report ──
-console.log(`\nBenchmark regression check — tolerance ${tolerance}× vs ${args.baseline}\n`);
+console.log(`\nBenchmark regression check — default tolerance ${tolerance}× vs ${args.baseline} (a benchmark's own \`tolerance\` overrides this)\n`);
 const namePad = Math.max(4, ...rows.map((r) => r.name.length));
-console.log(`${'name'.padEnd(namePad)}  ${'baseline'.padStart(10)}  ${'current'.padStart(10)}  ${'ratio'.padStart(7)}  status`);
+console.log(`${'name'.padEnd(namePad)}  ${'baseline'.padStart(10)}  ${'current'.padStart(10)}  ${'ratio'.padStart(7)}  ${'tol'.padStart(5)}  status`);
 for (const r of rows.sort((a, b) => b.ratio - a.ratio)) {
   console.log(
-    `${r.name.padEnd(namePad)}  ${fmt(r.base).padStart(10)}  ${fmt(r.cur).padStart(10)}  ${(r.ratio.toFixed(2) + '×').padStart(7)}  ${r.flag}`,
+    `${r.name.padEnd(namePad)}  ${fmt(r.base).padStart(10)}  ${fmt(r.cur).padStart(10)}  ${(r.ratio.toFixed(2) + '×').padStart(7)}  ${(r.tolerance + '×').padStart(5)}  ${r.flag}`,
   );
 }
 
@@ -178,7 +202,7 @@ if (missing.length) console.log(`\n⚠ ${missing.length} baseline benchmark(s) m
 
 if (regressions.length || budgetBreaches.length) {
   console.error('\n✗ Benchmark regression gate FAILED:');
-  for (const r of regressions) console.error(`  - ${r.name}: ${r.ratio.toFixed(2)}× slower than baseline (> ${tolerance}×)`);
+  for (const r of regressions) console.error(`  - ${r.name}: ${r.ratio.toFixed(2)}× slower than baseline (> ${r.tolerance}×)`);
   for (const b of budgetBreaches) console.error(`  - ${b.name}: ${fmt(b.mean)} exceeds budget ${fmt(b.budgetMs)}`);
   process.exit(1);
 }

--- a/tests/main/bench-baseline.json
+++ b/tests/main/bench-baseline.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Committed benchmark baseline (#1099). The Bench workflow fails when a benchmark runs >`tolerance`x slower than its `mean` here. Regenerate on the macos-latest Bench runner (dispatch with update_baseline=true, or `pnpm bench:baseline` locally) and commit the diff — mean/hz refresh, the hand-set fields below are preserved. `budgetMs`: optional absolute ceiling in ms (a scale-envelope gate) applied on top of the ratio check. `gate: false`: track for week-over-week diffing but never fail on it — for inherently high-variance benches. (The 5k-note indexAllNotes bench was gate:false while it was GC-dominated & ±215%; #1473 removed the O(N²) link-resolution churn — it's now ~1.2s at ±<1%, so it's gated again.)",
+  "_comment": "Committed benchmark baseline (#1099). The Bench workflow fails when a benchmark runs >`tolerance`x slower than its `mean` here. Regenerate on the macos-latest Bench runner (dispatch with update_baseline=true, or `pnpm bench:baseline` locally) and commit the diff — mean/hz refresh, the hand-set fields below are preserved. `budgetMs`: optional absolute ceiling in ms (a scale-envelope gate) applied on top of the ratio check. `tolerance`: optional per-benchmark override of the top-level ratio gate below — tighten it (e.g. 1.3) once a bench has demonstrated low run-to-run variance, so its slack matches its actual noise instead of the noisiest bench in the file (#1945). `gate: false`: track for week-over-week diffing but never fail on it — for inherently high-variance benches. (The 5k-note indexAllNotes bench was gate:false while it was GC-dominated & ±215%; #1473 removed the O(N²) link-resolution churn — it's now ~1.2s at ±<1%, so it's gated again, with a 1800ms budgetMs ceiling and 1.3x tolerance to match. The two queryGraph cache-hit benches are similarly low-variance and share the tighter 1.3x.)",
   "tolerance": 2,
   "benchmarks": [
     {
@@ -24,7 +24,8 @@
       "name": "indexAllNotes: 5000 notes from scratch",
       "mean": 1181.86,
       "hz": 0.85,
-      "budgetMs": null
+      "budgetMs": 1800,
+      "tolerance": 1.3
     },
     {
       "name": "indexNote: a note (title + tag + wiki-link) into a 500-note store",
@@ -42,13 +43,15 @@
       "name": "queryGraph: simple SELECT (cache hit after first call)",
       "mean": 0.563548,
       "hz": 1774.47,
-      "budgetMs": 5
+      "budgetMs": 5,
+      "tolerance": 1.3
     },
     {
       "name": "queryGraph: tag filter (cache hit after first call)",
       "mean": 0.887726,
       "hz": 1126.47,
-      "budgetMs": 5
+      "budgetMs": 5,
+      "tolerance": 1.3
     },
     {
       "name": "re-index (invalidates) + queryGraph (cold rebuild) at 2000 notes",

--- a/tests/scripts/bench-check.test.ts
+++ b/tests/scripts/bench-check.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The benchmark regression gate (#1099 / #1945) had no test of its own — the
+ * mechanism (an absolute `budgetMs` ceiling, a per-benchmark `tolerance`
+ * override) was built but never exercised, so a change here could silently
+ * stop failing the gate it exists to enforce. Spawns the real script against
+ * crafted baseline/current fixtures and asserts on its actual CLI contract
+ * (exit code + stdout), since it's invoked as a subprocess from the Bench
+ * workflow, not imported as a module.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/bench-check.mjs');
+
+function run(args: string[]): { status: number; stdout: string } {
+  try {
+    const stdout = execFileSync('node', [SCRIPT, ...args], { encoding: 'utf-8' });
+    return { status: 0, stdout };
+  } catch (err) {
+    const e = err as { status: number; stdout: string; stderr: string };
+    return { status: e.status, stdout: e.stdout + e.stderr };
+  }
+}
+
+/** vitest `--outputJson` shape: files → groups → benchmarks. */
+function currentJson(benchmarks: Array<{ name: string; mean: number; hz?: number }>) {
+  return { files: [{ groups: [{ benchmarks: benchmarks.map((b) => ({ hz: 1000 / b.mean, ...b })) }] }] };
+}
+
+function writeTemp(dir: string, name: string, data: unknown): string {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, JSON.stringify(data));
+  return p;
+}
+
+describe('bench-check.mjs', () => {
+  let dir: string;
+  const withTempDir = (fn: (dir: string) => void) => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-bench-check-'));
+    try {
+      fn(dir);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  it('passes when current is within tolerance and under budget', () => {
+    withTempDir((d) => {
+      const baseline = writeTemp(d, 'baseline.json', {
+        tolerance: 2,
+        benchmarks: [{ name: 'slow op', mean: 100, hz: 10, budgetMs: 200 }],
+      });
+      const current = writeTemp(d, 'current.json', currentJson([{ name: 'slow op', mean: 150 }]));
+      const { status, stdout } = run(['--current', current, '--baseline', baseline]);
+      expect(status).toBe(0);
+      expect(stdout).toContain('No benchmark regressed beyond tolerance');
+    });
+  });
+
+  it('fails the ceiling check when a benchmark breaches budgetMs even within ratio tolerance', () => {
+    withTempDir((d) => {
+      // 250ms is only 1.25x the 200ms baseline (well under the 2x ratio
+      // tolerance), but it breaches the 220ms budgetMs ceiling — this is
+      // exactly the "deliberate regression" case #1945 asks to prove fires.
+      const baseline = writeTemp(d, 'baseline.json', {
+        tolerance: 2,
+        benchmarks: [{ name: 'scale op', mean: 200, hz: 5, budgetMs: 220 }],
+      });
+      const current = writeTemp(d, 'current.json', currentJson([{ name: 'scale op', mean: 250 }]));
+      const { status, stdout } = run(['--current', current, '--baseline', baseline]);
+      expect(status).toBe(1);
+      expect(stdout).toContain('OVER BUDGET');
+      expect(stdout).toContain('exceeds budget');
+    });
+  });
+
+  it('fails on ratio regression using the file-level default tolerance', () => {
+    withTempDir((d) => {
+      const baseline = writeTemp(d, 'baseline.json', {
+        tolerance: 2,
+        benchmarks: [{ name: 'noisy op', mean: 100, hz: 10, budgetMs: null }],
+      });
+      const current = writeTemp(d, 'current.json', currentJson([{ name: 'noisy op', mean: 250 }])); // 2.5x
+      const { status, stdout } = run(['--current', current, '--baseline', baseline]);
+      expect(status).toBe(1);
+      expect(stdout).toContain('REGRESSED');
+    });
+  });
+
+  it('a per-benchmark tolerance overrides the file-level default', () => {
+    withTempDir((d) => {
+      // 1.5x would pass the file-level 2x tolerance, but this benchmark's
+      // own tighter 1.3x must catch it instead.
+      const baseline = writeTemp(d, 'baseline.json', {
+        tolerance: 2,
+        benchmarks: [{ name: 'low-variance op', mean: 100, hz: 10, budgetMs: null, tolerance: 1.3 }],
+      });
+      const current = writeTemp(d, 'current.json', currentJson([{ name: 'low-variance op', mean: 150 }]));
+      const { status, stdout } = run(['--current', current, '--baseline', baseline]);
+      expect(status).toBe(1);
+      expect(stdout).toContain('REGRESSED');
+      expect(stdout).toContain('1.3');
+    });
+  });
+
+  it('an explicit --tolerance flag overrides every benchmark, including its own tolerance', () => {
+    withTempDir((d) => {
+      const baseline = writeTemp(d, 'baseline.json', {
+        tolerance: 2,
+        benchmarks: [{ name: 'low-variance op', mean: 100, hz: 10, budgetMs: null, tolerance: 1.3 }],
+      });
+      // 1.5x would fail the benchmark's own 1.3x tolerance, but an explicit
+      // --tolerance 3 on the CLI should let it through regardless.
+      const current = writeTemp(d, 'current.json', currentJson([{ name: 'low-variance op', mean: 150 }]));
+      const { status } = run(['--current', current, '--baseline', baseline, '--tolerance', '3']);
+      expect(status).toBe(0);
+    });
+  });
+
+  it('--update preserves hand-set budgetMs/tolerance/gate while refreshing mean/hz', () => {
+    withTempDir((d) => {
+      const baselinePath = writeTemp(d, 'baseline.json', {
+        tolerance: 2,
+        benchmarks: [
+          { name: 'scale op', mean: 100, hz: 10, budgetMs: 220, tolerance: 1.3 },
+          { name: 'noisy op', mean: 50, hz: 20, budgetMs: null, gate: false },
+        ],
+      });
+      const current = writeTemp(
+        d,
+        'current.json',
+        currentJson([
+          { name: 'scale op', mean: 105 },
+          { name: 'noisy op', mean: 60 },
+        ]),
+      );
+      const { status } = run(['--current', current, '--baseline', baselinePath, '--update']);
+      expect(status).toBe(0);
+
+      const updated = JSON.parse(fs.readFileSync(baselinePath, 'utf-8'));
+      const scaleOp = updated.benchmarks.find((b: { name: string }) => b.name === 'scale op');
+      const noisyOp = updated.benchmarks.find((b: { name: string }) => b.name === 'noisy op');
+      expect(scaleOp.mean).toBe(105);
+      expect(scaleOp.budgetMs).toBe(220);
+      expect(scaleOp.tolerance).toBe(1.3);
+      expect(noisyOp.mean).toBe(60);
+      expect(noisyOp.gate).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The `bench-check.mjs` gate mechanism (absolute `budgetMs` ceiling, ratio-to-baseline gate) was already built but had no numbers exercising the ceiling and no test of its own — a flat 2.0x tolerance (a 99% slowdown passes) applied to every benchmark regardless of how noisy it actually is.

- **`scripts/bench-check.mjs`** — benchmarks can now set their own `tolerance`, overriding the file-level default (still 2.0x). An explicit `--tolerance`/`BENCH_TOLERANCE` override still wins over everything, per-bench or not, since it's a one-off operator request. Preserved across `--update` re-blessing alongside `budgetMs`/`gate`.
- **`tests/main/bench-baseline.json`** — set `budgetMs: 1800` + `tolerance: 1.3` on `indexAllNotes: 5000 notes` (1,181ms at ±<1% per the baseline's own comment — 1800ms is generous but meaningful) and tightened the two already-budgeted `queryGraph` cache-hit benches to the same 1.3x, since they're demonstrably low-variance too (confirmed locally: ~2-3% rme). Left the other benches at the 2.0x default — a local run showed several (`writeAndReindex`, `indexNote`) at 2x+ their committed baseline just from this machine being slower than the dedicated CI bench runner, exactly the noise the flat tolerance exists to absorb. Tightening those without real CI-runner variance data would just be guessing.
- **`tests/scripts/bench-check.test.ts`** — new. Spawns the real script against crafted baseline/current fixtures and asserts on its actual CLI contract (exit code + stdout). Proves the `budgetMs` ceiling fires on a deliberate regression even when the ratio is well within tolerance, that per-bench `tolerance` overrides the file-level default, and that `--update` preserves hand-set `budgetMs`/`tolerance`/`gate` across a re-bless.

Fixes #1945

## Test plan
- [x] `pnpm test tests/scripts/bench-check.test.ts` — 6 new tests, including a deliberate-regression case that proves the budget ceiling fires
- [x] Ran `pnpm bench:json` locally and diffed against the updated baseline — the three tightened benches (`indexAllNotes: 5000 notes`, both `queryGraph` benches) pass comfortably even on a noisier local machine
- [x] Full unit suite (`pnpm test`) passes — 626 files, 6837 passed
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)