### PR TITLE
refactor(notebase): extract createWatchHandlers() out of openProjectInWindow

### DIFF
--- a/src/main/notebase/watch-handlers.ts
+++ b/src/main/notebase/watch-handlers.ts
@@ -1,0 +1,239 @@
+/**
+ * File-watcher callback bundle for one open project (#1907 — extracted out
+ * of the ~270-line `openProjectInWindow` in `../window-manager.ts`, one of
+ * only two genuine long-procedure cases in the codebase).
+ *
+ * `createWatchHandlers()` owns its own debounce state (the persist timer, the
+ * per-.py-file kernel-invalidate queue) — nothing outside a single project's
+ * watch lifecycle needs either, so a fresh instance per call is exactly the
+ * right lifetime. Takes a `broadcastIfAlive` callback instead of a
+ * `BrowserWindow` so the handlers are testable without constructing one —
+ * the thing the stale-vector bug (#1892) needed and didn't have.
+ */
+import { Channels } from '../../shared/channels';
+import type { EventMap } from '../../shared/ipc-contract';
+import * as graph from '../graph/index';
+import * as search from '../search/index';
+import * as notebaseFs from './fs';
+import * as tables from '../sources/tables';
+import { indexAllFor, removeAllFor } from './index-fanout';
+import { invalidate as invalidatePythonModules } from '../compute/python-kernel';
+import * as vectors from '../embeddings/vector-store';
+import { citedTextFromTtl } from '../sources/create-excerpt';
+import { wasHandled } from './path-dedup';
+import type { ProjectContext } from '../project-context-types';
+import type { WatcherCallbacks } from './watcher';
+
+/** Channels these handlers broadcast — all fire-and-forget "something
+ *  changed" pings with no payload. */
+type NoPayloadEvent = { [K in keyof EventMap]: Parameters<EventMap[K]> extends [] ? K : never }[keyof EventMap];
+
+export interface WatchHandlerDeps {
+  rootPath: string;
+  projectCtx: ProjectContext;
+  /** Broadcasts a payload-less channel to the window if it's still alive —
+   *  abstracts away `win.isDestroyed()` / `broadcast(win, …)` so these
+   *  handlers don't need a real `BrowserWindow` to be exercised in a test. */
+  broadcastIfAlive: (channel: NoPayloadEvent) => void;
+}
+
+/**
+ * Builds the `WatcherCallbacks` bundle `startWatching` invokes for one open
+ * project.
+ */
+export function createWatchHandlers(deps: WatchHandlerDeps): WatcherCallbacks {
+  const { rootPath, projectCtx, broadcastIfAlive } = deps;
+
+  // Deduplication: IPC handlers mark paths they've already indexed
+  // (see `notebase/path-dedup.ts`).
+  let indexPersistTimer: ReturnType<typeof setTimeout> | null = null;
+  const debouncedPersist = () => {
+    if (indexPersistTimer) clearTimeout(indexPersistTimer);
+    indexPersistTimer = setTimeout(async () => {
+      // graph.ttl is a cold snapshot now (#348) — fully reconstructible
+      // from notes/sources/excerpts/CSVs/conversations/proposals, so we
+      // skip per-write serialization. Search index isn't reconstructed
+      // automatically, so it still gets the live persist.
+      await search.persist(projectCtx);
+    }, 1000);
+  };
+
+  // Coalesce `.py` edits into a single kernel-invalidate call (#529).
+  // A flurry of editor saves (autosave, formatter pass, find-replace) on
+  // the same module shouldn't fan out into a separate invalidate per
+  // write — the kernel just needs to know "these modules are stale" once
+  // the writes settle. 300ms matches the responsiveness window for
+  // re-running an importing cell while still grouping a multi-file
+  // formatter pass.
+  let pyInvalidatePaths = new Set<string>();
+  let pyInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
+  const queuePyInvalidate = (relativePath: string) => {
+    pyInvalidatePaths.add(relativePath);
+    if (pyInvalidateTimer) clearTimeout(pyInvalidateTimer);
+    pyInvalidateTimer = setTimeout(() => {
+      const paths = [...pyInvalidatePaths];
+      pyInvalidatePaths = new Set();
+      pyInvalidateTimer = null;
+      invalidatePythonModules(rootPath, paths);
+    }, 300);
+  };
+
+  /**
+   * Given a watched path that might affect a CSV's registration,
+   * return the project-relative path of the CSV to re-register, or
+   * null when no sibling table needs updating (#237).
+   *
+   * Two trigger shapes:
+   *   - `<stem>.csv.schema.yaml` → re-register `<stem>.csv`.
+   *   - `<stem>.md` (companion note) → re-register `<stem>.csv` if it
+   *     exists on disk. The companion may declare `table_name:` or
+   *     a `csv:` schema block, either of which changes registration.
+   *
+   * The .csv itself is handled by the existing branch in the caller —
+   * this helper specifically covers the sibling-edit case.
+   */
+  async function siblingCsvForReregister(relativePath: string): Promise<string | null> {
+    if (relativePath.endsWith('.csv.schema.yaml')) {
+      return relativePath.slice(0, -'.schema.yaml'.length);
+    }
+    if (relativePath.toLowerCase().endsWith('.md')) {
+      const csvCandidate = relativePath.replace(/\.md$/i, '.csv');
+      try {
+        await notebaseFs.readFile(rootPath, csvCandidate);
+        return csvCandidate;
+      } catch { /* no sibling CSV — common case */ }
+    }
+    return null;
+  }
+
+  async function reregisterSibling(relativePath: string): Promise<void> {
+    const csvPath = await siblingCsvForReregister(relativePath);
+    if (!csvPath) return;
+    try {
+      await tables.registerCsv(projectCtx, csvPath);
+      broadcastIfAlive(Channels.TABLES_CHANGED);
+      // Collisions broadcast via the per-project listener attached
+      // before acquireProject — no extra wiring here.
+    } catch (err) {
+      console.warn(`[tables] sibling re-register failed for ${csvPath} (via ${relativePath}):`, err);
+    }
+  }
+
+  /**
+   * Shared tail for `onFileChanged` / `onFileCreated` (#1907): the two used
+   * to duplicate this block verbatim — CSV branch, `.py` kernel-invalidate,
+   * `.csv.schema.yaml` early return, read→index→reregister-tables→persist —
+   * differing only in a comment. A newly-created `.py` file can land while a
+   * same-named, just-deleted one is still in `sys.modules` (e.g. a git
+   * checkout/restore), so treating create the same as change for the
+   * invalidate branch is deliberate, not an oversight.
+   */
+  async function upsert(relativePath: string): Promise<void> {
+    // CSVs route to DuckDB first in an independent try. registerCsv doesn't
+    // read the file content into memory (DuckDB reads lazily on query), so
+    // it's cheap and hard to fail — keeping it outside the graph+search
+    // pipeline means a graph indexing hiccup can't skip table registration.
+    if (relativePath.toLowerCase().endsWith('.csv')) {
+      try {
+        await tables.registerCsv(projectCtx, relativePath);
+        broadcastIfAlive(Channels.TABLES_CHANGED);
+      } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
+    } else {
+      await reregisterSibling(relativePath);
+    }
+    if (relativePath.toLowerCase().endsWith('.py')) {
+      queuePyInvalidate(relativePath);
+    }
+    // Sidecar yaml schemas aren't notes — skip the graph/search pass for
+    // them. The watcher fires for them only so the registerCsv branch
+    // above can update DuckDB.
+    if (relativePath.endsWith('.csv.schema.yaml')) return;
+    try {
+      const content = await notebaseFs.readFile(rootPath, relativePath);
+      await indexAllFor(projectCtx, relativePath, content);
+      // Captioned markdown tables in the note re-register in DuckDB (#1358).
+      if (relativePath.toLowerCase().endsWith('.md')) {
+        const r = await tables.reregisterNoteTables(projectCtx, relativePath, content);
+        if (r.changed) broadcastIfAlive(Channels.TABLES_CHANGED);
+      }
+      debouncedPersist();
+    } catch (err) {
+      // Usually a race (file deleted between events), but log so real bugs
+      // don't hide in silence.
+      console.warn(`[watcher] indexing failed for ${relativePath}:`, err);
+    }
+  }
+
+  return {
+    onFileChanged: async (relativePath) => {
+      if (wasHandled(relativePath)) return;
+      await upsert(relativePath);
+    },
+    onFileCreated: async (relativePath) => {
+      if (wasHandled(relativePath)) return;
+      await upsert(relativePath);
+    },
+    onFileDeleted: async (relativePath) => {
+      if (wasHandled(relativePath)) return;
+      if (relativePath.toLowerCase().endsWith('.csv')) {
+        try {
+          await tables.unregisterCsv(projectCtx, relativePath);
+          broadcastIfAlive(Channels.TABLES_CHANGED);
+        } catch (err) { console.warn(`[tables] unregisterCsv failed for ${relativePath}:`, err); }
+      } else {
+        // Schema sidecar deleted → CSV reverts to read_csv_auto. Same
+        // helper because the sibling lookup logic is identical; the CSV
+        // re-registers without the schema.
+        await reregisterSibling(relativePath);
+      }
+      if (relativePath.endsWith('.csv.schema.yaml')) return;
+      try {
+        removeAllFor(projectCtx, relativePath);
+        // Drop any DuckDB tables the deleted note owned (#1358). A rename
+        // surfaces as delete+create, so the create half re-registers them.
+        if (relativePath.toLowerCase().endsWith('.md')) {
+          await tables.unregisterNoteTables(projectCtx, relativePath);
+          broadcastIfAlive(Channels.TABLES_CHANGED);
+        }
+      } catch (err) {
+        console.warn(`[watcher] removeNote failed for ${relativePath}:`, err);
+      }
+      debouncedPersist();
+    },
+    onSourceMetaChanged: async (sourceId) => {
+      try {
+        const metaContent = await notebaseFs.readFile(rootPath, `.minerva/sources/${sourceId}/meta.ttl`);
+        let bodyContent: string | undefined;
+        try {
+          bodyContent = await notebaseFs.readFile(rootPath, `.minerva/sources/${sourceId}/body.md`);
+        } catch { /* body optional */ }
+        graph.indexSource(projectCtx, sourceId, metaContent, bodyContent);
+        void vectors.indexSource(projectCtx, sourceId, bodyContent ?? ''); // #839
+        debouncedPersist();
+        broadcastIfAlive(Channels.SOURCES_CHANGED);
+      } catch { /* meta.ttl may have been deleted between events */ }
+    },
+    onSourceMetaDeleted: (sourceId) => {
+      graph.removeSource(projectCtx, sourceId);
+      void vectors.removeSource(projectCtx, sourceId); // #839
+      debouncedPersist();
+      broadcastIfAlive(Channels.SOURCES_CHANGED);
+    },
+    onExcerptChanged: async (excerptId) => {
+      try {
+        const relPath = `.minerva/excerpts/${excerptId}.ttl`;
+        const content = await notebaseFs.readFile(rootPath, relPath);
+        graph.indexExcerpt(projectCtx, excerptId, content);
+        void vectors.indexExcerpt(projectCtx, excerptId, citedTextFromTtl(content) ?? ''); // #839
+        debouncedPersist();
+        broadcastIfAlive(Channels.EXCERPTS_CHANGED);
+      } catch { /* file may have been deleted between events */ }
+    },
+    onExcerptDeleted: (excerptId) => {
+      graph.removeExcerpt(projectCtx, excerptId);
+      void vectors.removeExcerpt(projectCtx, excerptId); // #839
+      debouncedPersist();
+      broadcastIfAlive(Channels.EXCERPTS_CHANGED);
+    },
+  };
+}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -5,20 +5,15 @@ import { broadcast } from './ipc/broadcast';
 import { appIconPath } from './app-icon';
 import { resolveDisplayName } from './project-config';
 import { startWatching, stopWatching } from './notebase/watcher';
-import { markPathHandled as markPathHandledImpl, wasHandled } from './notebase/path-dedup';
-import * as graph from './graph/index';
-import * as search from './search/index';
-import * as notebaseFs from './notebase/fs';
+import { createWatchHandlers } from './notebase/watch-handlers';
+import { markPathHandled as markPathHandledImpl } from './notebase/path-dedup';
+import type * as graph from './graph/index';
 import * as templates from './notebase/templates';
 import * as tables from './sources/tables';
-import { indexAllFor, removeAllFor } from './notebase/index-fanout';
-import { invalidate as invalidatePythonModules } from './compute/python-kernel';
 import { addRecentProject } from './recent-projects';
 import { saveSession, type WindowState } from './session';
 import { acquireProject, releaseProject } from './project-context';
 import { runBackfill } from './embeddings/backfill';
-import * as vectors from './embeddings/vector-store';
-import { citedTextFromTtl } from './sources/create-excerpt';
 import { installNavigationGuards, HARDENED_WEB_PREFERENCES } from './security';
 import { ensureClipperRunning, stopClipperServer, isClipperEnabled } from './clipper/lifecycle';
 import type { ProjectContext } from './project-context-types';
@@ -292,216 +287,13 @@ export async function openProjectInWindow(win: BrowserWindow, rootPath: string):
   // running:false tick clears the indicator. project-close aborts it.
   void runBackfill(projectCtx, { onProgress: (p) => broadcastBackfillProgress(rootPath, p) });
 
-  // Deduplication: IPC handlers mark paths they've already indexed
-  // (see `notebase/path-dedup.ts`).
-  let indexPersistTimer: ReturnType<typeof setTimeout> | null = null;
-  const debouncedPersist = () => {
-    if (indexPersistTimer) clearTimeout(indexPersistTimer);
-    indexPersistTimer = setTimeout(async () => {
-      // graph.ttl is a cold snapshot now (#348) — fully reconstructible
-      // from notes/sources/excerpts/CSVs/conversations/proposals, so we
-      // skip per-write serialization. Search index isn't reconstructed
-      // automatically, so it still gets the live persist.
-      await search.persist(projectCtx);
-    }, 1000);
-  };
-
-  // Coalesce `.py` edits into a single kernel-invalidate call (#529).
-  // A flurry of editor saves (autosave, formatter pass, find-replace) on
-  // the same module shouldn't fan out into a separate invalidate per
-  // write — the kernel just needs to know "these modules are stale" once
-  // the writes settle. 300ms matches the responsiveness window for
-  // re-running an importing cell while still grouping a multi-file
-  // formatter pass.
-  let pyInvalidatePaths = new Set<string>();
-  let pyInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
-  const queuePyInvalidate = (relativePath: string) => {
-    pyInvalidatePaths.add(relativePath);
-    if (pyInvalidateTimer) clearTimeout(pyInvalidateTimer);
-    pyInvalidateTimer = setTimeout(() => {
-      const paths = [...pyInvalidatePaths];
-      pyInvalidatePaths = new Set();
-      pyInvalidateTimer = null;
-      invalidatePythonModules(rootPath, paths);
-    }, 300);
-  };
-
   // startWatching returns a ready-promise (#345); we don't await here
   // because the watcher works fine before its initial scan completes.
-  /**
-   * Given a watched path that might affect a CSV's registration,
-   * return the project-relative path of the CSV to re-register, or
-   * null when no sibling table needs updating (#237).
-   *
-   * Two trigger shapes:
-   *   - `<stem>.csv.schema.yaml` → re-register `<stem>.csv`.
-   *   - `<stem>.md` (companion note) → re-register `<stem>.csv` if it
-   *     exists on disk. The companion may declare `table_name:` or
-   *     a `csv:` schema block, either of which changes registration.
-   *
-   * The .csv itself is handled by the existing branch in the caller —
-   * this helper specifically covers the sibling-edit case.
-   */
-  async function siblingCsvForReregister(relativePath: string): Promise<string | null> {
-    if (relativePath.endsWith('.csv.schema.yaml')) {
-      return relativePath.slice(0, -'.schema.yaml'.length);
-    }
-    if (relativePath.toLowerCase().endsWith('.md')) {
-      const csvCandidate = relativePath.replace(/\.md$/i, '.csv');
-      try {
-        await notebaseFs.readFile(rootPath, csvCandidate);
-        return csvCandidate;
-      } catch { /* no sibling CSV — common case */ }
-    }
-    return null;
-  }
-
-  async function reregisterSibling(relativePath: string): Promise<void> {
-    const csvPath = await siblingCsvForReregister(relativePath);
-    if (!csvPath) return;
-    try {
-      await tables.registerCsv(projectCtx, csvPath);
-      if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
-      // Collisions broadcast via the per-project listener attached
-      // before acquireProject — no extra wiring here.
-    } catch (err) {
-      console.warn(`[tables] sibling re-register failed for ${csvPath} (via ${relativePath}):`, err);
-    }
-  }
-
-  void startWatching(rootPath, win, win.id, {
-    onFileChanged: async (relativePath) => {
-      if (wasHandled(relativePath)) return;
-      // CSVs route to DuckDB first in an independent try. registerCsv doesn't
-      // read the file content into memory (DuckDB reads lazily on query), so
-      // it's cheap and hard to fail — keeping it outside the graph+search
-      // pipeline means a graph indexing hiccup can't skip table registration.
-      if (relativePath.toLowerCase().endsWith('.csv')) {
-        try {
-          await tables.registerCsv(projectCtx, relativePath);
-          if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
-        } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
-      } else {
-        await reregisterSibling(relativePath);
-      }
-      // #529 — editing a .py file invalidates its module in the running
-      // Python kernel so a re-run of an importing cell picks up the new
-      // definition without a manual Restart. Debounced + a no-op when
-      // no kernel is running.
-      if (relativePath.toLowerCase().endsWith('.py')) {
-        queuePyInvalidate(relativePath);
-      }
-      // Sidecar yaml schemas aren't notes — skip the graph/search pass for
-      // them. The watcher fires for them only so the registerCsv branch
-      // above can update DuckDB.
-      if (relativePath.endsWith('.csv.schema.yaml')) return;
-      try {
-        const content = await notebaseFs.readFile(rootPath, relativePath);
-        await indexAllFor(projectCtx, relativePath, content);
-        // Captioned markdown tables in the note re-register in DuckDB (#1358).
-        if (relativePath.toLowerCase().endsWith('.md')) {
-          const r = await tables.reregisterNoteTables(projectCtx, relativePath, content);
-          if (r.changed && !win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
-        }
-        debouncedPersist();
-      } catch (err) {
-        // Usually a race (file deleted between events), but log so real bugs
-        // don't hide in silence.
-        console.warn(`[watcher] indexing failed for ${relativePath}:`, err);
-      }
-    },
-    onFileCreated: async (relativePath) => {
-      if (wasHandled(relativePath)) return;
-      if (relativePath.toLowerCase().endsWith('.csv')) {
-        try {
-          await tables.registerCsv(projectCtx, relativePath);
-          if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
-        } catch (err) { console.warn(`[tables] registerCsv failed for ${relativePath}:`, err); }
-      } else {
-        await reregisterSibling(relativePath);
-      }
-      // A newly-added .py file with the same name as a previously-deleted
-      // one (e.g. via git checkout / restore) can land while a stale entry
-      // is still in sys.modules. Treat add the same as change for safety.
-      if (relativePath.toLowerCase().endsWith('.py')) {
-        queuePyInvalidate(relativePath);
-      }
-      if (relativePath.endsWith('.csv.schema.yaml')) return;
-      try {
-        const content = await notebaseFs.readFile(rootPath, relativePath);
-        await indexAllFor(projectCtx, relativePath, content);
-        if (relativePath.toLowerCase().endsWith('.md')) {
-          const r = await tables.reregisterNoteTables(projectCtx, relativePath, content);
-          if (r.changed && !win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
-        }
-        debouncedPersist();
-      } catch (err) {
-        console.warn(`[watcher] indexing failed for ${relativePath}:`, err);
-      }
-    },
-    onFileDeleted: async (relativePath) => {
-      if (wasHandled(relativePath)) return;
-      if (relativePath.toLowerCase().endsWith('.csv')) {
-        try {
-          await tables.unregisterCsv(projectCtx, relativePath);
-          if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
-        } catch (err) { console.warn(`[tables] unregisterCsv failed for ${relativePath}:`, err); }
-      } else {
-        // Schema sidecar deleted → CSV reverts to read_csv_auto. Same
-        // helper because the sibling lookup logic is identical; the CSV
-        // re-registers without the schema.
-        await reregisterSibling(relativePath);
-      }
-      if (relativePath.endsWith('.csv.schema.yaml')) return;
-      try {
-        removeAllFor(projectCtx, relativePath);
-        // Drop any DuckDB tables the deleted note owned (#1358). A rename
-        // surfaces as delete+create, so the create half re-registers them.
-        if (relativePath.toLowerCase().endsWith('.md')) {
-          await tables.unregisterNoteTables(projectCtx, relativePath);
-          if (!win.isDestroyed()) broadcast(win, Channels.TABLES_CHANGED);
-        }
-      } catch (err) {
-        console.warn(`[watcher] removeNote failed for ${relativePath}:`, err);
-      }
-      debouncedPersist();
-    },
-    onSourceMetaChanged: async (sourceId) => {
-      try {
-        const metaContent = await notebaseFs.readFile(rootPath, `.minerva/sources/${sourceId}/meta.ttl`);
-        let bodyContent: string | undefined;
-        try {
-          bodyContent = await notebaseFs.readFile(rootPath, `.minerva/sources/${sourceId}/body.md`);
-        } catch { /* body optional */ }
-        graph.indexSource(projectCtx, sourceId, metaContent, bodyContent);
-        void vectors.indexSource(projectCtx, sourceId, bodyContent ?? ''); // #839
-        debouncedPersist();
-        if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
-      } catch { /* meta.ttl may have been deleted between events */ }
-    },
-    onSourceMetaDeleted: (sourceId) => {
-      graph.removeSource(projectCtx, sourceId);
-      void vectors.removeSource(projectCtx, sourceId); // #839
-      debouncedPersist();
-      if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
-    },
-    onExcerptChanged: async (excerptId) => {
-      try {
-        const relPath = `.minerva/excerpts/${excerptId}.ttl`;
-        const content = await notebaseFs.readFile(rootPath, relPath);
-        graph.indexExcerpt(projectCtx, excerptId, content);
-        void vectors.indexExcerpt(projectCtx, excerptId, citedTextFromTtl(content) ?? ''); // #839
-        debouncedPersist();
-        if (!win.isDestroyed()) broadcast(win, Channels.EXCERPTS_CHANGED);
-      } catch { /* file may have been deleted between events */ }
-    },
-    onExcerptDeleted: (excerptId) => {
-      graph.removeExcerpt(projectCtx, excerptId);
-      void vectors.removeExcerpt(projectCtx, excerptId); // #839
-      debouncedPersist();
-      if (!win.isDestroyed()) broadcast(win, Channels.EXCERPTS_CHANGED);
-    },
-  });
+  void startWatching(rootPath, win, win.id, createWatchHandlers({
+    rootPath,
+    projectCtx,
+    broadcastIfAlive: (channel) => { if (!win.isDestroyed()) broadcast(win, channel); },
+  }));
   watchers.set(win.id, rootPath);
 
   // Tables panel subscribes to this; fires once after the project's initial

--- a/tests/main/notebase/watch-handlers.test.ts
+++ b/tests/main/notebase/watch-handlers.test.ts
@@ -1,0 +1,242 @@
+/**
+ * `createWatchHandlers()` (#1907, extracted out of `window-manager.ts`'s
+ * ~270-line `openProjectInWindow`). All downstream modules are mocked, the
+ * same shape as the sibling `index-fanout.test.ts` — no `BrowserWindow` is
+ * constructed anywhere here; `broadcastIfAlive` is a plain function, which is
+ * the whole point of the extraction (#1892's stale-vector bug was hard to
+ * regression-test while these handlers only existed as closures inline in
+ * `startWatching(rootPath, win, win.id, { ... })`).
+ *
+ * `onFileChanged` / `onFileCreated` share their `upsert` tail (#1907) — the
+ * parametrized describe block below runs the same scenarios against both to
+ * prove that sharing didn't silently drop either one's behavior.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  wasHandled: vi.fn().mockReturnValue(false),
+  readFile: vi.fn().mockResolvedValue('# content'),
+  indexAllFor: vi.fn().mockResolvedValue(undefined),
+  removeAllFor: vi.fn(),
+  registerCsv: vi.fn().mockResolvedValue(undefined),
+  unregisterCsv: vi.fn().mockResolvedValue(undefined),
+  reregisterNoteTables: vi.fn().mockResolvedValue({ changed: false }),
+  unregisterNoteTables: vi.fn().mockResolvedValue(undefined),
+  invalidatePythonModules: vi.fn(),
+  searchPersist: vi.fn().mockResolvedValue(undefined),
+  graphIndexSource: vi.fn(),
+  graphRemoveSource: vi.fn(),
+  graphIndexExcerpt: vi.fn(),
+  graphRemoveExcerpt: vi.fn(),
+  vectorsIndexSource: vi.fn().mockResolvedValue(undefined),
+  vectorsRemoveSource: vi.fn().mockResolvedValue(undefined),
+  vectorsIndexExcerpt: vi.fn().mockResolvedValue(undefined),
+  vectorsRemoveExcerpt: vi.fn().mockResolvedValue(undefined),
+  citedTextFromTtl: vi.fn().mockReturnValue('cited text'),
+}));
+
+vi.mock('../../../src/main/notebase/path-dedup', () => ({ wasHandled: h.wasHandled }));
+vi.mock('../../../src/main/notebase/fs', () => ({ readFile: h.readFile }));
+vi.mock('../../../src/main/notebase/index-fanout', () => ({
+  indexAllFor: h.indexAllFor,
+  removeAllFor: h.removeAllFor,
+}));
+vi.mock('../../../src/main/sources/tables', () => ({
+  registerCsv: h.registerCsv,
+  unregisterCsv: h.unregisterCsv,
+  reregisterNoteTables: h.reregisterNoteTables,
+  unregisterNoteTables: h.unregisterNoteTables,
+}));
+vi.mock('../../../src/main/compute/python-kernel', () => ({ invalidate: h.invalidatePythonModules }));
+vi.mock('../../../src/main/search/index', () => ({ persist: h.searchPersist }));
+vi.mock('../../../src/main/graph/index', () => ({
+  indexSource: h.graphIndexSource,
+  removeSource: h.graphRemoveSource,
+  indexExcerpt: h.graphIndexExcerpt,
+  removeExcerpt: h.graphRemoveExcerpt,
+}));
+vi.mock('../../../src/main/embeddings/vector-store', () => ({
+  indexSource: h.vectorsIndexSource,
+  removeSource: h.vectorsRemoveSource,
+  indexExcerpt: h.vectorsIndexExcerpt,
+  removeExcerpt: h.vectorsRemoveExcerpt,
+}));
+vi.mock('../../../src/main/sources/create-excerpt', () => ({ citedTextFromTtl: h.citedTextFromTtl }));
+
+import { createWatchHandlers, type WatchHandlerDeps } from '../../../src/main/notebase/watch-handlers';
+import { Channels } from '../../../src/shared/channels';
+import type { ProjectContext } from '../../../src/main/project-context-types';
+
+const CTX = { rootPath: '/vault', _brand: 'ProjectContext' as const } as unknown as ProjectContext;
+
+function makeHandlers(overrides: Partial<WatchHandlerDeps> = {}) {
+  const broadcastIfAlive = vi.fn();
+  const handlers = createWatchHandlers({
+    rootPath: '/vault',
+    projectCtx: CTX,
+    broadcastIfAlive,
+    ...overrides,
+  });
+  return { handlers, broadcastIfAlive };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.wasHandled.mockReturnValue(false);
+  h.readFile.mockResolvedValue('# content');
+  h.reregisterNoteTables.mockResolvedValue({ changed: false });
+});
+
+describe.each([
+  ['onFileChanged', (handlers: ReturnType<typeof createWatchHandlers>) => handlers.onFileChanged] as const,
+  ['onFileCreated', (handlers: ReturnType<typeof createWatchHandlers>) => handlers.onFileCreated] as const,
+])('%s (shared upsert, #1907)', (_name, pick) => {
+  it('does nothing when the path was already handled by an IPC write', async () => {
+    h.wasHandled.mockReturnValue(true);
+    const { handlers } = makeHandlers();
+    await pick(handlers)('notes/a.md');
+    expect(h.indexAllFor).not.toHaveBeenCalled();
+    expect(h.registerCsv).not.toHaveBeenCalled();
+  });
+
+  it('indexes a markdown note and persists', async () => {
+    const { handlers } = makeHandlers();
+    await pick(handlers)('notes/a.md');
+    expect(h.readFile).toHaveBeenCalledWith('/vault', 'notes/a.md');
+    expect(h.indexAllFor).toHaveBeenCalledWith(CTX, 'notes/a.md', '# content');
+    expect(h.reregisterNoteTables).toHaveBeenCalledWith(CTX, 'notes/a.md', '# content');
+  });
+
+  it('broadcasts TABLES_CHANGED when a markdown note\'s captioned table changed', async () => {
+    h.reregisterNoteTables.mockResolvedValue({ changed: true });
+    const { handlers, broadcastIfAlive } = makeHandlers();
+    await pick(handlers)('notes/a.md');
+    expect(broadcastIfAlive).toHaveBeenCalledWith(Channels.TABLES_CHANGED);
+  });
+
+  it('registers a .csv file with DuckDB independently of the graph pass', async () => {
+    const { handlers, broadcastIfAlive } = makeHandlers();
+    await pick(handlers)('data/t.csv');
+    expect(h.registerCsv).toHaveBeenCalledWith(CTX, 'data/t.csv');
+    expect(broadcastIfAlive).toHaveBeenCalledWith(Channels.TABLES_CHANGED);
+    // Still proceeds to the graph/search/vectors pass — CSVs are indexable notes.
+    expect(h.indexAllFor).toHaveBeenCalledWith(CTX, 'data/t.csv', '# content');
+  });
+
+  it('re-registers a sibling CSV when its schema sidecar changes, and skips the graph pass', async () => {
+    const { handlers } = makeHandlers();
+    await pick(handlers)('data/t.csv.schema.yaml');
+    // The schema-sidecar shape resolves the sibling by string-slice, not a
+    // disk probe (unlike the .md-companion shape below) — the .csv is
+    // presumed to exist since its own schema file is what's changing.
+    expect(h.registerCsv).toHaveBeenCalledWith(CTX, 'data/t.csv');
+    // The sidecar itself is not a note — no readFile/indexAllFor for it.
+    expect(h.readFile).not.toHaveBeenCalled();
+    expect(h.indexAllFor).not.toHaveBeenCalled();
+  });
+
+  it('queues a Python kernel invalidate for a .py file', async () => {
+    vi.useFakeTimers();
+    try {
+      const { handlers } = makeHandlers();
+      await pick(handlers)('scripts/a.py');
+      expect(h.invalidatePythonModules).not.toHaveBeenCalled(); // debounced
+      await vi.advanceTimersByTimeAsync(300);
+      expect(h.invalidatePythonModules).toHaveBeenCalledWith('/vault', ['scripts/a.py']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('logs and swallows a read failure instead of throwing (common race: file deleted mid-event)', async () => {
+    h.readFile.mockRejectedValue(new Error('ENOENT'));
+    const { handlers } = makeHandlers();
+    await expect(pick(handlers)('notes/a.md')).resolves.toBeUndefined();
+  });
+});
+
+describe('onFileDeleted', () => {
+  it('does nothing when the path was already handled by an IPC write', async () => {
+    h.wasHandled.mockReturnValue(true);
+    const { handlers } = makeHandlers();
+    await handlers.onFileDeleted('notes/a.md');
+    expect(h.removeAllFor).not.toHaveBeenCalled();
+  });
+
+  it('removes a markdown note and its owned tables', async () => {
+    const { handlers, broadcastIfAlive } = makeHandlers();
+    await handlers.onFileDeleted('notes/a.md');
+    expect(h.removeAllFor).toHaveBeenCalledWith(CTX, 'notes/a.md');
+    expect(h.unregisterNoteTables).toHaveBeenCalledWith(CTX, 'notes/a.md');
+    expect(broadcastIfAlive).toHaveBeenCalledWith(Channels.TABLES_CHANGED);
+  });
+
+  it('unregisters a deleted .csv from DuckDB', async () => {
+    const { handlers, broadcastIfAlive } = makeHandlers();
+    await handlers.onFileDeleted('data/t.csv');
+    expect(h.unregisterCsv).toHaveBeenCalledWith(CTX, 'data/t.csv');
+    expect(broadcastIfAlive).toHaveBeenCalledWith(Channels.TABLES_CHANGED);
+    expect(h.removeAllFor).toHaveBeenCalledWith(CTX, 'data/t.csv');
+  });
+
+  it('re-registers the sibling CSV (schema reverts) and skips removeAllFor for a schema sidecar', async () => {
+    const { handlers } = makeHandlers();
+    await handlers.onFileDeleted('data/t.csv.schema.yaml');
+    expect(h.registerCsv).toHaveBeenCalledWith(CTX, 'data/t.csv');
+    expect(h.removeAllFor).not.toHaveBeenCalled();
+  });
+});
+
+describe('source/excerpt watch handlers', () => {
+  it('onSourceMetaChanged indexes the source into graph + vectors and broadcasts', async () => {
+    h.readFile.mockImplementation((_root: string, rel: string) =>
+      rel.endsWith('meta.ttl') ? Promise.resolve('meta ttl') : Promise.reject(new Error('no body')));
+    const { handlers, broadcastIfAlive } = makeHandlers();
+    await handlers.onSourceMetaChanged!('smith-2023');
+    expect(h.graphIndexSource).toHaveBeenCalledWith(CTX, 'smith-2023', 'meta ttl', undefined);
+    expect(h.vectorsIndexSource).toHaveBeenCalledWith(CTX, 'smith-2023', '');
+    expect(broadcastIfAlive).toHaveBeenCalledWith(Channels.SOURCES_CHANGED);
+  });
+
+  it('onSourceMetaChanged silently no-ops when meta.ttl is gone (race with deletion)', async () => {
+    h.readFile.mockRejectedValue(new Error('ENOENT'));
+    const { handlers, broadcastIfAlive } = makeHandlers();
+    await expect(handlers.onSourceMetaChanged!('gone')).resolves.toBeUndefined();
+    expect(h.graphIndexSource).not.toHaveBeenCalled();
+    expect(broadcastIfAlive).not.toHaveBeenCalled();
+  });
+
+  it('onSourceMetaDeleted removes the source from graph + vectors and broadcasts', () => {
+    const { handlers, broadcastIfAlive } = makeHandlers();
+    handlers.onSourceMetaDeleted!('smith-2023');
+    expect(h.graphRemoveSource).toHaveBeenCalledWith(CTX, 'smith-2023');
+    expect(h.vectorsRemoveSource).toHaveBeenCalledWith(CTX, 'smith-2023');
+    expect(broadcastIfAlive).toHaveBeenCalledWith(Channels.SOURCES_CHANGED);
+  });
+
+  it('onExcerptChanged indexes the excerpt into graph + vectors (cited text) and broadcasts', async () => {
+    const { handlers, broadcastIfAlive } = makeHandlers();
+    await handlers.onExcerptChanged!('p42-graphs');
+    expect(h.graphIndexExcerpt).toHaveBeenCalledWith(CTX, 'p42-graphs', '# content');
+    expect(h.citedTextFromTtl).toHaveBeenCalledWith('# content');
+    expect(h.vectorsIndexExcerpt).toHaveBeenCalledWith(CTX, 'p42-graphs', 'cited text');
+    expect(broadcastIfAlive).toHaveBeenCalledWith(Channels.EXCERPTS_CHANGED);
+  });
+
+  it('onExcerptDeleted removes the excerpt from graph + vectors and broadcasts', () => {
+    const { handlers, broadcastIfAlive } = makeHandlers();
+    handlers.onExcerptDeleted!('p42-graphs');
+    expect(h.graphRemoveExcerpt).toHaveBeenCalledWith(CTX, 'p42-graphs');
+    expect(h.vectorsRemoveExcerpt).toHaveBeenCalledWith(CTX, 'p42-graphs');
+    expect(broadcastIfAlive).toHaveBeenCalledWith(Channels.EXCERPTS_CHANGED);
+  });
+});
+
+describe('broadcastIfAlive abstraction (#1907)', () => {
+  it('never constructs a BrowserWindow — the deps object is a plain function', async () => {
+    const calls: string[] = [];
+    const { handlers } = makeHandlers({ broadcastIfAlive: (channel) => { calls.push(channel); } });
+    await handlers.onFileChanged('data/t.csv');
+    expect(calls).toContain(Channels.TABLES_CHANGED);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1907. `window-manager.ts`'s `openProjectInWindow` was a 268-line procedure — one of only two genuine long-procedure cases in the codebase — whose `:296-506` region was a closure factory over `(rootPath, projectCtx, win)` with no lifecycle logic of its own. `onFileChanged`/`onFileCreated` were near-identical: same CSV branch, same `.csv.schema.yaml` early return, same read→index→reregister→persist tail, differing only in a comment.

Moved the whole watch-handler bundle — the debounce state (persist timer, Python-kernel invalidate queue), the sibling-CSV reregistration helpers, and all seven `WatcherCallbacks` — into `src/main/notebase/watch-handlers.ts`'s `createWatchHandlers()`. `onFileChanged` and `onFileCreated` now share one `upsert()` tail instead of duplicating it, with a merged doc comment explaining why create is treated the same as change for the `.py`-invalidate branch (both original comments' rationale, preserved).

`createWatchHandlers()` takes a `broadcastIfAlive(channel)` callback instead of a `BrowserWindow` — `window-manager.ts`'s own call site still does the real `win.isDestroyed()` / `broadcast(win, channel)` check, but the handlers themselves only ever see a plain function. That's the actual point of the extraction: #1892's stale-vector bug was hard to regression-test while this logic only existed as closures inline in a `startWatching(rootPath, win, win.id, { ... })` call that needed a live `BrowserWindow` to reach at all.

536 → 328 lines.

## Test

`tests/main/notebase/watch-handlers.test.ts` (new, 24 tests) exercises all seven callbacks with every downstream dependency mocked — the same pattern the sibling `index-fanout.test.ts` already established. **No `BrowserWindow` anywhere.** Covers:
- the `wasHandled` dedup guard
- the CSV / schema-sidecar / markdown branches
- the shared `upsert` tail, parametrized across `onFileChanged` and `onFileCreated` so neither could silently diverge from the other after sharing the code
- the source/excerpt handlers (graph + vectors + broadcast, and the meta.ttl-deleted-mid-race silent no-op)

Verified the dedup-guard test genuinely catches a regression: temporarily removed one `wasHandled` check, confirmed the corresponding test failed, then restored it.

## BUDGETS

No entry existed for `window-manager.ts` before this PR — 536 lines was already under the 600-line tracking threshold, so there was nothing to lower. `watch-handlers.ts` (239 lines) doesn't need one either.

## Test plan

- [x] `pnpm lint` passes (`tsc`, `svelte-check`, `eslint`)
- [x] New test file: 24/24 pass, zero `BrowserWindow` construction
- [x] `pnpm test` — 643 test files / 6986 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)