### PR TITLE
refactor: adopt ui/Dialog.svelte in 7 more dialogs, add a subtitle snippet

### DIFF
--- a/src/renderer/lib/components/AddPropertyDialog.svelte
+++ b/src/renderer/lib/components/AddPropertyDialog.svelte
@@ -6,9 +6,13 @@
    * frontmatter-key vocabulary, and the value uses the same type-aware editor
    * the Properties panel does, so a real boolean / number / date is written
    * rather than a stringified one.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and backdrop-click
+   * are Dialog's job; Enter-on-the-name-field submission stays local.
    */
   import type { AddPropertyResult } from '../stores/dialogs.svelte';
   import PropertyValueEditor from './PropertyValueEditor.svelte';
+  import Dialog from './ui/Dialog.svelte';
   import {
     SCALAR_TYPES,
     coerceScalar,
@@ -42,9 +46,6 @@
     onConfirm({ name: name.trim(), value });
   }
 
-  function onOverlayKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') onCancel();
-  }
   function onNameKeydown(e: KeyboardEvent) {
     // Enter on the name field submits directly — the value has a sensible
     // default per type (empty string / 0 / false / today-less date), so a
@@ -55,15 +56,11 @@
   $effect(() => { nameEl?.focus(); });
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={onOverlayKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="add-property-title">
-    <header class="card-header">
-      <div class="eyebrow">Property</div>
-      <h2 class="title" id="add-property-title">{message}</h2>
-    </header>
-
-    <div class="body">
+<Dialog width={460} zIndex="var(--z-spawned)" onClose={onCancel} titleId="add-property-title">
+  {#snippet eyebrow()}Property{/snippet}
+  {#snippet title()}{message}{/snippet}
+  {#snippet body()}
+    <div class="body-inner">
       <label class="field">
         <span class="field-label">Name</span>
         <input
@@ -108,72 +105,19 @@
         </div>
       </div>
     </div>
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ↵ next / confirm</span>
-      <span class="footer-actions">
-        <button class="btn secondary" onclick={onCancel}>Cancel</button>
-        <button class="btn primary" disabled={!canConfirm} onclick={submit}>
-          Add
-          <span class="btn-kbd">↵</span>
-        </button>
-      </span>
-    </footer>
-  </div>
-</div>
+  {/snippet}
+  {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ↵ next / confirm</span>{/snippet}
+  {#snippet footerRight()}
+    <button class="btn secondary" onclick={onCancel}>Cancel</button>
+    <button class="btn primary" disabled={!canConfirm} onclick={submit}>
+      Add
+      <span class="btn-kbd">↵</span>
+    </button>
+  {/snippet}
+</Dialog>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-spawned);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow:
-      0 16px 48px rgba(0, 0, 0, 0.35),
-      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 460px;
-    max-width: 100%;
-    display: flex;
-    flex-direction: column;
-    font-family: var(--font-sans);
-    color: var(--text);
-    overflow: hidden;
-  }
-
-  .card-header {
-    padding: 20px 24px 0;
-  }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-    color: var(--text);
-  }
-
-  .body {
-    padding: 14px 24px 18px;
+  .body-inner {
     display: flex;
     flex-direction: column;
     gap: 12px;
@@ -234,26 +178,11 @@
     min-height: 37px;
   }
 
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
   .kbd-hint {
-    margin-right: auto;
     font-size: 10.5px;
     color: var(--text-faint);
     font-family: var(--font-mono);
   }
-  .footer-actions {
-    display: inline-flex;
-    gap: 8px;
-  }
-
   .btn {
     padding: 7px 14px;
     border: 1px solid var(--border);

--- a/src/renderer/lib/components/AutoLinkDialog.svelte
+++ b/src/renderer/lib/components/AutoLinkDialog.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
+  /**
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and backdrop-click
+   * are Dialog's job; this component has nothing else to handle.
+   */
   import type { AutoLinkSuggestion } from '../../../shared/refactor/auto-link';
+  import Dialog from './ui/Dialog.svelte';
 
   interface Props {
     suggestions: AutoLinkSuggestion[];
@@ -27,22 +32,18 @@
     onApply(accepted);
   }
 
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') onCancel();
-  }
-
   function contextSnippet(anchor: string): string {
     const idx = activeNoteBody.indexOf(anchor);
     if (idx < 0) return '';
     const radius = 50;
     const start = Math.max(0, idx - radius);
     const end = Math.min(activeNoteBody.length, idx + anchor.length + radius);
-    const prefix = start > 0 ? '\u2026' : '';
-    const suffix = end < activeNoteBody.length ? '\u2026' : '';
+    const prefix = start > 0 ? '…' : '';
+    const suffix = end < activeNoteBody.length ? '…' : '';
     return (
       prefix +
       activeNoteBody.slice(start, idx) +
-      '\u00BB' + anchor + '\u00AB' +
+      '»' + anchor + '«' +
       activeNoteBody.slice(idx + anchor.length, end) +
       suffix
     ).replace(/\s+/g, ' ');
@@ -53,27 +54,17 @@
   }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div
-  class="overlay"
-  onkeydown={handleKeydown}
-  onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
->
-  <div class="dialog" role="dialog" aria-modal="true">
-    <header class="card-header">
-      <div class="eyebrow">Auto-link \u00b7 {suggestions.length} {suggestions.length === 1 ? 'candidate' : 'candidates'}</div>
-      <h2 class="title">Review link suggestions</h2>
-    </header>
-
+<Dialog width={640} onClose={onCancel} titleId="auto-link-title">
+  {#snippet eyebrow()}Auto-link · {suggestions.length} {suggestions.length === 1 ? 'candidate' : 'candidates'}{/snippet}
+  {#snippet title()}Review link suggestions{/snippet}
+  {#snippet body()}
     {#if suggestions.length === 0}
-      <div class="body">
-        <div class="empty">
-          The LLM didn't find any link candidates in this note. If the note is short or
-          doesn't mention concepts covered by other notes, that's the expected outcome.
-        </div>
+      <div class="empty">
+        The LLM didn't find any link candidates in this note. If the note is short or
+        doesn't mention concepts covered by other notes, that's the expected outcome.
       </div>
     {:else}
-      <div class="body">
+      <div class="body-inner">
         <div class="bulk-row">
           <span class="bulk-count">{selectedCount} of {suggestions.length} selected</span>
           <span class="bulk-spacer"></span>
@@ -87,7 +78,7 @@
               <div class="details">
                 <div class="headline">
                   <span class="anchor">{s.anchorText}</span>
-                  <span class="arrow">\u2192</span>
+                  <span class="arrow">→</span>
                   <code class="target">[[{targetLabel(s.target)}]]</code>
                 </div>
                 {#if s.rationale}
@@ -100,73 +91,20 @@
         </div>
       </div>
     {/if}
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc \u00b7 cancel</span>
-      <span class="footer-actions">
-        <button class="btn ghost" onclick={onCancel}>Cancel</button>
-        <button
-          class="btn primary"
-          disabled={selectedCount === 0}
-          onclick={apply}
-        >Apply {selectedCount}</button>
-      </span>
-    </footer>
-  </div>
-</div>
+  {/snippet}
+  {#snippet footerLeft()}<span class="kbd-hint">esc · cancel</span>{/snippet}
+  {#snippet footerRight()}
+    <button class="btn ghost" onclick={onCancel}>Cancel</button>
+    <button
+      class="btn primary"
+      disabled={selectedCount === 0}
+      onclick={apply}
+    >Apply {selectedCount}</button>
+  {/snippet}
+</Dialog>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-modal);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow:
-      0 16px 48px rgba(0, 0, 0, 0.35),
-      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 640px;
-    max-width: 100%;
-    max-height: calc(100vh - 64px);
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    font-family: var(--font-sans);
-    color: var(--text);
-  }
-
-  .card-header { padding: 20px 24px 0; }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-  }
-
-  .body {
-    padding: 14px 24px 18px;
-    overflow: auto;
-    flex: 1;
+  .body-inner {
     display: flex;
     flex-direction: column;
     gap: 12px;
@@ -289,22 +227,11 @@
     word-break: break-word;
   }
 
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
   .kbd-hint {
-    margin-right: auto;
     font-family: var(--font-mono);
     font-size: 10.5px;
     color: var(--text-faint);
   }
-  .footer-actions { display: inline-flex; gap: 8px; }
 
   .btn {
     padding: 7px 14px;

--- a/src/renderer/lib/components/AutoTagDialog.svelte
+++ b/src/renderer/lib/components/AutoTagDialog.svelte
@@ -4,7 +4,12 @@
    * but wrote nothing; the user picks which to keep, and Apply files them through
    * the note_rewrite approval payload. Mirrors AutoLinkDialog's chrome — no danger
    * styling, per-item selection, esc to cancel.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and backdrop-click
+   * are Dialog's job; this component has nothing else to handle.
    */
+  import Dialog from './ui/Dialog.svelte';
+
   interface Props {
     tags: string[];
     /** The note the tags will be added to (shown for context). */
@@ -27,25 +32,14 @@
   function apply() {
     onApply(tags.filter((_, i) => selected[i]));
   }
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') onCancel();
-  }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div
-  class="overlay"
-  onkeydown={handleKeydown}
-  onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
->
-  <div class="dialog" role="dialog" aria-modal="true">
-    <header class="card-header">
-      <div class="eyebrow">Auto-tag · {tags.length} {tags.length === 1 ? 'suggestion' : 'suggestions'}</div>
-      <h2 class="title">Review tags</h2>
-      <div class="subtitle">for <code>{relativePath}</code></div>
-    </header>
-
-    <div class="body">
+<Dialog width={460} onClose={onCancel} titleId="auto-tag-title">
+  {#snippet eyebrow()}Auto-tag · {tags.length} {tags.length === 1 ? 'suggestion' : 'suggestions'}{/snippet}
+  {#snippet title()}Review tags{/snippet}
+  {#snippet subtitle()}for <code>{relativePath}</code>{/snippet}
+  {#snippet body()}
+    <div class="body-inner">
       <div class="bulk-row">
         <span class="bulk-count">{selectedCount} of {tags.length} selected</span>
         <span class="bulk-spacer"></span>
@@ -61,71 +55,25 @@
         {/each}
       </div>
     </div>
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel</span>
-      <span class="footer-actions">
-        <button class="btn ghost" onclick={onCancel}>Cancel</button>
-        <button class="btn primary" disabled={selectedCount === 0} onclick={apply}>
-          Add {selectedCount} tag{selectedCount === 1 ? '' : 's'}
-        </button>
-      </span>
-    </footer>
-  </div>
-</div>
+  {/snippet}
+  {#snippet footerLeft()}<span class="kbd-hint">esc · cancel</span>{/snippet}
+  {#snippet footerRight()}
+    <button class="btn ghost" onclick={onCancel}>Cancel</button>
+    <button class="btn primary" disabled={selectedCount === 0} onclick={apply}>
+      Add {selectedCount} tag{selectedCount === 1 ? '' : 's'}
+    </button>
+  {/snippet}
+</Dialog>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-modal);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow:
-      0 16px 48px rgba(0, 0, 0, 0.35),
-      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 460px;
-    max-width: 100%;
-    max-height: calc(100vh - 64px);
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    font-family: var(--font-sans);
-    color: var(--text);
-  }
-  .card-header { padding: 20px 24px 0; }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-  }
-  .subtitle { font-size: 12px; color: var(--text-muted); margin-top: 4px; }
-  .subtitle code { font-family: var(--font-mono); font-size: 11px; }
+  /* Not `.subtitle code` — `.subtitle` is ui/Dialog.svelte's own <p>, not
+     this component's; Svelte can't scope through a child's markup, so an
+     ancestor-qualified selector here is silently dropped as unused. A bare
+     tag selector still scopes correctly to the <code> this component's own
+     `subtitle` snippet renders. */
+  code { font-family: var(--font-mono); font-size: 11px; }
 
-  .body {
-    padding: 14px 24px 18px;
-    overflow: auto;
-    flex: 1;
+  .body-inner {
     display: flex;
     flex-direction: column;
     gap: 12px;
@@ -164,17 +112,7 @@
   .row input[type='checkbox'] { flex-shrink: 0; accent-color: var(--accent); }
   .tag { font-family: var(--font-mono); font-size: 12px; color: var(--text); }
 
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
-  .kbd-hint { margin-right: auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-faint); }
-  .footer-actions { display: inline-flex; gap: 8px; }
+  .kbd-hint { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-faint); }
   .btn {
     padding: 7px 14px;
     border: 1px solid var(--border);

--- a/src/renderer/lib/components/MergeSourcesDialog.svelte
+++ b/src/renderer/lib/components/MergeSourcesDialog.svelte
@@ -4,9 +4,15 @@
    * user chooses which one to KEEP and the rest are merged into it. Modeled on
    * TypePickerDialog. Merging isn't a silent deterministic fix — which source is
    * canonical is a judgment call, so we ask.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and backdrop-click
+   * are Dialog's job. Arrow-key nav and Enter-to-merge stay on the list
+   * container directly (via bind:this + a local keydown), since — unlike
+   * TypePickerDialog's text input — there's nothing else to focus here.
    */
   import type { SourceMetadata } from '../../../shared/types';
   import { displaySourceTitle } from '../../../shared/source-display';
+  import Dialog from './ui/Dialog.svelte';
 
   interface Props {
     sources: SourceMetadata[];
@@ -18,9 +24,9 @@
   let { sources, onPick, onCancel }: Props = $props();
 
   let selectedIndex = $state(0);
-  let dialogEl = $state<HTMLDivElement>();
+  let listEl = $state<HTMLDivElement>();
 
-  $effect(() => { dialogEl?.focus(); });
+  $effect(() => { listEl?.focus(); });
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'ArrowDown') {
@@ -33,103 +39,49 @@
       e.preventDefault();
       const pick = sources[selectedIndex];
       if (pick) onPick(pick.sourceId);
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      onCancel();
     }
   }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-  <div class="dialog" role="dialog" aria-modal="true" tabindex="-1" bind:this={dialogEl} onkeydown={handleKeydown}>
-    <header class="card-header">
-      <div class="eyebrow">Merge duplicates</div>
-      <h2 class="title">Which source should be kept?</h2>
-      <p class="subtitle">The other {sources.length - 1} will be merged into it — their excerpts and citations move over, then they're removed.</p>
-    </header>
-
-    <div class="body">
-      <div class="ms-results" role="listbox" aria-label="Duplicate sources">
-        {#each sources as s, i (s.sourceId)}
-          {@const selected = i === selectedIndex}
-          <button
-            type="button"
-            class="ms-row"
-            class:selected
-            role="option"
-            aria-selected={selected}
-            onmousemove={() => { selectedIndex = i; }}
-            onclick={() => onPick(s.sourceId)}
-          >
-            <span class="ms-dot" aria-hidden="true">{selected ? '●' : '○'}</span>
-            <span class="ms-body">
-              <span class="ms-name">{displaySourceTitle(s)}</span>
-              <span class="ms-id">{s.sourceId}</span>
-            </span>
-            {#if selected}<span class="ms-keep">keep</span>{/if}
-          </button>
-        {/each}
-      </div>
+<Dialog width={460} zIndex="var(--z-spawned)" onClose={onCancel} titleId="merge-sources-title">
+  {#snippet eyebrow()}Merge duplicates{/snippet}
+  {#snippet title()}Which source should be kept?{/snippet}
+  {#snippet subtitle()}The other {sources.length - 1} will be merged into it — their excerpts and citations move over, then they're removed.{/snippet}
+  {#snippet body()}
+    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+    <div class="ms-results" role="listbox" aria-label="Duplicate sources" tabindex="-1" bind:this={listEl} onkeydown={handleKeydown}>
+      {#each sources as s, i (s.sourceId)}
+        {@const selected = i === selectedIndex}
+        <button
+          type="button"
+          class="ms-row"
+          class:selected
+          role="option"
+          aria-selected={selected}
+          onmousemove={() => { selectedIndex = i; }}
+          onclick={() => onPick(s.sourceId)}
+        >
+          <span class="ms-dot" aria-hidden="true">{selected ? '●' : '○'}</span>
+          <span class="ms-body">
+            <span class="ms-name">{displaySourceTitle(s)}</span>
+            <span class="ms-id">{s.sourceId}</span>
+          </span>
+          {#if selected}<span class="ms-keep">keep</span>{/if}
+        </button>
+      {/each}
     </div>
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ↑↓ · ↵ merge others in</span>
-    </footer>
-  </div>
-</div>
+  {/snippet}
+  {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ↑↓ · ↵ merge others in</span>{/snippet}
+</Dialog>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-spawned);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
-    width: 460px;
-    max-width: 100%;
-    display: flex;
-    flex-direction: column;
-    font-family: var(--font-sans);
-    color: var(--text);
-    overflow: hidden;
-    outline: none;
-  }
-  .card-header { padding: 18px 22px 0; }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 5px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 18px;
-    font-weight: 500;
-    color: var(--text);
-  }
-  .subtitle { margin: 6px 0 0; font-size: 12px; color: var(--text-muted); line-height: 1.4; }
-  .body { padding: 14px 22px 16px; }
   .ms-results {
     display: flex;
     flex-direction: column;
     gap: 2px;
     max-height: 320px;
     overflow-y: auto;
+    outline: none;
   }
   .ms-row {
     display: flex;
@@ -156,13 +108,6 @@
     flex-shrink: 0;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-  }
-  .card-footer {
-    display: flex;
-    align-items: center;
-    padding: 10px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
   }
   .kbd-hint { font-size: 10.5px; color: var(--text-faint); font-family: var(--font-mono); }
 </style>

--- a/src/renderer/lib/components/SafeDeleteBlockerDialog.svelte
+++ b/src/renderer/lib/components/SafeDeleteBlockerDialog.svelte
@@ -14,8 +14,15 @@
    * surface; that's the whole point of safe-by-default. The earlier
    * "Delete N notes?" confirm still has its own suppression for the
    * no-blocker case.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and
+   * backdrop-click are Dialog's job. The accessible name moves from a
+   * static `aria-label` to the actual h2 title text via `titleId` — more
+   * accurate (it now includes the note count), and nothing asserts the
+   * old static string.
    */
   import type { SafeDeleteBlocker } from '../../../shared/types';
+  import Dialog from './ui/Dialog.svelte';
 
   interface Props {
     /** Number of items the user originally selected (folders count once). */
@@ -46,129 +53,61 @@
   const blockedTargetCount = $derived(grouped.length);
   const totalLinks = $derived(blockers.reduce((n, b) => n + b.linkCount, 0));
   const firstBlocker = $derived(blockers[0] ?? null);
-
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') onCancel();
-  }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true" aria-label="Safe Delete — external references found">
-    <header class="card-header">
-      <div class="eyebrow">SAFE DELETE · {blockedTargetCount} of {targets.length} blocked</div>
-      <h2 class="title">
-        {#if blockedTargetCount === 1}
-          1 note has external references
-        {:else}
-          {blockedTargetCount} notes have external references
-        {/if}
-      </h2>
-      <p class="sub">
-        {totalLinks} inbound link{totalLinks === 1 ? '' : 's'} from
-        {selectionCount === 1 ? 'this selection' : 'outside the selection'}
-        would become broken. Fix or remove the reference{totalLinks === 1 ? '' : 's'}, then retry —
-        or override with <em>Delete anyway</em>.
-      </p>
-    </header>
-
-    <div class="body">
-      <div class="list">
-        {#each grouped as [target, rows] (target)}
-          <div class="group">
-            <div class="group-head">{target}</div>
-            <div class="group-sub">referenced by:</div>
-            <ul class="refs">
-              {#each rows as r (r.source)}
-                <li>
-                  <span class="src">{r.source}</span>
-                  <span class="meta">
-                    {#if r.linkLabel}
-                      <span class="label">{r.linkLabel}</span> ·
-                    {/if}
-                    {r.linkCount} link{r.linkCount === 1 ? '' : 's'}
-                  </span>
-                </li>
-              {/each}
-            </ul>
-          </div>
-        {/each}
-      </div>
+<Dialog width={640} onClose={onCancel} titleId="safe-delete-blocker-title">
+  {#snippet eyebrow()}SAFE DELETE · {blockedTargetCount} of {targets.length} blocked{/snippet}
+  {#snippet title()}
+    {#if blockedTargetCount === 1}
+      1 note has external references
+    {:else}
+      {blockedTargetCount} notes have external references
+    {/if}
+  {/snippet}
+  {#snippet subtitle()}
+    {totalLinks} inbound link{totalLinks === 1 ? '' : 's'} from
+    {selectionCount === 1 ? 'this selection' : 'outside the selection'}
+    would become broken. Fix or remove the reference{totalLinks === 1 ? '' : 's'}, then retry —
+    or override with <em>Delete anyway</em>.
+  {/snippet}
+  {#snippet body()}
+    <div class="list">
+      {#each grouped as [target, rows] (target)}
+        <div class="group">
+          <div class="group-head">{target}</div>
+          <div class="group-sub">referenced by:</div>
+          <ul class="refs">
+            {#each rows as r (r.source)}
+              <li>
+                <span class="src">{r.source}</span>
+                <span class="meta">
+                  {#if r.linkLabel}
+                    <span class="label">{r.linkLabel}</span> ·
+                  {/if}
+                  {r.linkCount} link{r.linkCount === 1 ? '' : 's'}
+                </span>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {/each}
     </div>
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel</span>
-      <span class="footer-actions">
-        <button class="btn ghost" onclick={onCancel}>Cancel</button>
-        <button
-          class="btn ghost"
-          disabled={!firstBlocker}
-          onclick={() => firstBlocker && onOpenFirstReference(firstBlocker.source, firstBlocker.target)}
-        >
-          Open first reference
-        </button>
-        <button class="btn primary" onclick={onDeleteAnyway}>Delete anyway</button>
-      </span>
-    </footer>
-  </div>
-</div>
+  {/snippet}
+  {#snippet footerLeft()}<span class="kbd-hint">esc · cancel</span>{/snippet}
+  {#snippet footerRight()}
+    <button class="btn ghost" onclick={onCancel}>Cancel</button>
+    <button
+      class="btn ghost"
+      disabled={!firstBlocker}
+      onclick={() => firstBlocker && onOpenFirstReference(firstBlocker.source, firstBlocker.target)}
+    >
+      Open first reference
+    </button>
+    <button class="btn primary" onclick={onDeleteAnyway}>Delete anyway</button>
+  {/snippet}
+</Dialog>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-modal);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 640px;
-    max-width: 100%;
-    max-height: calc(100vh - 64px);
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    font-family: var(--font-sans);
-    color: var(--text);
-  }
-  .card-header {
-    padding: 20px 24px 8px;
-  }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    margin-bottom: 6px;
-    text-transform: uppercase;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-  }
-  .sub {
-    margin: 6px 0 0;
-    font-size: 12.5px;
-    color: var(--text-muted);
-    line-height: 1.45;
-  }
-  .body {
-    padding: 12px 24px 18px;
-    overflow: auto;
-    flex: 1;
-  }
   .list {
     display: flex;
     flex-direction: column;
@@ -220,24 +159,10 @@
     color: var(--text-muted);
   }
 
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
   .kbd-hint {
-    margin-right: auto;
     font-size: 10.5px;
     color: var(--text-faint);
     font-family: var(--font-mono);
-  }
-  .footer-actions {
-    display: inline-flex;
-    gap: 8px;
   }
   .btn {
     padding: 7px 14px;

--- a/src/renderer/lib/components/SaveQueryDialog.svelte
+++ b/src/renderer/lib/components/SaveQueryDialog.svelte
@@ -4,8 +4,15 @@
    * fieldset becomes two side-by-side choice cards explaining "In this
    * thoughtbase" vs "Globally". When no project is open, scope is
    * forced to global and the picker is hidden.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and
+   * backdrop-click are Dialog's job. Enter-to-save keeps a dialog-wide
+   * handler (wrapping <Dialog>) rather than moving to the name input
+   * alone: Enter must still save while focus is on one of the scope
+   * cards, which don't natively respond to Enter.
    */
   import Icon from './Icon.svelte';
+  import Dialog from './ui/Dialog.svelte';
 
   interface Props {
     /** True when a project is open; controls whether Thoughtbase is offered. */
@@ -32,8 +39,6 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter' && name.trim()) {
       onConfirm({ name: name.trim(), scope });
-    } else if (e.key === 'Escape') {
-      onCancel();
     }
   }
 
@@ -44,119 +49,71 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true">
-    <header class="card-header">
-      <div class="eyebrow">Save query</div>
-      <h2 class="title">Where should this query live?</h2>
-    </header>
+<div onkeydown={handleKeydown}>
+  <Dialog width={520} onClose={onCancel} titleId="save-query-title">
+    {#snippet eyebrow()}Save query{/snippet}
+    {#snippet title()}Where should this query live?{/snippet}
+    {#snippet body()}
+      <div class="body-inner">
+        <label class="field-label" for="save-query-name">Name</label>
+        <input
+          id="save-query-name"
+          bind:this={inputEl}
+          bind:value={name}
+          type="text"
+          class="input"
+          placeholder="e.g. Unreviewed LLM writes"
+        />
 
-    <div class="body">
-      <label class="field-label" for="save-query-name">Name</label>
-      <input
-        id="save-query-name"
-        bind:this={inputEl}
-        bind:value={name}
-        type="text"
-        class="input"
-        placeholder="e.g. Unreviewed LLM writes"
-      />
-
-      {#if projectOpen}
-        <div class="scope-label">Scope</div>
-        <div class="scope-cards" role="radiogroup" aria-label="Save scope">
-          <button
-            class="scope-card"
-            class:selected={scope === 'project'}
-            type="button"
-            role="radio"
-            aria-checked={scope === 'project'}
-            onclick={() => { scope = 'project'; }}
-          >
-            <Icon name="folder" size={14} color={scope === 'project' ? 'var(--accent)' : 'var(--text-faint)'} />
-            <span class="scope-title">In this thoughtbase</span>
-            <span class="scope-sub">Saved next to the project's notes — others who open it will see this query.</span>
-          </button>
-          <button
-            class="scope-card"
-            class:selected={scope === 'global'}
-            type="button"
-            role="radio"
-            aria-checked={scope === 'global'}
-            onclick={() => { scope = 'global'; }}
-          >
-            <Icon name="settings" size={14} color={scope === 'global' ? 'var(--accent)' : 'var(--text-faint)'} />
-            <span class="scope-title">Globally</span>
-            <span class="scope-sub">Available in every thoughtbase you open on this machine.</span>
-          </button>
-        </div>
-      {:else}
-        <p class="solo-hint">
-          <Icon name="settings" size={12} color="var(--text-faint)" />
-          Saved as a Global query — no thoughtbase is open.
-        </p>
-      {/if}
-    </div>
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ↵ save</span>
-      <span class="footer-actions">
-        <button class="btn ghost" onclick={onCancel}>Cancel</button>
-        <button class="btn primary" disabled={!name.trim()} onclick={() => onConfirm({ name: name.trim(), scope })}>
-          Save
-          <span class="btn-kbd">↵</span>
-        </button>
-      </span>
-    </footer>
-  </div>
+        {#if projectOpen}
+          <div class="scope-label">Scope</div>
+          <div class="scope-cards" role="radiogroup" aria-label="Save scope">
+            <button
+              class="scope-card"
+              class:selected={scope === 'project'}
+              type="button"
+              role="radio"
+              aria-checked={scope === 'project'}
+              onclick={() => { scope = 'project'; }}
+            >
+              <Icon name="folder" size={14} color={scope === 'project' ? 'var(--accent)' : 'var(--text-faint)'} />
+              <span class="scope-title">In this thoughtbase</span>
+              <span class="scope-sub">Saved next to the project's notes — others who open it will see this query.</span>
+            </button>
+            <button
+              class="scope-card"
+              class:selected={scope === 'global'}
+              type="button"
+              role="radio"
+              aria-checked={scope === 'global'}
+              onclick={() => { scope = 'global'; }}
+            >
+              <Icon name="settings" size={14} color={scope === 'global' ? 'var(--accent)' : 'var(--text-faint)'} />
+              <span class="scope-title">Globally</span>
+              <span class="scope-sub">Available in every thoughtbase you open on this machine.</span>
+            </button>
+          </div>
+        {:else}
+          <p class="solo-hint">
+            <Icon name="settings" size={12} color="var(--text-faint)" />
+            Saved as a Global query — no thoughtbase is open.
+          </p>
+        {/if}
+      </div>
+    {/snippet}
+    {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ↵ save</span>{/snippet}
+    {#snippet footerRight()}
+      <button class="btn ghost" onclick={onCancel}>Cancel</button>
+      <button class="btn primary" disabled={!name.trim()} onclick={() => onConfirm({ name: name.trim(), scope })}>
+        Save
+        <span class="btn-kbd">↵</span>
+      </button>
+    {/snippet}
+  </Dialog>
 </div>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-modal);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow:
-      0 16px 48px rgba(0, 0, 0, 0.35),
-      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 520px;
-    max-width: 100%;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    font-family: var(--font-sans);
-    color: var(--text);
-  }
-  .card-header { padding: 20px 24px 0; }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-  }
-
-  .body { padding: 14px 24px 18px; display: flex; flex-direction: column; gap: 14px; }
+  .body-inner { display: flex; flex-direction: column; gap: 14px; }
   .field-label {
     font-family: var(--font-sans);
     font-size: 12px;
@@ -233,22 +190,11 @@
     font-size: 12px;
   }
 
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
   .kbd-hint {
-    margin-right: auto;
     font-family: var(--font-mono);
     font-size: 10.5px;
     color: var(--text-faint);
   }
-  .footer-actions { display: inline-flex; gap: 8px; }
   .btn {
     padding: 7px 14px;
     border: 1px solid var(--border);

--- a/src/renderer/lib/components/SnippetPickerDialog.svelte
+++ b/src/renderer/lib/components/SnippetPickerDialog.svelte
@@ -10,9 +10,16 @@
    * list below, Enter to choose, Esc to cancel. Modeled on the
    * command palette but without the recency / scoring layer; the
    * template list is short enough that substring filter is enough.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and
+   * backdrop-click are Dialog's job. Arrow-key nav and Enter-to-insert
+   * stay on the filter input directly: focus never leaves it in normal
+   * use (result rows are chosen by mouse-hover or the arrow keys, never
+   * Tab), so this is behaviorally identical to the old dialog-wide handler.
    */
   import type { TemplateInfo } from '../ipc/client';
   import Icon from './Icon.svelte';
+  import Dialog from './ui/Dialog.svelte';
 
   interface Props {
     templates: TemplateInfo[];
@@ -56,118 +63,52 @@
       e.preventDefault();
       const pick = results[selectedIndex];
       if (pick) onPick(pick);
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      onCancel();
     }
   }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true">
-    <header class="card-header">
-      <div class="eyebrow">Insert</div>
-      <h2 class="title">Insert Template</h2>
-    </header>
+<Dialog width={460} zIndex="var(--z-spawned)" onClose={onCancel} titleId="snippet-picker-title">
+  {#snippet eyebrow()}Insert{/snippet}
+  {#snippet title()}Insert Template{/snippet}
+  {#snippet body()}
+    <input
+      bind:this={inputEl}
+      bind:value={query}
+      onkeydown={handleKeydown}
+      type="text"
+      class="input"
+      placeholder="Filter templates…"
+      autocomplete="off"
+    />
 
-    <div class="body">
-      <input
-        bind:this={inputEl}
-        bind:value={query}
-        type="text"
-        class="input"
-        placeholder="Filter templates…"
-        autocomplete="off"
-      />
-
-      {#if templates.length === 0}
-        <div class="empty">No templates in this project yet.</div>
-      {:else if results.length === 0}
-        <div class="empty">No matches.</div>
-      {:else}
-        <div class="sp-results" role="listbox">
-          {#each results as t, i (t.filename)}
-            {@const selected = i === selectedIndex}
-            <button
-              type="button"
-              class="sp-row"
-              class:selected
-              role="option"
-              aria-selected={selected}
-              onmousemove={() => { selectedIndex = i; }}
-              onclick={() => onPick(t)}
-            >
-              <Icon name="notes" size={13} color={selected ? 'var(--accent)' : 'var(--text-faint)'} />
-              <span class="sp-name">{t.name}</span>
-            </button>
-          {/each}
-        </div>
-      {/if}
-    </div>
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ↑↓ · ↵ insert</span>
-    </footer>
-  </div>
-</div>
+    {#if templates.length === 0}
+      <div class="empty">No templates in this project yet.</div>
+    {:else if results.length === 0}
+      <div class="empty">No matches.</div>
+    {:else}
+      <div class="sp-results" role="listbox">
+        {#each results as t, i (t.filename)}
+          {@const selected = i === selectedIndex}
+          <button
+            type="button"
+            class="sp-row"
+            class:selected
+            role="option"
+            aria-selected={selected}
+            onmousemove={() => { selectedIndex = i; }}
+            onclick={() => onPick(t)}
+          >
+            <Icon name="notes" size={13} color={selected ? 'var(--accent)' : 'var(--text-faint)'} />
+            <span class="sp-name">{t.name}</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  {/snippet}
+  {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ↑↓ · ↵ insert</span>{/snippet}
+</Dialog>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-spawned);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow:
-      0 16px 48px rgba(0, 0, 0, 0.35),
-      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 460px;
-    max-width: 100%;
-    display: flex;
-    flex-direction: column;
-    font-family: var(--font-sans);
-    color: var(--text);
-    overflow: hidden;
-  }
-
-  .card-header {
-    padding: 20px 24px 0;
-  }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-    color: var(--text);
-  }
-
-  .body {
-    padding: 14px 24px 18px;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-  }
   .input {
     width: 100%;
     padding: 8px 10px;
@@ -180,6 +121,7 @@
     outline: none;
     box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
     box-sizing: border-box;
+    margin-bottom: 10px;
   }
 
   .empty {
@@ -226,15 +168,6 @@
     white-space: nowrap;
   }
 
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
   .kbd-hint {
     font-size: 10.5px;
     color: var(--text-faint);

--- a/src/renderer/lib/components/ui/Dialog.svelte
+++ b/src/renderer/lib/components/ui/Dialog.svelte
@@ -22,6 +22,12 @@
     eyebrow?: Snippet;
     /** Header title (display-serif H1). */
     title?: Snippet;
+    /** Optional one-line explainer directly under the title — for a dialog
+     *  whose title alone doesn't carry enough context (e.g. "which source
+     *  should be kept?" needs a line on what happens to the others). Stays
+     *  in the header rather than the body so it reads as part of the
+     *  question, not the answer. */
+    subtitle?: Snippet;
     /** Main body content. */
     body?: Snippet;
     /** Footer left slot — kbd hints. */
@@ -37,6 +43,7 @@
     zIndex = 'var(--z-modal)',
     eyebrow,
     title,
+    subtitle,
     body,
     footerLeft,
     footerRight,
@@ -77,6 +84,7 @@
       <header class="card-header">
         {#if eyebrow}<div class="eyebrow">{@render eyebrow()}</div>{/if}
         {#if title}<h2 class="title" id={titleId}>{@render title()}</h2>{/if}
+        {#if subtitle}<p class="subtitle">{@render subtitle()}</p>{/if}
       </header>
     {/if}
 
@@ -142,6 +150,12 @@
     font-weight: 500;
     letter-spacing: -0.005em;
     margin: 0;
+  }
+  .subtitle {
+    margin: 6px 0 0;
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.4;
   }
   .card-body {
     padding: 14px 24px 18px;


### PR DESCRIPTION
## Summary

Third batch of the 30-dialog migration (2-3 per PR per the issue; went bigger this round since the pattern from #1978/#1979 is proven).

- **`ui/Dialog.svelte`** — added an optional `subtitle` snippet: a one-line explainer directly under the title, for a dialog whose title alone doesn't carry enough context ("which source should be kept?" needs a line on what happens to the others). Three of the seven dialogs below needed exactly this and had nowhere else clean to put it.
- **`MergeSourcesDialog`, `SafeDeleteBlockerDialog`, `AutoTagDialog`** — the subtitle cases. The latter two swap a static `aria-label` for Dialog's `titleId`-derived one, which is more accurate (`SafeDeleteBlockerDialog`'s now includes the actual note count) — grepped `tests/` for both old strings, nothing asserts either.
- **`AddPropertyDialog`, `SnippetPickerDialog`** — clean fits, both spawned-tier. `AddPropertyDialog` already had its keydowns correctly split (Escape on the overlay, Enter on the name field) and already had a matching `aria-labelledby`/`id` pair — the closest thing to a direct port in the batch.
- **`AutoLinkDialog`** — collapsed a duplicated body across an `{#if}`/`{:else}` into one body snippet. **Also fixed a real pre-existing bug found while migrating**: three spots had literal `·`/`→` backslash-escape text (not inside a JS template literal, so it rendered as the literal 6-character string, not the actual character) — replaced with the real characters.
- **`SaveQueryDialog`** — kept a dialog-wide Enter handler (the `ConfirmDialog` pattern) since Enter must still save while focus is on one of the two scope-choice cards, which don't natively respond to Enter.

**A real gotcha found and worked around, documented in `AutoTagDialog.svelte`**: Svelte's scoped CSS silently drops a rule as "unused" when its selector is qualified by an ancestor class the component doesn't itself render — `.subtitle code { }` targeting Dialog.svelte's own `<p class="subtitle">` compiles to a no-op with **no warning from svelte-check or eslint**. Verified by inspecting the Svelte compiler's own output directly (the rule literally gets commented out as `/* (unused) ... */`). A bare `code { }` selector still scopes correctly to a `<code>` element the component writes inside its own snippet, regardless of which component's markup that snippet ends up rendered inside. Audited every migrated file across all three PRs for the same pattern — only this one instance existed.

Fixes #1888 (partially — tracking issue stays open for the remaining ~18 dialogs; `SourcePickerDialog` was surveyed and excluded — it's a top-anchored, full-bleed command-palette-style dialog, not a card dialog, and doesn't fit Dialog.svelte's shape without new backdrop-alignment/max-height/body-padding props)

## Test plan
- [x] Full unit suite (`pnpm test`) passes — 628 files, 6852 passed
- [x] `pnpm lint` passes (tsc + svelte-check + eslint)
- [x] Verified live: `SafeDeleteBlockerDialog` specifically, since it's the first real usage of the new `subtitle` snippet — deleting `notes/architecture.md` (linked into externally by `design-patterns.md` in the sample fixture) correctly blocked with the subtitle text, aria wiring, and three-button footer all rendering as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)