### PR TITLE
fix: watcher-driven note edits never update the vector store (#1892)

### DIFF
--- a/src/main/embeddings/backfill.ts
+++ b/src/main/embeddings/backfill.ts
@@ -18,6 +18,24 @@
  *
  * A per-project registry guarantees one run at a time and lets project-close
  * abort an in-flight backfill.
+ *
+ * ── #1892 stale-embeddings decision ─────────────────────────────────────────
+ * Before #1892, watcher-driven note edits skipped the vector store entirely
+ * (a hand-copied fan-out omitted it), and this backfill's own skip set
+ * (`embeddedNotePaths`) only tracks "has a row," not "row matches current
+ * content" — so an affected note's embedding is stale, not merely missing,
+ * and a plain run here would keep skipping it forever.
+ *
+ * Decided: no automatic one-time re-embed ships with the fix. The `force`
+ * path above already exists precisely for "embeddings might be stale" (it's
+ * wired to the menu's manual "Rebuild Embeddings" action) and unconditionally
+ * re-embeds every note/source/excerpt — running it once clears any staleness
+ * this bug left behind, same as it would for a model change. Forcing that
+ * automatically on next project open would re-embed the *entire* corpus for
+ * every user to fix content that, for most projects, only external
+ * (non-Minerva) edits during the affected window could have gone stale —
+ * disproportionate for a corpus-wide default. A user who suspects stale
+ * related-notes results can run the existing manual rebuild.
  */
 
 import fs from 'node:fs/promises';

--- a/src/main/ipc/helpers.ts
+++ b/src/main/ipc/helpers.ts
@@ -4,9 +4,9 @@ import path from 'node:path';
 import { Channels } from '../../shared/channels';
 import * as notebaseFs from '../notebase/fs';
 import { isIndexable } from '../notebase/indexable-files';
-import * as graph from '../graph/index';
+import type * as graph from '../graph/index';
 import * as search from '../search/index';
-import * as vectors from '../embeddings/vector-store';
+import { indexAllFor, removeAllFor } from '../notebase/index-fanout';
 import { projectContext } from '../project-context-types';
 import { getRootPath, markPathHandled, windowsForProject } from '../window-manager';
 import type { WritePipelineHooks } from '../notebase/write-pipeline';
@@ -80,20 +80,12 @@ export function withRootPathWin<A extends unknown[], R>(
 export async function reindexFile(rootPath: string, relativePath: string): Promise<void> {
   if (!isIndexable(relativePath)) return;
   const content = await notebaseFs.readFile(rootPath, relativePath);
-  const ctx = projectContext(rootPath);
-  await graph.indexNote(ctx, relativePath, content);
-  if (relativePath.endsWith('.md')) {
-    search.indexNote(ctx, relativePath, content);
-    void vectors.indexNote(ctx, relativePath, content); // #835; no-op when disabled
-  }
+  await indexAllFor(projectContext(rootPath), relativePath, content);
 }
 
 export function removeFromIndexes(rootPath: string, relativePath: string): void {
   if (!isIndexable(relativePath)) return;
-  const ctx = projectContext(rootPath);
-  search.removeNote(ctx, relativePath);
-  graph.removeNote(ctx, relativePath);
-  void vectors.removeNote(ctx, relativePath); // #835; no-op when disabled
+  removeAllFor(projectContext(rootPath), relativePath);
 }
 
 export async function listIndexableFiles(rootPath: string, relDir: string): Promise<string[]> {

--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -11,9 +11,9 @@ import { renameSource, renameExcerpt } from '../notebase/rename-source-excerpt';
 import { getOrFetchRemoteImage } from '../images/remote-image-cache';
 import { resolveDisplayName, setDisplayName, getDisplayName, readProjectConfig } from '../project-config';
 import { getOrFetchThumbnail } from '../youtube/thumbnail-cache';
-import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import { writeAndReindex } from '../notebase/write-pipeline';
+import { indexAllFor } from '../notebase/index-fanout';
 import * as search from '../search/index';
 import * as vectors from '../embeddings/vector-store';
 import { clearRecentProjects, defaultThoughtbaseDir } from '../recent-projects';
@@ -231,9 +231,7 @@ export function registerNotebase(): void {
   handle(Channels.NOTEBASE_CREATE_FILE, withRootPath(async (rootPath, relativePath: string) => {
     markPathHandled(relativePath);
     await notebaseFs.createFile(rootPath, relativePath);
-    const ctx = projectContext(rootPath);
-    await graph.indexNote(ctx, relativePath, '');
-    search.indexNote(ctx, relativePath, '');
+    await indexAllFor(projectContext(rootPath), relativePath, '');
   }));
 
   handle(Channels.NOTEBASE_DELETE_FILE, withRootPath(async (rootPath, relativePath: string) => {

--- a/src/main/notebase/index-fanout.ts
+++ b/src/main/notebase/index-fanout.ts
@@ -1,0 +1,44 @@
+/**
+ * Single fan-out for "a note's content changed" / "a note was removed"
+ * (#1892). Electron-free so it stays usable from both the watcher
+ * (`window-manager.ts`) and the IPC layer (`ipc/helpers.ts`) without a
+ * circular import between them.
+ *
+ * Policy: graph indexing covers every note extension (.md/.ttl/.csv/.py) —
+ * `graph.indexNote` dispatches internally. Full-text search and semantic
+ * embeddings are markdown-only, matching `search.indexAllNotes`' bulk
+ * walker — MiniSearch and the embedder are for prose, not raw Turtle/CSV/
+ * Python source.
+ *
+ * Three hand-copied versions of this fan-out existed before and had
+ * drifted: the watcher's `onFileChanged`/`onFileCreated` ran full-text
+ * search on every note extension (not just `.md`, unlike the bulk indexer
+ * and the IPC-layer copy) and never called into the vector store at all —
+ * so a watcher-driven note edit left stale embeddings, and nothing else
+ * ever re-checks a note that's already been embedded once
+ * (`embeddings/backfill.ts` skips notes with existing rows).
+ */
+import * as graph from '../graph/index';
+import * as search from '../search/index';
+import * as vectors from '../embeddings/vector-store';
+import type { ProjectContext } from '../project-context-types';
+
+/** Index (or re-index) a note's content into every backend that should have it. */
+export async function indexAllFor(ctx: ProjectContext, relativePath: string, content: string): Promise<void> {
+  await graph.indexNote(ctx, relativePath, content);
+  if (relativePath.endsWith('.md')) {
+    search.indexNote(ctx, relativePath, content);
+    void vectors.indexNote(ctx, relativePath, content); // #835; no-op when disabled
+  }
+}
+
+/**
+ * Mirror of {@link indexAllFor} for removal. Unconditional across all three
+ * backends — removing a key that was never indexed there is a no-op, so
+ * there's no need to gate by extension the way the index direction does.
+ */
+export function removeAllFor(ctx: ProjectContext, relativePath: string): void {
+  search.removeNote(ctx, relativePath);
+  graph.removeNote(ctx, relativePath);
+  void vectors.removeNote(ctx, relativePath); // #835; no-op when disabled
+}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -11,6 +11,7 @@ import * as search from './search/index';
 import * as notebaseFs from './notebase/fs';
 import * as templates from './notebase/templates';
 import * as tables from './sources/tables';
+import { indexAllFor, removeAllFor } from './notebase/index-fanout';
 import { invalidate as invalidatePythonModules } from './compute/python-kernel';
 import { addRecentProject } from './recent-projects';
 import { saveSession, type WindowState } from './session';
@@ -396,8 +397,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       if (relativePath.endsWith('.csv.schema.yaml')) return;
       try {
         const content = await notebaseFs.readFile(rootPath, relativePath);
-        await graph.indexNote(projectCtx, relativePath, content);
-        search.indexNote(projectCtx, relativePath, content);
+        await indexAllFor(projectCtx, relativePath, content);
         // Captioned markdown tables in the note re-register in DuckDB (#1358).
         if (relativePath.toLowerCase().endsWith('.md')) {
           const r = await tables.reregisterNoteTables(projectCtx, relativePath, content);
@@ -429,8 +429,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       if (relativePath.endsWith('.csv.schema.yaml')) return;
       try {
         const content = await notebaseFs.readFile(rootPath, relativePath);
-        await graph.indexNote(projectCtx, relativePath, content);
-        search.indexNote(projectCtx, relativePath, content);
+        await indexAllFor(projectCtx, relativePath, content);
         if (relativePath.toLowerCase().endsWith('.md')) {
           const r = await tables.reregisterNoteTables(projectCtx, relativePath, content);
           if (r.changed && !win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
@@ -455,8 +454,7 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
       }
       if (relativePath.endsWith('.csv.schema.yaml')) return;
       try {
-        search.removeNote(projectCtx, relativePath);
-        graph.removeNote(projectCtx, relativePath);
+        removeAllFor(projectCtx, relativePath);
         // Drop any DuckDB tables the deleted note owned (#1358). A rename
         // surfaces as delete+create, so the create half re-registers them.
         if (relativePath.toLowerCase().endsWith('.md')) {

--- a/tests/main/ipc/register-notebase.test.ts
+++ b/tests/main/ipc/register-notebase.test.ts
@@ -393,6 +393,9 @@ describe('register-notebase — the write path', () => {
     expect(h.order).toEqual(['mark', 'create']);
     expect(h.indexNote).toHaveBeenCalledWith(CTX, 'notes/new.md', '');
     expect(h.searchIndexNote).toHaveBeenCalledWith(CTX, 'notes/new.md', '');
+    // #1892 — this handler used to hand-roll graph+search only, missing the
+    // vector store (now routed through the shared indexAllFor fan-out).
+    expect(h.vectorsIndexNote).toHaveBeenCalledWith(CTX, 'notes/new.md', '');
   });
 
   it('NOTEBASE_DELETE_FILE claims the path, deletes, de-indexes, then persists', async () => {

--- a/tests/main/window-manager-watcher-fanout.test.ts
+++ b/tests/main/window-manager-watcher-fanout.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The watcher-driven note fan-out in `window-manager.ts` (#1892).
+ *
+ * `onFileChanged` / `onFileCreated` / `onFileDeleted` used to hand-roll their
+ * own graph+search(+vectors) calls, and the hand-rolled copies never called
+ * into the vector store — so a note edited on disk (the watcher path, as
+ * opposed to an IPC-driven save) kept a stale embedding forever (nothing else
+ * ever re-checks a note that's already been embedded once). This drives the
+ * real `openProjectInWindow`, captures the `WatcherCallbacks` object handed to
+ * `startWatching`, and invokes those callbacks directly to prove the watcher
+ * now goes through the shared `indexAllFor`/`removeAllFor` fan-out
+ * (`notebase/index-fanout.ts`) instead of its own copy.
+ *
+ * Everything `openProjectInWindow` touches outside that fan-out — electron,
+ * project acquisition, tables, templates, the python kernel, sessions,
+ * backfill, the clipper lifecycle — is mocked to a no-op; only
+ * `notebase/index-fanout` runs for real, so this test actually exercises the
+ * wiring rather than re-asserting the fan-out's own unit tests.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { WatcherCallbacks } from '../../src/main/notebase/watcher';
+
+const h = vi.hoisted(() => ({
+  watcherCallbacks: undefined as WatcherCallbacks | undefined,
+  fileContents: new Map<string, string>(),
+  graphIndexNote: vi.fn().mockResolvedValue({}),
+  graphRemoveNote: vi.fn(),
+  searchIndexNote: vi.fn(),
+  searchRemoveNote: vi.fn(),
+  vectorsIndexNote: vi.fn().mockResolvedValue(undefined),
+  vectorsRemoveNote: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [], fromId: () => null, getFocusedWindow: () => null },
+  app: {},
+  session: {},
+  shell: {},
+}));
+
+vi.mock('../../src/main/ipc/broadcast', () => ({ broadcast: vi.fn() }));
+vi.mock('../../src/main/project-config', () => ({ resolveDisplayName: () => 'Test Project' }));
+vi.mock('../../src/main/notebase/watcher', () => ({
+  startWatching: vi.fn((_rootPath: string, _win: unknown, _id: number, callbacks: WatcherCallbacks) => {
+    h.watcherCallbacks = callbacks;
+    return Promise.resolve();
+  }),
+  stopWatching: vi.fn(),
+}));
+vi.mock('../../src/main/notebase/path-dedup', () => ({
+  markPathHandled: vi.fn(),
+  wasHandled: () => false,
+}));
+vi.mock('../../src/main/graph/index', () => ({
+  indexNote: h.graphIndexNote,
+  removeNote: h.graphRemoveNote,
+}));
+vi.mock('../../src/main/search/index', () => ({
+  indexNote: h.searchIndexNote,
+  removeNote: h.searchRemoveNote,
+  persist: vi.fn(),
+}));
+vi.mock('../../src/main/embeddings/vector-store', () => ({
+  indexNote: h.vectorsIndexNote,
+  removeNote: h.vectorsRemoveNote,
+  indexSource: vi.fn(),
+  removeSource: vi.fn(),
+  indexExcerpt: vi.fn(),
+  removeExcerpt: vi.fn(),
+}));
+vi.mock('../../src/main/notebase/fs', () => ({
+  readFile: vi.fn((_rootPath: string, relativePath: string) => {
+    const content = h.fileContents.get(relativePath);
+    if (content === undefined) return Promise.reject(new Error(`no fixture for ${relativePath}`));
+    return Promise.resolve(content);
+  }),
+}));
+vi.mock('../../src/main/notebase/templates', () => ({ ensureSeeded: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../src/main/sources/tables', () => ({
+  onCsvTableCollision: () => () => {},
+  registerCsv: vi.fn().mockResolvedValue(undefined),
+  unregisterCsv: vi.fn().mockResolvedValue(undefined),
+  reregisterNoteTables: vi.fn().mockResolvedValue({ changed: false }),
+  unregisterNoteTables: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../src/main/compute/python-kernel', () => ({ invalidate: vi.fn() }));
+vi.mock('../../src/main/recent-projects', () => ({ addRecentProject: vi.fn() }));
+vi.mock('../../src/main/session', () => ({ saveSession: vi.fn() }));
+vi.mock('../../src/main/project-context', () => ({
+  acquireProject: vi.fn((rootPath: string) => Promise.resolve({ rootPath, _brand: 'ProjectContext' })),
+  releaseProject: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../src/main/embeddings/backfill', () => ({ runBackfill: vi.fn() }));
+vi.mock('../../src/main/sources/create-excerpt', () => ({ citedTextFromTtl: () => '' }));
+vi.mock('../../src/main/clipper/lifecycle', () => ({
+  ensureClipperRunning: vi.fn().mockResolvedValue(undefined),
+  stopClipperServer: vi.fn().mockResolvedValue(undefined),
+  isClipperEnabled: vi.fn().mockResolvedValue(false),
+}));
+
+import { openProjectInWindow } from '../../src/main/window-manager';
+
+function fakeWindow(id: number) {
+  return {
+    id,
+    isDestroyed: () => false,
+    once: () => {},
+    webContents: { send: vi.fn() },
+  } as unknown as Electron.BrowserWindow;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  h.watcherCallbacks = undefined;
+  h.fileContents.clear();
+  await openProjectInWindow(fakeWindow(1), '/vault');
+});
+
+describe('watcher onFileChanged / onFileCreated fan-out (#1892)', () => {
+  it.each(['onFileChanged', 'onFileCreated'] as const)(
+    '%s sends a markdown note to graph, search, AND the vector store',
+    async (event) => {
+      h.fileContents.set('notes/a.md', '# hello');
+      await h.watcherCallbacks![event]('notes/a.md');
+
+      expect(h.graphIndexNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md', '# hello');
+      expect(h.searchIndexNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md', '# hello');
+      expect(h.vectorsIndexNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md', '# hello');
+    },
+  );
+
+  it.each(['onFileChanged', 'onFileCreated'] as const)(
+    '%s sends a non-markdown note (.ttl) to the graph only',
+    async (event) => {
+      h.fileContents.set('data/t.ttl', 'content');
+      await h.watcherCallbacks![event]('data/t.ttl');
+
+      expect(h.graphIndexNote).toHaveBeenCalled();
+      expect(h.searchIndexNote).not.toHaveBeenCalled();
+      expect(h.vectorsIndexNote).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('watcher onFileDeleted fan-out (#1892)', () => {
+  it('removes a note from graph, search, AND the vector store', async () => {
+    await h.watcherCallbacks!.onFileDeleted('notes/a.md');
+
+    expect(h.graphRemoveNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md');
+    expect(h.searchRemoveNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md');
+    expect(h.vectorsRemoveNote).toHaveBeenCalledWith(expect.anything(), 'notes/a.md');
+  });
+});


### PR DESCRIPTION
## Summary

Three hand-copied versions of the "note content changed" fan-out had drifted:

- `window-manager.ts`'s watcher callbacks (`onFileChanged`, `onFileCreated`) called `graph.indexNote` + `search.indexNote` only.
- `ipc/helpers.ts`'s `reindexFile` also called `vectors.indexNote`.

So a note edited on disk — or by any watcher-driven path — kept a **stale embedding forever**: `embeddings/backfill.ts` skips notes that already have a row, so nothing ever self-healed it. `onFileDeleted` had the mirror gap (no `vectors.removeNote`).

- Extracted one fan-out, `src/main/notebase/index-fanout.ts` (electron-free, so it can be shared by `window-manager.ts` and `ipc/helpers.ts` without an import cycle between them):
  - `indexAllFor` — `graph.indexNote` always (it dispatches per-extension internally); `search.indexNote` + `vectors.indexNote` gated to `.md`, matching `search.indexAllNotes`' bulk walker (MiniSearch/embeddings are for prose, not raw Turtle/CSV/Python).
  - `removeAllFor` — all three, unconditionally.
- `ipc/helpers.ts`'s `reindexFile`/`removeFromIndexes` and `window-manager.ts`'s three watcher callbacks now delegate to it.
- Also fixed `register-notebase.ts`'s `NOTEBASE_CREATE_FILE` handler — a fourth hand-rolled copy missing vectors, found while auditing for others.
- **Left for a follow-up** (will file separately): `NOTEBASE_RENAME_SOURCE` / `RENAME_EXCERPT` / `RENAME_ANCHOR`'s `reindexHook` callbacks in `register-notebase.ts` have the same missing-vectors shape, but a different callback-based call structure — out of scope for this fix.

## Backfill decision (recorded in `embeddings/backfill.ts`)

No automatic one-time re-embed ships with this fix. The existing `force` rebuild path (wired to the menu's "Rebuild Embeddings" action) already unconditionally re-embeds everything, which is what clearing this staleness needs. Forcing that on every project open would re-embed the whole corpus by default for content that, for most projects, only external (non-Minerva) edits during the affected window could have gone stale — disproportionate as a default. A user who suspects stale related-notes results can run the existing manual rebuild.

## Test plan

- [x] New `tests/main/window-manager-watcher-fanout.test.ts`: drives the real `openProjectInWindow`, captures the `WatcherCallbacks` handed to `startWatching`, and proves `onFileChanged`/`onFileCreated`/`onFileDeleted` go through the shared fan-out (markdown → graph+search+vectors; non-markdown → graph only; delete → all three removed).
- [x] Updated `register-notebase.test.ts`'s `NOTEBASE_CREATE_FILE` test to also assert the vector store is now called.
- [x] `pnpm lint` passes.
- [x] `pnpm test` — full suite green (631 files, 6863 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)