### PR TITLE
fix: NOTEBASE_RENAME_SOURCE/RENAME_EXCERPT/RENAME_ANCHOR skip vectors on rewritten notes (#1985)

### DIFF
--- a/src/main/ipc/register-notebase.ts
+++ b/src/main/ipc/register-notebase.ts
@@ -13,9 +13,7 @@ import { resolveDisplayName, setDisplayName, getDisplayName, readProjectConfig }
 import { getOrFetchThumbnail } from '../youtube/thumbnail-cache';
 import { projectContext } from '../project-context-types';
 import { writeAndReindex } from '../notebase/write-pipeline';
-import { indexAllFor } from '../notebase/index-fanout';
-import * as search from '../search/index';
-import * as vectors from '../embeddings/vector-store';
+import { indexAllFor, indexSearchAndVectorsFor, removeSearchAndVectorsFor } from '../notebase/index-fanout';
 import { clearRecentProjects, defaultThoughtbaseDir } from '../recent-projects';
 import { rebuildMenu } from '../menu';
 import { createWindow, openProjectInWindow, closeProjectInWindow, markPathHandled, windowsForProject } from '../window-manager';
@@ -256,16 +254,8 @@ export function registerNotebase(): void {
     const ctx = projectContext(rootPath);
     const { transitions, rewrittenPaths } = await renameWithLinkRewrites(rootPath, oldRelPath, newRelPath, {
       markPathHandled,
-      reindexHook: (relPath, content) => {
-        if (relPath.endsWith(".md")) {
-          search.indexNote(ctx, relPath, content);
-          void vectors.indexNote(ctx, relPath, content); // #835
-        }
-      },
-      removeHook: (relPath) => {
-        search.removeNote(ctx, relPath);
-        void vectors.removeNote(ctx, relPath); // #835
-      },
+      reindexHook: (relPath, content) => indexSearchAndVectorsFor(ctx, relPath, content),
+      removeHook: (relPath) => removeSearchAndVectorsFor(ctx, relPath),
     });
 
     // Broadcast to every window showing this project so their editor tabs
@@ -291,16 +281,8 @@ export function registerNotebase(): void {
     const result = await mergeNotes(rootPath, sourceRelPath, targetRelPath, {
       ...(separator !== undefined ? { separator } : {}),
       markPathHandled,
-      reindexHook: (relPath, content) => {
-        if (relPath.endsWith(".md")) {
-          search.indexNote(ctx, relPath, content);
-          void vectors.indexNote(ctx, relPath, content); // #835
-        }
-      },
-      removeHook: (relPath) => {
-        search.removeNote(ctx, relPath);
-        void vectors.removeNote(ctx, relPath); // #835
-      },
+      reindexHook: (relPath, content) => indexSearchAndVectorsFor(ctx, relPath, content),
+      removeHook: (relPath) => removeSearchAndVectorsFor(ctx, relPath),
     });
     // Broadcast: source disappeared (RENAMED with one transition signals
     // editor tabs to drop / reroute) plus the rewritten set so other
@@ -326,9 +308,7 @@ export function registerNotebase(): void {
     const ctx = projectContext(rootPath);
     const { rewrittenPaths } = await renameSource(rootPath, oldId, newId, {
       markPathHandled,
-      reindexHook: (relPath, content) => {
-        if (relPath.endsWith('.md')) search.indexNote(ctx, relPath, content);
-      },
+      reindexHook: (relPath, content) => indexSearchAndVectorsFor(ctx, relPath, content),
     });
     broadcastRewritten(rootPath, rewrittenPaths);
     await persistIndexes(rootPath);
@@ -339,9 +319,7 @@ export function registerNotebase(): void {
     const ctx = projectContext(rootPath);
     const { rewrittenPaths } = await renameExcerpt(rootPath, oldId, newId, {
       markPathHandled,
-      reindexHook: (relPath, content) => {
-        if (relPath.endsWith('.md')) search.indexNote(ctx, relPath, content);
-      },
+      reindexHook: (relPath, content) => indexSearchAndVectorsFor(ctx, relPath, content),
     });
     broadcastRewritten(rootPath, rewrittenPaths);
     await persistIndexes(rootPath);
@@ -354,9 +332,7 @@ export function registerNotebase(): void {
       const ctx = projectContext(rootPath);
       const { rewrittenPaths } = await renameAnchor(rootPath, targetRelativePath, oldSlug, newSlug, {
         markPathHandled,
-        reindexHook: (relPath, content) => {
-          if (relPath.endsWith('.md')) search.indexNote(ctx, relPath, content);
-        },
+        reindexHook: (relPath, content) => indexSearchAndVectorsFor(ctx, relPath, content),
       });
 
       // Same tab-refresh pipeline as #145 — open editors for rewritten notes

--- a/src/main/notebase/index-fanout.ts
+++ b/src/main/notebase/index-fanout.ts
@@ -26,10 +26,7 @@ import type { ProjectContext } from '../project-context-types';
 /** Index (or re-index) a note's content into every backend that should have it. */
 export async function indexAllFor(ctx: ProjectContext, relativePath: string, content: string): Promise<void> {
   await graph.indexNote(ctx, relativePath, content);
-  if (relativePath.endsWith('.md')) {
-    search.indexNote(ctx, relativePath, content);
-    void vectors.indexNote(ctx, relativePath, content); // #835; no-op when disabled
-  }
+  indexSearchAndVectorsFor(ctx, relativePath, content);
 }
 
 /**
@@ -38,7 +35,27 @@ export async function indexAllFor(ctx: ProjectContext, relativePath: string, con
  * there's no need to gate by extension the way the index direction does.
  */
 export function removeAllFor(ctx: ProjectContext, relativePath: string): void {
-  search.removeNote(ctx, relativePath);
   graph.removeNote(ctx, relativePath);
+  removeSearchAndVectorsFor(ctx, relativePath);
+}
+
+/**
+ * The search+vectors half of {@link indexAllFor}, for callers that already
+ * indexed the note into the graph themselves (#1985). The rename/merge
+ * helpers (`rename.ts`, `merge.ts`, `rename-source-excerpt.ts`,
+ * `rename-anchor.ts`) call `graph.indexNote` directly on each rewritten note
+ * — they're re-parsing a note whose *links* changed, not any content
+ * `indexAllFor`'s caller already has fresh — and pass this as their
+ * `reindexHook` for the rest of the fan-out.
+ */
+export function indexSearchAndVectorsFor(ctx: ProjectContext, relativePath: string, content: string): void {
+  if (!relativePath.endsWith('.md')) return;
+  search.indexNote(ctx, relativePath, content);
+  void vectors.indexNote(ctx, relativePath, content); // #835; no-op when disabled
+}
+
+/** The search+vectors half of {@link removeAllFor}, mirroring {@link indexSearchAndVectorsFor}. */
+export function removeSearchAndVectorsFor(ctx: ProjectContext, relativePath: string): void {
+  search.removeNote(ctx, relativePath);
   void vectors.removeNote(ctx, relativePath); // #835; no-op when disabled
 }

--- a/tests/main/ipc/register-notebase.test.ts
+++ b/tests/main/ipc/register-notebase.test.ts
@@ -570,10 +570,59 @@ describe('register-notebase — rename / merge broadcasts', () => {
     expect(h.broadcastRewritten).toHaveBeenCalledWith(ROOT, ['a.md']);
   });
 
+  // #1985 — this reindexHook used to call search.indexNote only, leaving a
+  // rewritten note's embedding stale after a source rename.
+  it("NOTEBASE_RENAME_SOURCE's reindex hook routes a rewritten markdown note to search + vectors too", async () => {
+    h.renameSource.mockImplementation(async (
+      _root: string, _old: string, _new: string,
+      opts: { reindexHook: (p: string, c: string) => void },
+    ) => {
+      opts.reindexHook('a.md', 'body');
+      return { rewrittenPaths: ['a.md'] };
+    });
+
+    await call(Channels.NOTEBASE_RENAME_SOURCE, 'old', 'new');
+
+    expect(h.searchIndexNote).toHaveBeenCalledWith(CTX, 'a.md', 'body');
+    expect(h.vectorsIndexNote).toHaveBeenCalledWith(CTX, 'a.md', 'body');
+  });
+
   it('NOTEBASE_RENAME_EXCERPT reports the rewritten notes and refreshes them', async () => {
     h.renameExcerpt.mockResolvedValue({ rewrittenPaths: ['a.md'] });
     await expect(call(Channels.NOTEBASE_RENAME_EXCERPT, 'old', 'new')).resolves.toEqual({ rewrittenPaths: ['a.md'] });
     expect(h.broadcastRewritten).toHaveBeenCalledWith(ROOT, ['a.md']);
+  });
+
+  // #1985 — same gap as NOTEBASE_RENAME_SOURCE, for excerpt renames.
+  it("NOTEBASE_RENAME_EXCERPT's reindex hook routes a rewritten markdown note to search + vectors too", async () => {
+    h.renameExcerpt.mockImplementation(async (
+      _root: string, _old: string, _new: string,
+      opts: { reindexHook: (p: string, c: string) => void },
+    ) => {
+      opts.reindexHook('a.md', 'body');
+      return { rewrittenPaths: ['a.md'] };
+    });
+
+    await call(Channels.NOTEBASE_RENAME_EXCERPT, 'old', 'new');
+
+    expect(h.searchIndexNote).toHaveBeenCalledWith(CTX, 'a.md', 'body');
+    expect(h.vectorsIndexNote).toHaveBeenCalledWith(CTX, 'a.md', 'body');
+  });
+
+  // #1985 — same gap as NOTEBASE_RENAME_SOURCE, for anchor-slug renames.
+  it("NOTEBASE_RENAME_ANCHOR's reindex hook routes a rewritten markdown note to search + vectors too", async () => {
+    h.renameAnchor.mockImplementation(async (
+      _root: string, _target: string, _old: string, _new: string,
+      opts: { reindexHook: (p: string, c: string) => void },
+    ) => {
+      opts.reindexHook('c.md', 'body');
+      return { rewrittenPaths: ['c.md'] };
+    });
+
+    await call(Channels.NOTEBASE_RENAME_ANCHOR, 'a.md', 'old', 'new');
+
+    expect(h.searchIndexNote).toHaveBeenCalledWith(CTX, 'c.md', 'body');
+    expect(h.vectorsIndexNote).toHaveBeenCalledWith(CTX, 'c.md', 'body');
   });
 });
 

--- a/tests/main/notebase/index-fanout.test.ts
+++ b/tests/main/notebase/index-fanout.test.ts
@@ -1,0 +1,94 @@
+/**
+ * `src/main/notebase/index-fanout.ts` — the shared graph/search/vectors
+ * fan-out (#1892, #1985), tested directly rather than only through the
+ * callers that route to it (`ipc/helpers.ts`, `window-manager.ts`,
+ * `register-notebase.ts`'s rename/merge handlers).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  graphIndexNote: vi.fn().mockResolvedValue({}),
+  graphRemoveNote: vi.fn(),
+  searchIndexNote: vi.fn(),
+  searchRemoveNote: vi.fn(),
+  vectorsIndexNote: vi.fn().mockResolvedValue(undefined),
+  vectorsRemoveNote: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/main/graph/index', () => ({
+  indexNote: h.graphIndexNote,
+  removeNote: h.graphRemoveNote,
+}));
+vi.mock('../../../src/main/search/index', () => ({
+  indexNote: h.searchIndexNote,
+  removeNote: h.searchRemoveNote,
+}));
+vi.mock('../../../src/main/embeddings/vector-store', () => ({
+  indexNote: h.vectorsIndexNote,
+  removeNote: h.vectorsRemoveNote,
+}));
+
+import {
+  indexAllFor,
+  removeAllFor,
+  indexSearchAndVectorsFor,
+  removeSearchAndVectorsFor,
+} from '../../../src/main/notebase/index-fanout';
+
+const CTX = { rootPath: '/vault', _brand: 'ProjectContext' as const };
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('indexAllFor', () => {
+  it('sends a markdown note to graph, search, and vectors', async () => {
+    await indexAllFor(CTX, 'notes/a.md', '# hello');
+    expect(h.graphIndexNote).toHaveBeenCalledWith(CTX, 'notes/a.md', '# hello');
+    expect(h.searchIndexNote).toHaveBeenCalledWith(CTX, 'notes/a.md', '# hello');
+    expect(h.vectorsIndexNote).toHaveBeenCalledWith(CTX, 'notes/a.md', '# hello');
+  });
+
+  it.each(['data/t.ttl', 'data/t.csv', 'scripts/t.py'])(
+    'sends a non-markdown note (%s) to the graph only',
+    async (rel) => {
+      await indexAllFor(CTX, rel, 'content');
+      expect(h.graphIndexNote).toHaveBeenCalled();
+      expect(h.searchIndexNote).not.toHaveBeenCalled();
+      expect(h.vectorsIndexNote).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('removeAllFor', () => {
+  it('removes a note from graph, search, and vectors unconditionally', () => {
+    removeAllFor(CTX, 'data/t.ttl');
+    expect(h.graphRemoveNote).toHaveBeenCalledWith(CTX, 'data/t.ttl');
+    expect(h.searchRemoveNote).toHaveBeenCalledWith(CTX, 'data/t.ttl');
+    expect(h.vectorsRemoveNote).toHaveBeenCalledWith(CTX, 'data/t.ttl');
+  });
+});
+
+// The search+vectors-only half, used by the rename/merge reindexHook/removeHook
+// callbacks that already index the note into the graph themselves (#1985).
+describe('indexSearchAndVectorsFor', () => {
+  it('indexes a markdown note into search and vectors, not the graph', () => {
+    indexSearchAndVectorsFor(CTX, 'notes/a.md', 'body');
+    expect(h.searchIndexNote).toHaveBeenCalledWith(CTX, 'notes/a.md', 'body');
+    expect(h.vectorsIndexNote).toHaveBeenCalledWith(CTX, 'notes/a.md', 'body');
+    expect(h.graphIndexNote).not.toHaveBeenCalled();
+  });
+
+  it('skips a non-markdown note entirely', () => {
+    indexSearchAndVectorsFor(CTX, 'data/t.csv', 'a,b');
+    expect(h.searchIndexNote).not.toHaveBeenCalled();
+    expect(h.vectorsIndexNote).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeSearchAndVectorsFor', () => {
+  it('removes a note from search and vectors, not the graph', () => {
+    removeSearchAndVectorsFor(CTX, 'notes/a.md');
+    expect(h.searchRemoveNote).toHaveBeenCalledWith(CTX, 'notes/a.md');
+    expect(h.vectorsRemoveNote).toHaveBeenCalledWith(CTX, 'notes/a.md');
+    expect(h.graphRemoveNote).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #1892/#1984. `NOTEBASE_RENAME`'s and `NOTEBASE_MERGE`'s `reindexHook` callbacks in `register-notebase.ts` correctly refresh both search and vectors for a rewritten `.md` note; `NOTEBASE_RENAME_SOURCE`, `NOTEBASE_RENAME_EXCERPT`, and `NOTEBASE_RENAME_ANCHOR`'s `reindexHook`s called `search.indexNote` only. So renaming a source, an excerpt, or an anchor slug rewrites wiki-links across the vault and refreshes every affected note's full-text index — but leaves its embedding stale, same failure shape as #1892 with a different trigger.

- Extracted the search+vectors half of `notebase/index-fanout.ts`'s fan-out into two new exports, `indexSearchAndVectorsFor`/`removeSearchAndVectorsFor`. The rename/merge helpers (`rename.ts`, `merge.ts`, `rename-source-excerpt.ts`, `rename-anchor.ts`) already call `graph.indexNote` themselves for each rewritten note right before invoking `reindexHook` — `reindexHook`'s contract was always "the rest of the fan-out," never graph — so these two new functions are exactly that half, and `indexAllFor`/`removeAllFor` now delegate to them internally rather than duplicating the `.md` gate.
- All five `reindexHook`/`removeHook` call sites in `register-notebase.ts` (`RENAME`, `MERGE`, `RENAME_SOURCE`, `RENAME_EXCERPT`, `RENAME_ANCHOR`) now share the same two functions, closing the drift between them.

## Test plan

- [x] New `tests/main/notebase/index-fanout.test.ts` — direct unit coverage for all four exported functions (`indexAllFor`, `removeAllFor`, `indexSearchAndVectorsFor`, `removeSearchAndVectorsFor`).
- [x] New regression test per previously-broken handler in `register-notebase.test.ts`: drives the handler's `reindexHook` and asserts the vector store is now called for a rewritten markdown note (`RENAME_SOURCE`, `RENAME_EXCERPT`, `RENAME_ANCHOR`).
- [x] `pnpm lint` passes.
- [x] `pnpm test` — full suite green (632 files, 6874 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)