### PR TITLE
feat: aggregate e2e retry counts into a visible flake report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,3 +173,27 @@ jobs:
         # entry. Single test today (#394 smoke); add cases per
         # "the app stopped working entirely" incident.
         run: pnpm test:e2e
+
+      # Flake visibility (#1946): Playwright retries a test twice in CI so a
+      # transient Electron-boot hiccup doesn't fail the job, but nothing
+      # previously aggregated how often that retry actually fired — a test
+      # that needed one on every run was indistinguishable from one that
+      # always passed first try. `if: always()` so this runs (and the rate
+      # gets recorded) even when the job ultimately failed.
+      #
+      # Decision recorded here: a retry does NOT fail the job today (no
+      # --max-flaky passed). Failing on any retry would defeat the reason
+      # retries exist (#1097), and the actual flake rate isn't known yet —
+      # this step's job right now is accumulating that history in the
+      # Actions run summaries so a real numeric budget can be set later.
+      - name: E2E flake report
+        if: always()
+        run: node scripts/e2e-flake-report.mjs playwright-report.json
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: playwright-report.json
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ out/
 clipper/*.zip
 test-results/
 playwright-report/
+playwright-report.json
 .vite/
 .minerva/
 coverage/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,10 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   // `list` prints a "retry #N" line for every retried spec, so genuine
   // flake stays visible in the CI log rather than being silently masked.
-  reporter: 'list',
+  // `json` feeds scripts/e2e-flake-report.mjs (#1946) — nothing previously
+  // aggregated those "retry #N" lines, so a test that needed a retry on
+  // every single run was indistinguishable from one that always passed.
+  reporter: [['list'], ['json', { outputFile: 'playwright-report.json' }]],
   use: {
     actionTimeout: 10_000,
   },

--- a/scripts/e2e-flake-report.mjs
+++ b/scripts/e2e-flake-report.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * E2E flake visibility (#1946).
+ *
+ * Playwright retries twice in CI (playwright.config.ts) so a single Electron
+ * boot hiccup doesn't fail the job — but nothing aggregated the "retry #N"
+ * lines the `list` reporter prints, so a test that needed a retry on every
+ * run was indistinguishable from one that always passed first try. This
+ * script reads Playwright's own JSON report (which already tracks retries
+ * per test and a `stats.flaky` count) and:
+ *
+ *   - prints a summary table of any test that needed a retry, win or lose
+ *   - appends the same summary to $GITHUB_STEP_SUMMARY when set, so the rate
+ *     is visible per-run in the Actions UI over time without needing a
+ *     separate dashboard
+ *   - exits non-zero only if flaky-test count exceeds --max-flaky
+ *
+ * Decision recorded (#1946): --max-flaky defaults to Infinity, i.e. a retry
+ * does NOT fail the job today. Retries exist specifically so a transient
+ * Electron-boot hiccup doesn't fail CI (#1097) — making any retry fail the
+ * job would defeat that, and the actual flake rate isn't known yet (two
+ * local runs weren't enough to measure it). This script's real job right now
+ * is accumulating that history in the Actions run summaries; once several
+ * weeks of runs show a stable baseline, revisit whether a real --max-flaky
+ * budget (e.g. 0, or 1 per N runs) belongs in ci.yml.
+ *
+ * Usage:
+ *   node scripts/e2e-flake-report.mjs <playwright-report.json> [--max-flaky <n>]
+ */
+import { readFileSync, appendFileSync } from 'node:fs';
+
+function parseArgs(argv) {
+  const args = { maxFlaky: Infinity };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--max-flaky') args.maxFlaky = Number(argv[++i]);
+    else if (!args.report) args.report = a;
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  return args;
+}
+
+/** Every test whose results array shows at least one retry attempt,
+ *  regardless of whether it eventually passed. */
+export function collectRetriedTests(json) {
+  const out = [];
+  const walk = (suite, titlePath) => {
+    for (const spec of suite.specs ?? []) {
+      const path = [...titlePath, spec.title].join(' › ');
+      for (const test of spec.tests ?? []) {
+        const results = test.results ?? [];
+        if (results.length <= 1) continue;
+        const finalStatus = results[results.length - 1]?.status ?? 'unknown';
+        out.push({ title: path, attempts: results.length, finalStatus });
+      }
+    }
+    for (const s of suite.suites ?? []) walk(s, [...titlePath, s.title]);
+  };
+  for (const s of json.suites ?? []) walk(s, [s.title]);
+  return out;
+}
+
+export function formatReport(json) {
+  const retried = collectRetriedTests(json);
+  const stats = json.stats ?? {};
+  const summary = `E2E flake report — ${stats.expected ?? 0} passed, ${stats.unexpected ?? 0} failed, ${stats.flaky ?? 0} flaky, ${stats.skipped ?? 0} skipped`;
+  const body =
+    retried.length === 0
+      ? 'No test needed a retry.'
+      : ['| test | attempts | final |', '|---|---|---|', ...retried.map((r) => `| ${r.title} | ${r.attempts} | ${r.finalStatus} |`)].join('\n');
+  return { summary, body, flakyCount: stats.flaky ?? 0, retried };
+}
+
+// ── CLI entry point ──
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.report) {
+    console.error('e2e-flake-report: a Playwright JSON report path is required');
+    process.exit(2);
+  }
+  let raw;
+  try {
+    raw = readFileSync(args.report, 'utf-8');
+  } catch {
+    // The run may have failed before Playwright produced a report at all
+    // (e.g. electron-forge packaging itself crashed) — that failure already
+    // surfaced in the step before this one, so don't pile on with a stack
+    // trace for a file that was never going to exist.
+    console.log(`e2e-flake-report: no report at ${args.report} — nothing to analyze.`);
+    process.exit(0);
+  }
+  const { summary, body, flakyCount } = formatReport(JSON.parse(raw));
+  console.log(`\n${summary}\n\n${body}\n`);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n## ${summary}\n\n${body}\n`);
+  }
+
+  if (flakyCount > args.maxFlaky) {
+    console.error(`\n✗ ${flakyCount} flaky test(s) exceeds the budget of ${args.maxFlaky}.`);
+    process.exit(1);
+  }
+  process.exit(0);
+}

--- a/tests/scripts/e2e-flake-report.test.ts
+++ b/tests/scripts/e2e-flake-report.test.ts
@@ -1,0 +1,155 @@
+/**
+ * E2E flake visibility (#1946). Playwright retries a test twice in CI but
+ * nothing aggregated the "retry #N" lines its `list` reporter prints — a
+ * test that needed a retry every run was indistinguishable from one that
+ * always passed first try. These tests pin the parsing logic against
+ * Playwright's own JSON report shape and the CLI's exit-code contract.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { collectRetriedTests, formatReport } from '../../scripts/e2e-flake-report.mjs';
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/e2e-flake-report.mjs');
+
+function report(overrides: { flaky?: number; failed?: number } = {}) {
+  return {
+    suites: [
+      {
+        title: 'a11y.spec.ts',
+        specs: [
+          {
+            title: 'flaky test',
+            tests: [{ results: [{ status: 'failed', retry: 0 }, { status: 'passed', retry: 1 }] }],
+          },
+          {
+            title: 'solid test',
+            tests: [{ results: [{ status: 'passed', retry: 0 }] }],
+          },
+          {
+            title: 'always-fails test',
+            tests: [{ results: [{ status: 'failed', retry: 0 }, { status: 'failed', retry: 1 }, { status: 'failed', retry: 2 }] }],
+          },
+        ],
+        suites: [
+          {
+            title: 'nested',
+            specs: [
+              {
+                title: 'nested flaky test',
+                tests: [{ results: [{ status: 'failed', retry: 0 }, { status: 'passed', retry: 1 }] }],
+              },
+            ],
+            suites: [],
+          },
+        ],
+      },
+    ],
+    stats: { expected: 2, unexpected: 1, flaky: overrides.flaky ?? 2, skipped: 0, ...overrides },
+  };
+}
+
+describe('collectRetriedTests', () => {
+  it('finds every test with more than one result, at any nesting depth', () => {
+    const retried = collectRetriedTests(report());
+    expect(retried.map((r) => r.title)).toEqual([
+      'a11y.spec.ts › flaky test',
+      'a11y.spec.ts › always-fails test',
+      'a11y.spec.ts › nested › nested flaky test',
+    ]);
+  });
+
+  it('ignores a test that passed on the first attempt', () => {
+    const retried = collectRetriedTests(report());
+    expect(retried.some((r) => r.title.includes('solid test'))).toBe(false);
+  });
+
+  it('reports the final status and attempt count, including a retry that never recovered', () => {
+    const retried = collectRetriedTests(report());
+    const alwaysFails = retried.find((r) => r.title.includes('always-fails'));
+    expect(alwaysFails).toMatchObject({ attempts: 3, finalStatus: 'failed' });
+    const flaky = retried.find((r) => r.title === 'a11y.spec.ts › flaky test');
+    expect(flaky).toMatchObject({ attempts: 2, finalStatus: 'passed' });
+  });
+
+  it('returns nothing for a report with no suites', () => {
+    expect(collectRetriedTests({})).toEqual([]);
+  });
+});
+
+describe('formatReport', () => {
+  it('summarizes stats and lists every retried test as a markdown table', () => {
+    const { summary, body, flakyCount } = formatReport(report());
+    expect(summary).toContain('2 flaky');
+    expect(body).toContain('| a11y.spec.ts › flaky test | 2 | passed |');
+    expect(flakyCount).toBe(2);
+  });
+
+  it('says plainly that nothing needed a retry when the run was clean', () => {
+    const clean = { suites: [], stats: { expected: 5, unexpected: 0, flaky: 0, skipped: 0 } };
+    const { body } = formatReport(clean);
+    expect(body).toBe('No test needed a retry.');
+  });
+});
+
+describe('CLI contract', () => {
+  let dir: string;
+  const withTempDir = (fn: (dir: string) => void) => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-e2e-flake-'));
+    try {
+      fn(dir);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  function run(args: string[]): { status: number; stdout: string } {
+    try {
+      const stdout = execFileSync('node', [SCRIPT, ...args], { encoding: 'utf-8' });
+      return { status: 0, stdout };
+    } catch (err) {
+      const e = err as { status: number; stdout: string; stderr: string };
+      return { status: e.status, stdout: e.stdout + e.stderr };
+    }
+  }
+
+  it('exits 0 by default even with flaky tests — a retry does not fail the job (#1946 decision)', () => {
+    withTempDir((d) => {
+      const p = path.join(d, 'report.json');
+      fs.writeFileSync(p, JSON.stringify(report()));
+      const { status, stdout } = run([p]);
+      expect(status).toBe(0);
+      expect(stdout).toContain('2 flaky');
+    });
+  });
+
+  it('exits 1 once flaky count exceeds an explicit --max-flaky budget', () => {
+    withTempDir((d) => {
+      const p = path.join(d, 'report.json');
+      fs.writeFileSync(p, JSON.stringify(report()));
+      const { status, stdout } = run([p, '--max-flaky', '0']);
+      expect(status).toBe(1);
+      expect(stdout).toContain('exceeds the budget of 0');
+    });
+  });
+
+  it('stays under a --max-flaky budget that covers the observed count', () => {
+    withTempDir((d) => {
+      const p = path.join(d, 'report.json');
+      fs.writeFileSync(p, JSON.stringify(report()));
+      const { status } = run([p, '--max-flaky', '5']);
+      expect(status).toBe(0);
+    });
+  });
+
+  it('exits 0 without a stack trace when the report was never produced (e.g. packaging crashed first)', () => {
+    withTempDir((d) => {
+      const missing = path.join(d, 'never-written.json');
+      const { status, stdout } = run([missing]);
+      expect(status).toBe(0);
+      expect(stdout).toContain('nothing to analyze');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Playwright retries a test twice in CI so a transient Electron-boot hiccup doesn't fail the job, but nothing aggregated the "retry #N" lines its `list` reporter prints — a test that needed a retry on every single run was indistinguishable from one that always passed first try.

- **`playwright.config.ts`** — the reporter now also emits a `json` report alongside `list`, giving `scripts/e2e-flake-report.mjs` structured per-test retry data (Playwright already tracks a `results[]` array per test and a `stats.flaky` aggregate).
- **`scripts/e2e-flake-report.mjs`** — new. Parses the JSON report, prints a table of every test that needed a retry (win or lose), and appends the same summary to `$GITHUB_STEP_SUMMARY` when set — visible per-run in the Actions UI over time with no extra dashboard. Supports an optional `--max-flaky` budget that fails the job once exceeded; defaults to `Infinity` (no failure) today.
- **`ci.yml`** — wired the report into the e2e job with `if: always()` (so retries get recorded even when the job ultimately fails) and uploads the raw JSON report as a 30-day artifact for deeper investigation.
- **`tests/scripts/e2e-flake-report.test.ts`** — new. Pins the parsing logic against Playwright's JSON shape and the CLI's exit-code contract.

**Decision recorded** (success criterion 3): a retry does **not** fail the job today. Failing on any retry would defeat the reason retries exist (#1097 — a single Electron-boot hiccup shouldn't fail CI), and the real flake rate isn't known yet — two local runs weren't enough to measure it per the QA report. This step's job right now is accumulating that history in the Actions run summaries so a real numeric `--max-flaky` budget can be set once a baseline exists.

Fixes #1946

## Test plan
- [x] `pnpm test tests/scripts/e2e-flake-report.test.ts` — 10 tests, including one that caught a real bug while writing them (the suite-walk dropped the top-level suite's own title from retried-test names)
- [x] Ran the real e2e suite locally with the dual reporter, confirmed `playwright-report.json` is produced and the flake script parses it correctly (0 flaky) and also against a synthetic flaky report (1 flaky, correct table)
- [x] Full unit suite (`pnpm test`) passes — 626 files, 6841 passed
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)