### PR TITLE
refactor: adopt ui/Dialog.svelte in 6 more dialogs

### DIFF
--- a/src/renderer/lib/components/MineReferencesDialog.svelte
+++ b/src/renderer/lib/components/MineReferencesDialog.svelte
@@ -7,9 +7,18 @@
    * Each row is selected by default; user can uncheck individual
    * entries before Approve. The mining call already happened so
    * we render the results immediately; the dialog never re-fetches.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and
+   * backdrop-click are Dialog's job. ⌘/Ctrl+Enter-to-approve keeps a
+   * dialog-wide handler (wrapping <Dialog>) since it must fire
+   * regardless of which reference checkbox has focus. The accessible
+   * name moves from a static `aria-label` to the actual h2 title text
+   * via `titleId` — more specific (names the source), and nothing in
+   * tests/ asserts the old static string.
    */
   import type { ParsedReference } from '../../../shared/mine-references';
   import Icon from './Icon.svelte';
+  import Dialog from './ui/Dialog.svelte';
 
   interface Props {
     /** Parent source the references will be linked from. Used only
@@ -46,8 +55,7 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') onCancel();
-    else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void apply();
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void apply();
   }
 
   function bylineOf(ref: ParsedReference): string {
@@ -74,127 +82,69 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true" aria-label="Review references">
-    <header class="card-header">
-      <div class="eyebrow">REVIEW REFERENCES · {refs.length} {refs.length === 1 ? 'candidate' : 'candidates'}</div>
-      <h2 class="title">Mine references from "{parentTitle}"</h2>
-      <p class="sub">
-        Each accepted reference becomes a stub source linked from
-        this paper. Stubs can be promoted to full sources later with
-        Resolve.
-      </p>
-    </header>
-
-    {#if refs.length === 0}
-      <div class="body">
+<div onkeydown={handleKeydown}>
+  <Dialog width={720} onClose={onCancel} titleId="mine-references-title">
+    {#snippet eyebrow()}Review references · {refs.length} {refs.length === 1 ? 'candidate' : 'candidates'}{/snippet}
+    {#snippet title()}Mine references from "{parentTitle}"{/snippet}
+    {#snippet subtitle()}
+      Each accepted reference becomes a stub source linked from
+      this paper. Stubs can be promoted to full sources later with
+      Resolve.
+    {/snippet}
+    {#snippet body()}
+      {#if refs.length === 0}
         <div class="empty">
           The LLM didn't find any references it could parse. If the
           paper has a References section, the formatting may be too
           irregular for first-pass extraction.
         </div>
-      </div>
-    {:else}
-      <div class="body">
-        <div class="bulk-row">
-          <span class="bulk-count">{selectedCount} of {refs.length} selected</span>
-          <span class="bulk-spacer"></span>
-          <button class="bulk-btn" onclick={() => toggleAll(true)}>Select all</button>
-          <button class="bulk-btn" onclick={() => toggleAll(false)}>Select none</button>
-        </div>
-        <div class="list">
-          {#each refs as ref, i (i)}
-            <label class="row" class:selected={selected[i]}>
-              <input type="checkbox" bind:checked={selected[i]} />
-              <div class="details">
-                <div class="title-line">
-                  <span class="rtitle">{ref.title}</span>
-                  <span class="subtype">{ref.subtype}</span>
+      {:else}
+        <div class="body-inner">
+          <div class="bulk-row">
+            <span class="bulk-count">{selectedCount} of {refs.length} selected</span>
+            <span class="bulk-spacer"></span>
+            <button class="bulk-btn" onclick={() => toggleAll(true)}>Select all</button>
+            <button class="bulk-btn" onclick={() => toggleAll(false)}>Select none</button>
+          </div>
+          <div class="list">
+            {#each refs as ref, i (i)}
+              <label class="row" class:selected={selected[i]}>
+                <input type="checkbox" bind:checked={selected[i]} />
+                <div class="details">
+                  <div class="title-line">
+                    <span class="rtitle">{ref.title}</span>
+                    <span class="subtype">{ref.subtype}</span>
+                  </div>
+                  {#if ref.authors.length || ref.year}
+                    <div class="byline">{bylineOf(ref)}</div>
+                  {/if}
+                  {#if ref.containerTitle}
+                    <div class="container">{ref.containerTitle}</div>
+                  {/if}
+                  {#each idChips(ref) as chip}
+                    <span class="id-chip">{chip.kind} · <span class="mono">{chip.value}</span></span>
+                  {/each}
+                  <div class="raw" title="Verbatim citation text">{ref.raw}</div>
                 </div>
-                {#if ref.authors.length || ref.year}
-                  <div class="byline">{bylineOf(ref)}</div>
-                {/if}
-                {#if ref.containerTitle}
-                  <div class="container">{ref.containerTitle}</div>
-                {/if}
-                {#each idChips(ref) as chip}
-                  <span class="id-chip">{chip.kind} · <span class="mono">{chip.value}</span></span>
-                {/each}
-                <div class="raw" title="Verbatim citation text">{ref.raw}</div>
-              </div>
-            </label>
-          {/each}
+              </label>
+            {/each}
+          </div>
         </div>
-      </div>
-    {/if}
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ⌘↵ approve</span>
-      <span class="footer-actions">
-        <button class="btn ghost" onclick={onCancel}>Cancel</button>
-        <button class="btn primary" disabled={selectedCount === 0 || saving} onclick={apply}>
-          <Icon name="plus" size={11} />
-          {saving ? 'Creating…' : `Create ${selectedCount} stub${selectedCount === 1 ? '' : 's'}`}
-        </button>
-      </span>
-    </footer>
-  </div>
+      {/if}
+    {/snippet}
+    {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ⌘↵ approve</span>{/snippet}
+    {#snippet footerRight()}
+      <button class="btn ghost" onclick={onCancel}>Cancel</button>
+      <button class="btn primary" disabled={selectedCount === 0 || saving} onclick={apply}>
+        <Icon name="plus" size={11} />
+        {saving ? 'Creating…' : `Create ${selectedCount} stub${selectedCount === 1 ? '' : 's'}`}
+      </button>
+    {/snippet}
+  </Dialog>
 </div>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-modal);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 720px;
-    max-width: 100%;
-    max-height: calc(100vh - 64px);
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    font-family: var(--font-sans);
-    color: var(--text);
-  }
-  .card-header {
-    padding: 20px 24px 8px;
-  }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-  }
-  .sub {
-    margin: 6px 0 0;
-    font-size: 12.5px;
-    color: var(--text-muted);
-    line-height: 1.45;
-  }
-  .body {
-    padding: 12px 24px 18px;
-    overflow: auto;
-    flex: 1;
+  .body-inner {
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -222,8 +172,6 @@
   }
   .bulk-btn:hover { color: var(--text); border-color: var(--border-strong); }
   .list {
-    flex: 1;
-    overflow-y: auto;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -309,21 +257,11 @@
     border-radius: 4px;
     word-break: break-word;
   }
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-  }
   .kbd-hint {
-    margin-right: auto;
     font-family: var(--font-mono);
     font-size: 10.5px;
     color: var(--text-faint);
   }
-  .footer-actions { display: inline-flex; gap: 8px; }
   .btn {
     padding: 7px 14px;
     border: 1px solid var(--border);

--- a/src/renderer/lib/components/NewNoteDialog.svelte
+++ b/src/renderer/lib/components/NewNoteDialog.svelte
@@ -9,12 +9,19 @@
    *
    * Returns `{ name, ext }` via the host's resolver. The host appends
    * the extension if the user didn't type one already.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and
+   * backdrop-click are Dialog's job. Enter-to-create keeps a dialog-wide
+   * handler (wrapping <Dialog>): the type/template pickers are grids of
+   * focusable `role="radio"` buttons, and Enter must create the note
+   * regardless of which one currently has focus.
    */
   import Icon from './Icon.svelte';
   import type { IconName } from './icons/registry';
   import { api, type TemplateInfo } from '../ipc/client';
   import type { TypeInfo } from '../../../shared/objects/type-def';
   import type { NoteExt, NewNoteResult } from './new-note-dialog-types';
+  import Dialog from './ui/Dialog.svelte';
 
   interface TypeOption {
     ext: NoteExt;
@@ -101,187 +108,131 @@
     if (e.key === 'Enter') {
       const norm = normalize();
       if (norm) onConfirm(norm);
-    } else if (e.key === 'Escape') {
-      onCancel();
     }
   }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true">
-    <header class="card-header">
-      <div class="eyebrow">New</div>
-      <h2 class="title">{selectedType ? `New ${selectedType.label}` : 'New Note'}</h2>
-    </header>
-
-    <div class="body">
-      <!-- Left: type picker. Vertical list so future additions don't
-           pinch the horizontal layout. -->
-      <div class="type-list" role="radiogroup" aria-label="Note type">
-        {#each TYPES as t (t.ext)}
-          {@const active = ext === t.ext && !selectedType}
-          <button
-            type="button"
-            class="type-row"
-            class:active
-            role="radio"
-            aria-checked={active}
-            onclick={() => pickExt(t.ext)}
-          >
-            <Icon name={t.icon} size={14} color={active ? 'var(--accent)' : 'currentColor'} />
-            <span class="type-text">
-              <span class="type-label">{t.label}</span>
-              <span class="type-desc">{t.description}</span>
-            </span>
-            <span class="type-ext">{t.ext}</span>
-          </button>
-        {/each}
-
-        <!-- Domain types (#1064): "New Book" is a menu choice, not a syntax. -->
-        {#if types.length > 0}
-          <div class="type-divider">Types</div>
-          {#each types as t (t.id)}
-            {@const active = selectedType?.id === t.id}
+<div onkeydown={handleKeydown}>
+  <Dialog width={560} zIndex="var(--z-spawned)" onClose={onCancel} titleId="new-note-title">
+    {#snippet eyebrow()}New{/snippet}
+    {#snippet title()}{selectedType ? `New ${selectedType.label}` : 'New Note'}{/snippet}
+    {#snippet body()}
+      <div class="body-inner">
+        <!-- Left: type picker. Vertical list so future additions don't
+             pinch the horizontal layout. -->
+        <div class="type-list" role="radiogroup" aria-label="Note type">
+          {#each TYPES as t (t.ext)}
+            {@const active = ext === t.ext && !selectedType}
             <button
               type="button"
               class="type-row"
               class:active
               role="radio"
               aria-checked={active}
-              onclick={() => pickType(t)}
-              title={t.source === 'user' ? 'Your type' : 'Built-in type'}
+              onclick={() => pickExt(t.ext)}
             >
-              <span class="type-emoji" style={t.color ? `color:${t.color}` : undefined}>{t.icon ?? '◆'}</span>
+              <Icon name={t.icon} size={14} color={active ? 'var(--accent)' : 'currentColor'} />
               <span class="type-text">
                 <span class="type-label">{t.label}</span>
-                <span class="type-desc">{t.properties.length} field{t.properties.length === 1 ? '' : 's'}</span>
+                <span class="type-desc">{t.description}</span>
               </span>
+              <span class="type-ext">{t.ext}</span>
             </button>
           {/each}
-        {/if}
-      </div>
 
-      <!-- Right: name + reserved Template slot. -->
-      <div class="form">
-        <label class="field">
-          <span class="field-label">Name</span>
-          <input
-            bind:this={inputEl}
-            bind:value={name}
-            type="text"
-            class="input"
-            autocomplete="off"
-            placeholder="My note"
-          />
-        </label>
-
-        {#if templatesApply}
-          <div class="template-slot">
-            <span class="field-label">Template</span>
-            <div class="template-list" role="radiogroup" aria-label="Template">
+          <!-- Domain types (#1064): "New Book" is a menu choice, not a syntax. -->
+          {#if types.length > 0}
+            <div class="type-divider">Types</div>
+            {#each types as t (t.id)}
+              {@const active = selectedType?.id === t.id}
               <button
                 type="button"
-                class="template-row"
-                class:active={templateFilename === null}
+                class="type-row"
+                class:active
                 role="radio"
-                aria-checked={templateFilename === null}
-                onclick={() => { templateFilename = null; inputEl?.focus(); }}
+                aria-checked={active}
+                onclick={() => pickType(t)}
+                title={t.source === 'user' ? 'Your type' : 'Built-in type'}
               >
-                <span class="template-name">(none)</span>
-                <span class="template-hint">blank file</span>
+                <span class="type-emoji" style={t.color ? `color:${t.color}` : undefined}>{t.icon ?? '◆'}</span>
+                <span class="type-text">
+                  <span class="type-label">{t.label}</span>
+                  <span class="type-desc">{t.properties.length} field{t.properties.length === 1 ? '' : 's'}</span>
+                </span>
               </button>
-              {#each templates as t (t.filename)}
-                {@const active = templateFilename === t.filename}
+            {/each}
+          {/if}
+        </div>
+
+        <!-- Right: name + reserved Template slot. -->
+        <div class="form">
+          <label class="field">
+            <span class="field-label">Name</span>
+            <input
+              bind:this={inputEl}
+              bind:value={name}
+              type="text"
+              class="input"
+              autocomplete="off"
+              placeholder="My note"
+            />
+          </label>
+
+          {#if templatesApply}
+            <div class="template-slot">
+              <span class="field-label">Template</span>
+              <div class="template-list" role="radiogroup" aria-label="Template">
                 <button
                   type="button"
                   class="template-row"
-                  class:active
+                  class:active={templateFilename === null}
                   role="radio"
-                  aria-checked={active}
-                  onclick={() => { templateFilename = t.filename; inputEl?.focus(); }}
+                  aria-checked={templateFilename === null}
+                  onclick={() => { templateFilename = null; inputEl?.focus(); }}
                 >
-                  <span class="template-name">{t.name}</span>
+                  <span class="template-name">(none)</span>
+                  <span class="template-hint">blank file</span>
                 </button>
-              {/each}
+                {#each templates as t (t.filename)}
+                  {@const active = templateFilename === t.filename}
+                  <button
+                    type="button"
+                    class="template-row"
+                    class:active
+                    role="radio"
+                    aria-checked={active}
+                    onclick={() => { templateFilename = t.filename; inputEl?.focus(); }}
+                  >
+                    <span class="template-name">{t.name}</span>
+                  </button>
+                {/each}
+              </div>
             </div>
-          </div>
-        {/if}
+          {/if}
+        </div>
       </div>
-    </div>
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ↵ create</span>
-      <span class="footer-actions">
-        <button class="btn secondary" onclick={onCancel}>Cancel</button>
-        <button
-          class="btn primary"
-          disabled={!name.trim()}
-          onclick={() => { const n = normalize(); if (n) onConfirm(n); }}
-        >
-          Create
-          <span class="btn-kbd">↵</span>
-        </button>
-      </span>
-    </footer>
-  </div>
+    {/snippet}
+    {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ↵ create</span>{/snippet}
+    {#snippet footerRight()}
+      <button class="btn secondary" onclick={onCancel}>Cancel</button>
+      <button
+        class="btn primary"
+        disabled={!name.trim()}
+        onclick={() => { const n = normalize(); if (n) onConfirm(n); }}
+      >
+        Create
+        <span class="btn-kbd">↵</span>
+      </button>
+    {/snippet}
+  </Dialog>
 </div>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-spawned);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow:
-      0 16px 48px rgba(0, 0, 0, 0.35),
-      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 560px;
-    max-width: 100%;
-    display: flex;
-    flex-direction: column;
-    font-family: var(--font-sans);
-    color: var(--text);
-    overflow: hidden;
-  }
-
-  .card-header {
-    padding: 20px 24px 0;
-  }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-    color: var(--text);
-  }
-
-  .body {
+  .body-inner {
     display: grid;
     grid-template-columns: 200px 1fr;
     gap: 16px;
-    padding: 16px 24px 18px;
   }
 
   /* ── Type list (left column) ───────────────────────────────────── */
@@ -443,25 +394,10 @@
   }
   .template-row.active .template-hint { color: var(--accent); opacity: 0.7; }
 
-  /* ── Footer ────────────────────────────────────────────────────── */
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
   .kbd-hint {
-    margin-right: auto;
     font-size: 10.5px;
     color: var(--text-faint);
     font-family: var(--font-mono);
-  }
-  .footer-actions {
-    display: inline-flex;
-    gap: 8px;
   }
 
   .btn {

--- a/src/renderer/lib/components/PublishDialog.svelte
+++ b/src/renderer/lib/components/PublishDialog.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
+  /**
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and backdrop-click
+   * are Dialog's job. Adding a real header/footer border (previously this
+   * dialog had none — one flat padded column) brings its chrome in line with
+   * every other migrated dialog; not a regression, the point of #1888.
+   */
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
   import { getPublishStore } from '../stores/publish.svelte';
   import type { PublishTarget, PublishGitResponse } from '../ipc/client';
+  import Dialog from './ui/Dialog.svelte';
 
   interface Props {
     onClose: () => void;
@@ -202,24 +209,14 @@
   function copyError(msg: string): void {
     void navigator.clipboard.writeText(msg);
   }
-
-  function onBackdrop(e: MouseEvent): void {
-    if (e.target === e.currentTarget) onClose();
-  }
-
-  // Keyboard parity for the backdrop dismiss (matches ConfirmDialog/PromptDialog).
-  function onKeydown(e: KeyboardEvent): void {
-    if (e.key === 'Escape') onClose();
-  }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="publish-backdrop" onmousedown={onBackdrop} onkeydown={onKeydown}>
-  <div class="publish-dialog" role="dialog" aria-labelledby="publish-title">
-    <h2 id="publish-title">Publish to Web</h2>
-    <p class="sub">Push an export to a git remote (e.g. a static site to GitHub Pages) or upload it
-      to an S3 / S3-compatible bucket (Amazon S3, Cloudflare R2, Backblaze B2, MinIO, …).</p>
-
+<Dialog width={640} onClose={onClose} titleId="publish-title">
+  {#snippet eyebrow()}Publish{/snippet}
+  {#snippet title()}Publish to Web{/snippet}
+  {#snippet subtitle()}Push an export to a git remote (e.g. a static site to GitHub Pages) or upload it
+    to an S3 / S3-compatible bucket (Amazon S3, Cloudflare R2, Backblaze B2, MinIO, …).{/snippet}
+  {#snippet body()}
     {#if !loaded}
       <p class="muted">Loading…</p>
     {:else}
@@ -384,31 +381,16 @@
         </div>
       {/if}
     {/if}
-
-    <div class="footer">
-      {#if loaded && !showForm}
-        <button onclick={() => { showForm = true; }}>Add target…</button>
-      {/if}
-      <button class="ghost" onclick={onClose}>Close</button>
-    </div>
-  </div>
-</div>
+  {/snippet}
+  {#snippet footerRight()}
+    {#if loaded && !showForm}
+      <button onclick={() => { showForm = true; }}>Add target…</button>
+    {/if}
+    <button class="ghost" onclick={onClose}>Close</button>
+  {/snippet}
+</Dialog>
 
 <style>
-  .publish-backdrop {
-    position: fixed; inset: 0; z-index: var(--z-modal);
-    background: var(--scrim-bg); backdrop-filter: var(--scrim-blur);
-    display: flex; align-items: center; justify-content: center; padding: 32px;
-  }
-  .publish-dialog {
-    background: var(--bg-elev); color: var(--text);
-    border: 1px solid var(--border-strong); border-radius: 12px;
-    padding: 20px 24px; width: 640px; max-width: 100%; max-height: calc(100vh - 64px);
-    display: flex; flex-direction: column; overflow-y: auto;
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
-  }
-  h2 { margin: 0 0 4px; font-weight: 500; }
-  .sub { color: var(--text-muted); font-size: 0.85rem; margin: 0 0 16px; }
   .muted { color: var(--text-muted); font-size: 0.85rem; }
   code { background: var(--bg-inset, var(--bg)); padding: 0 4px; border-radius: 4px; }
 
@@ -423,6 +405,7 @@
   button {
     background: var(--bg-button); color: var(--text); border: 1px solid var(--border);
     border-radius: 6px; padding: 4px 12px; font-size: 0.85rem; cursor: pointer;
+    font-family: var(--font-sans);
   }
   button:hover:not(:disabled) { background: var(--bg-button-hover); }
   button:disabled { opacity: 0.5; cursor: default; }
@@ -460,6 +443,4 @@
   .check-result { font-size: 0.82rem; }
   .check-result.ok { color: var(--sage, #6a9); }
   .check-result.bad { color: var(--rust, #c66); }
-
-  .footer { display: flex; justify-content: space-between; gap: 8px; margin-top: 18px; }
 </style>

--- a/src/renderer/lib/components/ResolveStubDialog.svelte
+++ b/src/renderer/lib/components/ResolveStubDialog.svelte
@@ -4,8 +4,17 @@
    * search returned >1 plausible candidate (or the top one's
    * confidence didn't clear the auto-apply threshold). User picks
    * which DOI to apply.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and
+   * backdrop-click are Dialog's job. ⌘/Ctrl+Enter-to-apply keeps a
+   * dialog-wide handler (wrapping <Dialog>) since it must fire
+   * regardless of which candidate radio has focus. The accessible name
+   * moves from a static `aria-label="Resolve stub"` to the actual h2
+   * title text via `titleId` — more specific (names the stub), and
+   * nothing in tests/ asserts the old static string.
    */
   import type { ResolveCandidate } from '../../../shared/resolve-stub';
+  import Dialog from './ui/Dialog.svelte';
 
   interface Props {
     stubTitle: string;
@@ -32,8 +41,7 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') onCancel();
-    else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void apply();
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void apply();
   }
 
   function bylineOf(c: ResolveCandidate): string {
@@ -51,28 +59,23 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true" aria-label="Resolve stub">
-    <header class="card-header">
-      <div class="eyebrow">RESOLVE STUB · {candidates.length} {candidates.length === 1 ? 'candidate' : 'candidates'}</div>
-      <h2 class="title">Match "{stubTitle}" to a DOI</h2>
-      <p class="sub">
-        Pick the candidate that best matches your stub. The chosen
-        DOI's full metadata replaces the stub's; the source id
-        stays the same.
-      </p>
-    </header>
-
-    {#if candidates.length === 0}
-      <div class="body">
+<div onkeydown={handleKeydown}>
+  <Dialog width={640} onClose={onCancel} titleId="resolve-stub-title">
+    {#snippet eyebrow()}Resolve stub · {candidates.length} {candidates.length === 1 ? 'candidate' : 'candidates'}{/snippet}
+    {#snippet title()}Match "{stubTitle}" to a DOI{/snippet}
+    {#snippet subtitle()}
+      Pick the candidate that best matches your stub. The chosen
+      DOI's full metadata replaces the stub's; the source id
+      stays the same.
+    {/snippet}
+    {#snippet body()}
+      {#if candidates.length === 0}
         <div class="empty">
           CrossRef returned no matches. Try refining the stub's
           title or authors and rerun Resolve, or paste the DOI
           directly via Ingest identifier.
         </div>
-      </div>
-    {:else}
-      <div class="body">
+      {:else}
         <div class="list">
           {#each candidates as c (c.doi)}
             <label class="row" class:selected={selectedDoi === c.doi}>
@@ -102,77 +105,19 @@
             </label>
           {/each}
         </div>
-      </div>
-    {/if}
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ⌘↵ apply</span>
-      <span class="footer-actions">
-        <button class="btn ghost" onclick={onCancel}>Cancel</button>
-        <button class="btn primary" disabled={!selectedDoi || applying} onclick={apply}>
-          {applying ? 'Applying…' : 'Apply'}
-        </button>
-      </span>
-    </footer>
-  </div>
+      {/if}
+    {/snippet}
+    {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ⌘↵ apply</span>{/snippet}
+    {#snippet footerRight()}
+      <button class="btn ghost" onclick={onCancel}>Cancel</button>
+      <button class="btn primary" disabled={!selectedDoi || applying} onclick={apply}>
+        {applying ? 'Applying…' : 'Apply'}
+      </button>
+    {/snippet}
+  </Dialog>
 </div>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-modal);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 640px;
-    max-width: 100%;
-    max-height: calc(100vh - 64px);
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    font-family: var(--font-sans);
-    color: var(--text);
-  }
-  .card-header { padding: 20px 24px 8px; }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-  }
-  .sub {
-    margin: 6px 0 0;
-    font-size: 12.5px;
-    color: var(--text-muted);
-    line-height: 1.45;
-  }
-  .body {
-    padding: 12px 24px 18px;
-    overflow: auto;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-  }
   .empty {
     font-size: 13px;
     color: var(--text-muted);
@@ -256,21 +201,11 @@
     color: var(--text-faint);
     margin-top: 2px;
   }
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-  }
   .kbd-hint {
-    margin-right: auto;
     font-family: var(--font-mono);
     font-size: 10.5px;
     color: var(--text-faint);
   }
-  .footer-actions { display: inline-flex; gap: 8px; }
   .btn {
     padding: 7px 14px;
     border: 1px solid var(--border);

--- a/src/renderer/lib/components/ThoughtbaseProperties.svelte
+++ b/src/renderer/lib/components/ThoughtbaseProperties.svelte
@@ -12,9 +12,15 @@
    *
    * Reads its values directly (reads are allowed in components); mutations
    * route through the notebase store via the `onSave` callback.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and backdrop-click
+   * are Dialog's job. Enter-to-save moves onto the name field directly (it was
+   * already narrowed there via an `e.target.id` check) — the base-IRI field is
+   * multiline-ish intent (paste a long URL), so it must NOT take Enter.
    */
   import { onMount } from 'svelte';
   import { api } from '../ipc/client';
+  import Dialog from './ui/Dialog.svelte';
 
   interface Props {
     /** Persist name + (when changed) base IRI. Resolves to the outcome so a
@@ -63,118 +69,65 @@
     }
   }
 
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') onCancel();
-    // Enter saves only from the name field — the base-IRI field is multiline-ish
-    // intent (paste a long URL), so don't hijack Enter there.
-    else if (e.key === 'Enter' && (e.target as HTMLElement)?.id === 'tb-props-name') void save();
+  function handleNameKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') void save();
   }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="tb-props-title">
-    <header class="card-header">
-      <div class="eyebrow">Thoughtbase</div>
-      <h2 class="title" id="tb-props-title">Properties</h2>
-    </header>
+<Dialog width={460} onClose={onCancel} titleId="tb-props-title">
+  {#snippet eyebrow()}Thoughtbase{/snippet}
+  {#snippet title()}Properties{/snippet}
+  {#snippet body()}
+    <label class="field-label" for="tb-props-name">Name</label>
+    <input
+      id="tb-props-name"
+      bind:this={nameInput}
+      bind:value={name}
+      onkeydown={handleNameKeydown}
+      type="text"
+      class="input"
+      placeholder={folderName}
+      autocomplete="off"
+      spellcheck="false"
+    />
+    <p class="hint">
+      A display label, independent of the folder on disk. Leave blank to use
+      the folder name{folderName ? ` (${folderName})` : ''}.
+    </p>
 
-    <div class="body">
-      <label class="field-label" for="tb-props-name">Name</label>
-      <input
-        id="tb-props-name"
-        bind:this={nameInput}
-        bind:value={name}
-        type="text"
-        class="input"
-        placeholder={folderName}
-        autocomplete="off"
-        spellcheck="false"
-      />
-      <p class="hint">
-        A display label, independent of the folder on disk. Leave blank to use
-        the folder name{folderName ? ` (${folderName})` : ''}.
-      </p>
+    <details class="advanced">
+      <summary>Advanced</summary>
+      <div class="advanced-body">
+        <label class="field-label" for="tb-props-base">Graph base IRI</label>
+        <input
+          id="tb-props-base"
+          bind:value={baseUri}
+          type="text"
+          class="input"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <p class="hint warn">
+          Rewrites every knowledge-graph identifier (a full re-index runs on save).
+          Pending and reviewed proposals are migrated to the new base automatically;
+          wiki-links are unaffected. Existing exports and any hand-pasted IRIs that
+          used the old base will no longer resolve.
+        </p>
+      </div>
+    </details>
 
-      <details class="advanced">
-        <summary>Advanced</summary>
-        <div class="advanced-body">
-          <label class="field-label" for="tb-props-base">Graph base IRI</label>
-          <input
-            id="tb-props-base"
-            bind:value={baseUri}
-            type="text"
-            class="input"
-            autocomplete="off"
-            spellcheck="false"
-          />
-          <p class="hint warn">
-            Rewrites every knowledge-graph identifier (a full re-index runs on save).
-            Pending and reviewed proposals are migrated to the new base automatically;
-            wiki-links are unaffected. Existing exports and any hand-pasted IRIs that
-            used the old base will no longer resolve.
-          </p>
-        </div>
-      </details>
-
-      {#if error}
-        <p class="error-msg">✗ {error}</p>
-      {/if}
-    </div>
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ↵ save</span>
-      <span class="footer-actions">
-        <button class="btn secondary" onclick={onCancel}>Cancel</button>
-        <button class="btn primary" disabled={saving} onclick={save}>{saving ? 'Saving…' : 'Save'}<span class="btn-kbd">↵</span></button>
-      </span>
-    </footer>
-  </div>
-</div>
+    {#if error}
+      <p class="error-msg">✗ {error}</p>
+    {/if}
+  {/snippet}
+  {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ↵ save</span>{/snippet}
+  {#snippet footerRight()}
+    <button class="btn secondary" onclick={onCancel}>Cancel</button>
+    <button class="btn primary" disabled={saving} onclick={save}>{saving ? 'Saving…' : 'Save'}<span class="btn-kbd">↵</span></button>
+  {/snippet}
+</Dialog>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-modal);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 460px;
-    max-width: 100%;
-    display: flex;
-    flex-direction: column;
-    font-family: var(--font-sans);
-    color: var(--text);
-    overflow: hidden;
-  }
-  .card-header { padding: 20px 24px 0; }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-  }
-  .body { padding: 14px 24px 18px; }
   .field-label {
     display: block;
     font-size: 11px;
@@ -219,22 +172,11 @@
     font-size: 12px;
     color: var(--rust, #c66);
   }
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
   .kbd-hint {
-    margin-right: auto;
     font-size: 10.5px;
     color: var(--text-faint);
     font-family: var(--font-mono);
   }
-  .footer-actions { display: inline-flex; gap: 8px; }
   .btn {
     padding: 7px 14px;
     border: 1px solid var(--border);

--- a/src/renderer/lib/components/ToolParamsDialog.svelte
+++ b/src/renderer/lib/components/ToolParamsDialog.svelte
@@ -8,10 +8,16 @@
    * Owns the local form state (param values + the lazily-loaded note-picker
    * options); hands the raw values back via `onRun`. The caller resolves
    * note-picker params and drives execution, so this stays a dumb form.
+   *
+   * Renders via ui/Dialog.svelte (#1888) — Escape-to-cancel and backdrop-click
+   * are Dialog's job. ⌘/Ctrl+Enter-to-run keeps a dialog-wide handler (wrapping
+   * <Dialog>) since parameter fields are arbitrary and any of them may have
+   * focus when the user runs.
    */
   import { api } from '../ipc/client';
   import { flattenNoteFiles } from '../tools/resolve-note-params';
   import type { ThinkingToolInfo, ToolContext } from '../../../shared/tools/types';
+  import Dialog from './ui/Dialog.svelte';
 
   interface Props {
     tool: ThinkingToolInfo;
@@ -32,7 +38,7 @@
   // Note-picker (#516) options — flat list of project .md files, loaded lazily
   // when a tool has a `note` parameter.
   let noteOptions = $state<{ name: string; relativePath: string }[]>([]);
-  let dialogEl = $state<HTMLElement>();
+  let wrapperEl = $state<HTMLElement>();
 
   $effect(() => {
     if (params.some((p) => p.type === 'note') && noteOptions.length === 0) {
@@ -41,30 +47,25 @@
   });
 
   // Focus the first field so the user can start typing immediately.
-  $effect(() => { dialogEl?.querySelector<HTMLElement>('input, textarea, select')?.focus(); });
+  $effect(() => { wrapperEl?.querySelector<HTMLElement>('input, textarea, select')?.focus(); });
 
   function run() {
     onRun($state.snapshot(paramValues));
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') {
-      onCancel();
-    } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       run();
     }
   }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay" onkeydown={handleKeydown} onmousedown={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
-  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="tool-params-title" bind:this={dialogEl}>
-    <header class="card-header">
-      <div class="eyebrow">{tool.description || 'Tool'}</div>
-      <h2 class="title" id="tool-params-title">{tool.name}</h2>
-    </header>
-
-    <div class="body">
+<div onkeydown={handleKeydown} bind:this={wrapperEl}>
+  <Dialog width={460} onClose={onCancel} titleId="tool-params-title">
+    {#snippet eyebrow()}{tool.description || 'Tool'}{/snippet}
+    {#snippet title()}{tool.name}{/snippet}
+    {#snippet body()}
       {#if tool.longDescription}
         <p class="tool-info">{tool.longDescription}</p>
       {/if}
@@ -114,76 +115,19 @@
       {:else if context.fullNoteContent}
         <div class="context-preview">Full note: {context.fullNoteTitle ?? 'Untitled'}</div>
       {/if}
-    </div>
-
-    <footer class="card-footer">
-      <span class="kbd-hint">esc · cancel · ⌘↵ run</span>
-      <span class="footer-actions">
-        <button class="btn secondary" onclick={onCancel}>Cancel</button>
-        <button class="btn primary" onclick={run}>
-          Run
-          <span class="btn-kbd">⌘↵</span>
-        </button>
-      </span>
-    </footer>
-  </div>
+    {/snippet}
+    {#snippet footerLeft()}<span class="kbd-hint">esc · cancel · ⌘↵ run</span>{/snippet}
+    {#snippet footerRight()}
+      <button class="btn secondary" onclick={onCancel}>Cancel</button>
+      <button class="btn primary" onclick={run}>
+        Run
+        <span class="btn-kbd">⌘↵</span>
+      </button>
+    {/snippet}
+  </Dialog>
 </div>
 
 <style>
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-modal);
-    background: var(--scrim-bg);
-    backdrop-filter: var(--scrim-blur);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 32px;
-  }
-
-  .dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    box-shadow:
-      0 16px 48px rgba(0, 0, 0, 0.35),
-      0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-    width: 460px;
-    max-width: 100%;
-    max-height: calc(100vh - 64px);
-    display: flex;
-    flex-direction: column;
-    font-family: var(--font-sans);
-    color: var(--text);
-    overflow: hidden;
-  }
-
-  .card-header {
-    padding: 20px 24px 0;
-  }
-  .eyebrow {
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    color: var(--text-faint);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 6px;
-  }
-  .title {
-    margin: 0;
-    font-family: var(--font-display);
-    font-size: 19px;
-    font-weight: 500;
-    letter-spacing: -0.005em;
-    line-height: 1.3;
-    color: var(--text);
-  }
-
-  .body {
-    padding: 14px 24px 18px;
-    overflow-y: auto;
-  }
   .tool-info {
     margin: 0 0 14px;
     font-size: 12px;
@@ -228,24 +172,10 @@
     color: var(--text-muted);
   }
 
-  .card-footer {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 18px;
-    border-top: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 0 0 12px 12px;
-  }
   .kbd-hint {
-    margin-right: auto;
     font-size: 10.5px;
     color: var(--text-faint);
     font-family: var(--font-mono);
-  }
-  .footer-actions {
-    display: inline-flex;
-    gap: 8px;
   }
 
   .btn {


### PR DESCRIPTION
## Summary

Fourth batch of the 30-dialog migration (2-3 per PR per the issue; kept the bigger-batch pace from the previous PR).

- **`ToolParamsDialog`, `ThoughtbaseProperties`** — the two cleanest fits found yet: eyebrow+h2 headers already matching Dialog's shape, footer CSS already byte-identical to the primitive's convention, `aria-labelledby`/`id` pairs already correct. `ThoughtbaseProperties`' Enter handler moves from a dialog-wide `e.target.id === 'tb-props-name'` check onto the name field directly — the check already scoped it there, so this is a straight simplification, not a behavior change.
- **`NewNoteDialog`** — spawned tier (`zIndex="var(--z-spawned)"`, literal form for the z-index-layering test). Kept a dialog-wide Enter handler: the type/template pickers are grids of focusable `role="radio"` buttons, and Enter must create the note regardless of which one has focus.
- **`MineReferencesDialog`, `ResolveStubDialog`** — `subtitle` snippet cases, same pattern as the third batch. Both swap a static `aria-label` for Dialog's `titleId`-derived one (more specific); grepped `tests/` for both old strings, nothing asserts either.
- **`PublishDialog`** — the flattest of the six: no header/body/footer structure at all previously (one padded column, no borders), a `.sub` paragraph that fits `subtitle` exactly, and **no keydown handler whatsoever** (Escape did nothing before this — Dialog's window-capture listener is a genuine new capability, not a behavior change to preserve). Its non-standard `.footer { justify-content: space-between }` with a left-aligned "Add target…" button doesn't fit Dialog's `footerLeft` (styled for mono kbd-hint text, not a full button) — moved both buttons into `footerRight` instead, matching every other migrated dialog's footer convention.

**Surveyed and excluded** (same top-anchored command-palette or branded-splash shape as the already-excluded `SourcePickerDialog`): `GotoNoteDialog`, `CollectionPickerDialog`, `FindInNotesDialog`, `OnboardingDialog`. **Surveyed as viable but deferred to their own dedicated PRs**: `ExportDialog` (756 lines, no header/body/footer structure today — a real redesign, not a lift-and-shift) and `SmartCollectionEditorDialog` (its header is an editable name `<input>` where Dialog expects a static `h2` title — needs a deliberate design decision on where the name field goes, not a batch item).

Fixes #1888 (partially — tracking issue stays open; ~12 dialogs remain, mostly excluded/deferred ones noted above)

## Test plan
- [x] Full unit suite (`pnpm test`) passes — 628 files, 6852 passed
- [x] `pnpm lint` passes (tsc + svelte-check + eslint)
- [x] Verified live: `NewNoteDialog` (Cmd+N) — two-column grid body, spawned z-index (2500), 14 radio buttons all present, Escape closes it. `PublishDialog` (Publish to Web menu item) — subtitle renders, both footer buttons land correctly in `footerRight`

🤖 Generated with [Claude Code](https://claude.com/claude-code)