### PR TITLE
chore: delete three dead exports, wire up disposeSharedEmbedder (#1898)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -16,6 +16,7 @@ import { flushAllProjects } from './project-context';
 import { shutdownAllKernels } from './compute/python-kernel';
 import { sweepStaleRpcSockets } from './compute/rpc-server';
 import { stopClipperServer } from './clipper/lifecycle';
+import { disposeSharedEmbedder } from './embeddings/shared-embedder';
 import { registerSkillsAtStartup } from './skills/register';
 import { initAutoUpdate, setUpdateStateListener } from './auto-update';
 import { installE2EHooks } from './e2e-hooks';
@@ -132,6 +133,7 @@ app.on('before-quit', (event) => {
     flushAllProjects(),
     shutdownAllKernels(),
     stopClipperServer(),
+    disposeSharedEmbedder(),
   ])
     .catch((err) => console.warn('[quit] shutdown failed:', err))
     .finally(() => app.quit());

--- a/src/main/skills/template.ts
+++ b/src/main/skills/template.ts
@@ -80,8 +80,6 @@ const FILTERS: Record<string, Filter> = {
   stem: (s) => s.replace(/\.md$/i, ''),
 };
 
-export const KNOWN_FILTERS: readonly string[] = Object.keys(FILTERS);
-
 // ---- Tokenizer --------------------------------------------------------------
 
 type Token =

--- a/src/main/sources/tables.ts
+++ b/src/main/sources/tables.ts
@@ -659,8 +659,3 @@ export async function listTables(ctx: ProjectContext): Promise<TableInfo[]> {
   out.sort((a, b) => a.relativePath.localeCompare(b.relativePath) || a.name.localeCompare(b.name));
   return out;
 }
-
-/** Exposed for tests. */
-export function _isOpen(ctx: ProjectContext): boolean {
-  return store.has(ctx);
-}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -531,10 +531,6 @@ export function closeProjectInWindow(winId: number): void {
   void syncClipperLifecycle();
 }
 
-export function getWindowById(id: number): BrowserWindow | null {
-  return BrowserWindow.fromId(id) ?? null;
-}
-
 export function getFocusedWindow(): BrowserWindow | null {
   return BrowserWindow.getFocusedWindow();
 }

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -77,7 +77,7 @@ const BUDGETS: Record<string, number> = {
   'src/shared/channels.ts': 701,
   'src/renderer/lib/app/note-ops.ts': 687,
   'src/renderer/lib/editor/formatting.ts': 671,
-  'src/main/sources/tables.ts': 666,
+  'src/main/sources/tables.ts': 661,
   'src/renderer/lib/components/FindInNotesDialog.svelte': 601,
   'src/preload/preload.ts': 614,
   'src/main/ipc/register-conversation-drafts.ts': 608,

--- a/tests/main/embeddings/shared-embedder.test.ts
+++ b/tests/main/embeddings/shared-embedder.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Process-wide embedder singleton (#835), specifically `disposeSharedEmbedder`
+ * (#1898) — previously declared but never called anywhere, now wired into
+ * `main.ts`'s `before-quit` handler alongside the other subsystem shutdowns.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  instances: [] as Array<{ dispose: ReturnType<typeof vi.fn> }>,
+}));
+
+vi.mock('../../../src/main/embeddings/embedder-service', () => ({
+  createEmbedderService: vi.fn(() => {
+    const instance = { dim: 384, embed: vi.fn(), dispose: vi.fn().mockResolvedValue(undefined) };
+    h.instances.push(instance);
+    return instance;
+  }),
+}));
+
+import { getSharedEmbedder, disposeSharedEmbedder } from '../../../src/main/embeddings/shared-embedder';
+
+afterEach(async () => {
+  await disposeSharedEmbedder();
+  h.instances.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('getSharedEmbedder', () => {
+  it('returns the same instance on repeated calls (process-wide singleton)', () => {
+    const a = getSharedEmbedder();
+    const b = getSharedEmbedder();
+    expect(a).toBe(b);
+    expect(h.instances).toHaveLength(1);
+  });
+});
+
+describe('disposeSharedEmbedder', () => {
+  it('terminates the current instance and lets a later call create a fresh one', async () => {
+    const first = getSharedEmbedder();
+    await disposeSharedEmbedder();
+
+    expect(first.dispose).toHaveBeenCalledTimes(1);
+
+    const second = getSharedEmbedder();
+    expect(second).not.toBe(first);
+    expect(h.instances).toHaveLength(2);
+  });
+
+  it('is a safe no-op when no embedder has been created yet', async () => {
+    await expect(disposeSharedEmbedder()).resolves.toBeUndefined();
+    expect(h.instances).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Four exports had zero references anywhere outside their own definition line (verified via `grep -rn '\bNAME\b' src tests`):

- **`disposeSharedEmbedder`** — the only cleanup path for the process-wide embedder worker, never called. Decided to **wire it in rather than delete**: it terminates a real `worker_threads` `Worker`, and `main.ts`'s `before-quit` handler already runs the equivalent orderly shutdown for three sibling subsystems (`flushAllProjects`, `shutdownAllKernels`, `stopClipperServer`) — this is the natural fourth. Added `shared-embedder.test.ts` (this module had no test file at all) since it's no longer dead code.
- **`getWindowById`** (`window-manager.ts`) — deleted. `getFocusedWindow` next to it is real API surface; this one had none.
- **`KNOWN_FILTERS`** (`skills/template.ts`) — deleted. The underlying `FILTERS` map it derived from is still used internally by the template engine; only the exported name list had no consumer.
- **`_isOpen`** (`sources/tables.ts`) — deleted. Its own comment claimed "Exposed for tests," but no test (or anything else) used it.

## Test plan

- [x] New `tests/main/embeddings/shared-embedder.test.ts` — direct unit coverage for the singleton + dispose behavior, mocking the worker-spawning `embedder-service` module.
- [x] File-size budget lowered for `sources/tables.ts` (666 → 661) after the `_isOpen` removal.
- [x] `pnpm lint` passes.
- [x] `pnpm test` — full suite green (637 files, 6901 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)