### PR TITLE
feat: lint against an unawaited waitFor(...) instead of expect.assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,44 @@ generic `reset()`/`clear()` export. Decision, not an oversight:
   underscore-prefixed, same convention as `_setPersistDebounceMsForTests` in
   `search/index.ts`) and call it in `afterEach` — not a general reset.
 
+#### `waitFor(...)` must be awaited — enforced by lint, not `expect.assertions` (#1947)
+
+~200 sites across the component test suite assert inside a
+`@testing-library/svelte` `waitFor(() => expect(...))` callback. `waitFor`
+polls that callback on an interval; if the call itself isn't `await`ed (or
+explicitly `void`ed for deliberate fire-and-forget), the test function can
+return — and be marked passed — before the assertion ever gets to observe
+the state it's waiting for. The audit behind this note found zero existing
+offenders, but nothing was stopping a future one.
+
+`expect.assertions(n)` — the usual defense for "did this callback actually
+run" — was tried and rejected here, for a reason worth recording so it
+isn't tried again: **`waitFor` invokes its callback once per retry tick**,
+so the assertion inside fires a timing-dependent number of times, not once.
+Measured directly: a condition that resolved after 30ms on a 5ms poll
+interval ticked `expect()` 7 times. An exact `expect.assertions(n)` would be
+flaky by construction — pass or fail depending on how many retries a given
+run happened to need. `expect.hasAssertions()` fares no better in the other
+direction: `waitFor` checks its callback once synchronously on the very
+first call, before any interval fires, so even a `waitFor(...)` call with
+the `await` accidentally dropped still ticks the counter at least once —
+the exact bug this is meant to catch slips through it silently.
+
+The actual fix is `no-restricted-syntax` in `eslint.config.mjs`, scoped to
+`tests/**/*.ts`: it flags any `waitFor(...)` sitting as a bare
+`ExpressionStatement` (i.e. not `await`ed, not `void`ed, not assigned or
+returned). That's a static, deterministic check — no timing dependency, and
+it catches the bug before any test runs at all, which a runtime assertion
+count never could.
+
+**Where `expect.assertions`/`expect.hasAssertions` DO earn their keep:** a
+genuinely fire-and-forget async branch with no retry loop — e.g. an
+assertion inside a raw `.then()` callback, or an event handler invoked by a
+mocked callback the test never otherwise awaits. There, the callback runs
+(at most) once, so an exact count is meaningful and won't flap. Reach for
+one of those there; reach for the lint rule (already on, nothing to add)
+for `waitFor`.
+
 ### UI & UX Philosophy
 This is a **professional tool**. Design accordingly:
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -200,6 +200,27 @@ export default tseslint.config(
       // necessarily reference mock functions unbound; there's no real
       // `this`-binding hazard with vi.fn() mocks, so the rule is noise here.
       '@typescript-eslint/unbound-method': 'off',
+      // `no-floating-promises` is off in this block (above) because
+      // vitest's mocking patterns trip it broadly, but an unawaited
+      // `waitFor(...)` is a narrower, real bug worth catching on its own
+      // (#1947): testing-library's `waitFor` retries its callback on an
+      // interval, so its assertion runs on borrowed time — if the call
+      // isn't awaited (or explicitly `void`ed), the test function can
+      // return and be marked "passed" before the assertion ever gets a
+      // chance to actually observe the awaited state, silently discarding
+      // whatever it would have caught. `expect.assertions(n)` was
+      // considered and rejected for this: `waitFor` invokes its callback
+      // once per retry tick, so `expect()` inside it fires a
+      // timing-dependent number of times — an exact assertion count would
+      // be flaky by construction (confirmed empirically: a 30ms condition
+      // on a 5ms interval assertion-counted 7, not 1). This rule instead
+      // enforces the actual invariant at lint time, deterministically: the
+      // call must be `await`ed, assigned, returned, or `void`ed — never a
+      // bare expression statement.
+      'no-restricted-syntax': ['error', {
+        selector: "ExpressionStatement > CallExpression[callee.name='waitFor']",
+        message: 'waitFor(...) must be awaited (or explicitly void\'d for deliberate fire-and-forget) — otherwise its assertion may never run before the test is marked passed (#1947).',
+      }],
     },
   },
   {

--- a/tests/architecture/waitfor-must-be-awaited.test.ts
+++ b/tests/architecture/waitfor-must-be-awaited.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment node
+ *
+ * Coverage for the `waitFor(...)` must-be-awaited lint rule (#1947).
+ *
+ * `@testing-library/svelte`'s `waitFor` polls its callback on an interval; if
+ * the call itself isn't awaited (or explicitly `void`ed), a test can return —
+ * and be marked passed — before the assertion inside ever gets a chance to
+ * run. `expect.assertions(n)` was tried and rejected as the defense here (see
+ * the CLAUDE.md note by the same issue number): `waitFor` invokes its
+ * callback once per retry tick, so an exact assertion count is flaky by
+ * construction, and `expect.hasAssertions()` doesn't catch the bug either
+ * (the first, synchronous check ticks the counter even when the call is
+ * never awaited). The actual fix is the `no-restricted-syntax` rule in
+ * `eslint.config.mjs`, scoped to `tests/**\/*.ts` — this test extracts that
+ * REAL rule config (not a hand-copied selector that could drift from it) and
+ * runs it against fixture snippets, so a future edit that weakens the
+ * selector fails here instead of silently reopening the hole.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+// @ts-expect-error -- plain JS flat config, no .d.ts
+import eslintConfig from '../../eslint.config.mjs';
+
+function testFileRule(): unknown[] {
+  const block = (eslintConfig as Array<{ files?: string[]; rules?: Record<string, unknown> }>).find(
+    (c) => Array.isArray(c.files) && c.files.includes('tests/**/*.ts'),
+  );
+  const rule = block?.rules?.['no-restricted-syntax'];
+  if (!rule) throw new Error('no-restricted-syntax rule not found on the tests/**/*.ts block — did eslint.config.mjs change shape?');
+  return rule as unknown[];
+}
+
+function lint(code: string): number {
+  const linter = new Linter();
+  const messages = linter.verify(code, {
+    languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+    rules: { 'no-restricted-syntax': testFileRule() as never },
+  });
+  return messages.filter((m) => m.ruleId === 'no-restricted-syntax').length;
+}
+
+describe('waitFor(...) must be awaited (tests/**/*.ts eslint rule)', () => {
+  it('flags a bare, unawaited waitFor(...) call', () => {
+    expect(lint(`waitFor(() => { expect(1).toBe(1); });`)).toBe(1);
+  });
+
+  it('allows an awaited waitFor(...) call', () => {
+    expect(lint(`await waitFor(() => { expect(1).toBe(1); });`)).toBe(0);
+  });
+
+  it('allows an explicitly void-ed waitFor(...) call (deliberate fire-and-forget)', () => {
+    expect(lint(`void waitFor(() => { expect(1).toBe(1); });`)).toBe(0);
+  });
+
+  it('allows an assigned or returned waitFor(...) call', () => {
+    expect(lint(`const p = waitFor(() => {});`)).toBe(0);
+    expect(lint(`function f() { return waitFor(() => {}); }`)).toBe(0);
+  });
+
+  it('does not flag an unrelated function that happens to also be unawaited', () => {
+    expect(lint(`somethingElse(() => { expect(1).toBe(1); });`)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

~200 sites across the component test suite assert inside a `@testing-library/svelte` `waitFor(() => expect(...))` callback. If the call itself isn't awaited (or explicitly voided), the test can return — and be marked passed — before the assertion ever gets a chance to run. The audit behind this issue found zero existing offenders, but nothing was stopping a future one.

**`expect.assertions(n)`, the technique the issue suggested, was tried and empirically rejected** (see the reasoning in CLAUDE.md and the commit message): `waitFor` invokes its callback once per retry tick, so `expect()` inside it fires a timing-dependent number of times — a condition that resolved after 30ms on a 5ms poll interval ticked `expect()` 7 times in a throwaway test. An exact assertion count would be flaky by construction. `expect.hasAssertions()` doesn't catch the actual bug either: `waitFor` checks its callback once synchronously on the very first call, so even a dropped-await `waitFor(...)` still ticks the counter at least once.

The real fix is a `no-restricted-syntax` rule in `eslint.config.mjs`, scoped to `tests/**/*.ts`: it flags any `waitFor(...)` sitting as a bare `ExpressionStatement` (not awaited, not voided, not assigned/returned) — a static, deterministic check with no timing dependency. Running it against the existing suite found zero violations, confirming the QA report's own "assertion audit came back clean" finding.

- **`eslint.config.mjs`** — the new rule, with the full reasoning (including the empirical assertion-count numbers) so a future editor doesn't reach for `expect.assertions` again without knowing why it doesn't work here.
- **`tests/architecture/waitfor-must-be-awaited.test.ts`** — new. Imports the REAL rule config from `eslint.config.mjs` (not a hand-copied selector that could drift) and runs it against awaited/voided/bare fixtures.
- **`CLAUDE.md`** — recorded the convention: where `expect.assertions`/`hasAssertions` actually help (a genuine fire-and-forget callback with no retry loop, e.g. a raw `.then()`) versus where they don't (`waitFor`, covered by the lint rule instead). No such fire-and-forget pattern exists in the current suite, so there's nothing to retrofit today.

Fixes #1947

## Test plan
- [x] `pnpm test tests/architecture/waitfor-must-be-awaited.test.ts` — 5 tests
- [x] Ran the new lint rule against the existing suite — zero violations (matches the issue's own audit)
- [x] Manually broke a real test's `await waitFor(...)` and confirmed the rule catches it, then restored it
- [x] Full unit suite (`pnpm test`) passes — 627 files, 6842 passed
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)