### PR TITLE
refactor(preview): extract click-routing table out of Preview.svelte

### DIFF
--- a/src/renderer/lib/components/Preview.svelte
+++ b/src/renderer/lib/components/Preview.svelte
@@ -15,9 +15,6 @@
     import {clampSubmenu} from '../utils/menuClamp';
     import {type ChartHandle} from '../charts';
     import {getToolInfosByCategory} from '../tools/tool-registry';
-    import {planOutputEdit} from '../editor/output-block';
-    import {findRunnableFences, codeOf, RUNNABLE_LANGUAGE_SET} from '../../../shared/compute/fences';
-    import {runAllCellsInContent} from '../compute/run-all-cells';
     import type {CellResult} from '../ipc/client';
     import {stripFrontmatter, countFrontmatterLines} from '../preview/text';
     import {
@@ -50,6 +47,11 @@
         hydrateTransclusions,
         hydrateLocalMedia,
     } from '../preview/hydrate';
+    import {
+        handleClick as handleClickOp,
+        runAllCells as runAllCellsOp,
+        type ClickRoutingOps,
+    } from '../preview/click-routing';
 
     interface Props {
         content: string;
@@ -585,269 +587,35 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
         });
     });
 
-    // Click routing (#993). handleClick walks a [selector, handler] table and
-    // dispatches to the first branch whose `.closest(selector)` matches the
-    // click target. Each handler receives the matched element + the event and
-    // returns true once it has consumed the click (false = "not mine, keep
-    // looking" — used by the branches that only conditionally handle). The
-    // task-checkbox case tests the target element itself, not an ancestor, so
-    // it can't ride the `.closest()` table and runs first as a pre-check.
-    type ClickRouteHandler = (matched: HTMLElement, e: MouseEvent) => boolean;
-    const clickRoutes: [selector: string, handler: ClickRouteHandler][] = [
-        ['.cite-link', handleCiteLinkClick],
-        ['.quote-link', handleQuoteLinkClick],
-        ['.wiki-link', handleWikiLinkClick],
-        ['.transclusion-open', handleTransclusionOpenClick],
-        ['.note-tag', handleTagClick],
-        ['.compute-output-menu-btn', handleComputeMenuBtnClick],
-        ['.compute-output-image', handleOutputImageClick],
-        ['[data-fence-action]', handleFenceActionClick],
-        ['.youtube-embed', handleYouTubeEmbedClick],
-        ['a[href^="https://doi.org/"]', handleDoiAnchorClick],
-        ['a[href^="#"]', handleInternalAnchorClick],
-    ];
+    const clickRoutingOps: ClickRoutingOps = {
+        getPreviewEl: () => previewEl,
+        getContent: () => content,
+        getNotePath: () => notePath,
+        getRunningFences: () => runningFences,
+        getCollapsedFences: () => collapsedFences,
+        onNavigate,
+        onOpenSource,
+        onOpenExcerpt,
+        onTagSelect,
+        onDoiClick,
+        onTaskToggle,
+        onRunCell,
+        onApplyCellOutputEdit,
+        dismissTooltip: () => dismissTooltip(),
+        openOutputMenu: (btn, wrap) => openOutputMenu(btn, wrap),
+    };
 
     function handleClick(e: MouseEvent) {
-        const el = e.target as HTMLElement;
-        // Dismiss any open hover tooltip first. Clicking a wiki-link navigates
-        // the preview and replaces the DOM before a `mouseout` can fire on the
-        // now-destroyed link, which otherwise leaves the tooltip stuck onscreen
-        // over the newly-loaded note. A click means "acting, not hovering".
-        dismissTooltip();
-        if (handleTaskCheckboxClick(el)) return;
-        for (const [selector, handler] of clickRoutes) {
-            const matched = el.closest<HTMLElement>(selector);
-            if (matched && handler(matched, e)) return;
-        }
-    }
-
-    function handleTaskCheckboxClick(el: HTMLElement): boolean {
-        if (
-            !(el instanceof HTMLInputElement) ||
-            el.type !== 'checkbox' ||
-            el.dataset.taskLine === undefined
-        ) {
-            return false;
-        }
-        const line = parseInt(el.dataset.taskLine, 10);
-        if (!Number.isNaN(line)) onTaskToggle?.(line);
-        // Don't preventDefault — the native toggle gives an instant flicker-free
-        // response. The content re-render will land the DOM in the same state.
-        return true;
-    }
-
-    function handleCiteLinkClick(citeLink: HTMLElement, e: MouseEvent): boolean {
-        e.preventDefault();
-        const sourceId = citeLink.dataset.sourceId;
-        if (sourceId && onOpenSource) onOpenSource(sourceId);
-        return true;
-    }
-
-    function handleQuoteLinkClick(quoteLink: HTMLElement, e: MouseEvent): boolean {
-        e.preventDefault();
-        const excerptId = quoteLink.dataset.excerptId;
-        if (excerptId && onOpenExcerpt) onOpenExcerpt(excerptId);
-        return true;
-    }
-
-    function handleWikiLinkClick(wikiLink: HTMLElement, e: MouseEvent): boolean {
-        e.preventDefault();
-        const linkTarget = wikiLink.dataset.target;
-        if (linkTarget) onNavigate(linkTarget);
-        return true;
-    }
-
-    // Transclusion header → open the embedded note (#906).
-    function handleTransclusionOpenClick(transclusionOpen: HTMLElement, e: MouseEvent): boolean {
-        e.preventDefault();
-        const t = transclusionOpen.dataset.target;
-        if (t) onNavigate(t);
-        return true;
-    }
-
-    function handleTagClick(tagEl: HTMLElement, e: MouseEvent): boolean {
-        e.preventDefault();
-        const tag = tagEl.dataset.tag;
-        if (tag && onTagSelect) onTagSelect(tag);
-        return true;
-    }
-
-    // Compute-output overflow menu (#244).
-    function handleComputeMenuBtnClick(menuBtn: HTMLElement, e: MouseEvent): boolean {
-        e.preventDefault();
-        e.stopPropagation();
-        const wrap = menuBtn.closest<HTMLElement>('.compute-output-wrap');
-        if (!wrap) return true;
-        openOutputMenu(menuBtn, wrap);
-        return true;
-    }
-
-    // Click-to-zoom on inline compute output images (#243). Toggles a `.zoomed`
-    // class so the stylesheet flips between thumbnail and full-size views
-    // without a modal dialog. Not an image element → fall through to the next
-    // route (matches the original guard).
-    function handleOutputImageClick(outputImg: HTMLElement, e: MouseEvent): boolean {
-        if (!(outputImg instanceof HTMLImageElement)) return false;
-        e.preventDefault();
-        outputImg.classList.toggle('zoomed');
-        return true;
-    }
-
-    // Fence toolbar — collapse toggle + run button.
-    function handleFenceActionClick(fenceBtn: HTMLElement, e: MouseEvent): boolean {
-        e.preventDefault();
-        e.stopPropagation();
-        const action = fenceBtn.getAttribute('data-fence-action');
-        const block = fenceBtn.closest<HTMLElement>('.fence-block');
-        const lineAttr = block?.getAttribute('data-fence-line');
-        const openingLine = lineAttr ? parseInt(lineAttr, 10) : NaN;
-        if (!block || Number.isNaN(openingLine)) return true;
-        if (action === 'collapse') {
-            // Pure UI toggle — flip the class on the live DOM instead of
-            // forcing a markdown re-render. The collapsedFences set stays
-            // in sync so the next real re-render (e.g. after an edit)
-            // honors the current state.
-            if (collapsedFences.has(openingLine)) {
-                collapsedFences.delete(openingLine);
-                block.classList.remove('fence-collapsed');
-            } else {
-                collapsedFences.add(openingLine);
-                block.classList.add('fence-collapsed');
-            }
-            const tBtn = block.querySelector<HTMLElement>('.fence-collapse-btn');
-            if (tBtn) tBtn.textContent = collapsedFences.has(openingLine) ? '▸' : '▾';
-            return true;
-        }
-        if (action === 'run') {
-            void runFenceAt(openingLine);
-            return true;
-        }
-        if (action === 'refresh-vega') {
-            // Re-resolve a data-bound chart (#832): drop its rendered state and
-            // re-hydrate, which re-runs the query against the current graph.
-            const vegaBlock = block.querySelector<HTMLElement>('.vega-block');
-            if (vegaBlock) {
-                vegaBlock.removeAttribute('data-vega-rendered');
-                vegaBlock.innerHTML = '';
-                if (previewEl) void hydrateVegaBlocks(previewEl, content);
-            }
-            return true;
-        }
-        return true;
-    }
-
-    // YouTube poster card (#904) — open the video in the real browser rather
-    // than navigating the renderer. `data-youtube-url` is a normalized
-    // youtube.com watch URL; openExternal's main-process handler re-validates
-    // it's http(s) before handing off to the OS.
-    function handleYouTubeEmbedClick(ytEmbed: HTMLElement, e: MouseEvent): boolean {
-        e.preventDefault();
-        const url = ytEmbed.getAttribute('data-youtube-url');
-        if (url) void api.shell.openExternal(url);
-        return true;
-    }
-
-    // DOI link click — the doi-plugin auto-linker rendered this. The host
-    // decides between "open existing source" and "offer to ingest" based on
-    // whether the DOI matches a known source. (#473) Without an onDoiClick
-    // handler, leave the click alone (fall through to the next route).
-    function handleDoiAnchorClick(doiAnchor: HTMLElement, e: MouseEvent): boolean {
-        if (!onDoiClick) return false;
-        e.preventDefault();
-        const href = doiAnchor.getAttribute('href') ?? '';
-        const doi = href.replace(/^https:\/\/doi\.org\//, '');
-        if (doi) onDoiClick(doi);
-        return true;
-    }
-
-    // Internal anchor click (footnote ref ↔ body, heading anchor jumps,
-    // etc.). The browser's native handling would scroll instantly and
-    // also tack `#fn1` onto the URL hash — neither great for an
-    // Electron renderer where the URL is `file:` or `chrome-error:`.
-    // Intercept, smooth-scroll the matching id into view, no hash
-    // mutation.
-    function handleInternalAnchorClick(anchorEl: HTMLElement, e: MouseEvent): boolean {
-        const href = anchorEl.getAttribute('href') ?? '';
-        const id = href.slice(1);
-        if (id) {
-            const target = previewEl?.querySelector<HTMLElement>(`#${CSS.escape(id)}`);
-            if (target) {
-                e.preventDefault();
-                target.scrollIntoView({behavior: 'smooth', block: 'center'});
-                // Brief highlight so the user's eye locks onto the landing
-                // spot — especially useful for footnote bodies that may be
-                // visually adjacent to their neighbors.
-                target.classList.add('anchor-landing');
-                setTimeout(() => target.classList.remove('anchor-landing'), 1200);
-            }
-        }
-        return true;
-    }
-
-    // ── Run-fence-from-preview handler ─────────────────────────────────────────
-    //
-    // Click on a ▶ run button on a python/sparql/sql code fence. We
-    // locate the fence by its opening-line number in the source
-    // markdown (markdown-it stamped it onto the fence-block wrapper),
-    // call the host's `onRunCell` (same trust-gated wrapper the editor
-    // uses), splice the resulting output fence block into
-    // the doc via the shared `planOutputEdit` helper, and hand the new
-    // full content back through `onApplyCellOutputEdit`. The host
-    // routes it through the editor's `setContent` so the edit shows up
-    // in undo history, autosave, and the dirty-state indicator just
-    // like a typed change.
-    //
-    // The whole pipeline lives in the editor side too — sharing
-    // `findRunnableFences` / `codeOf` / `planOutputEdit` from
-    // `editor/output-block.ts` means a run from preview and a run from
-    // the editor gutter produce bit-identical doc edits.
-    async function runFenceAt(openingLine: number): Promise<void> {
-        if (!onRunCell || !onApplyCellOutputEdit || !notePath) return;
-        if (runningFences.has(openingLine)) return;
-        // Locate the fence in the live content. We could trust the line
-        // number from markdown-it, but the doc may have been edited since
-        // last render — re-scanning is cheap and rules out stale-token
-        // bugs.
-        const fences = findRunnableFences(content, RUNNABLE_LANGUAGE_SET);
-        const fence = fences.find((f) => f.openingLine === openingLine);
-        if (!fence) {
-            console.warn(`[preview] runFenceAt: no fence at line ${openingLine}`);
-            return;
-        }
-        const code = codeOf(content, fence);
-        runningFences.add(openingLine);
-        try {
-            const result = await onRunCell(fence.language, code, notePath);
-            const edit = planOutputEdit(content, fence, result);
-            const newContent = content.slice(0, edit.from) + edit.insert + content.slice(edit.to);
-            onApplyCellOutputEdit(newContent);
-        } catch (e) {
-            console.warn('[preview] runFenceAt failed:', e);
-        } finally {
-            runningFences.delete(openingLine);
-        }
+        handleClickOp(clickRoutingOps, e);
     }
 
     /**
      * Re-run every runnable fence in the note, top to bottom — the
      * preview-mode counterpart to the editor's Run-all, so the toolbar
-     * button works when no editor is mounted. The sequential/stop-on-error
-     * loop lives in `runAllCellsInContent`; here we just wire it to the
-     * host's run + apply callbacks and the per-cell running indicator.
+     * button works when no editor is mounted.
      */
     export async function runAllCells(): Promise<void> {
-        if (!onRunCell || !onApplyCellOutputEdit || !notePath) return;
-        const runCell = onRunCell;
-        const apply = onApplyCellOutputEdit;
-        const np = notePath;
-        await runAllCellsInContent(content, RUNNABLE_LANGUAGE_SET, {
-            runCell: (language, code) => runCell(language, code, np),
-            apply,
-            setRunning: (line, running) => {
-                if (running) runningFences.add(line);
-                else runningFences.delete(line);
-            },
-        });
+        await runAllCellsOp(clickRoutingOps);
     }
 
     // ── Note context menu (read-only mirror of Editor's right-click menu) ──────

--- a/src/renderer/lib/preview/click-routing.ts
+++ b/src/renderer/lib/preview/click-routing.ts
@@ -1,0 +1,311 @@
+/**
+ * Preview.svelte's click routing (#993, extracted #1904). `handleClick` walks
+ * a `[selector, handler]` table and dispatches to the first branch whose
+ * `.closest(selector)` matches the click target. Each handler receives the
+ * matched element + the event and returns true once it has consumed the
+ * click (false = "not mine, keep looking" — used by the branches that only
+ * conditionally handle). Bundled with the fence-run pipeline
+ * (`runFenceAt`/`runAllCells`) since the fence-action route is the one click
+ * handler that can't finish synchronously.
+ *
+ * Same shape as `editor/context-menu.ts` / `editor/view-commands.ts`: an
+ * `Ops` closure struct so these stay pure functions instead of touching
+ * Svelte state directly. Preview.svelte keeps a one-line wrapper per
+ * template-bound handler (`onclick={handleClick}`) and for the exported
+ * `runAllCells` (`bind:this` access).
+ */
+import { api } from '../ipc/client';
+import type { CellResult } from '../ipc/client';
+import { findRunnableFences, codeOf, RUNNABLE_LANGUAGE_SET } from '../../../shared/compute/fences';
+import { runAllCellsInContent } from '../compute/run-all-cells';
+import { planOutputEdit } from '../editor/output-block';
+import { hydrateVegaBlocks } from '../markdown/vega-renderer';
+
+export interface ClickRoutingOps {
+  getPreviewEl: () => HTMLDivElement | undefined;
+  getContent: () => string;
+  getNotePath: () => string | null;
+  getRunningFences: () => Set<number>;
+  getCollapsedFences: () => Set<number>;
+  onNavigate: (target: string) => void;
+  onOpenSource: ((sourceId: string) => void) | undefined;
+  onOpenExcerpt: ((excerptId: string) => void) | undefined;
+  onTagSelect: ((tag: string) => void) | undefined;
+  onDoiClick: ((doi: string) => void) | undefined;
+  onTaskToggle: ((lineIndex: number) => void) | undefined;
+  onRunCell: ((language: string, code: string, notePath: string) => Promise<CellResult>) | undefined;
+  onApplyCellOutputEdit: ((newContent: string) => void) | undefined;
+  /** Dismisses the hover tooltip — owned by Preview's tooltip concern; a click
+   *  always dismisses first so a stale tooltip can't linger over new content. */
+  dismissTooltip: () => void;
+  /** Opens the compute-output overflow menu — owned by Preview's output-menu
+   *  concern; the fence toolbar's "⋯" button routes here. */
+  openOutputMenu: (btn: HTMLElement, wrap: HTMLElement) => void;
+}
+
+type ClickRouteHandler = (ops: ClickRoutingOps, matched: HTMLElement, e: MouseEvent) => boolean;
+
+const CLICK_ROUTES: [selector: string, handler: ClickRouteHandler][] = [
+  ['.cite-link', handleCiteLinkClick],
+  ['.quote-link', handleQuoteLinkClick],
+  ['.wiki-link', handleWikiLinkClick],
+  ['.transclusion-open', handleTransclusionOpenClick],
+  ['.note-tag', handleTagClick],
+  ['.compute-output-menu-btn', handleComputeMenuBtnClick],
+  ['.compute-output-image', handleOutputImageClick],
+  ['[data-fence-action]', handleFenceActionClick],
+  ['.youtube-embed', handleYouTubeEmbedClick],
+  ['a[href^="https://doi.org/"]', handleDoiAnchorClick],
+  ['a[href^="#"]', handleInternalAnchorClick],
+];
+
+export function handleClick(ops: ClickRoutingOps, e: MouseEvent): void {
+  const el = e.target as HTMLElement;
+  // Dismiss any open hover tooltip first. Clicking a wiki-link navigates
+  // the preview and replaces the DOM before a `mouseout` can fire on the
+  // now-destroyed link, which otherwise leaves the tooltip stuck onscreen
+  // over the newly-loaded note. A click means "acting, not hovering".
+  ops.dismissTooltip();
+  if (handleTaskCheckboxClick(ops, el)) return;
+  for (const [selector, handler] of CLICK_ROUTES) {
+    const matched = el.closest<HTMLElement>(selector);
+    if (matched && handler(ops, matched, e)) return;
+  }
+}
+
+function handleTaskCheckboxClick(ops: ClickRoutingOps, el: HTMLElement): boolean {
+  if (
+    !(el instanceof HTMLInputElement) ||
+    el.type !== 'checkbox' ||
+    el.dataset.taskLine === undefined
+  ) {
+    return false;
+  }
+  const line = parseInt(el.dataset.taskLine, 10);
+  if (!Number.isNaN(line)) ops.onTaskToggle?.(line);
+  // Don't preventDefault — the native toggle gives an instant flicker-free
+  // response. The content re-render will land the DOM in the same state.
+  return true;
+}
+
+function handleCiteLinkClick(ops: ClickRoutingOps, citeLink: HTMLElement, e: MouseEvent): boolean {
+  e.preventDefault();
+  const sourceId = citeLink.dataset.sourceId;
+  if (sourceId && ops.onOpenSource) ops.onOpenSource(sourceId);
+  return true;
+}
+
+function handleQuoteLinkClick(ops: ClickRoutingOps, quoteLink: HTMLElement, e: MouseEvent): boolean {
+  e.preventDefault();
+  const excerptId = quoteLink.dataset.excerptId;
+  if (excerptId && ops.onOpenExcerpt) ops.onOpenExcerpt(excerptId);
+  return true;
+}
+
+function handleWikiLinkClick(ops: ClickRoutingOps, wikiLink: HTMLElement, e: MouseEvent): boolean {
+  e.preventDefault();
+  const linkTarget = wikiLink.dataset.target;
+  if (linkTarget) ops.onNavigate(linkTarget);
+  return true;
+}
+
+// Transclusion header → open the embedded note (#906).
+function handleTransclusionOpenClick(ops: ClickRoutingOps, transclusionOpen: HTMLElement, e: MouseEvent): boolean {
+  e.preventDefault();
+  const t = transclusionOpen.dataset.target;
+  if (t) ops.onNavigate(t);
+  return true;
+}
+
+function handleTagClick(ops: ClickRoutingOps, tagEl: HTMLElement, e: MouseEvent): boolean {
+  e.preventDefault();
+  const tag = tagEl.dataset.tag;
+  if (tag && ops.onTagSelect) ops.onTagSelect(tag);
+  return true;
+}
+
+// Compute-output overflow menu (#244).
+function handleComputeMenuBtnClick(ops: ClickRoutingOps, menuBtn: HTMLElement, e: MouseEvent): boolean {
+  e.preventDefault();
+  e.stopPropagation();
+  const wrap = menuBtn.closest<HTMLElement>('.compute-output-wrap');
+  if (!wrap) return true;
+  ops.openOutputMenu(menuBtn, wrap);
+  return true;
+}
+
+// Click-to-zoom on inline compute output images (#243). Toggles a `.zoomed`
+// class so the stylesheet flips between thumbnail and full-size views
+// without a modal dialog. Not an image element → fall through to the next
+// route (matches the original guard).
+function handleOutputImageClick(_ops: ClickRoutingOps, outputImg: HTMLElement, e: MouseEvent): boolean {
+  if (!(outputImg instanceof HTMLImageElement)) return false;
+  e.preventDefault();
+  outputImg.classList.toggle('zoomed');
+  return true;
+}
+
+// Fence toolbar — collapse toggle + run button.
+function handleFenceActionClick(ops: ClickRoutingOps, fenceBtn: HTMLElement, e: MouseEvent): boolean {
+  e.preventDefault();
+  e.stopPropagation();
+  const action = fenceBtn.getAttribute('data-fence-action');
+  const block = fenceBtn.closest<HTMLElement>('.fence-block');
+  const lineAttr = block?.getAttribute('data-fence-line');
+  const openingLine = lineAttr ? parseInt(lineAttr, 10) : NaN;
+  if (!block || Number.isNaN(openingLine)) return true;
+  if (action === 'collapse') {
+    // Pure UI toggle — flip the class on the live DOM instead of
+    // forcing a markdown re-render. The collapsedFences set stays
+    // in sync so the next real re-render (e.g. after an edit)
+    // honors the current state.
+    const collapsedFences = ops.getCollapsedFences();
+    if (collapsedFences.has(openingLine)) {
+      collapsedFences.delete(openingLine);
+      block.classList.remove('fence-collapsed');
+    } else {
+      collapsedFences.add(openingLine);
+      block.classList.add('fence-collapsed');
+    }
+    const tBtn = block.querySelector<HTMLElement>('.fence-collapse-btn');
+    if (tBtn) tBtn.textContent = collapsedFences.has(openingLine) ? '▸' : '▾';
+    return true;
+  }
+  if (action === 'run') {
+    void runFenceAt(ops, openingLine);
+    return true;
+  }
+  if (action === 'refresh-vega') {
+    // Re-resolve a data-bound chart (#832): drop its rendered state and
+    // re-hydrate, which re-runs the query against the current graph.
+    const vegaBlock = block.querySelector<HTMLElement>('.vega-block');
+    if (vegaBlock) {
+      vegaBlock.removeAttribute('data-vega-rendered');
+      vegaBlock.innerHTML = '';
+      const previewEl = ops.getPreviewEl();
+      if (previewEl) void hydrateVegaBlocks(previewEl, ops.getContent());
+    }
+    return true;
+  }
+  return true;
+}
+
+// YouTube poster card (#904) — open the video in the real browser rather
+// than navigating the renderer. `data-youtube-url` is a normalized
+// youtube.com watch URL; openExternal's main-process handler re-validates
+// it's http(s) before handing off to the OS.
+function handleYouTubeEmbedClick(_ops: ClickRoutingOps, ytEmbed: HTMLElement, e: MouseEvent): boolean {
+  e.preventDefault();
+  const url = ytEmbed.getAttribute('data-youtube-url');
+  if (url) void api.shell.openExternal(url);
+  return true;
+}
+
+// DOI link click — the doi-plugin auto-linker rendered this. The host
+// decides between "open existing source" and "offer to ingest" based on
+// whether the DOI matches a known source. (#473) Without an onDoiClick
+// handler, leave the click alone (fall through to the next route).
+function handleDoiAnchorClick(ops: ClickRoutingOps, doiAnchor: HTMLElement, e: MouseEvent): boolean {
+  if (!ops.onDoiClick) return false;
+  e.preventDefault();
+  const href = doiAnchor.getAttribute('href') ?? '';
+  const doi = href.replace(/^https:\/\/doi\.org\//, '');
+  if (doi) ops.onDoiClick(doi);
+  return true;
+}
+
+// Internal anchor click (footnote ref ↔ body, heading anchor jumps,
+// etc.). The browser's native handling would scroll instantly and
+// also tack `#fn1` onto the URL hash — neither great for an
+// Electron renderer where the URL is `file:` or `chrome-error:`.
+// Intercept, smooth-scroll the matching id into view, no hash
+// mutation.
+function handleInternalAnchorClick(ops: ClickRoutingOps, anchorEl: HTMLElement, e: MouseEvent): boolean {
+  const href = anchorEl.getAttribute('href') ?? '';
+  const id = href.slice(1);
+  if (id) {
+    const previewEl = ops.getPreviewEl();
+    const target = previewEl?.querySelector<HTMLElement>(`#${CSS.escape(id)}`);
+    if (target) {
+      e.preventDefault();
+      target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      // Brief highlight so the user's eye locks onto the landing
+      // spot — especially useful for footnote bodies that may be
+      // visually adjacent to their neighbors.
+      target.classList.add('anchor-landing');
+      setTimeout(() => target.classList.remove('anchor-landing'), 1200);
+    }
+  }
+  return true;
+}
+
+// ── Run-fence-from-preview handler ─────────────────────────────────────────
+//
+// Click on a ▶ run button on a python/sparql/sql code fence. We
+// locate the fence by its opening-line number in the source
+// markdown (markdown-it stamped it onto the fence-block wrapper),
+// call the host's `onRunCell` (same trust-gated wrapper the editor
+// uses), splice the resulting output fence block into
+// the doc via the shared `planOutputEdit` helper, and hand the new
+// full content back through `onApplyCellOutputEdit`. The host
+// routes it through the editor's `setContent` so the edit shows up
+// in undo history, autosave, and the dirty-state indicator just
+// like a typed change.
+//
+// The whole pipeline lives in the editor side too — sharing
+// `findRunnableFences` / `codeOf` / `planOutputEdit` from
+// `editor/output-block.ts` means a run from preview and a run from
+// the editor gutter produce bit-identical doc edits.
+export async function runFenceAt(ops: ClickRoutingOps, openingLine: number): Promise<void> {
+  const content = ops.getContent();
+  const notePath = ops.getNotePath();
+  if (!ops.onRunCell || !ops.onApplyCellOutputEdit || !notePath) return;
+  const runningFences = ops.getRunningFences();
+  if (runningFences.has(openingLine)) return;
+  // Locate the fence in the live content. We could trust the line
+  // number from markdown-it, but the doc may have been edited since
+  // last render — re-scanning is cheap and rules out stale-token
+  // bugs.
+  const fences = findRunnableFences(content, RUNNABLE_LANGUAGE_SET);
+  const fence = fences.find((f) => f.openingLine === openingLine);
+  if (!fence) {
+    console.warn(`[preview] runFenceAt: no fence at line ${openingLine}`);
+    return;
+  }
+  const code = codeOf(content, fence);
+  runningFences.add(openingLine);
+  try {
+    const result = await ops.onRunCell(fence.language, code, notePath);
+    const edit = planOutputEdit(content, fence, result);
+    const newContent = content.slice(0, edit.from) + edit.insert + content.slice(edit.to);
+    ops.onApplyCellOutputEdit(newContent);
+  } catch (e) {
+    console.warn('[preview] runFenceAt failed:', e);
+  } finally {
+    runningFences.delete(openingLine);
+  }
+}
+
+/**
+ * Re-run every runnable fence in the note, top to bottom — the
+ * preview-mode counterpart to the editor's Run-all, so the toolbar
+ * button works when no editor is mounted. The sequential/stop-on-error
+ * loop lives in `runAllCellsInContent`; here we just wire it to the
+ * host's run + apply callbacks and the per-cell running indicator.
+ */
+export async function runAllCells(ops: ClickRoutingOps): Promise<void> {
+  const content = ops.getContent();
+  const notePath = ops.getNotePath();
+  if (!ops.onRunCell || !ops.onApplyCellOutputEdit || !notePath) return;
+  const runCell = ops.onRunCell;
+  const apply = ops.onApplyCellOutputEdit;
+  const runningFences = ops.getRunningFences();
+  await runAllCellsInContent(content, RUNNABLE_LANGUAGE_SET, {
+    runCell: (language, code) => runCell(language, code, notePath),
+    apply,
+    setRunning: (line, running) => {
+      if (running) runningFences.add(line);
+      else runningFences.delete(line);
+    },
+  });
+}

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -55,7 +55,7 @@ const THRESHOLD = 600;
  */
 const BUDGETS: Record<string, number> = {
   'src/renderer/App.svelte': 2075,
-  'src/renderer/lib/components/Preview.svelte': 1531,
+  'src/renderer/lib/components/Preview.svelte': 1299,
   'src/renderer/lib/components/SourceDetail.svelte': 1337,
   'src/renderer/lib/components/SourcesPanel.svelte': 1297,
   'src/renderer/lib/ipc/client.ts': 1239,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -364,12 +364,21 @@ export default defineConfig({
           functions: 12,
           branches: 18,
         },
-        // Preview.svelte ~40.3 L / 38.9 S / 35.0 F / 23.4 B.
+        // Preview.svelte ~54.8 L / 50.3 S / 41.6 F / 37.1 B. Retuned UP from
+        // the #1597-era floor (30 L): #1904 extracted the ~240-line click-
+        // routing table (handleClick + its per-selector handlers, plus the
+        // fence-run pipeline) into `preview/click-routing.ts`, which raised
+        // Preview.svelte's own ratio the same way #1903's Editor.svelte
+        // extraction did — floors sit ~7-8pts under the new measured.
+        // click-routing.ts itself gets no floor entry: Preview.test.ts
+        // exercises it only lightly (~14% L/S/F/B, via simulated clicks),
+        // matching the accepted gap on other extracted-but-thin editor/
+        // preview Ops modules (context-menu.ts, build-extensions.ts).
         'src/renderer/lib/components/Preview.svelte': {
-          lines: 30,
-          statements: 30,
-          functions: 25,
-          branches: 14,
+          lines: 47,
+          statements: 43,
+          functions: 34,
+          branches: 29,
         },
         // SourceDetail.svelte ~40.2 L / 33.7 S / 27.0 F / 25.8 B (#1597).
         'src/renderer/lib/components/SourceDetail.svelte': {


### PR DESCRIPTION
## Summary

Closes #1904 (dependency on #1903, already merged — same extraction pattern applied here). `Preview.svelte` carried the ~240-line click-routing concern (#993): `handleClick`'s `[selector, handler]` dispatch table, its eleven per-selector handlers (cite/quote/wiki-link, transclusion, tag, compute-output menu + image zoom, fence toolbar, YouTube embed, DOI link, internal anchor), plus the fence-run pipeline (`runFenceAt` / `runAllCells`) the fence toolbar's "run" action calls into. This was already commented as one cohesive unit and was the single largest seam in the file.

Moved to `src/renderer/lib/preview/click-routing.ts`, following the same `Ops`-closure shape `editor/context-menu.ts` and `editor/view-commands.ts` (#1903) already established: pure functions taking a `ClickRoutingOps` struct instead of touching Svelte state directly. Two callbacks — `dismissTooltip`, `openOutputMenu` — cross back into concerns intentionally left in the component for this PR (the hover-tooltip and compute-output-menu state); they're passed through as ops functions rather than pulled into this extraction too, keeping the PR scoped to one seam per the issue's own success criteria. `Preview.svelte` keeps a one-line `handleClick` wrapper for its `onclick` binding and a thin `runAllCells` export for `bind:this` access — every moved function body is **unchanged**, just re-parameterized through `ops` instead of closing over component-local state/props.

1531 → 1299 lines.

## The two required same-diff updates

- **`BUDGETS` entry** for `Preview.svelte` lowered 1531 → 1299.
- **`vitest.config.mts` per-file coverage floor retuned UP**, same as #1903's Editor.svelte case: removing the block raised Preview.svelte's own measured ratio from ~40/39/35/23 to ~55/50/42/37 (L/S/F/B), so floors move to 47/43/34/29. `click-routing.ts` itself gets no floor entry of its own — `Preview.test.ts` exercises it only lightly (~14% via simulated clicks), matching the accepted gap on its equally-thin siblings (`context-menu.ts`, `build-extensions.ts`).

## Test plan

- [x] `pnpm lint` passes (`tsc`, `svelte-check`, `eslint`)
- [x] `pnpm test` — 641 test files / 6962 tests pass, including all 12 existing `Preview.test.ts` cases
- [x] Full `--coverage` run passes with the retuned floor
- [ ] Manual browser/app verification of the moved click handlers — **not performed**, same rationale as #1903: a mechanical extraction (identical function bodies, re-parameterized through the `Ops` struct) verified by `tsc`+`svelte-check`+the existing test suite; flagging explicitly rather than claiming UI verification I didn't do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)