### PR TITLE
refactor: adopt ui/Dialog.svelte in PromptDialog + ConfirmDialog

### DIFF
--- a/src/renderer/lib/components/ConfirmDialog.svelte
+++ b/src/renderer/lib/components/ConfirmDialog.svelte
@@ -5,7 +5,14 @@
    * the rendering. Keeps the "Don't ask again" checkbox per CLAUDE.md
    * unless `hideDontAskAgain` is set, and the primary CTA stays on
    * the accent color even for destructive verbs (no danger styling).
+   *
+   * Renders via ui/Dialog.svelte (#1888) rather than hand-rolling the
+   * overlay/card scaffolding — Escape-to-cancel and backdrop-click are
+   * Dialog's job now; this component only owns Enter-to-confirm and its
+   * own body content (code preview / checkbox).
    */
+  import Dialog from './ui/Dialog.svelte';
+
   interface Props {
     message: string;
     confirmLabel?: string;
@@ -35,8 +42,6 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter') {
       onConfirm(dontAskAgain);
-    } else if (e.key === 'Escape') {
-      onCancel();
     }
   }
 
@@ -46,15 +51,12 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
-    <header class="card-header">
-      <div class="eyebrow">Confirm action</div>
-      <h2 class="title" id="confirm-dialog-title">{message}</h2>
-    </header>
-
-    {#if code !== undefined || !hideDontAskAgain}
-      <div class="body">
+<div onkeydown={handleKeydown}>
+  <Dialog width={440} zIndex="var(--z-spawned)" onClose={onCancel} titleId="confirm-dialog-title">
+    {#snippet eyebrow()}Confirm action{/snippet}
+    {#snippet title()}{message}{/snippet}
+    {#snippet body()}
+      {#if code !== undefined || !hideDontAskAgain}
         {#if code !== undefined}
           <pre class="code-preview"><code>{code}</code></pre>
         {/if}
@@ -64,76 +66,20 @@
             {dontAskLabel}
           </label>
         {/if}
-      </div>
-    {/if}
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ↵ confirm</span>
-      <span class="footer-actions">
-        <button class="btn secondary" onclick={onCancel}>Cancel</button>
-        <button class="btn primary" bind:this={confirmBtn} onclick={() => onConfirm(dontAskAgain)}>
-          {confirmLabel}
-          <span class="btn-kbd">↵</span>
-        </button>
-      </span>
-    </footer>
-  </div>
+      {/if}
+    {/snippet}
+    {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ↵ confirm</span>{/snippet}
+    {#snippet footerRight()}
+      <button class="btn secondary" onclick={onCancel}>Cancel</button>
+      <button class="btn primary" bind:this={confirmBtn} onclick={() => onConfirm(dontAskAgain)}>
+        {confirmLabel}
+        <span class="btn-kbd">↵</span>
+      </button>
+    {/snippet}
+  </Dialog>
 </div>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-spawned);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow:
-      0 16px 48px rgba(0, 0, 0, 0.35),
-      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 440px;
-    max-width: 100%;
-    display: flex;
-    flex-direction: column;
-    font-family: var(--font-sans);
-    color: var(--text);
-    overflow: hidden;
-  }
-
-  .card-header {
-    padding: 20px 24px 0;
-  }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-    color: var(--text);
-  }
-
-  .body {
-    padding: 14px 24px 18px;
-    font-size: 13px;
-  }
   .code-preview {
     margin: 0 0 12px;
     padding: 12px 14px;
@@ -162,24 +108,10 @@
     cursor: pointer;
   }
 
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
   .kbd-hint {
-    margin-right: auto;
     font-size: 10.5px;
     color: var(--text-faint);
     font-family: var(--font-mono);
-  }
-  .footer-actions {
-    display: inline-flex;
-    gap: 8px;
   }
 
   .btn {

--- a/src/renderer/lib/components/PromptDialog.svelte
+++ b/src/renderer/lib/components/PromptDialog.svelte
@@ -2,7 +2,14 @@
   /**
    * Prompt dialog refreshed per IMPLEMENTATION.md §10.1. Signature
    * (`showPrompt(message, opts)`) is unchanged — only the rendering.
+   *
+   * Renders via ui/Dialog.svelte (#1888) rather than hand-rolling the
+   * overlay/card scaffolding — Escape-to-cancel and backdrop-click are
+   * Dialog's job now; this component only owns the input and the
+   * Enter-to-confirm behavior specific to it.
    */
+  import Dialog from './ui/Dialog.svelte';
+
   interface Props {
     message: string;
     onConfirm: (value: string) => void;
@@ -32,8 +39,6 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter' && value.trim()) {
       onConfirm(value.trim());
-    } else if (e.key === 'Escape') {
-      onCancel();
     }
   }
 
@@ -46,99 +51,39 @@
   });
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="prompt-dialog-title">
-    <header class="card-header">
-      <div class="eyebrow">Input</div>
-      <h2 class="title" id="prompt-dialog-title">{message}</h2>
-    </header>
-
-    <div class="body">
-      <input
-        bind:this={inputEl}
-        bind:value
-        type="text"
-        class="input"
-        aria-labelledby="prompt-dialog-title"
-        list={suggestions.length > 0 ? listId : undefined}
-        autocomplete="off"
-      />
-      {#if suggestions.length > 0}
-        <datalist id={listId}>
-          {#each suggestions as s}
-            <option value={s}></option>
-          {/each}
-        </datalist>
-      {/if}
-    </div>
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ↵ confirm</span>
-      <span class="footer-actions">
-        <button class="btn secondary" onclick={onCancel}>Cancel</button>
-        <button class="btn primary" disabled={!value.trim()} onclick={() => onConfirm(value.trim())}>
-          OK
-          <span class="btn-kbd">↵</span>
-        </button>
-      </span>
-    </footer>
-  </div>
-</div>
+<Dialog width={460} zIndex="var(--z-spawned)" onClose={onCancel} titleId="prompt-dialog-title">
+  {#snippet eyebrow()}Input{/snippet}
+  {#snippet title()}{message}{/snippet}
+  {#snippet body()}
+    <input
+      bind:this={inputEl}
+      bind:value
+      onkeydown={handleKeydown}
+      type="text"
+      class="input"
+      aria-labelledby="prompt-dialog-title"
+      list={suggestions.length > 0 ? listId : undefined}
+      autocomplete="off"
+    />
+    {#if suggestions.length > 0}
+      <datalist id={listId}>
+        {#each suggestions as s}
+          <option value={s}></option>
+        {/each}
+      </datalist>
+    {/if}
+  {/snippet}
+  {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ↵ confirm</span>{/snippet}
+  {#snippet footerRight()}
+    <button class="btn secondary" onclick={onCancel}>Cancel</button>
+    <button class="btn primary" disabled={!value.trim()} onclick={() => onConfirm(value.trim())}>
+      OK
+      <span class="btn-kbd">↵</span>
+    </button>
+  {/snippet}
+</Dialog>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-spawned);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow:
-      0 16px 48px rgba(0, 0, 0, 0.35),
-      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 460px;
-    max-width: 100%;
-    display: flex;
-    flex-direction: column;
-    font-family: var(--font-sans);
-    color: var(--text);
-    overflow: hidden;
-  }
-
-  .card-header {
-    padding: 20px 24px 0;
-  }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-    color: var(--text);
-  }
-
-  .body {
-    padding: 14px 24px 18px;
-  }
   .input {
     width: 100%;
     padding: 8px 10px;
@@ -152,24 +97,10 @@
     box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
   }
 
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
   .kbd-hint {
-    margin-right: auto;
     font-size: 10.5px;
     color: var(--text-faint);
     font-family: var(--font-mono);
-  }
-  .footer-actions {
-    display: inline-flex;
-    gap: 8px;
   }
 
   .btn {

--- a/src/renderer/lib/components/ui/Dialog.svelte
+++ b/src/renderer/lib/components/ui/Dialog.svelte
@@ -7,9 +7,17 @@
     width?: number;
     /** Click on the backdrop / Escape key. Both are routed here. */
     onClose?: () => void;
-    /** Optional aria-labelledby — typically the eyebrow + title elements id'd
-     *  by the caller. When omitted we set role="dialog" with no label. */
-    'aria-labelledby'?: string;
+    /** DOM id for the title heading. Sets `aria-labelledby` on the dialog to
+     *  match automatically — the id lives on the `<h2>` this component
+     *  already renders, so the caller never has to nest a second id'd
+     *  element inside the `title` snippet just to have something to point
+     *  at. Omit for role="dialog" with no accessible name (rare). */
+    titleId?: string;
+    /** Stacking tier, as a `var(--z-*)` token from global.css. Defaults to
+     *  the modal tier; a dialog that can itself be raised from inside an
+     *  already-open modal (prompt/confirm/…) must outrank it — pass
+     *  `var(--z-spawned)` (see tests/renderer/z-index-layering.test.ts). */
+    zIndex?: string;
     /** Header eyebrow (mono-uppercase). */
     eyebrow?: Snippet;
     /** Header title (display-serif H1). */
@@ -25,7 +33,8 @@
   let {
     width = 440,
     onClose,
-    'aria-labelledby': ariaLabelledBy,
+    titleId,
+    zIndex = 'var(--z-modal)',
     eyebrow,
     title,
     body,
@@ -55,18 +64,19 @@
 <div
   class="backdrop"
   onclick={onBackdropClick}
+  style:z-index={zIndex}
 >
   <div
     class="card"
     role="dialog"
     aria-modal="true"
-    aria-labelledby={ariaLabelledBy}
+    aria-labelledby={titleId}
     style:width="{width}px"
   >
     {#if eyebrow || title}
       <header class="card-header">
         {#if eyebrow}<div class="eyebrow">{@render eyebrow()}</div>{/if}
-        {#if title}<h2 class="title">{@render title()}</h2>{/if}
+        {#if title}<h2 class="title" id={titleId}>{@render title()}</h2>{/if}
       </header>
     {/if}
 
@@ -91,7 +101,8 @@
   .backdrop {
     position: fixed;
     inset: 0;
-    z-index: var(--z-modal);
+    /* z-index set via the `zIndex` prop (style:z-index above) — the tier
+       varies per caller (modal vs spawned), so it isn't a static rule. */
     display: flex;
     align-items: center;
     justify-content: center;

--- a/tests/renderer/modal-scrim.test.ts
+++ b/tests/renderer/modal-scrim.test.ts
@@ -84,10 +84,14 @@ describe('modal scrim', () => {
 
   it('still paints a backdrop on the dialogs that had one', () => {
     // The opposite failure: a search-and-replace that dropped the scrim
-    // entirely would leave dialogs floating with no separation at all.
+    // entirely would leave dialogs floating with no separation at all. Two
+    // forms count: the component paints its own backdrop, or (PromptDialog /
+    // ConfirmDialog, since #1888) composes ui/Dialog.svelte, which does.
     for (const name of ['NewNoteDialog', 'PromptDialog', 'ConfirmDialog', 'SettingsDialog', 'ui/Dialog']) {
       const src = fs.readFileSync(path.join(RENDERER, `lib/components/${name}.svelte`), 'utf-8');
-      expect(src, `${name} lost its backdrop`).toContain('var(--scrim-bg)');
+      const ownBackdrop = src.includes('var(--scrim-bg)');
+      const viaDialog = /<Dialog\b/.test(src) && src.includes("from './ui/Dialog.svelte'");
+      expect(ownBackdrop || viaDialog, `${name} lost its backdrop`).toBe(true);
     }
   });
 });

--- a/tests/renderer/z-index-layering.test.ts
+++ b/tests/renderer/z-index-layering.test.ts
@@ -78,12 +78,17 @@ describe('overlay components use the scale', () => {
 
   it('gives every DialogHost dialog the spawned tier', () => {
     // These are exactly the components DialogHost renders; each must outrank a
-    // modal because a modal is what typically raises it.
+    // modal because a modal is what typically raises it. Two forms count: a
+    // hand-rolled backdrop setting the tier directly in CSS, or (PromptDialog /
+    // ConfirmDialog, since #1888) composing ui/Dialog.svelte and passing it the
+    // tier via the `zIndex` prop instead.
     const host = fs.readFileSync(path.join(RENDERER, 'lib/components/DialogHost.svelte'), 'utf-8');
     for (const name of SPAWNED) {
       expect(host, `DialogHost no longer renders ${name} — update this list`).toContain(`${name}.svelte`);
       const src = fs.readFileSync(path.join(RENDERER, `lib/components/${name}.svelte`), 'utf-8');
-      expect(src, `${name} must use var(--z-spawned)`).toContain('z-index: var(--z-spawned)');
+      const handRolled = src.includes('z-index: var(--z-spawned)');
+      const viaDialogProp = src.includes('zIndex="var(--z-spawned)"');
+      expect(handRolled || viaDialogProp, `${name} must use var(--z-spawned)`).toBe(true);
     }
   });
 


### PR DESCRIPTION
## Summary

**Decision recorded: adopt, not delete.** `ui/Dialog.svelte` was a complete, documented dialog primitive with zero importers while 30 components hand-rolled its overlay/card scaffolding — the last backdrop change (#1818) was a 30-file edit across four drifted opacities, exactly the cost a shared primitive is supposed to remove. This PR migrates the two dialogs the issue names ("mostly style block") to prove the primitive actually works for a real caller.

Starting the migration surfaced two real gaps in `ui/Dialog.svelte`, both fixed on the primitive itself (zero prior consumers, so no compatibility concern):
- **No way to override the stacking tier.** Hardcoded `var(--z-modal)`, but prompt/confirm must render `var(--z-spawned)` (one tier above modal) since either can be raised from inside an already-open modal (Settings → Object Types → Rename, the compute-consent prompt) and must not paint behind it. Added a `zIndex` prop.
- **No clean way to label the dialog.** The old `aria-labelledby` prop expected the caller to separately id an element inside its own `title` snippet — workable but awkward, never actually exercised. Replaced with `titleId`: the id lives on the `<h2>` Dialog already renders.

**`PromptDialog.svelte` / `ConfirmDialog.svelte`** — replaced the hand-rolled overlay/card/header/footer markup and ~90 lines each of scaffolding CSS with `<Dialog>` + snippets, keeping only what's specific to each. Backdrop-click and Escape are now Dialog's job. Enter-to-confirm behavior was reviewed per-component: PromptDialog moved it onto the input directly (equivalent in practice, drops a latent double-fire the old dialog-wide handler had); ConfirmDialog kept a dialog-wide handler since Enter must still confirm with focus on the "don't ask again" checkbox (which doesn't natively respond to Enter).

Two existing tests (`modal-scrim.test.ts`, `z-index-layering.test.ts`) hardcoded "the scrim/z-index CSS lives directly in this component's own `<style>` block" — updated both to accept the new "composes `ui/Dialog`" form too.

**Scope**: per the issue's own guidance ("migrate 2-3 dialogs per PR"), this covers only `PromptDialog` and `ConfirmDialog`. The remaining 28 hand-rolled dialogs are follow-up work against the same issue.

Fixes #1888 (partially — tracking issue stays open for the remaining dialogs)

## Test plan
- [x] Full unit suite (`pnpm test`) passes — 627 files, 6847 passed
- [x] `pnpm lint` passes (tsc + svelte-check + eslint)
- [x] Manually verified against the real packaged app (not just the unit suite): launched Minerva, exercised Rename (PromptDialog) and Delete (ConfirmDialog) through the actual file-tree context menu — confirmed backdrop/z-index (2500, matching `--z-spawned`)/focus/aria wiring end-to-end, Escape-cancels, Enter-confirms (including with focus on the checkbox), and that a rename actually lands on disk
- [x] Screenshots taken of both dialogs mid-flow, visually match the pre-migration design exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)