### PR TITLE
refactor(menu): move pure accelerator utilities out of menu.ts

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,5 +1,6 @@
 import { Menu, shell, dialog, BrowserWindow } from 'electron';
 import path from 'node:path';
+import { formatAccelerator, collectAcceleratorsByMenu } from './menu/accelerators';
 import { Channels } from '../shared/channels';
 import { broadcast } from './ipc/broadcast';
 import type { EventMap } from '../shared/ipc-contract';
@@ -1016,57 +1017,4 @@ export function getMenuShortcuts(): ShortcutGroup[] {
     groups.push({ menu, items });
   }
   return groups;
-}
-
-/** Render an Electron accelerator string for display on the current platform
- *  (⌘⇧S on macOS, Ctrl+Shift+S elsewhere). */
-export function formatAccelerator(accelerator: string, platform: NodeJS.Platform = process.platform): string {
-  const isMac = platform === 'darwin';
-  const mac: Record<string, string> = {
-    CmdOrCtrl: '⌘', Cmd: '⌘', Command: '⌘', Ctrl: '⌃', Control: '⌃',
-    Alt: '⌥', Option: '⌥', Shift: '⇧', Super: '⌘', Plus: '+', Minus: '−',
-  };
-  const other: Record<string, string> = {
-    CmdOrCtrl: 'Ctrl', Cmd: 'Ctrl', Command: 'Ctrl', Ctrl: 'Ctrl', Control: 'Ctrl',
-    Alt: 'Alt', Option: 'Alt', Shift: 'Shift', Super: 'Win', Plus: '+', Minus: '−',
-  };
-  const map = isMac ? mac : other;
-  const tokens = accelerator.split('+').map((t) => map[t] ?? t);
-  return isMac ? tokens.join('') : tokens.join('+');
-}
-
-/**
- * Walk a menu template tree and collect every accelerator under each
- * top-level menu. Returns a Map keyed by top-level menu label. Pure;
- * no Electron runtime dependency. Used by the accelerator-collision
- * test (#398).
- */
-export function collectAcceleratorsByMenu(
-  template: Electron.MenuItemConstructorOptions[],
-): Map<string, Array<{ accelerator: string; path: string[] }>> {
-  const out = new Map<string, Array<{ accelerator: string; path: string[] }>>();
-  for (const top of template) {
-    const topLabel = String(top.label ?? top.role ?? '(unnamed)');
-    const found: Array<{ accelerator: string; path: string[] }> = [];
-    walkInto(top, [topLabel], found);
-    if (found.length > 0) out.set(topLabel, found);
-  }
-  return out;
-}
-
-function walkInto(
-  item: Electron.MenuItemConstructorOptions,
-  path: string[],
-  out: Array<{ accelerator: string; path: string[] }>,
-): void {
-  if (typeof item.accelerator === 'string') {
-    out.push({ accelerator: item.accelerator, path });
-  }
-  const sub = item.submenu;
-  if (Array.isArray(sub)) {
-    for (const child of sub) {
-      const childLabel = String(child.label ?? child.role ?? '(unnamed)');
-      walkInto(child, [...path, childLabel], out);
-    }
-  }
 }

--- a/src/main/menu/accelerators.ts
+++ b/src/main/menu/accelerators.ts
@@ -1,0 +1,62 @@
+/**
+ * Menu accelerator utilities (#1906 — split out of menu.ts).
+ *
+ * Pure and Electron-free: given a menu template (plain data — an array of
+ * `MenuItemConstructorOptions`) or an accelerator string, these compute a
+ * result with no Electron runtime dependency. `menu.ts` builds the actual
+ * template (which DOES need Electron); this module only reads it back.
+ */
+import type { MenuItemConstructorOptions } from 'electron';
+
+/** Render an Electron accelerator string for display on the current platform
+ *  (⌘⇧S on macOS, Ctrl+Shift+S elsewhere). */
+export function formatAccelerator(accelerator: string, platform: NodeJS.Platform = process.platform): string {
+  const isMac = platform === 'darwin';
+  const mac: Record<string, string> = {
+    CmdOrCtrl: '⌘', Cmd: '⌘', Command: '⌘', Ctrl: '⌃', Control: '⌃',
+    Alt: '⌥', Option: '⌥', Shift: '⇧', Super: '⌘', Plus: '+', Minus: '−',
+  };
+  const other: Record<string, string> = {
+    CmdOrCtrl: 'Ctrl', Cmd: 'Ctrl', Command: 'Ctrl', Ctrl: 'Ctrl', Control: 'Ctrl',
+    Alt: 'Alt', Option: 'Alt', Shift: 'Shift', Super: 'Win', Plus: '+', Minus: '−',
+  };
+  const map = isMac ? mac : other;
+  const tokens = accelerator.split('+').map((t) => map[t] ?? t);
+  return isMac ? tokens.join('') : tokens.join('+');
+}
+
+/**
+ * Walk a menu template tree and collect every accelerator under each
+ * top-level menu. Returns a Map keyed by top-level menu label. Pure;
+ * no Electron runtime dependency. Used by the accelerator-collision
+ * test (#398).
+ */
+export function collectAcceleratorsByMenu(
+  template: MenuItemConstructorOptions[],
+): Map<string, Array<{ accelerator: string; path: string[] }>> {
+  const out = new Map<string, Array<{ accelerator: string; path: string[] }>>();
+  for (const top of template) {
+    const topLabel = String(top.label ?? top.role ?? '(unnamed)');
+    const found: Array<{ accelerator: string; path: string[] }> = [];
+    walkInto(top, [topLabel], found);
+    if (found.length > 0) out.set(topLabel, found);
+  }
+  return out;
+}
+
+function walkInto(
+  item: MenuItemConstructorOptions,
+  path: string[],
+  out: Array<{ accelerator: string; path: string[] }>,
+): void {
+  if (typeof item.accelerator === 'string') {
+    out.push({ accelerator: item.accelerator, path });
+  }
+  const sub = item.submenu;
+  if (Array.isArray(sub)) {
+    for (const child of sub) {
+      const childLabel = String(child.label ?? child.role ?? '(unnamed)');
+      walkInto(child, [...path, childLabel], out);
+    }
+  }
+}

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -63,7 +63,7 @@ const BUDGETS: Record<string, number> = {
   'src/renderer/lib/components/Editor.svelte': 829,
   'src/renderer/lib/stores/editor.svelte.ts': 1183,
     'src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte': 1156,
-  'src/main/menu.ts': 1072,
+  'src/main/menu.ts': 1020,
   'src/main/graph/indexers.ts': 723,
   'src/renderer/lib/components/Sidebar.svelte': 998,
   'src/renderer/lib/app/refactor-ops.svelte.ts': 827,

--- a/tests/main/menu-accelerators.test.ts
+++ b/tests/main/menu-accelerators.test.ts
@@ -1,69 +1,14 @@
 /**
- * Menu accelerator-collision check (#398).
+ * Menu accelerator utilities (#398, #804; extracted from menu.ts in #1906).
  *
- * The cheapest valuable menu test: build the application menu
- * template, walk it, assert that no two items inside the same
- * top-level menu share an accelerator. CodeMirror's keymap is
- * separately tested; this catches the menu-side half of the cross-
- * keymap collision risk by at least flagging within-menu duplicates,
- * which would render the second item's accelerator dead.
- *
- * Mocks the entire Electron + project-state surface that menu.ts
- * pulls in — the production code queries focused-window state, recent
- * projects, saved queries, etc. at template-build time, and we don't
- * care about any of that for the accelerator walk.
+ * `formatAccelerator` / `collectAcceleratorsByMenu` are pure and
+ * Electron-free — no mocks needed to reach them, unlike when they lived in
+ * menu.ts (see the sibling `tests/main/menu-shortcuts.test.ts`, which still
+ * mocks Electron + project state to exercise the real `rebuildMenu()`
+ * template these functions read).
  */
-
-import { describe, it, expect, vi } from 'vitest';
-import os from 'node:os';
-
-// ── Electron + project-state mocks ───────────────────────────────────────
-//
-// menu.ts imports BrowserWindow / Menu / shell / dialog / app from
-// 'electron' plus a half-dozen project modules at top level. The
-// template-build then queries them at call time. Stub each with the
-// thinnest shape the build path actually touches.
-
-vi.mock('electron', () => ({
-  Menu: {
-    buildFromTemplate: (t: unknown) => t,
-    setApplicationMenu: () => undefined,
-  },
-  BrowserWindow: {
-    getFocusedWindow: () => null,
-    getAllWindows: () => [],
-    fromId: () => null,
-  },
-  shell: { openExternal: () => Promise.resolve() },
-  dialog: {},
-  app: { getPath: () => os.tmpdir() },
-}));
-
-vi.mock('../../src/main/recent-projects', () => ({
-  getRecentProjects: () => [],
-  clearRecentProjects: () => undefined,
-}));
-
-vi.mock('../../src/main/window-manager', () => ({
-  createWindow: () => ({ webContents: { once: () => undefined, send: () => undefined } }),
-  openProjectInWindow: async () => undefined,
-  getRootPath: () => null,
-}));
-
-vi.mock('../../src/main/graph/index', () => ({ exportGraph: async () => undefined }));
-vi.mock('../../src/main/project-context-types', () => ({ projectContext: () => ({}) }));
-vi.mock('../../src/main/search/index', () => ({}));
-vi.mock('../../src/main/sources/tables', () => ({}));
-vi.mock('../../src/main/saved-queries', () => ({ listSavedQueries: () => [] }));
-vi.mock('../../src/main/compute/python-kernel', () => ({ restartKernel: () => undefined }));
-vi.mock('../../src/main/publish', () => ({
-  listExporters: () => [],
-  listExportGroups: () => [],
-}));
-
-// ── The actual test ──────────────────────────────────────────────────────
-
-import { rebuildMenu, collectAcceleratorsByMenu, formatAccelerator, getMenuShortcuts } from '../../src/main/menu';
+import { describe, it, expect } from 'vitest';
+import { collectAcceleratorsByMenu, formatAccelerator } from '../../src/main/menu/accelerators';
 
 describe('collectAcceleratorsByMenu (#398)', () => {
   it('returns empty for an empty template', () => {
@@ -119,30 +64,6 @@ describe('collectAcceleratorsByMenu (#398)', () => {
   });
 });
 
-describe('production menu has no within-menu accelerator collisions (#398)', () => {
-  it('every top-level menu uses each accelerator at most once', () => {
-    const template = rebuildMenu();
-    const byMenu = collectAcceleratorsByMenu(template);
-    const collisions: string[] = [];
-    for (const [menuLabel, entries] of byMenu) {
-      const seen = new Map<string, string[][]>();
-      for (const { accelerator, path } of entries) {
-        const list = seen.get(accelerator) ?? [];
-        list.push(path);
-        seen.set(accelerator, list);
-      }
-      for (const [acc, paths] of seen) {
-        if (paths.length > 1) {
-          collisions.push(
-            `${menuLabel} ▸ ${acc} fires for ${paths.length} items: ${paths.map((p) => p.join(' › ')).join(' | ')}`,
-          );
-        }
-      }
-    }
-    expect(collisions, collisions.join('\n')).toEqual([]);
-  });
-});
-
 describe('formatAccelerator (#804)', () => {
   it('renders macOS symbol form, joined without separators', () => {
     expect(formatAccelerator('CmdOrCtrl+Shift+S', 'darwin')).toBe('⌘⇧S');
@@ -153,23 +74,5 @@ describe('formatAccelerator (#804)', () => {
   it('renders Ctrl-word form on other platforms, plus-joined', () => {
     expect(formatAccelerator('CmdOrCtrl+Shift+S', 'win32')).toBe('Ctrl+Shift+S');
     expect(formatAccelerator('CmdOrCtrl+/', 'linux')).toBe('Ctrl+/');
-  });
-});
-
-describe('getMenuShortcuts (#804)', () => {
-  it('groups the live accelerators by top-level menu, top label dropped', () => {
-    rebuildMenu(); // populate the cached template
-    const groups = getMenuShortcuts();
-    expect(groups.length).toBeGreaterThan(0);
-    for (const g of groups) {
-      expect(typeof g.menu).toBe('string');
-      expect(g.items.length).toBeGreaterThan(0);
-      for (const item of g.items) {
-        expect(item.label).not.toBe('');
-        expect(item.keys).not.toBe('');
-        // The top-level menu label is dropped from the item label.
-        expect(item.label.startsWith(`${g.menu} › `)).toBe(false);
-      }
-    }
   });
 });

--- a/tests/main/menu-shortcuts.test.ts
+++ b/tests/main/menu-shortcuts.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Menu-shortcuts reference + accelerator-collision check (#398, #804).
+ *
+ * The cheapest valuable menu test: build the application menu
+ * template, walk it, assert that no two items inside the same
+ * top-level menu share an accelerator. CodeMirror's keymap is
+ * separately tested; this catches the menu-side half of the cross-
+ * keymap collision risk by at least flagging within-menu duplicates,
+ * which would render the second item's accelerator dead.
+ *
+ * `rebuildMenu()` / `getMenuShortcuts()` are impure — they build the real
+ * Electron menu template and query project/window state — so this file still
+ * mocks the entire Electron + project-state surface `menu.ts` pulls in at
+ * template-build time. `collectAcceleratorsByMenu` / `formatAccelerator`
+ * themselves are pure and Electron-free (moved to `menu/accelerators.ts`,
+ * #1906); their own unit tests live mock-free in
+ * `tests/main/menu/accelerators.test.ts`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import os from 'node:os';
+
+// ── Electron + project-state mocks ───────────────────────────────────────
+//
+// menu.ts imports BrowserWindow / Menu / shell / dialog / app from
+// 'electron' plus a half-dozen project modules at top level. The
+// template-build then queries them at call time. Stub each with the
+// thinnest shape the build path actually touches.
+
+vi.mock('electron', () => ({
+  Menu: {
+    buildFromTemplate: (t: unknown) => t,
+    setApplicationMenu: () => undefined,
+  },
+  BrowserWindow: {
+    getFocusedWindow: () => null,
+    getAllWindows: () => [],
+    fromId: () => null,
+  },
+  shell: { openExternal: () => Promise.resolve() },
+  dialog: {},
+  app: { getPath: () => os.tmpdir() },
+}));
+
+vi.mock('../../src/main/recent-projects', () => ({
+  getRecentProjects: () => [],
+  clearRecentProjects: () => undefined,
+}));
+
+vi.mock('../../src/main/window-manager', () => ({
+  createWindow: () => ({ webContents: { once: () => undefined, send: () => undefined } }),
+  openProjectInWindow: async () => undefined,
+  getRootPath: () => null,
+}));
+
+vi.mock('../../src/main/graph/index', () => ({ exportGraph: async () => undefined }));
+vi.mock('../../src/main/project-context-types', () => ({ projectContext: () => ({}) }));
+vi.mock('../../src/main/search/index', () => ({}));
+vi.mock('../../src/main/sources/tables', () => ({}));
+vi.mock('../../src/main/saved-queries', () => ({ listSavedQueries: () => [] }));
+vi.mock('../../src/main/compute/python-kernel', () => ({ restartKernel: () => undefined }));
+vi.mock('../../src/main/publish', () => ({
+  listExporters: () => [],
+  listExportGroups: () => [],
+}));
+
+// ── The actual test ──────────────────────────────────────────────────────
+
+import { rebuildMenu, getMenuShortcuts } from '../../src/main/menu';
+import { collectAcceleratorsByMenu } from '../../src/main/menu/accelerators';
+
+describe('production menu has no within-menu accelerator collisions (#398)', () => {
+  it('every top-level menu uses each accelerator at most once', () => {
+    const template = rebuildMenu();
+    const byMenu = collectAcceleratorsByMenu(template);
+    const collisions: string[] = [];
+    for (const [menuLabel, entries] of byMenu) {
+      const seen = new Map<string, string[][]>();
+      for (const { accelerator, path } of entries) {
+        const list = seen.get(accelerator) ?? [];
+        list.push(path);
+        seen.set(accelerator, list);
+      }
+      for (const [acc, paths] of seen) {
+        if (paths.length > 1) {
+          collisions.push(
+            `${menuLabel} ▸ ${acc} fires for ${paths.length} items: ${paths.map((p) => p.join(' › ')).join(' | ')}`,
+          );
+        }
+      }
+    }
+    expect(collisions, collisions.join('\n')).toEqual([]);
+  });
+});
+
+describe('getMenuShortcuts (#804)', () => {
+  it('groups the live accelerators by top-level menu, top label dropped', () => {
+    rebuildMenu(); // populate the cached template
+    const groups = getMenuShortcuts();
+    expect(groups.length).toBeGreaterThan(0);
+    for (const g of groups) {
+      expect(typeof g.menu).toBe('string');
+      expect(g.items.length).toBeGreaterThan(0);
+      for (const item of g.items) {
+        expect(item.label).not.toBe('');
+        expect(item.keys).not.toBe('');
+        // The top-level menu label is dropped from the item label.
+        expect(item.label.startsWith(`${g.menu} › `)).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1906. `formatAccelerator`, `collectAcceleratorsByMenu`, and `walkInto` were pure and Electron-free — the doc comment at their old location already said so — but lived in `menu.ts`. The proof they were in the wrong file was in their own test: it had to mock the entire Electron + project-state surface `menu.ts` pulls in just to reach three functions that touch none of it.

Moved the three to `src/main/menu/accelerators.ts`. The only import from `electron` is `import type { MenuItemConstructorOptions } from 'electron'` — type-only, erased at build time, so the module has zero runtime Electron dependency (same pattern already used by `notebase/watcher.ts` / `ipc/broadcast.ts` for `BrowserWindow`).

1072 → 1020 lines.

## Test split

The old `tests/main/menu-accelerators.test.ts` mixed two genuinely different concerns under one roof: pure unit tests for the three moved functions, and two tests that build the *real* Electron menu template via `rebuildMenu()` (the production accelerator-collision check, and `getMenuShortcuts()`). Splitting them was necessary, not optional — `rebuildMenu()` itself stays in `menu.ts` and stays impure, so those two tests can't drop their mocks no matter where the pure functions live.

- **`tests/main/menu-accelerators.test.ts`** — same filename, rewritten to import directly from `menu/accelerators.ts`. **Zero mocks.**
- **`tests/main/menu-shortcuts.test.ts`** (new) — keeps the full Electron + project-state mock surface for the two tests that call the real `rebuildMenu()`.

## The two required same-diff updates

- **`BUDGETS` entry** for `menu.ts` lowered 1072 → 1020.
- No coverage-floor entry existed for `menu.ts` before or needs one now (main-process files aren't in the per-file `src/renderer/**` coverage-floor bucket).

## Test plan

- [x] `pnpm lint` passes (`tsc`, `svelte-check`, `eslint`)
- [x] Both accelerator test files pass — 8 tests total (identical count to the original single file)
- [x] `pnpm test` — 642 test files / 6962 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)