### PR TITLE
fix: resolveBaseUri clobbers .minerva/config.json (#1891)

### DIFF
--- a/src/main/config/project-config-store.ts
+++ b/src/main/config/project-config-store.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared read/patch leaf for `.minerva/config.json` (#1891).
+ *
+ * Both the graph module (`baseUri`) and `project-config.ts` (display name,
+ * bibliography, onboarding, excerpt folder, publish targets) persist into the
+ * same file. Before this module existed, `graph/index.ts` had its own
+ * reader/writer pair and `writeConfig` replaced the WHOLE file with just
+ * `{baseUri}`, destroying every other field the moment `resolveBaseUri` ran
+ * on a project that already had e.g. a `displayName` or `publishTargets` set.
+ * Electron-free, like the rest of `./graph`, so it stays usable outside the
+ * Electron main process.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+function configPath(rootPath: string): string {
+  return path.join(rootPath, '.minerva', 'config.json');
+}
+
+/**
+ * Read `.minerva/config.json` as a raw record. A missing file reads as `{}`
+ * — a project simply hasn't written config yet, not an error. A corrupt or
+ * otherwise unreadable file THROWS instead of silently returning `{}`: a
+ * caller that went on to merge-and-write over that `{}` is exactly how
+ * #1891 turned "config is corrupt" into "config is gone."
+ */
+export function readRawProjectConfig(rootPath: string): Record<string, unknown> {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath(rootPath), 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw err;
+  }
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/**
+ * Shallow-merge `patch` into the on-disk config and write the result back.
+ * Reads via `readRawProjectConfig`, so a corrupt file throws here too — the
+ * patch is never applied on top of a file that couldn't actually be parsed.
+ */
+export function patchRawProjectConfig(rootPath: string, patch: Record<string, unknown>): void {
+  const existing = readRawProjectConfig(rootPath);
+  const next = { ...existing, ...patch };
+  fs.mkdirSync(path.dirname(configPath(rootPath)), { recursive: true });
+  fs.writeFileSync(configPath(rootPath), JSON.stringify(next, null, 2), 'utf-8');
+}

--- a/src/main/graph/index.ts
+++ b/src/main/graph/index.ts
@@ -1,8 +1,8 @@
 import * as $rdf from 'rdflib';
 import fs from 'node:fs/promises';
-import fsSync from 'node:fs';
 import path from 'node:path';
 import * as uriHelpers from './uri-helpers';
+import { readRawProjectConfig, patchRawProjectConfig } from '../config/project-config-store';
 
 import type { ProjectContext } from '../project-context-types';
 import { EMPTY_TYPE_CATALOG } from '../../shared/objects/type-def';
@@ -82,30 +82,15 @@ export {
 import { checkLLMWriteGuard } from './write-guard';
 
 // ── Project config (persisted in .minerva/config.json) ─────────────────────
-
-interface ProjectConfig {
-  baseUri: string;
-}
-
-function configPath(rootPath: string): string {
-  return path.join(rootPath, '.minerva', 'config.json');
-}
-
-function readConfig(rootPath: string): ProjectConfig | null {
-  try {
-    return JSON.parse(fsSync.readFileSync(configPath(rootPath), 'utf-8')) as ProjectConfig;
-  } catch { return null; }
-}
-
-function writeConfig(rootPath: string, config: ProjectConfig): void {
-  fsSync.writeFileSync(configPath(rootPath), JSON.stringify(config, null, 2), 'utf-8');
-}
+// Read/write goes through the shared leaf in ../config/project-config-store
+// (#1891) — this module used to have its own reader/writer that replaced the
+// whole file with just `{baseUri}`, destroying displayName/publishTargets/etc.
 
 function resolveBaseUri(rootPath: string): string {
-  const existing = readConfig(rootPath);
-  if (existing?.baseUri) return existing.baseUri;
+  const existing = readRawProjectConfig(rootPath);
+  if (typeof existing.baseUri === 'string' && existing.baseUri) return existing.baseUri;
   const coined = uriHelpers.coinBaseUri(rootPath);
-  writeConfig(rootPath, { baseUri: coined });
+  patchRawProjectConfig(rootPath, { baseUri: coined });
   return coined;
 }
 

--- a/src/main/project-config.ts
+++ b/src/main/project-config.ts
@@ -11,6 +11,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { encryptSecret, decryptSecret } from './secret-storage';
 import { loadConfigFileSync, asRecord } from './config/config-store';
+import { patchRawProjectConfig } from './config/project-config-store';
 
 export interface ProjectConfigShape {
   baseUri?: string;
@@ -137,12 +138,15 @@ export function readProjectConfig(rootPath: string): ProjectConfigShape {
  * Merge `patch` into the on-disk config. Top-level keys are replaced
  * wholesale; this is intentional — none of the current consumers want
  * a deep merge, and a shallow one is easy to reason about.
+ *
+ * Delegates to the shared `patchRawProjectConfig` leaf (#1891) rather than
+ * reading via the lenient `readProjectConfig` — that reader soft-fails a
+ * corrupt file to `{}` (fine for a plain read), but merging a patch onto that
+ * `{}` and writing it back would silently destroy the corrupt-but-otherwise-
+ * intact file, the same bug `graph/index.ts`'s writer had.
  */
 export function patchProjectConfig(rootPath: string, patch: ProjectConfigShape): void {
-  const existing = readProjectConfig(rootPath);
-  const next: ProjectConfigShape = { ...existing, ...patch };
-  fs.mkdirSync(path.dirname(configPath(rootPath)), { recursive: true });
-  fs.writeFileSync(configPath(rootPath), JSON.stringify(next, null, 2), 'utf-8');
+  patchRawProjectConfig(rootPath, patch as Record<string, unknown>);
 }
 
 /** The user-chosen display name, or null when unset (#1443). */

--- a/tests/architecture/pattern-ratchets.test.ts
+++ b/tests/architecture/pattern-ratchets.test.ts
@@ -131,7 +131,6 @@ const SWALLOW_BASELINE: Record<string, number> = {
   'src/main/git/github-repo.ts': 2,
   'src/main/git/index.ts': 1,
   'src/main/git/publish-git.ts': 1,
-  'src/main/graph/index.ts': 1,
   'src/main/graph/indexers/excerpt.ts': 1,
   'src/main/graph/indexers/source.ts': 1,
   'src/main/graph/parser.ts': 1,

--- a/tests/main/config/project-config-store.test.ts
+++ b/tests/main/config/project-config-store.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared `.minerva/config.json` read/patch leaf (#1891). The bug this closes:
+ * `graph/index.ts` used to have its own reader/writer and `writeConfig`
+ * replaced the WHOLE file with `{baseUri}`, destroying displayName /
+ * publishTargets / etc. the moment `resolveBaseUri` ran on a project that
+ * already had other config fields. Worse, its reader's `catch { return null }`
+ * treated a corrupt file the same as a missing one — exactly the case that
+ * triggered the destructive overwrite.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { readRawProjectConfig, patchRawProjectConfig } from '../../../src/main/config/project-config-store';
+import { useTempDir } from '../../helpers/temp-project';
+
+const project = useTempDir('minerva-project-config-store-test-');
+
+function configFile(root: string): string {
+  return path.join(root, '.minerva', 'config.json');
+}
+
+describe('readRawProjectConfig (#1891)', () => {
+  it('returns {} when the file is missing', () => {
+    expect(readRawProjectConfig(project.root)).toEqual({});
+  });
+
+  it('throws on a corrupt file instead of returning {}', () => {
+    fs.mkdirSync(path.join(project.root, '.minerva'), { recursive: true });
+    fs.writeFileSync(configFile(project.root), '{ not valid json', 'utf-8');
+    expect(() => readRawProjectConfig(project.root)).toThrow();
+  });
+});
+
+describe('patchRawProjectConfig (#1891)', () => {
+  it('a config with displayName + publishTargets survives a patch', () => {
+    patchRawProjectConfig(project.root, {
+      displayName: 'My Thoughtbase',
+      publish: { targets: [{ id: 'gh-pages', label: 'GitHub Pages' }] },
+    });
+    patchRawProjectConfig(project.root, { baseUri: 'https://example.com/' });
+
+    const cfg = readRawProjectConfig(project.root);
+    expect(cfg.displayName).toBe('My Thoughtbase');
+    expect(cfg.publish).toEqual({ targets: [{ id: 'gh-pages', label: 'GitHub Pages' }] });
+    expect(cfg.baseUri).toBe('https://example.com/');
+  });
+
+  it('a corrupt config throws and is left on disk untouched — no field loss', () => {
+    fs.mkdirSync(path.join(project.root, '.minerva'), { recursive: true });
+    const corrupt = '{ displayName: "unterminated';
+    fs.writeFileSync(configFile(project.root), corrupt, 'utf-8');
+
+    expect(() => patchRawProjectConfig(project.root, { baseUri: 'https://example.com/' })).toThrow();
+
+    // The whole point: a failed patch must not clobber the corrupt file with
+    // just the patch fields (the original #1891 bug).
+    expect(fs.readFileSync(configFile(project.root), 'utf-8')).toBe(corrupt);
+  });
+});

--- a/tests/main/graph/resolve-base-uri.test.ts
+++ b/tests/main/graph/resolve-base-uri.test.ts
@@ -1,0 +1,57 @@
+/**
+ * `resolveBaseUri` / `initGraph` config handling (#1891). Regression coverage
+ * for the data-loss bug: `graph/index.ts` used to overwrite the WHOLE
+ * `.minerva/config.json` with just `{baseUri}` on first open, destroying
+ * displayName/publishTargets/etc., and its own reader conflated a corrupt
+ * file with a missing one — the exact condition that triggered the
+ * destructive overwrite. Now both writers share one leaf
+ * (`config/project-config-store.ts`) that merges instead of replacing, and
+ * throws on a corrupt file instead of silently defaulting.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { initGraph } from '../../../src/main/graph/index';
+import { projectContext } from '../../../src/main/project-context-types';
+import { readProjectConfig } from '../../../src/main/project-config';
+import { useTempDir } from '../../helpers/temp-project';
+
+const project = useTempDir('minerva-resolve-base-uri-test-');
+
+function configFile(root: string): string {
+  return path.join(root, '.minerva', 'config.json');
+}
+
+describe('resolveBaseUri via initGraph (#1891)', () => {
+  it('preserves displayName + publishTargets when coining a baseUri', async () => {
+    fs.mkdirSync(path.join(project.root, '.minerva'), { recursive: true });
+    fs.writeFileSync(
+      configFile(project.root),
+      JSON.stringify({
+        displayName: 'My Thoughtbase',
+        publish: { targets: [{ id: 'gh-pages', label: 'GitHub Pages' }] },
+      }, null, 2),
+      'utf-8',
+    );
+
+    await initGraph(projectContext(project.root));
+
+    const cfg = readProjectConfig(project.root);
+    expect(cfg.displayName).toBe('My Thoughtbase');
+    expect(cfg.publish?.targets).toHaveLength(1);
+    expect(typeof cfg.baseUri).toBe('string');
+    expect(cfg.baseUri).toBeTruthy();
+  });
+
+  it('a corrupt config throws instead of being silently overwritten', async () => {
+    fs.mkdirSync(path.join(project.root, '.minerva'), { recursive: true });
+    const corrupt = '{ "displayName": "unterminated';
+    fs.writeFileSync(configFile(project.root), corrupt, 'utf-8');
+
+    await expect(initGraph(projectContext(project.root))).rejects.toThrow();
+
+    // No field loss: the corrupt bytes are exactly as they were, not
+    // replaced by a freshly-coined `{baseUri}`.
+    expect(fs.readFileSync(configFile(project.root), 'utf-8')).toBe(corrupt);
+  });
+});


### PR DESCRIPTION
## Summary

- `graph/index.ts` had its own `readConfig`/`writeConfig` pair for `.minerva/config.json`. `writeConfig` replaced the **whole file** with just `{baseUri}` — destroying `displayName`, `publishTargets`, `bibliography`, and `onboarding` the instant `resolveBaseUri` ran on a project that already had other config fields set.
- Its reader made this worse: `catch { return null }` treated a corrupt file identically to a missing one, and a missing/corrupt read is exactly what triggers `resolveBaseUri` to coin + write a fresh `{baseUri}` — so a corrupt config was the direct trigger for the destructive overwrite.
- Extracted one electron-free `.minerva/config.json` read/patch leaf, `src/main/config/project-config-store.ts`:
  - `readRawProjectConfig` — ENOENT → `{}`, any other read/parse error → throws (follows the `readJsonFileOr` contract from CLAUDE.md).
  - `patchRawProjectConfig` — merges via the throwing reader, then writes back. A corrupt file now throws before any write happens, instead of being silently replaced.
- `graph/index.ts`'s `resolveBaseUri` and `project-config.ts`'s `patchProjectConfig` both now delegate to this leaf. `project-config.ts`'s `readProjectConfig` (used by all the plain getters — display name, bibliography, etc.) is left on its existing lenient `loadConfigFileSync`, unchanged — a corrupt config still doesn't crash every read path, only a *write* now refuses to proceed on top of unparseable content.
- Dropped the now-cleared `src/main/graph/index.ts` entry from the swallowed-errors pattern ratchet (its `catch { return null }` is gone).

## Test plan

- [x] New unit tests for the leaf module (`tests/main/config/project-config-store.test.ts`): missing → `{}`, corrupt → throws, patch preserves unrelated keys, patch on a corrupt file throws and leaves the original bytes untouched.
- [x] New regression test exercising the real bug via `initGraph`/`resolveBaseUri` (`tests/main/graph/resolve-base-uri.test.ts`): a config with `displayName` + `publishTargets` survives a `resolveBaseUri` call, and a corrupt config throws instead of being silently overwritten.
- [x] `pnpm lint` passes.
- [x] `pnpm test` — full suite green (630 files, 6858 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)