### PR TITLE
refactor: extract fileAndApprove() in register-conversation-drafts.ts (#1895)

### DIFF
--- a/src/main/ipc/register-conversation-drafts.ts
+++ b/src/main/ipc/register-conversation-drafts.ts
@@ -15,7 +15,7 @@ import { Channels } from '../../shared/channels';
 import { broadcast } from './broadcast';
 import * as notebaseFs from '../notebase/fs';
 import * as graph from '../graph/index';
-import { projectContext } from '../project-context-types';
+import { projectContext, type ProjectContext } from '../project-context-types';
 import { writeAndReindex } from '../notebase/write-pipeline';
 import { runWithHistorySource } from '../history';
 import { ingestUrl } from '../sources/ingest';
@@ -102,6 +102,31 @@ function conversationProvenance(conversationId: string): { conversationUri: stri
   };
 }
 
+/**
+ * File a write proposal and immediately approve it — the shared shape behind
+ * every "Approve" click on a draft card (#1895). The user already reviewed
+ * the card, so auto-approving here doesn't weaken the Trust Principle; the
+ * approval engine still records a pending-then-approved Proposal either way.
+ *
+ * `applied` reflects `approveProposal`'s real `ok` result rather than being
+ * hardcoded `true` — the six call sites this replaces all hardcoded it even
+ * when `proposal` came back falsy and nothing was filed, the same shape as
+ * the vestigial `GIT_COMMIT.success` CLAUDE.md already flags. `proposeWrite`
+ * doesn't currently return a falsy value (it throws instead, via
+ * `assertWiredPayloads`), so the `if (!proposal)` branch below is defensive
+ * rather than reachable today — but it means a future change to that
+ * contract can't silently start lying about `applied` again.
+ */
+export async function fileAndApprove(
+  ctx: ProjectContext,
+  write: approval.ProposedWrite,
+): Promise<{ proposalUri: string | null; applied: boolean; filedPaths: string[]; rewrittenPaths: string[] }> {
+  const proposal = await approval.proposeWrite(ctx, write);
+  if (!proposal) return { proposalUri: null, applied: false, filedPaths: [], rewrittenPaths: [] };
+  const result = await approval.approveProposal(ctx, proposal.uri);
+  return { proposalUri: proposal.uri, applied: result.ok, filedPaths: result.filedPaths, rewrittenPaths: result.rewrittenPaths };
+}
+
 export function registerConversationDrafts(): void {
   // The user clicked Approve on a propose_notes draft card. We file the
   // bundle through the standard approval engine AND auto-approve it —
@@ -117,22 +142,13 @@ export function registerConversationDrafts(): void {
       });
       ensureDraftItems(draft, 'payloads', 'FILE_DRAFT');
       const ctx = projectContext(rootPath);
-      const proposal = await approval.proposeWrite(ctx, {
+      const { proposalUri, applied, filedPaths } = await fileAndApprove(ctx, {
         operationType: 'component_creation',
         payloads: draft.payloads,
         note: draft.note,
         ...conversationProvenance(draft.conversationId),
       });
-      let filedPaths: string[] = [];
-      if (proposal) {
-        const result = await approval.approveProposal(ctx, proposal.uri);
-        filedPaths = result.filedPaths;
-      }
-      return {
-        proposalUri: proposal?.uri ?? null,
-        applied: true,
-        filedPaths,
-      };
+      return { proposalUri, applied, filedPaths };
     }),
   );
 
@@ -146,7 +162,7 @@ export function registerConversationDrafts(): void {
       const ctx = projectContext(rootPath);
       // A folder move (propose_folder_move sets isFolder) files a folder-refactor
       // payload; a single-note move files note-refactor. Both re-plan at apply.
-      const proposal = await approval.proposeWrite(ctx, {
+      const { proposalUri, applied } = await fileAndApprove(ctx, {
         operationType: 'note_refactor',
         payloads: [draft.isFolder
           ? { kind: 'folder-refactor', fromPath: draft.fromPath, toPath: draft.toPath }
@@ -154,8 +170,7 @@ export function registerConversationDrafts(): void {
         note: draft.note,
         ...conversationProvenance(draft.conversationId),
       });
-      if (proposal) await approval.approveProposal(ctx, proposal.uri);
-      return { proposalUri: proposal?.uri ?? null, applied: true };
+      return { proposalUri, applied };
     }),
   );
 
@@ -178,14 +193,13 @@ export function registerConversationDrafts(): void {
       // A folder batch files `folder-refactor` payloads — same bundle, same
       // ordered apply and reverse-order rollback, different payload kind.
       const kind = draft.isFolder ? ('folder-refactor' as const) : ('note-refactor' as const);
-      const proposal = await approval.proposeWrite(ctx, {
+      const { proposalUri, applied } = await fileAndApprove(ctx, {
         operationType: 'note_refactor',
         payloads: ordered.map((i) => ({ kind, fromPath: i.fromPath, toPath: i.toPath })),
         note: draft.note,
         ...conversationProvenance(draft.conversationId),
       });
-      if (proposal) await approval.approveProposal(ctx, proposal.uri);
-      return { proposalUri: proposal?.uri ?? null, applied: true };
+      return { proposalUri, applied };
     }),
   );
 
@@ -216,7 +230,7 @@ export function registerConversationDrafts(): void {
         return { proposalUri: null, applied: false };
       }
 
-      const proposal = await approval.proposeWrite(ctx, {
+      const { proposalUri, applied } = await fileAndApprove(ctx, {
         operationType: 'note_delete',
         payloads: isFolderDelete
           ? chosenFolders.map((path) => ({ kind: 'folder-delete' as const, path }))
@@ -224,8 +238,7 @@ export function registerConversationDrafts(): void {
         note: draft.note,
         ...conversationProvenance(draft.conversationId),
       });
-      if (proposal) await approval.approveProposal(ctx, proposal.uri);
-      return { proposalUri: proposal?.uri ?? null, applied: true };
+      return { proposalUri, applied };
     }),
   );
 
@@ -257,7 +270,7 @@ export function registerConversationDrafts(): void {
         // ONE proposal carrying one `note-rewrite` payload per note. applyBundle
         // applies them in order and rolls the whole bundle back on any failure,
         // so a twenty-note rewrite can't land half-applied.
-        const proposal = await approval.proposeWrite(ctx, {
+        const { proposalUri, applied, rewrittenPaths } = await fileAndApprove(ctx, {
           operationType: 'note_rewrite',
           payloads: chosen.map((i) => ({
             kind: 'note-rewrite' as const,
@@ -267,13 +280,8 @@ export function registerConversationDrafts(): void {
           note: draft.note,
           ...conversationProvenance(draft.conversationId),
         });
-        let applied = false;
-        if (proposal) {
-          const result = await approval.approveProposal(ctx, proposal.uri);
-          applied = result.ok;
-          hooks.broadcastRewritten(rootPath, result.rewrittenPaths);
-        }
-        return { proposalUri: proposal?.uri ?? null, applied };
+        hooks.broadcastRewritten(rootPath, rewrittenPaths);
+        return { proposalUri, applied };
       });
     }),
   );
@@ -331,13 +339,12 @@ export function registerConversationDrafts(): void {
           });
         });
 
-        const proposal = await approval.proposeWrite(ctx, {
+        await fileAndApprove(ctx, {
           operationType: 'component_creation',
           payloads,
           note: draft.note,
           ...conversationProvenance(draft.conversationId),
         });
-        if (proposal) await approval.approveProposal(ctx, proposal.uri);
 
         return { outcome: { sourceId, claimPaths, excerptIds } };
       } catch (err) {

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -80,7 +80,7 @@ const BUDGETS: Record<string, number> = {
   'src/main/sources/tables.ts': 665,
   'src/renderer/lib/components/FindInNotesDialog.svelte': 601,
   'src/preload/preload.ts': 614,
-  'src/main/ipc/register-conversation-drafts.ts': 601,
+  'src/main/ipc/register-conversation-drafts.ts': 608,
 };
 
 /** Source files this applies to: authored `.ts` / `.svelte` under `src/`. */

--- a/tests/main/ipc/register-conversation-drafts.test.ts
+++ b/tests/main/ipc/register-conversation-drafts.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `fileAndApprove()` in `register-conversation-drafts.ts` (#1895).
+ *
+ * Extracted from six duplicated `proposeWrite → if (proposal) approveProposal
+ * → return { applied: true }` blocks, one per draft-filing IPC handler. The
+ * duplication itself was harmless, but the hardcoded `applied: true` wasn't:
+ * every call site claimed success even on the `proposal` was falsy branch,
+ * the same shape as the vestigial `GIT_COMMIT.success` CLAUDE.md already
+ * flags. This tests the helper directly rather than every handler that now
+ * delegates to it — see #1900 for broader IPC-level coverage of these six
+ * channels, which had none before this file.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  proposeWrite: vi.fn(),
+  approveProposal: vi.fn(),
+}));
+
+vi.mock('../../../src/main/llm/approval', () => ({
+  proposeWrite: h.proposeWrite,
+  approveProposal: h.approveProposal,
+}));
+
+// register-conversation-drafts.ts's other imports pull in a large surface
+// (compute, sources ingest, history, ./helpers → window-manager → electron's
+// app.getPath called eagerly at module scope) that fileAndApprove itself
+// never touches. Stub them so the module loads without that chain.
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  withRootPath: (fn: unknown) => fn,
+  withRootPathWin: (fn: unknown) => fn,
+  reindexFile: vi.fn(),
+  persistIndexes: vi.fn(),
+  hooks: {},
+}));
+vi.mock('../../../src/main/ipc/typed-ipc', () => ({ handle: vi.fn() }));
+vi.mock('../../../src/main/ipc/register-compute', () => ({
+  formatComputeResultAsContext: vi.fn(),
+  recordComputeProposalRun: vi.fn(),
+  buildComputeProposalNoteBlock: vi.fn(),
+}));
+vi.mock('../../../src/main/notebase/fs', () => ({}));
+vi.mock('../../../src/main/graph/index', () => ({ withLLMContext: (fn: () => unknown) => fn() }));
+vi.mock('../../../src/main/notebase/write-pipeline', () => ({ writeAndReindex: vi.fn() }));
+vi.mock('../../../src/main/history', () => ({ runWithHistorySource: (_opts: unknown, fn: () => unknown) => fn() }));
+vi.mock('../../../src/main/sources/ingest', () => ({ ingestUrl: vi.fn() }));
+vi.mock('../../../src/main/sources/ingest-identifier', () => ({ ingestIdentifier: vi.fn() }));
+vi.mock('../../../src/main/privileged-sites', () => ({ privilegedFetch: vi.fn() }));
+vi.mock('../../../src/main/sources/source-meta-write', () => ({ ttlString: vi.fn() }));
+vi.mock('../../../src/main/llm/source-properties', () => ({ fileSourceProperties: vi.fn() }));
+vi.mock('../../../src/main/compute/registry', () => ({ runCell: vi.fn() }));
+vi.mock('../../../src/main/compute/consent', () => ({ computeConsentGuard: vi.fn() }));
+vi.mock('../../../src/main/compute/audit', () => ({ recordExecution: vi.fn() }));
+vi.mock('../../../src/main/sources/create-excerpt', () => ({ buildExcerptTtl: vi.fn() }));
+vi.mock('../../../src/main/llm/set-properties', () => ({ applyPropertyUpdates: vi.fn() }));
+vi.mock('../../../src/main/notebase/reorg', () => ({ orderRefactors: vi.fn() }));
+vi.mock('../../../src/main/llm/conversation', () => ({ appendMessage: vi.fn() }));
+
+import { fileAndApprove } from '../../../src/main/ipc/register-conversation-drafts';
+import { projectContext } from '../../../src/main/project-context-types';
+
+const CTX = projectContext('/vault');
+const WRITE = {
+  operationType: 'component_creation' as const,
+  payloads: [],
+  note: 'test',
+  proposedBy: 'llm:conversation:c1',
+};
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('fileAndApprove', () => {
+  it('files and approves, returning the real approve result', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'urn:proposal:1' });
+    h.approveProposal.mockResolvedValue({ ok: true, filedPaths: ['a.md'], rewrittenPaths: ['b.md'] });
+
+    const result = await fileAndApprove(CTX, WRITE);
+
+    expect(h.proposeWrite).toHaveBeenCalledWith(CTX, WRITE);
+    expect(h.approveProposal).toHaveBeenCalledWith(CTX, 'urn:proposal:1');
+    expect(result).toEqual({
+      proposalUri: 'urn:proposal:1',
+      applied: true,
+      filedPaths: ['a.md'],
+      rewrittenPaths: ['b.md'],
+    });
+  });
+
+  // The #1895 bug this closes: a falsy proposal must not read as `applied: true`.
+  it('reports applied: false and skips approveProposal when proposeWrite returns falsy', async () => {
+    h.proposeWrite.mockResolvedValue(null);
+
+    const result = await fileAndApprove(CTX, WRITE);
+
+    expect(h.approveProposal).not.toHaveBeenCalled();
+    expect(result).toEqual({ proposalUri: null, applied: false, filedPaths: [], rewrittenPaths: [] });
+  });
+
+  // Equally load-bearing: a proposal that WAS filed but failed to apply
+  // (revoked mid-flight, a payload apply error) must also report applied:
+  // false — the old hardcoded `applied: true` got this case wrong too, and
+  // unlike the falsy-proposal branch, this one is genuinely reachable today.
+  it('reports applied: false when the proposal was filed but approveProposal fails', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'urn:proposal:2' });
+    h.approveProposal.mockResolvedValue({ ok: false, filedPaths: [], rewrittenPaths: [] });
+
+    const result = await fileAndApprove(CTX, WRITE);
+
+    expect(result).toEqual({
+      proposalUri: 'urn:proposal:2',
+      applied: false,
+      filedPaths: [],
+      rewrittenPaths: [],
+    });
+  });
+});

--- a/tests/main/ipc/register-conversation.test.ts
+++ b/tests/main/ipc/register-conversation.test.ts
@@ -268,7 +268,7 @@ describe('CONVERSATION_SEND (#1612)', () => {
 describe('CONVERSATION_FILE_DRAFT — propose + auto-approve (#1612)', () => {
   it('files the draft through the approval engine and auto-approves it', async () => {
     h.proposeWrite.mockResolvedValue({ uri: 'proposal:abc' });
-    h.approveProposal.mockResolvedValue({ filedPaths: ['Filed.md'], rewrittenPaths: [] });
+    h.approveProposal.mockResolvedValue({ ok: true, filedPaths: ['Filed.md'], rewrittenPaths: [] });
 
     const draft = {
       draftId: 'd1',
@@ -292,7 +292,10 @@ describe('CONVERSATION_FILE_DRAFT — propose + auto-approve (#1612)', () => {
     expect(res).toEqual({ proposalUri: 'proposal:abc', applied: true, filedPaths: ['Filed.md'] });
   });
 
-  it('does not approve when proposeWrite files nothing (empty bundle)', async () => {
+  // #1895 — this used to assert `applied: true` here, pinning the bug the
+  // issue reports: fileAndApprove used to hardcode `applied: true` even when
+  // proposeWrite returned nothing to approve. It must read false.
+  it('does not approve when proposeWrite files nothing (empty bundle), and reports applied: false', async () => {
     h.proposeWrite.mockResolvedValue(null);
 
     const draft = {
@@ -304,7 +307,7 @@ describe('CONVERSATION_FILE_DRAFT — propose + auto-approve (#1612)', () => {
     const res = await fileDraft(evt, draft);
 
     expect(h.approveProposal).not.toHaveBeenCalled();
-    expect(res).toEqual({ proposalUri: null, applied: true, filedPaths: [] });
+    expect(res).toEqual({ proposalUri: null, applied: false, filedPaths: [] });
   });
 });
 
@@ -323,11 +326,11 @@ describe('CONVERSATION_FILE_DELETE_DRAFT — the selection UNIT differs by kind 
 
   beforeEach(() => {
     h.proposeWrite.mockResolvedValue({ uri: 'proposal:del' });
-    h.approveProposal.mockResolvedValue({ filedPaths: [], rewrittenPaths: [] });
+    h.approveProposal.mockResolvedValue({ ok: true, filedPaths: [], rewrittenPaths: [] });
   });
 
   it('files one folder-delete payload per SELECTED folder, in one proposal', async () => {
-    await fileDeleteDraft(evt, folderDraft, ['a', 'b']);
+    const res = await fileDeleteDraft(evt, folderDraft, ['a', 'b']);
 
     expect(h.proposeWrite).toHaveBeenCalledTimes(1);
     expect(h.proposeWrite.mock.calls[0]![1]).toMatchObject({
@@ -338,6 +341,9 @@ describe('CONVERSATION_FILE_DELETE_DRAFT — the selection UNIT differs by kind 
       ],
     });
     expect(h.approveProposal).toHaveBeenCalledWith(expect.anything(), 'proposal:del');
+    // #1895 — applied now reflects the real approveProposal result via
+    // fileAndApprove, not a hardcoded true.
+    expect(res).toEqual({ proposalUri: 'proposal:del', applied: true });
   });
 
   it('honours a partial folder selection', async () => {


### PR DESCRIPTION
## Summary

Six handlers in `register-conversation-drafts.ts` repeated `proposeWrite → if (proposal) approveProposal → return { applied: true }` — the unfinished half of a prior review item (`conversationProvenance()` shipped; `fileAndApprove` did not).

The duplication hid a real bug: `applied` was hardcoded `true` at four of the six sites even on the `if (proposal)` false branch, where nothing was filed or approved — the same shape as the vestigial `GIT_COMMIT.success` already on CLAUDE.md's list. A fifth site (`FILE_NOTE_BODY_DRAFT`) already computed `applied` correctly from `approveProposal`'s real `ok` result; the new helper generalizes that one's approach instead of the other four's.

- Extracted `fileAndApprove(ctx, write)` — proposes, approves if a proposal came back, and returns `{ proposalUri, applied, filedPaths, rewrittenPaths }` with `applied` reflecting `approveProposal`'s actual `ok` result.
- All six call sites (`FILE_DRAFT`, `FILE_REFACTOR_DRAFT`, `FILE_REORG_DRAFT`, `FILE_DELETE_DRAFT`, `FILE_NOTE_BODY_DRAFT`, `FILE_CLAIMS_DRAFT`) now delegate to it; each is a thin 2-8 line wrapper instead of repeating the sequence.
- `proposeWrite` currently never actually returns falsy (it throws via `assertWiredPayloads` instead), so the null-proposal branch is defensive rather than reachable today — but it's exactly the branch a future change to that contract could silently start lying about again without this helper owning it.

## Test plan

- [x] Found and fixed an **existing test that was pinning the bug**: `register-conversation.test.ts`'s "does not approve when proposeWrite files nothing" asserted `applied: true`. Now asserts `false` — this is the issue's explicit "proposal === null path" criterion, in a real IPC-dispatch test rather than a synthetic one.
- [x] Added an `applied: true` assertion to the delete-draft success-path test, confirming the real wiring end-to-end for one call site.
- [x] New `tests/main/ipc/register-conversation-drafts.test.ts` — direct unit coverage of `fileAndApprove` against both failure shapes: a falsy `proposal` (defensive, not reachable today) and a proposal that was filed but failed to apply (`approveProposal` returns `ok: false` — the one that's actually reachable in practice, and the more realistic version of the original bug).
- [x] Verified the new tests actually catch the bug: reverted `fileAndApprove` to the old hardcoded-`applied: true` shape and watched both the new unit tests and the fixed `register-conversation.test.ts` test fail, then restored the fix.
- [x] File-size budget bump for `register-conversation-drafts.ts` (601 → 608) for the extracted helper plus its explanatory comment.
- [x] `pnpm lint` passes.
- [x] `pnpm test` — full suite green (635 files, 6883 passed, 1 skipped).

Note: #1895 lists #1900 (broader IPC-level test coverage for these six channels, currently zero) as a dependency. This PR closes the specific gap #1895 asks for — the `fileAndApprove` helper and its null/failure-path coverage — without attempting #1900's full scope, which remains open as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)