### PR TITLE
test: cover all 11 register-conversation-drafts.ts handlers (#1900)

### DIFF
--- a/tests/main/ipc/register-conversation-drafts-write-guard.test.ts
+++ b/tests/main/ipc/register-conversation-drafts-write-guard.test.ts
@@ -1,0 +1,114 @@
+/**
+ * `CONVERSATION_FILE_NOTE_BODY_DRAFT`'s LLM write guard (#944, #1900).
+ *
+ * Of the eleven handlers in `register-conversation-drafts.ts`, this is the
+ * only one that wraps itself in `graph.withLLMContext` (see CLAUDE.md's
+ * "Write Guard" section) — arming `checkLLMWriteGuard` so a write that skips
+ * the approval engine's trusted-context wrapping is caught rather than
+ * landing silently. Proving that matters needs the REAL graph/write-guard
+ * machinery, which is why this is a separate file from
+ * `register-conversation-drafts.test.ts`: that file stubs `graph/index`
+ * wholesale for speed/isolation, which would make the guard a no-op here.
+ *
+ * `approval.proposeWrite`/`approveProposal` are still mocked — but the mock
+ * simulates a hypothetical regression in `approval.ts` itself (applying a
+ * bundle without its own `enterTrustedContext()` wrapping), so the ONLY
+ * thing standing between that regression and a silent bypass is this
+ * handler's `withLLMContext` wrapper. If that wrapper were ever removed,
+ * this test flips from "rejects" to "resolves" — the failure a future
+ * refactor should see.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const h = vi.hoisted(() => ({
+  proposeWrite: vi.fn(),
+  approveProposal: vi.fn(),
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: (...args: unknown[]) => unknown) => { h.handlers.set(channel, fn); } },
+}));
+vi.mock('../../../src/main/llm/approval', () => ({
+  proposeWrite: h.proposeWrite,
+  approveProposal: h.approveProposal,
+}));
+vi.mock('../../../src/main/ipc/helpers', () => ({
+  withRootPath: (fn: unknown) => fn,
+  withRootPathWin: (fn: unknown) => fn,
+  reindexFile: vi.fn(),
+  persistIndexes: vi.fn(),
+  hooks: { broadcastRewritten: vi.fn() },
+}));
+vi.mock('../../../src/main/ipc/register-compute', () => ({
+  formatComputeResultAsContext: vi.fn(),
+  recordComputeProposalRun: vi.fn(),
+  buildComputeProposalNoteBlock: vi.fn(),
+}));
+vi.mock('../../../src/main/notebase/fs', () => ({}));
+vi.mock('../../../src/main/notebase/write-pipeline', () => ({ writeAndReindex: vi.fn() }));
+vi.mock('../../../src/main/history', () => ({ runWithHistorySource: (_opts: unknown, fn: () => unknown) => fn() }));
+vi.mock('../../../src/main/sources/ingest', () => ({ ingestUrl: vi.fn() }));
+vi.mock('../../../src/main/sources/ingest-identifier', () => ({ ingestIdentifier: vi.fn() }));
+vi.mock('../../../src/main/privileged-sites', () => ({ privilegedFetch: vi.fn() }));
+vi.mock('../../../src/main/sources/source-meta-write', () => ({ ttlString: vi.fn() }));
+vi.mock('../../../src/main/llm/source-properties', () => ({ fileSourceProperties: vi.fn() }));
+vi.mock('../../../src/main/compute/registry', () => ({ runCell: vi.fn() }));
+vi.mock('../../../src/main/compute/consent', () => ({ computeConsentGuard: vi.fn() }));
+vi.mock('../../../src/main/compute/audit', () => ({ recordExecution: vi.fn() }));
+vi.mock('../../../src/main/sources/create-excerpt', () => ({ buildExcerptTtl: vi.fn() }));
+vi.mock('../../../src/main/llm/set-properties', () => ({ applyPropertyUpdates: vi.fn() }));
+vi.mock('../../../src/main/llm/conversation', () => ({ appendMessage: vi.fn() }));
+// graph/index is deliberately NOT mocked — this file's whole point is
+// exercising the real write guard wired into the real graph write path.
+
+import { registerConversationDrafts } from '../../../src/main/ipc/register-conversation-drafts';
+import { initGraph, indexNote } from '../../../src/main/graph/index';
+import { __resetWriteGuardForTests } from '../../../src/main/graph/write-guard';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+import { Channels } from '../../../src/shared/channels';
+
+registerConversationDrafts();
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!(...args);
+
+describe('CONVERSATION_FILE_NOTE_BODY_DRAFT — write guard wired (#1900)', () => {
+  let root: string;
+  let ctx: ProjectContext;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    __resetWriteGuardForTests();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-conv-drafts-guard-'));
+    ctx = projectContext(root);
+    await initGraph(ctx);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    __resetWriteGuardForTests();
+  });
+
+  it('rejects when approveProposal writes to the graph without the approval engine\'s trusted context', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'urn:p:guard' });
+    // Simulates a regression in approval.ts: applying the bundle without its
+    // own enterTrustedContext() wrapping around the graph write. The
+    // handler's withLLMContext wrapper is what's SUPPOSED to catch this.
+    h.approveProposal.mockImplementation(async () => {
+      await indexNote(ctx, 'a.md', '# untrusted write');
+      return { ok: true, filedPaths: ['a.md'], rewrittenPaths: [] };
+    });
+    const draft = { draftId: 'g1', conversationId: 'c1', note: 'x', items: [{ relativePath: 'a.md', afterContent: 'y' }] };
+
+    await expect(call(Channels.CONVERSATION_FILE_NOTE_BODY_DRAFT, root, draft, undefined))
+      .rejects.toThrow(/trust-guard/);
+  });
+
+  it('control: the same write OUTSIDE this handler does not throw', async () => {
+    // Proves the throw above comes from being inside the handler's LLM
+    // context, not from indexNote itself being broken or always throwing.
+    await expect(indexNote(ctx, 'a.md', '# untrusted write')).resolves.toBeDefined();
+  });
+});

--- a/tests/main/ipc/register-conversation-drafts.test.ts
+++ b/tests/main/ipc/register-conversation-drafts.test.ts
@@ -1,20 +1,62 @@
 /**
- * `fileAndApprove()` in `register-conversation-drafts.ts` (#1895).
+ * `register-conversation-drafts.ts` (#1895, #1900).
  *
- * Extracted from six duplicated `proposeWrite → if (proposal) approveProposal
- * → return { applied: true }` blocks, one per draft-filing IPC handler. The
- * duplication itself was harmless, but the hardcoded `applied: true` wasn't:
- * every call site claimed success even on the `proposal` was falsy branch,
- * the same shape as the vestigial `GIT_COMMIT.success` CLAUDE.md already
- * flags. This tests the helper directly rather than every handler that now
- * delegates to it — see #1900 for broader IPC-level coverage of these six
- * channels, which had none before this file.
+ * `fileAndApprove()` was extracted in #1895 from six duplicated
+ * `proposeWrite → if (proposal) approveProposal → return { applied: true }`
+ * blocks. This file has two halves:
+ *
+ *  - A direct unit-test of `fileAndApprove` itself (below), covering the
+ *    success path and both failure shapes (a falsy `proposal`, and a
+ *    proposal that was filed but failed to apply).
+ *  - IPC-level coverage of the handlers `registerConversationDrafts()`
+ *    registers, driving each through the real `handle()` → `ipcMain.handle`
+ *    wiring with only the domain modules mocked. Before this file, six of
+ *    the eleven channels here (`CONVERSATION_FILE_REFACTOR_DRAFT`,
+ *    `_REORG_DRAFT`, `_NOTE_BODY_DRAFT`, `_CLAIMS_DRAFT`,
+ *    `_PROPERTY_DRAFT`, `_RUN_COMPUTE_DRAFT`/`_INSERT_COMPUTE_DRAFT`) had
+ *    zero test references anywhere (#1900) — exactly the "approve and
+ *    apply, no second review" path CLAUDE.md's LLM/Graph checklist asks
+ *    about.
+ *
+ * Two of the eleven — `CONVERSATION_RUN_COMPUTE_DRAFT` and
+ * `_INSERT_COMPUTE_DRAFT` — do NOT go through `proposeWrite`/
+ * `approveProposal`: the compute "Run" action is gated by the separate
+ * per-cell consent guard (#1411/#1412), and "Insert into note" is a plain
+ * user-directed write, not an LLM auto-apply. Their tests assert the trust
+ * mechanism that actually applies to them instead of forcing an
+ * approval-engine assertion that doesn't.
+ *
+ * The write-guard regression for `CONVERSATION_FILE_NOTE_BODY_DRAFT`'s
+ * `withLLMContext` wrapper — the one handler here that arms it — lives in
+ * `register-conversation-drafts-write-guard.test.ts` instead: it needs the
+ * REAL graph module to exercise the real guard, which conflicts with this
+ * file's blanket `graph/index` stub.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const h = vi.hoisted(() => ({
   proposeWrite: vi.fn(),
   approveProposal: vi.fn(),
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  broadcastRewritten: vi.fn(),
+  readFile: vi.fn(),
+  writeAndReindex: vi.fn(),
+  applyPropertyUpdates: vi.fn(),
+  computeConsentGuard: vi.fn(),
+  runCell: vi.fn(),
+  recordExecution: vi.fn(),
+  appendMessage: vi.fn(),
+  recordComputeProposalRun: vi.fn(),
+  buildComputeProposalNoteBlock: vi.fn(),
+  formatComputeResultAsContext: vi.fn(),
+  buildExcerptTtl: vi.fn(),
+  fileSourceProperties: vi.fn(),
+  ingestUrl: vi.fn(),
+  ingestIdentifier: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (channel: string, fn: (...args: unknown[]) => unknown) => { h.handlers.set(channel, fn); } },
 }));
 
 vi.mock('../../../src/main/llm/approval', () => ({
@@ -24,40 +66,42 @@ vi.mock('../../../src/main/llm/approval', () => ({
 
 // register-conversation-drafts.ts's other imports pull in a large surface
 // (compute, sources ingest, history, ./helpers → window-manager → electron's
-// app.getPath called eagerly at module scope) that fileAndApprove itself
-// never touches. Stub them so the module loads without that chain.
+// app.getPath called eagerly at module scope) that most of these handlers
+// never touch. Stub them so the module loads without that chain; each stub
+// is wired to `h` so a test can configure/assert on it.
 vi.mock('../../../src/main/ipc/helpers', () => ({
   withRootPath: (fn: unknown) => fn,
   withRootPathWin: (fn: unknown) => fn,
   reindexFile: vi.fn(),
   persistIndexes: vi.fn(),
-  hooks: {},
+  hooks: { broadcastRewritten: h.broadcastRewritten },
 }));
-vi.mock('../../../src/main/ipc/typed-ipc', () => ({ handle: vi.fn() }));
 vi.mock('../../../src/main/ipc/register-compute', () => ({
-  formatComputeResultAsContext: vi.fn(),
-  recordComputeProposalRun: vi.fn(),
-  buildComputeProposalNoteBlock: vi.fn(),
+  formatComputeResultAsContext: h.formatComputeResultAsContext,
+  recordComputeProposalRun: h.recordComputeProposalRun,
+  buildComputeProposalNoteBlock: h.buildComputeProposalNoteBlock,
 }));
-vi.mock('../../../src/main/notebase/fs', () => ({}));
+vi.mock('../../../src/main/notebase/fs', () => ({ readFile: h.readFile }));
 vi.mock('../../../src/main/graph/index', () => ({ withLLMContext: (fn: () => unknown) => fn() }));
-vi.mock('../../../src/main/notebase/write-pipeline', () => ({ writeAndReindex: vi.fn() }));
+vi.mock('../../../src/main/notebase/write-pipeline', () => ({ writeAndReindex: h.writeAndReindex }));
 vi.mock('../../../src/main/history', () => ({ runWithHistorySource: (_opts: unknown, fn: () => unknown) => fn() }));
-vi.mock('../../../src/main/sources/ingest', () => ({ ingestUrl: vi.fn() }));
-vi.mock('../../../src/main/sources/ingest-identifier', () => ({ ingestIdentifier: vi.fn() }));
+vi.mock('../../../src/main/sources/ingest', () => ({ ingestUrl: h.ingestUrl }));
+vi.mock('../../../src/main/sources/ingest-identifier', () => ({ ingestIdentifier: h.ingestIdentifier }));
 vi.mock('../../../src/main/privileged-sites', () => ({ privilegedFetch: vi.fn() }));
-vi.mock('../../../src/main/sources/source-meta-write', () => ({ ttlString: vi.fn() }));
-vi.mock('../../../src/main/llm/source-properties', () => ({ fileSourceProperties: vi.fn() }));
-vi.mock('../../../src/main/compute/registry', () => ({ runCell: vi.fn() }));
-vi.mock('../../../src/main/compute/consent', () => ({ computeConsentGuard: vi.fn() }));
-vi.mock('../../../src/main/compute/audit', () => ({ recordExecution: vi.fn() }));
-vi.mock('../../../src/main/sources/create-excerpt', () => ({ buildExcerptTtl: vi.fn() }));
-vi.mock('../../../src/main/llm/set-properties', () => ({ applyPropertyUpdates: vi.fn() }));
-vi.mock('../../../src/main/notebase/reorg', () => ({ orderRefactors: vi.fn() }));
-vi.mock('../../../src/main/llm/conversation', () => ({ appendMessage: vi.fn() }));
+vi.mock('../../../src/main/sources/source-meta-write', () => ({ ttlString: (s: string) => JSON.stringify(s) }));
+vi.mock('../../../src/main/llm/source-properties', () => ({ fileSourceProperties: h.fileSourceProperties }));
+vi.mock('../../../src/main/compute/registry', () => ({ runCell: h.runCell }));
+vi.mock('../../../src/main/compute/consent', () => ({ computeConsentGuard: h.computeConsentGuard }));
+vi.mock('../../../src/main/compute/audit', () => ({ recordExecution: h.recordExecution }));
+vi.mock('../../../src/main/sources/create-excerpt', () => ({ buildExcerptTtl: h.buildExcerptTtl }));
+vi.mock('../../../src/main/llm/set-properties', () => ({ applyPropertyUpdates: h.applyPropertyUpdates }));
+vi.mock('../../../src/main/llm/conversation', () => ({ appendMessage: h.appendMessage }));
+// notebase/reorg is NOT mocked — orderRefactors is pure, already covered by
+// its own tests, and real behavior is what the REORG_DRAFT test wants.
 
-import { fileAndApprove } from '../../../src/main/ipc/register-conversation-drafts';
+import { fileAndApprove, registerConversationDrafts } from '../../../src/main/ipc/register-conversation-drafts';
 import { projectContext } from '../../../src/main/project-context-types';
+import { Channels } from '../../../src/shared/channels';
 
 const CTX = projectContext('/vault');
 const WRITE = {
@@ -112,5 +156,427 @@ describe('fileAndApprove', () => {
       filedPaths: [],
       rewrittenPaths: [],
     });
+  });
+});
+
+registerConversationDrafts();
+const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(channel)!(...args);
+
+describe('CONVERSATION_FILE_REFACTOR_DRAFT (#1900)', () => {
+  it('files a note_refactor proposal and auto-approves it', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'urn:p:refactor' });
+    h.approveProposal.mockResolvedValue({ ok: true, filedPaths: [], rewrittenPaths: [] });
+    const draft = { draftId: 'r1', conversationId: 'c1', fromPath: 'a.md', toPath: 'b.md', note: 'move a to b' };
+
+    const res = await call(Channels.CONVERSATION_FILE_REFACTOR_DRAFT, '/vault', draft);
+
+    expect(h.proposeWrite).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      operationType: 'note_refactor',
+      payloads: [{ kind: 'note-refactor', fromPath: 'a.md', toPath: 'b.md' }],
+      note: 'move a to b',
+      conversationUri: 'https://minerva.dev/ontology/thought#conversation/c1',
+      proposedBy: 'llm:conversation:c1',
+    }));
+    expect(h.approveProposal).toHaveBeenCalledWith(expect.anything(), 'urn:p:refactor');
+    expect(res).toEqual({ proposalUri: 'urn:p:refactor', applied: true });
+  });
+
+  it('files a folder-refactor payload when the draft is a folder move', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'urn:p:folder' });
+    h.approveProposal.mockResolvedValue({ ok: true, filedPaths: [], rewrittenPaths: [] });
+    const draft = { draftId: 'r2', conversationId: 'c1', fromPath: 'old', toPath: 'new', isFolder: true, note: 'move folder' };
+
+    await call(Channels.CONVERSATION_FILE_REFACTOR_DRAFT, '/vault', draft);
+
+    expect(h.proposeWrite).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      payloads: [{ kind: 'folder-refactor', fromPath: 'old', toPath: 'new' }],
+    }));
+  });
+
+  it('throws without filing anything when fromPath/toPath is missing', async () => {
+    await expect(call(Channels.CONVERSATION_FILE_REFACTOR_DRAFT, '/vault', { conversationId: 'c1' }))
+      .rejects.toThrow(/missing fromPath\/toPath/);
+    expect(h.proposeWrite).not.toHaveBeenCalled();
+  });
+});
+
+describe('CONVERSATION_FILE_REORG_DRAFT (#1900)', () => {
+  it('orders the selected moves and files them as ONE note_refactor proposal', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'urn:p:reorg' });
+    h.approveProposal.mockResolvedValue({ ok: true, filedPaths: [], rewrittenPaths: [] });
+    const draft = { draftId: 'g1', conversationId: 'c1', note: 'reorg', items: [], warnings: [] };
+    const selected = [{ fromPath: 'a.md', toPath: 'b.md' }, { fromPath: 'c.md', toPath: 'd.md' }];
+
+    const res = await call(Channels.CONVERSATION_FILE_REORG_DRAFT, '/vault', draft, selected);
+
+    expect(h.proposeWrite).toHaveBeenCalledTimes(1);
+    const sent = h.proposeWrite.mock.calls[0]![1] as { payloads: Array<{ kind: string }> };
+    expect(sent.payloads).toHaveLength(2);
+    expect(sent.payloads.every((p) => p.kind === 'note-refactor')).toBe(true);
+    expect(h.approveProposal).toHaveBeenCalledWith(expect.anything(), 'urn:p:reorg');
+    expect(res).toEqual({ proposalUri: 'urn:p:reorg', applied: true });
+  });
+
+  it('files folder-refactor payloads for a folder-batch reorg', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'urn:p:reorg-folder' });
+    h.approveProposal.mockResolvedValue({ ok: true, filedPaths: [], rewrittenPaths: [] });
+    const draft = { draftId: 'g2', conversationId: 'c1', note: 'reorg folders', isFolder: true, items: [], warnings: [] };
+
+    await call(Channels.CONVERSATION_FILE_REORG_DRAFT, '/vault', draft, [{ fromPath: 'a', toPath: 'b' }]);
+
+    const sent = h.proposeWrite.mock.calls[0]![1] as { payloads: Array<{ kind: string }> };
+    expect(sent.payloads).toEqual([{ kind: 'folder-refactor', fromPath: 'a', toPath: 'b' }]);
+  });
+
+  it('returns proposalUri: null, applied: false without filing anything when nothing is selected', async () => {
+    const draft = { draftId: 'g3', conversationId: 'c1', note: 'reorg', items: [], warnings: [] };
+
+    const res = await call(Channels.CONVERSATION_FILE_REORG_DRAFT, '/vault', draft, []);
+
+    expect(res).toEqual({ proposalUri: null, applied: false });
+    expect(h.proposeWrite).not.toHaveBeenCalled();
+  });
+});
+
+describe('CONVERSATION_FILE_NOTE_BODY_DRAFT (#1900)', () => {
+  it('files ONE note_rewrite proposal for the kept items, auto-approves, and broadcasts the rewritten paths', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'urn:p:notebody' });
+    h.approveProposal.mockResolvedValue({ ok: true, filedPaths: [], rewrittenPaths: ['a.md', 'b.md'] });
+    const draft = {
+      draftId: 'nb1', conversationId: 'c1', note: 'rewrite',
+      items: [
+        { relativePath: 'a.md', afterContent: 'new a' },
+        { relativePath: 'b.md', afterContent: 'new b' },
+      ],
+    };
+
+    const res = await call(Channels.CONVERSATION_FILE_NOTE_BODY_DRAFT, '/vault', draft, undefined);
+
+    expect(h.proposeWrite).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      operationType: 'note_rewrite',
+      payloads: [
+        { kind: 'note-rewrite', path: 'a.md', content: 'new a' },
+        { kind: 'note-rewrite', path: 'b.md', content: 'new b' },
+      ],
+    }));
+    expect(h.broadcastRewritten).toHaveBeenCalledWith('/vault', ['a.md', 'b.md']);
+    expect(res).toEqual({ proposalUri: 'urn:p:notebody', applied: true });
+  });
+
+  it('only files the SELECTED items when a selection is given', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'urn:p:notebody2' });
+    h.approveProposal.mockResolvedValue({ ok: true, filedPaths: [], rewrittenPaths: [] });
+    const draft = {
+      draftId: 'nb2', conversationId: 'c1', note: 'rewrite',
+      items: [
+        { relativePath: 'a.md', afterContent: 'new a' },
+        { relativePath: 'b.md', afterContent: 'new b' },
+      ],
+    };
+
+    await call(Channels.CONVERSATION_FILE_NOTE_BODY_DRAFT, '/vault', draft, ['b.md']);
+
+    const sent = h.proposeWrite.mock.calls[0]![1] as { payloads: unknown[] };
+    expect(sent.payloads).toEqual([{ kind: 'note-rewrite', path: 'b.md', content: 'new b' }]);
+  });
+
+  it('returns proposalUri: null, applied: false when the selection keeps nothing', async () => {
+    const draft = { draftId: 'nb3', conversationId: 'c1', note: 'rewrite', items: [{ relativePath: 'a.md', afterContent: 'x' }] };
+
+    const res = await call(Channels.CONVERSATION_FILE_NOTE_BODY_DRAFT, '/vault', draft, ['not-in-draft.md']);
+
+    expect(res).toEqual({ proposalUri: null, applied: false });
+    expect(h.proposeWrite).not.toHaveBeenCalled();
+  });
+
+  it('throws when the draft has no items', async () => {
+    await expect(call(Channels.CONVERSATION_FILE_NOTE_BODY_DRAFT, '/vault', { conversationId: 'c1', items: [] }, undefined))
+      .rejects.toThrow(/FILE_NOTE_BODY_DRAFT/);
+  });
+});
+
+describe('CONVERSATION_FILE_CLAIMS_DRAFT (#1900)', () => {
+  it('files a deduped excerpt+note bundle and auto-approves it', async () => {
+    h.proposeWrite.mockResolvedValue({ uri: 'urn:p:claims' });
+    h.approveProposal.mockResolvedValue({ ok: true, filedPaths: [], rewrittenPaths: [] });
+    const draft = {
+      draftId: 'cl1', conversationId: 'c1', sourceId: 'src1', note: 'claims',
+      claims: [
+        { text: 'Claim One', kind: 'empirical', quote: 'q1', confidence: 0.9, excerptId: 'ex1' },
+        // Shares excerptId with the first claim — the excerpt payload must be deduped.
+        { text: 'Claim Two', kind: 'empirical', quote: 'q2', confidence: 0.8, excerptId: 'ex1' },
+      ],
+    };
+
+    const res = await call(Channels.CONVERSATION_FILE_CLAIMS_DRAFT, '/vault', draft);
+
+    expect(h.proposeWrite).toHaveBeenCalledTimes(1);
+    const sent = h.proposeWrite.mock.calls[0]![1] as { operationType: string; payloads: Array<{ kind: string }> };
+    expect(sent.operationType).toBe('component_creation');
+    expect(sent.payloads.filter((p) => p.kind === 'excerpt')).toHaveLength(1);
+    expect(sent.payloads.filter((p) => p.kind === 'note')).toHaveLength(2);
+    expect(h.approveProposal).toHaveBeenCalledWith(expect.anything(), 'urn:p:claims');
+    expect(res).toEqual({
+      outcome: {
+        sourceId: 'src1',
+        claimPaths: [expect.stringContaining('src1-1-'), expect.stringContaining('src1-2-')],
+        excerptIds: ['ex1'],
+      },
+    });
+  });
+
+  it('throws when the draft has no sourceId', async () => {
+    const draft = { draftId: 'cl2', conversationId: 'c1', claims: [{ text: 'x', kind: 'empirical', quote: 'q', confidence: 0.5, excerptId: 'e' }] };
+    await expect(call(Channels.CONVERSATION_FILE_CLAIMS_DRAFT, '/vault', draft)).rejects.toThrow(/FILE_CLAIMS_DRAFT/);
+  });
+
+  it('reports a proposeWrite failure on the outcome instead of throwing (per-source, non-fatal)', async () => {
+    h.proposeWrite.mockRejectedValue(new Error('graph write failed'));
+    const draft = {
+      draftId: 'cl3', conversationId: 'c1', sourceId: 'src2', note: 'claims',
+      claims: [{ text: 'x', kind: 'empirical', quote: 'q', confidence: 0.5, excerptId: 'e' }],
+    };
+
+    const res = await call(Channels.CONVERSATION_FILE_CLAIMS_DRAFT, '/vault', draft);
+
+    expect(res).toEqual({ outcome: { sourceId: 'src2', claimPaths: [], excerptIds: [], error: 'graph write failed' } });
+  });
+});
+
+// #1900 — CONVERSATION_FILE_SOURCE_DRAFT doesn't go through proposeWrite/
+// approveProposal either: it runs the existing ingestUrl/ingestIdentifier
+// pipelines per source, the same path a user's own "Ingest URL…" menu
+// action takes.
+describe('CONVERSATION_FILE_SOURCE_DRAFT (#1900)', () => {
+  const fakeWin = () => ({ isDestroyed: () => false, webContents: { send: vi.fn() } });
+
+  it('ingests by identifier, reindexes, persists, and broadcasts SOURCES_CHANGED', async () => {
+    h.ingestIdentifier.mockResolvedValue({ sourceId: 's1', title: 'Paper One', duplicate: false, relativePath: '.minerva/sources/s1/meta.ttl' });
+    const win = fakeWin();
+    const draft = { draftId: 'sd1', conversationId: 'c1', sources: [{ identifier: '10.1000/xyz' }] };
+
+    const res = await call(Channels.CONVERSATION_FILE_SOURCE_DRAFT, '/vault', win, draft);
+
+    expect(h.ingestIdentifier).toHaveBeenCalledWith('/vault', '10.1000/xyz', expect.anything());
+    expect(win.webContents.send).toHaveBeenCalledWith(Channels.SOURCES_CHANGED);
+    expect(res).toEqual({ outcomes: [{ input: { identifier: '10.1000/xyz' }, sourceId: 's1', title: 'Paper One', duplicate: false }] });
+  });
+
+  it('ingests by url when no identifier is given', async () => {
+    h.ingestUrl.mockResolvedValue({ sourceId: 's2', title: 'Web Page', duplicate: false, relativePath: '.minerva/sources/s2/meta.ttl' });
+    const draft = { draftId: 'sd2', conversationId: 'c1', sources: [{ url: 'https://example.com' }] };
+
+    const res = await call(Channels.CONVERSATION_FILE_SOURCE_DRAFT, '/vault', fakeWin(), draft);
+
+    expect(h.ingestUrl).toHaveBeenCalledWith('/vault', 'https://example.com', expect.anything());
+    expect(res).toEqual({ outcomes: [{ input: { url: 'https://example.com' }, sourceId: 's2', title: 'Web Page', duplicate: false }] });
+  });
+
+  it('reports a per-source ingest failure on its own outcome — one bad entry does not block the rest', async () => {
+    h.ingestUrl.mockRejectedValue(new Error('fetch failed'));
+    h.ingestIdentifier.mockResolvedValue({ sourceId: 's3', title: 'OK', duplicate: false, relativePath: 'x' });
+    const draft = {
+      draftId: 'sd3', conversationId: 'c1',
+      sources: [{ url: 'https://bad.example' }, { identifier: '10.1/ok' }],
+    };
+
+    const res = await call(Channels.CONVERSATION_FILE_SOURCE_DRAFT, '/vault', fakeWin(), draft);
+
+    expect(res).toEqual({
+      outcomes: [
+        { input: { url: 'https://bad.example' }, error: 'fetch failed' },
+        { input: { identifier: '10.1/ok' }, sourceId: 's3', title: 'OK', duplicate: false },
+      ],
+    });
+  });
+
+  it('reports a malformed entry (neither identifier nor url) without throwing', async () => {
+    const draft = { draftId: 'sd4', conversationId: 'c1', sources: [{}] };
+
+    const res = await call(Channels.CONVERSATION_FILE_SOURCE_DRAFT, '/vault', fakeWin(), draft);
+
+    expect(res).toEqual({ outcomes: [{ input: {}, error: 'Source entry has neither `identifier` nor `url`.' }] });
+  });
+
+  it('throws when the draft has no sources', async () => {
+    await expect(call(Channels.CONVERSATION_FILE_SOURCE_DRAFT, '/vault', fakeWin(), { conversationId: 'c1', sources: [] }))
+      .rejects.toThrow(/FILE_SOURCE_DRAFT/);
+  });
+});
+
+describe('CONVERSATION_FILE_PROPERTY_DRAFT (#1900)', () => {
+  it('delegates to applyPropertyUpdates and broadcasts the rewritten paths', async () => {
+    const draft = { draftId: 'p1', conversationId: 'c1', updates: [{ relativePath: 'a.md', properties: { status: 'done' } }] };
+    h.applyPropertyUpdates.mockResolvedValue({
+      outcomes: [{ relativePath: 'a.md', changedKeys: ['status'], deletedKeys: [] }],
+      rewrittenPaths: ['a.md'],
+    });
+
+    const res = await call(Channels.CONVERSATION_FILE_PROPERTY_DRAFT, '/vault', draft);
+
+    expect(h.applyPropertyUpdates).toHaveBeenCalledWith('/vault', draft.updates, 'c1');
+    expect(h.broadcastRewritten).toHaveBeenCalledWith('/vault', ['a.md']);
+    expect(res).toEqual({ outcomes: [{ relativePath: 'a.md', changedKeys: ['status'], deletedKeys: [] }] });
+  });
+
+  it('throws when the draft has no updates', async () => {
+    await expect(call(Channels.CONVERSATION_FILE_PROPERTY_DRAFT, '/vault', { conversationId: 'c1', updates: [] }))
+      .rejects.toThrow(/FILE_PROPERTY_DRAFT/);
+    expect(h.applyPropertyUpdates).not.toHaveBeenCalled();
+  });
+});
+
+// #1900 — CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT delegates to
+// fileSourceProperties (llm/source-properties.ts), which is itself
+// approval-gated (#943) — that deeper proposeWrite/approveProposal wiring
+// has its own test coverage; this only verifies the handler's delegation.
+describe('CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT (#1900)', () => {
+  it('upserts dc:abstract and thought:tldr through fileSourceProperties', async () => {
+    h.fileSourceProperties.mockResolvedValue({ changedPredicates: ['dc:abstract', 'thought:tldr'] });
+    const draft = { draftId: 'sp1', conversationId: 'c1', sourceId: 'src1', abstract: 'An abstract.', tldr: 'Short version.' };
+
+    const res = await call(Channels.CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT, '/vault', draft);
+
+    expect(h.fileSourceProperties).toHaveBeenCalledWith('/vault', 'src1', [
+      { predicate: 'dc:abstract', value: JSON.stringify('An abstract.') },
+      { predicate: 'thought:tldr', value: JSON.stringify('Short version.') },
+    ]);
+    expect(res).toEqual({ outcome: { sourceId: 'src1', changedPredicates: ['dc:abstract', 'thought:tldr'] } });
+  });
+
+  it('throws when the draft has no sourceId', async () => {
+    await expect(call(Channels.CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT, '/vault', { conversationId: 'c1', abstract: 'x' }))
+      .rejects.toThrow(/FILE_SOURCE_PROPERTY_DRAFT/);
+  });
+
+  it('reports an error outcome, without calling fileSourceProperties, when neither field arrived', async () => {
+    const draft = { draftId: 'sp2', conversationId: 'c1', sourceId: 'src2' };
+
+    const res = await call(Channels.CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT, '/vault', draft);
+
+    expect(h.fileSourceProperties).not.toHaveBeenCalled();
+    expect(res).toEqual({
+      outcome: { sourceId: 'src2', changedPredicates: [], error: 'neither abstract nor tldr arrived across IPC — nothing written.' },
+    });
+  });
+
+  it('reports a fileSourceProperties failure on the outcome instead of throwing', async () => {
+    h.fileSourceProperties.mockRejectedValue(new Error('meta.ttl write failed'));
+    const draft = { draftId: 'sp3', conversationId: 'c1', sourceId: 'src3', abstract: 'x' };
+
+    const res = await call(Channels.CONVERSATION_FILE_SOURCE_PROPERTY_DRAFT, '/vault', draft);
+
+    expect(res).toEqual({ outcome: { sourceId: 'src3', changedPredicates: [], error: 'meta.ttl write failed' } });
+  });
+});
+
+// #1900 — CONVERSATION_RUN_COMPUTE_DRAFT and _INSERT_COMPUTE_DRAFT do NOT go
+// through proposeWrite/approveProposal. "Run" is gated by the per-cell
+// compute-consent guard (#1411/#1412); "Insert into note" is a plain
+// user-directed write. Each is tested against its own real trust mechanism.
+describe('CONVERSATION_RUN_COMPUTE_DRAFT (#1900)', () => {
+  it('refuses unconsented code without running it', async () => {
+    h.computeConsentGuard.mockReturnValue({ ok: false, error: 'not approved to run' });
+    const input = { draft: { draftId: 'd1', conversationId: 'c1', language: 'python', code: 'print(1)' } };
+
+    const res = await call(Channels.CONVERSATION_RUN_COMPUTE_DRAFT, '/vault', input);
+
+    expect(res).toEqual({ result: { ok: false, error: 'not approved to run' } });
+    expect(h.runCell).not.toHaveBeenCalled();
+    expect(h.proposeWrite).not.toHaveBeenCalled();
+  });
+
+  it('runs consented code, records execution + graph provenance, and appends context to the conversation', async () => {
+    h.computeConsentGuard.mockReturnValue(null);
+    h.runCell.mockResolvedValue({ ok: true, output: { type: 'text', value: '2' } });
+    h.formatComputeResultAsContext.mockReturnValue('```python\n1+1\n```\n=> 2');
+    const draft = { draftId: 'd2', conversationId: 'c1', language: 'python', code: '1+1' };
+
+    const res = await call(Channels.CONVERSATION_RUN_COMPUTE_DRAFT, '/vault', { draft });
+
+    expect(h.runCell).toHaveBeenCalledWith('python', '1+1', { rootPath: '/vault' });
+    expect(h.recordExecution).toHaveBeenCalledWith(expect.objectContaining({
+      project: '/vault', language: 'python', code: '1+1', provenance: 'conversation',
+    }));
+    expect(h.appendMessage).toHaveBeenCalledWith('/vault', 'c1', 'user', expect.stringContaining('2'));
+    expect(h.recordComputeProposalRun).toHaveBeenCalled();
+    expect(res).toEqual({ result: { ok: true, output: { type: 'text', value: '2' } } });
+    // Not the approval-engine path — no proposal filed for a compute run.
+    expect(h.proposeWrite).not.toHaveBeenCalled();
+  });
+
+  it('runs editedCode instead of the draft\'s own code when provided', async () => {
+    h.computeConsentGuard.mockReturnValue(null);
+    h.runCell.mockResolvedValue({ ok: true, output: { type: 'text', value: '4' } });
+    const draft = { draftId: 'd3', conversationId: 'c1', language: 'python', code: '1+1' };
+
+    await call(Channels.CONVERSATION_RUN_COMPUTE_DRAFT, '/vault', { draft, editedCode: '2+2' });
+
+    expect(h.runCell).toHaveBeenCalledWith('python', '2+2', { rootPath: '/vault' });
+  });
+
+  it('throws when the draft is missing language or code', async () => {
+    await expect(call(Channels.CONVERSATION_RUN_COMPUTE_DRAFT, '/vault', { draft: { draftId: 'd4', conversationId: 'c1' } }))
+      .rejects.toThrow(/RUN_COMPUTE_DRAFT/);
+  });
+
+  // Both of these are best-effort side records of a run that already
+  // happened — a failure logs and the result still comes back, rather than
+  // losing a real compute result over a conversation-log or graph hiccup.
+  it('still returns the result when appending to the conversation log fails', async () => {
+    h.computeConsentGuard.mockReturnValue(null);
+    h.runCell.mockResolvedValue({ ok: true, output: { type: 'text', value: '2' } });
+    h.appendMessage.mockRejectedValue(new Error('conversation store unavailable'));
+    const draft = { draftId: 'd5', conversationId: 'c1', language: 'python', code: '1+1' };
+
+    const res = await call(Channels.CONVERSATION_RUN_COMPUTE_DRAFT, '/vault', { draft });
+
+    expect(res).toEqual({ result: { ok: true, output: { type: 'text', value: '2' } } });
+  });
+
+  it('still returns the result when recording the ComputeProposal in the graph fails', async () => {
+    h.computeConsentGuard.mockReturnValue(null);
+    h.runCell.mockResolvedValue({ ok: true, output: { type: 'text', value: '2' } });
+    h.recordComputeProposalRun.mockImplementation(() => { throw new Error('graph not ready'); });
+    const draft = { draftId: 'd6', conversationId: 'c1', language: 'python', code: '1+1' };
+
+    const res = await call(Channels.CONVERSATION_RUN_COMPUTE_DRAFT, '/vault', { draft });
+
+    expect(res).toEqual({ result: { ok: true, output: { type: 'text', value: '2' } } });
+  });
+});
+
+describe('CONVERSATION_INSERT_COMPUTE_DRAFT (#1900)', () => {
+  it('appends the compute block to an existing note at the given destination', async () => {
+    h.readFile.mockResolvedValue('# Existing\n');
+    h.buildComputeProposalNoteBlock.mockReturnValue('```python\n1+1\n```');
+    const draft = { draftId: 'ic1', conversationId: 'c1', language: 'python', code: '1+1' };
+
+    const res = await call(Channels.CONVERSATION_INSERT_COMPUTE_DRAFT, '/vault', { draft, destinationPath: 'notes/x.md' });
+
+    expect(h.writeAndReindex).toHaveBeenCalledWith(
+      '/vault', 'notes/x.md', expect.stringContaining('# Existing'), expect.anything(),
+    );
+    expect(res).toEqual({ destinationPath: 'notes/x.md' });
+    // Not the approval-engine path — a direct, user-directed write.
+    expect(h.proposeWrite).not.toHaveBeenCalled();
+  });
+
+  it('defaults the destination and starts a fresh note when none exists yet', async () => {
+    h.readFile.mockRejectedValue(new Error('ENOENT'));
+    h.buildComputeProposalNoteBlock.mockReturnValue('```python\n1+1\n```');
+    const draft = { draftId: 'ic2', conversationId: 'convo-9', language: 'python', code: '1+1' };
+
+    const res = await call(Channels.CONVERSATION_INSERT_COMPUTE_DRAFT, '/vault', { draft });
+
+    expect(res).toEqual({ destinationPath: 'notes/inbox/conversations/convo-9.md' });
+    expect(h.writeAndReindex).toHaveBeenCalledWith(
+      '/vault', 'notes/inbox/conversations/convo-9.md', expect.stringContaining('# Conversation: convo-9'), expect.anything(),
+    );
+  });
+
+  it('throws when the draft is missing language or code', async () => {
+    await expect(call(Channels.CONVERSATION_INSERT_COMPUTE_DRAFT, '/vault', { draft: { draftId: 'ic3', conversationId: 'c1' } }))
+      .rejects.toThrow(/INSERT_COMPUTE_DRAFT/);
   });
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -220,6 +220,25 @@ export default defineConfig({
           statements: 95,
           branches: 90,
         },
+        // A third case of the same shape: six of this file's eleven
+        // approve-and-apply draft handlers had ZERO test references anywhere
+        // (#1900) — exactly the "does it go through the approval engine, and
+        // can the gate be skipped" path CLAUDE.md's LLM/Graph checklist asks
+        // about. Aggregate coverage from `register-conversation.test.ts`
+        // mocking this module out (to test its OWN two handlers) hid that the
+        // module implementing those six handlers was itself barely exercised.
+        // Now 100% L / 100% F / 100% S / 87.75% B via
+        // `register-conversation-drafts.test.ts` (channel-level coverage for
+        // all 11 handlers) and `register-conversation-drafts-write-guard.test.ts`
+        // (the one handler that arms `withLLMContext`, against the real graph
+        // module). Floors sit just under so a regression can't quietly widen
+        // the gap again.
+        'src/main/ipc/register-conversation-drafts.ts': {
+          lines: 90,
+          functions: 90,
+          statements: 90,
+          branches: 78,
+        },
         // Neglected top-level main modules — previously unfenced (#1100 / QA
         // H1). These sit at `src/main/*.ts` (no directory of their own), so
         // each gets its own per-file floor set ~10pts below the measured-at-


### PR DESCRIPTION
## Summary

Six of the eleven approve-and-apply draft channels in `register-conversation-drafts.ts` had **zero** test references anywhere: `CONVERSATION_FILE_PROPERTY_DRAFT`, `_CLAIMS_DRAFT`, `_REFACTOR_DRAFT`, `_REORG_DRAFT`, `_NOTE_BODY_DRAFT`, and `_RUN_COMPUTE_DRAFT`/`_INSERT_COMPUTE_DRAFT` — exactly the "does it go through the approval engine, can the gate be skipped" path CLAUDE.md's LLM/Graph review checklist asks about. `register-conversation.test.ts` only ever drove 2 of the 11 handlers (`FILE_DRAFT`, `FILE_DELETE_DRAFT`); this module had no dedicated test file at all.

- Extended `register-conversation-drafts.test.ts` (previously scoped to just #1895's `fileAndApprove` unit tests) with real `ipcMain.handle`-level coverage for **all 11 handlers**, including the two (`FILE_SOURCE_DRAFT`, `FILE_SOURCE_PROPERTY_DRAFT`) that already had indirect coverage via other tools' test files but zero coverage of *this module's* actual handler code.
- **Two of the eleven don't actually go through `proposeWrite`/`approveProposal`**, contrary to the issue's framing that all flagged channels do: `RUN_COMPUTE_DRAFT`'s "Run" is gated by the separate per-cell compute-consent guard (#1411/#1412), and `INSERT_COMPUTE_DRAFT`'s "Insert into note" is a plain user-directed write, not an LLM auto-apply. Their tests assert the trust mechanism that actually applies instead of forcing an approval-engine assertion that doesn't.
- New `register-conversation-drafts-write-guard.test.ts`: a regression for `CONVERSATION_FILE_NOTE_BODY_DRAFT`, the one handler that arms `graph.withLLMContext` (#944). Needs the REAL graph/write-guard machinery (the main test file stubs `graph/index` wholesale for isolation), so it lives separately — mirroring the existing `write-guard.test.ts` / `write-guard-wired.test.ts` split.

## Verification

Confirmed both new test files actually catch their target regressions before finalizing:
- Reverted the `withLLMContext` wrapper around `CONVERSATION_FILE_NOTE_BODY_DRAFT`'s body and watched the write-guard test fail, then restored it.
- (From #1895) Reverted `fileAndApprove`'s `applied` computation to the old hardcoded shape and watched the channel test that pins it fail, then restored it.

## Coverage

`src/main/ipc/register-conversation-drafts.ts` went from a low single-digit aggregate (hidden behind the module-mock in `register-conversation.test.ts`) to **100% lines / 100% functions / 100% statements / 87.75% branches**, measured directly. New per-file floor in `vitest.config.mts` sits ~10pts below (90/90/90/78) so a regression can't quietly widen the gap again.

## Test plan

- [x] `pnpm lint` passes.
- [x] `pnpm test` — full suite green (638 files, 6936 passed, 1 skipped).
- [x] `pnpm coverage` — full suite with the new per-file threshold enforced, exits 0 (all thresholds pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)