### PR TITLE
fix: health-checks running flag was module-global, not per-project (#1893)

### DIFF
--- a/src/main/graph/health-checks.ts
+++ b/src/main/graph/health-checks.ts
@@ -56,14 +56,19 @@ export interface Inspection {
 }
 
 const lastResultsByProject = new Map<string, Inspection[]>();
-let running = false;
+// Keyed by rootPath (#1893) — a module-global flag made a check in flight for
+// one project return [] for every OTHER project's concurrent check, which is
+// indistinguishable from "clean". Concurrent runs across windows/projects are
+// the normal case here: armAutoChecks debounces off every graph write and
+// there's a 5-minute periodic timer per project.
+const runningProjects = new Set<string>();
 
 export function getInspections(ctx: ProjectContext): Inspection[] {
   return lastResultsByProject.get(ctx.rootPath) ?? [];
 }
 
-export function isRunning(): boolean {
-  return running;
+export function isRunning(ctx: ProjectContext): boolean {
+  return runningProjects.has(ctx.rootPath);
 }
 
 /** The SPARQL rows every check reads, cast to the string-record shape once
@@ -93,8 +98,8 @@ export async function runAllChecks(
   ctx: ProjectContext,
   settings: InspectionSettings = DEFAULT_INSPECTION_SETTINGS,
 ): Promise<Inspection[]> {
-  if (running) return lastResultsByProject.get(ctx.rootPath) ?? [];
-  running = true;
+  if (runningProjects.has(ctx.rootPath)) return lastResultsByProject.get(ctx.rootPath) ?? [];
+  runningProjects.add(ctx.rootPath);
 
   const on = (type: string) => isInspectionEnabled(type, settings);
   const none = (): Promise<Inspection[]> => Promise.resolve([]);
@@ -123,7 +128,7 @@ export async function runAllChecks(
     emitInspectionsChanged(ctx.rootPath);
     return flat;
   } finally {
-    running = false;
+    runningProjects.delete(ctx.rootPath);
   }
 }
 

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -68,7 +68,7 @@ const BUDGETS: Record<string, number> = {
   'src/renderer/lib/components/Sidebar.svelte': 998,
   'src/renderer/lib/app/refactor-ops.svelte.ts': 827,
   'src/renderer/lib/components/SettingsDialog.svelte': 779,
-  'src/main/graph/health-checks.ts': 795,
+  'src/main/graph/health-checks.ts': 800,
   'src/renderer/lib/components/ExportDialog.svelte': 712,
   'src/renderer/lib/components/QueryPanel.svelte': 755,
   'src/renderer/lib/components/conversations/DraftCards.svelte': 740,

--- a/tests/main/graph/health-checks-concurrency.test.ts
+++ b/tests/main/graph/health-checks-concurrency.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `running` guard in `graph/health-checks.ts` (#1893).
+ *
+ * `runAllChecks` used to guard concurrent execution with a single
+ * module-global `let running = false` while every other piece of state
+ * (`lastResultsByProject`) was keyed by `rootPath`. Concurrent runs across
+ * different projects are the normal case, not an edge case: `armAutoChecks`
+ * debounces a run off every graph write, and there's a 5-minute periodic
+ * timer per project — with two+ thoughtbases open, their checks routinely
+ * overlap. A check in flight for project A made a concurrent check for
+ * project B return `[]`, indistinguishable from "clean."
+ *
+ * `runAllChecks` runs synchronously up through marking itself "running" and
+ * kicking off its `Promise.all([...])` of check queries — it only yields to
+ * the caller at that `await`. So firing two calls back-to-back without
+ * awaiting between them (as below) reliably overlaps them: by the time the
+ * second call's guard runs, the first has already marked itself running but
+ * has not yet reached its `finally`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { initGraph } from '../../../src/main/graph/index';
+import { runAllChecks } from '../../../src/main/graph/health-checks';
+import { applyTurtle } from '../../../src/main/llm/proposal-persistence';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+function mkTempProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-health-checks-concurrency-test-'));
+}
+
+describe('runAllChecks concurrency guard (#1893)', () => {
+  let rootA: string;
+  let rootB: string;
+  let ctxA: ProjectContext;
+  let ctxB: ProjectContext;
+
+  beforeEach(async () => {
+    rootA = mkTempProject();
+    rootB = mkTempProject();
+    ctxA = projectContext(rootA);
+    ctxB = projectContext(rootB);
+    await initGraph(ctxA);
+    await initGraph(ctxB);
+    await applyTurtle(ctxA, `<urn:claim:a> a thought:Claim ; thought:label "Claim A" .`);
+    await applyTurtle(ctxB, `<urn:claim:b> a thought:Claim ; thought:label "Claim B" .`);
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      fsp.rm(rootA, { recursive: true, force: true }),
+      fsp.rm(rootB, { recursive: true, force: true }),
+    ]);
+  });
+
+  it("project B's check returns its real results while project A's is in flight, not []", async () => {
+    const pA = runAllChecks(ctxA);
+    const pB = runAllChecks(ctxB); // fired before pA resolves — genuinely concurrent
+
+    const [resultsA, resultsB] = await Promise.all([pA, pB]);
+
+    expect(resultsA.some((i) => i.type === 'unsupported_claim' && i.nodeUri === 'urn:claim:a')).toBe(true);
+    expect(resultsB.some((i) => i.type === 'unsupported_claim' && i.nodeUri === 'urn:claim:b')).toBe(true);
+  });
+
+  // Not the #1893 bug (that's cross-project), but worth pinning: the dedup
+  // guard should still collapse a genuinely-concurrent SECOND call for the
+  // SAME project onto that project's own last known state — never onto
+  // another project's.
+  it('a second concurrent call for the SAME project collapses onto its own state, not an empty cross-project leak', async () => {
+    const first = runAllChecks(ctxA);
+    const second = runAllChecks(ctxA);
+
+    const [firstResults, secondResults] = await Promise.all([first, second]);
+    expect(firstResults.some((i) => i.type === 'unsupported_claim' && i.nodeUri === 'urn:claim:a')).toBe(true);
+    // No prior run had completed for A yet, so the collapsed call sees A's
+    // own (empty) last-known state — not [] because someone ELSE was running.
+    expect(secondResults).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`graph/health-checks.ts` kept results in a per-project `lastResultsByProject` Map but guarded execution with a single module-global `let running = false`. A check in flight for project A made a concurrent check for project B return `[]` immediately — indistinguishable from "clean." With `armAutoChecks` debouncing a run off every graph write and a 5-minute periodic timer per project, overlapping runs across open projects/windows are the normal case, not an edge case.

- Replaced the boolean with a `Set<rootPath>` (`runningProjects`), matching how `lastResultsByProject` is already keyed.
- `isRunning()` — unused anywhere today, but part of the module's public API — now takes a `ProjectContext` for the same reason, so it can't reintroduce the same bug if it's ever wired up.
- Bumped the `graph/health-checks.ts` file-size budget (795 → 800): a real line-count increase from the `Set`-based guard plus its explanatory comment.

## Test plan

- [x] New `tests/main/graph/health-checks-concurrency.test.ts`: fires `runAllChecks` for two different projects back-to-back without awaiting between them (which reliably overlaps them — `runAllChecks` only yields to its caller once it hits its internal `Promise.all`), and asserts project B's real results come back instead of `[]`. Also pins the *intentional* same-project dedup behavior (a genuinely concurrent second call for the SAME project collapses onto its own last-known state, never someone else's).
- [x] Verified the regression test actually catches the bug: reverted just the fix, watched the cross-project test fail (assert `false` where `true` was expected — project B got `[]` while A was in flight), then restored the fix.
- [x] `pnpm lint` passes.
- [x] `pnpm test` — full suite green (633 files, 6876 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)