### PR TITLE
refactor(preview): finish the install* convention in markdown-config.ts

### DIFF
--- a/src/renderer/lib/markdown/anchor-plugin.ts
+++ b/src/renderer/lib/markdown/anchor-plugin.ts
@@ -1,0 +1,121 @@
+/**
+ * Preview-addressability rule overrides (#1908 — split out of
+ * `preview/markdown-config.ts` to finish that file's `install*` convention).
+ *
+ * Three renderer-rule overrides that stamp navigable ids / metadata onto
+ * their tokens so `[[note#heading]]` / `[[note#^block]]` anchor navigation
+ * and task-checkbox toggling can find their target in the rendered DOM:
+ *
+ *  - `heading_open` — id = slug(heading text), matching the indexer's
+ *    heading-slug convention so a wiki-link anchor resolves to the same id.
+ *  - `paragraph_open` — id = `^block-id` when the paragraph ends with a
+ *    bare `^block-id` marker, which is then stripped from the rendered text.
+ *  - `list_item_open` — `[ ]`/`[x]` at the start of a list item becomes a
+ *    live checkbox stamped with the item's source line, so the click
+ *    handler on the preview root knows which line to flip in the editor.
+ *
+ * None of the three need any Preview-instance state (no `PreviewMarkdownDeps`
+ * dependency) — everything they read comes off the token tree markdown-it
+ * itself already built.
+ */
+import type { MarkdownIt, Token } from 'markdown-it';
+import { slugify } from '../../../shared/slug';
+
+export function installAnchors(md: MarkdownIt): void {
+    // Give every heading an id derived from its text so [[note#heading]] anchor
+    // navigation can target it. Slugs must match the indexer's convention.
+    const defaultHeadingOpen = md.renderer.rules.heading_open;
+    md.renderer.rules.heading_open = (tokens, idx, options, env, self) => {
+        const inline = tokens[idx + 1];
+        const text = inline && inline.type === 'inline' ? inline.content : '';
+        const slug = slugify(text);
+        if (slug) tokens[idx]!.attrSet('id', slug);
+        return defaultHeadingOpen
+            ? defaultHeadingOpen(tokens, idx, options, env, self)
+            : self.renderToken(tokens, idx, options);
+    };
+
+    // Watch for block-id paragraphs (`^block-id` at paragraph end) and mirror
+    // them onto the rendered <p> so [[note#^id]] scrolls can find the target.
+    const BLOCK_ID_RE = /\s*\^([\w-]+)\s*$/;
+    const defaultParagraphOpen = md.renderer.rules.paragraph_open;
+    md.renderer.rules.paragraph_open = (tokens, idx, options, env, self) => {
+        const inline = tokens[idx + 1];
+        if (inline && inline.type === 'inline') {
+            const m = inline.content.match(BLOCK_ID_RE);
+            if (m) {
+                tokens[idx]!.attrSet('id', `^${m[1]}`);
+                // Strip the marker from what renders.
+                inline.content = inline.content.replace(BLOCK_ID_RE, '');
+                if (inline.children) {
+                    for (let i = inline.children.length - 1; i >= 0; i--) {
+                        const child = inline.children[i]!;
+                        if (child.type === 'text') {
+                            const stripped = child.content.replace(BLOCK_ID_RE, '');
+                            if (stripped !== child.content) {
+                                child.content = stripped;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return defaultParagraphOpen
+            ? defaultParagraphOpen(tokens, idx, options, env, self)
+            : self.renderToken(tokens, idx, options);
+    };
+
+    // Task-list items: when a list item starts with `[ ]` or `[x]`, render a
+    // live <input type="checkbox"> and stamp `data-task-line` with the source
+    // line (from the list_item_open token's `map`) so the click handler on
+    // the preview root knows which line to flip in the editor store (#127).
+    const TASK_ITEM_RE = /^\[([ xX])\]\s/;
+    const defaultListItemOpen = md.renderer.rules.list_item_open;
+    md.renderer.rules.list_item_open = (tokens, idx, options, env, self) => {
+        // Scan forward to the first inline token inside this list item (typical
+        // structure: list_item_open → paragraph_open → inline). Stop if we hit
+        // the matching close without finding one.
+        let k = idx + 1;
+        while (k < tokens.length && tokens[k]!.type !== 'inline' && tokens[k]!.type !== 'list_item_close') k++;
+        const inlineTok = k < tokens.length && tokens[k]!.type === 'inline' ? tokens[k]! : null;
+        if (inlineTok) {
+            const m = inlineTok.content.match(TASK_ITEM_RE);
+            if (m) {
+                const checked = m[1] === 'x' || m[1] === 'X';
+                // `map[0]` is 0-indexed within whatever source was passed to
+                // `md.render` — which is the frontmatter-stripped content below.
+                // Add the env-carried offset so the checkbox's data-task-line
+                // points at the line index in the original note.
+                const rawLine = tokens[idx]!.map?.[0] ?? -1;
+                const line = rawLine >= 0 ? rawLine + ((env as { lineOffset?: number })?.lineOffset ?? 0) : -1;
+                tokens[idx]!.attrSet('data-task-line', String(line));
+                tokens[idx]!.attrJoin('class', 'task-list-item');
+                // Strip the `[ ]` prefix from the inline's aggregate content and
+                // from its first text child so the rendered output doesn't repeat it.
+                inlineTok.content = inlineTok.content.replace(TASK_ITEM_RE, '');
+                if (inlineTok.children) {
+                    for (let i = 0; i < inlineTok.children.length; i++) {
+                        const child = inlineTok.children[i]!;
+                        if (child.type === 'text') {
+                            child.content = child.content.replace(TASK_ITEM_RE, '');
+                            break;
+                        }
+                    }
+                    // Inject the checkbox as an html_inline prefix on the inline tree.
+                    // Recover the Token constructor from the inline token itself so we
+                    // don't have to deep-import `markdown-it/lib/token.mjs` (#347).
+                    const TokenCtor = inlineTok.constructor as new (
+                        type: string, tag: string, nesting: -1 | 0 | 1,
+                    ) => Token;
+                    const cb = new TokenCtor('html_inline', '', 0);
+                    cb.content = `<input type="checkbox" data-task-line="${line}"${checked ? ' checked' : ''}> `;
+                    inlineTok.children.unshift(cb);
+                }
+            }
+        }
+        return defaultListItemOpen
+            ? defaultListItemOpen(tokens, idx, options, env, self)
+            : self.renderToken(tokens, idx, options);
+    };
+}

--- a/src/renderer/lib/markdown/fence-plugin.ts
+++ b/src/renderer/lib/markdown/fence-plugin.ts
@@ -1,0 +1,181 @@
+/**
+ * Custom fence rendering (#994; split out of `preview/markdown-config.ts` in
+ * #1908 to finish that file's `install*` convention). The markdown-it fence
+ * rule computes the shared context (token, 1-based source line) once, then
+ * dispatches on the lowercased info string via `fenceRenderers`. Runnable
+ * fences (a language-set membership test) and the default code-block
+ * wrapper (the fallthrough) aren't keyable by a single info string, so
+ * they're dispatched explicitly after the map lookup.
+ *
+ * Needs `PreviewMarkdownDeps` (the per-fence collapse/running sets and the
+ * run-button gate) unlike the other `install*` plugins, which is why its
+ * signature carries a second argument.
+ */
+import type { MarkdownIt, Token } from 'markdown-it';
+import { detectDataSource } from '../../../shared/vega/data-binding';
+import { RUNNABLE_LANGUAGE_SET } from '../../../shared/compute/fences';
+import { renderYouTubeFence } from './youtube-embed';
+import { findSourceFenceBefore, renderComputeOutput } from '../preview/compute-output-render';
+import type { PreviewMarkdownDeps } from '../preview/markdown-deps';
+
+interface FenceRenderArgs {
+    tok: Token;
+    tokens: Token[];
+    idx: number;
+    info: string;
+    openingLine: number | null;
+    /** Reproduce markdown-it's built-in fence output (the highlighted code
+     *  block) — used by the runnable + default renderers. */
+    renderDefault: () => string;
+}
+
+export function installFences(md: MarkdownIt, deps: PreviewMarkdownDeps): void {
+    // Compute-cell output blocks (#238). A ```output fence below an executable
+    // fence carries the JSON payload the executor produced; render it as a
+    // shape-specific artifact (table / error / text / pretty JSON) rather
+    // than as a generic highlighted code block. Users editing the note in
+    // source view still see the raw JSON and can delete the block to re-run.
+    function renderOutputFence(args: FenceRenderArgs): string {
+        const source = findSourceFenceBefore(args.tokens, args.idx);
+        return renderComputeOutput(args.tok.content, source);
+    }
+
+    function renderMermaidFence(args: FenceRenderArgs): string {
+        const { tok, openingLine } = args;
+        const escaped = (tok.content ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+        // Mermaid blocks get a collapse toggle (no run — they auto-render
+        // on view) so a long diagram can be tucked away when scrolling
+        // through the rest of the note.
+        if (openingLine !== null) {
+            const isCollapsed = deps.collapsedFences.has(openingLine);
+            return `<div class="fence-block fence-mermaid${isCollapsed ? ' fence-collapsed' : ''}" data-fence-line="${openingLine}">`
+                + `<div class="fence-toolbar"><span class="fence-lang">mermaid</span>`
+                + `<button class="fence-collapse-btn" data-fence-action="collapse" type="button" title="Collapse / expand">${isCollapsed ? '▸' : '▾'}</button>`
+                + `</div>`
+                + `<div class="fence-body"><div class="mermaid-block" data-mermaid-pending="1">${escaped}</div></div>`
+                + `</div>\n`;
+        }
+        return `<div class="mermaid-block" data-mermaid-pending="1">${escaped}</div>\n`;
+    }
+
+    function renderVegaFence(args: FenceRenderArgs): string {
+        const { tok, info, openingLine } = args;
+        const escaped = (tok.content ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+        const mode = info === 'vega' ? 'full' : 'lite';
+        // Like mermaid, charts auto-render on view (no run button) but get a
+        // collapse toggle so a tall chart can be tucked away. The lazy hydrator
+        // (vega-renderer.ts) swaps the placeholder for an embedded SVG chart.
+        const block = `<div class="vega-block" data-vega-pending="1" data-vega-mode="${mode}">${escaped}</div>`;
+        // A data-bound chart (#832 — `data.sparql` etc.) gets a refresh button so
+        // the user can re-run the query after the graph changes without editing
+        // the note. Inline charts don't need it. Cheap parse — charts are few.
+        let isBound = false;
+        try {
+            isBound = detectDataSource(JSON.parse(tok.content ?? '')) !== null;
+        } catch { /* not bound */
+        }
+        if (openingLine !== null) {
+            const isCollapsed = deps.collapsedFences.has(openingLine);
+            const refreshBtn = isBound
+                ? `<button class="fence-refresh-btn" data-fence-action="refresh-vega" type="button" title="Refresh chart data">⟳</button>`
+                : '';
+            return `<div class="fence-block fence-vega${isCollapsed ? ' fence-collapsed' : ''}" data-fence-line="${openingLine}">`
+                + `<div class="fence-toolbar"><span class="fence-lang">${info}</span>`
+                + refreshBtn
+                + `<button class="fence-collapse-btn" data-fence-action="collapse" type="button" title="Collapse / expand">${isCollapsed ? '▸' : '▾'}</button>`
+                + `</div>`
+                + `<div class="fence-body">${block}</div>`
+                + `</div>\n`;
+        }
+        return `${block}\n`;
+    }
+
+    // A `youtube` fence renders a click-to-open poster card (#904) — thumbnail
+    // + ▶, opens in the browser on click. No live iframe, so no CSP change; the
+    // card is self-explanatory, so it skips the code-fence toolbar wrapper.
+    function renderYouTubeFenceCard(args: FenceRenderArgs): string {
+        return `${renderYouTubeFence(args.tok.content ?? '')}\n`;
+    }
+
+    // Runnable fences (python / sparql / sql) get a toolbar with a ▶
+    // run button (when the host wired `onRunCell` + `onApplyCellOutputEdit`)
+    // and a collapse toggle. The default highlighted-code body is
+    // wrapped inside `.fence-body` so the toggle can hide it.
+    function renderRunnableFence(args: FenceRenderArgs, openingLine: number): string {
+        const { info, renderDefault } = args;
+        const isCollapsed = deps.collapsedFences.has(openingLine);
+        const isRunning = deps.runningFences.has(openingLine);
+        const canRun = deps.getCanRun();
+        const defaultRender = renderDefault();
+        const runBtn = canRun
+            ? `<button class="fence-run-btn" data-fence-action="run" type="button" title="Run cell" ${isRunning ? 'disabled' : ''}>${isRunning ? '⋯' : '▶'}</button>`
+            : '';
+        return `<div class="fence-block fence-runnable${isCollapsed ? ' fence-collapsed' : ''}" data-fence-line="${openingLine}" data-fence-lang="${info}">`
+            + `<div class="fence-toolbar">`
+            + `<span class="fence-lang">${info}</span>`
+            + runBtn
+            + `<button class="fence-collapse-btn" data-fence-action="collapse" type="button" title="Collapse / expand">${isCollapsed ? '▸' : '▾'}</button>`
+            + `</div>`
+            + `<div class="fence-body">${defaultRender}</div>`
+            + `</div>\n`;
+    }
+
+    function renderDefaultFence(args: FenceRenderArgs): string {
+        const { info, renderDefault } = args;
+        const rendered = renderDefault();
+        // Wrap non-runnable, non-mermaid fences in a code-block container
+        // carrying the language label (§8.5). Empty `info` (a bare ```)
+        // skips the wrapper so plain code blocks don't get a stray label.
+        if (info && info !== 'output') {
+            return `<div class="code-block" data-language="${info}">${rendered}</div>\n`;
+        }
+        return rendered;
+    }
+
+    const fenceRenderers: Record<string, (args: FenceRenderArgs) => string> = {
+        output: renderOutputFence,
+        mermaid: renderMermaidFence,
+        vega: renderVegaFence,
+        'vega-lite': renderVegaFence,
+        youtube: renderYouTubeFenceCard,
+    };
+
+    const defaultFence = md.renderer.rules.fence;
+    md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+        const tok = tokens[idx]!;
+        const info = tok.info.trim().toLowerCase();
+        // tok.map is the [startLine, endLine] of the fence in the
+        // SOURCE-FED-TO-md.render — 0-indexed, and that source has had
+        // the YAML frontmatter stripped (see `renderContent` in Preview.svelte).
+        // `findRunnableFences` operates on the FULL content (frontmatter
+        // intact). Add back `env.lineOffset` (the frontmatter line count)
+        // and switch to 1-based numbering so the two helpers agree on
+        // line numbers — without this the lookup in `runFenceAt` would
+        // miss every fence in any note that has frontmatter. tok.map is
+        // null when markdown-it can't determine the position (rare;
+        // toolbar falls back to "no run button").
+        const frontmatterOffset = (env as { lineOffset?: number } | undefined)?.lineOffset ?? 0;
+        const openingLine = tok.map ? tok.map[0] + 1 + frontmatterOffset : null;
+        const renderDefault = () => (defaultFence
+            ? defaultFence(tokens, idx, options, env, self)
+            : self.renderToken(tokens, idx, options));
+        const args: FenceRenderArgs = { tok, tokens, idx, info, openingLine, renderDefault };
+
+        const typeRenderer = fenceRenderers[info];
+        if (typeRenderer) return typeRenderer(args);
+
+        // Runnable fences render a toolbar (▶ run + collapse) only when the
+        // source line is known; otherwise they fall through to the default
+        // code-block wrapper.
+        if (RUNNABLE_LANGUAGE_SET.has(info) && openingLine !== null) {
+            return renderRunnableFence(args, openingLine);
+        }
+        return renderDefaultFence(args);
+    };
+}

--- a/src/renderer/lib/preview/markdown-config.ts
+++ b/src/renderer/lib/preview/markdown-config.ts
@@ -23,48 +23,14 @@ import { installDoiAutolink } from '../../../shared/markdown/doi-plugin';
 import { installHighlight } from '../../../shared/markdown/highlight-plugin';
 import { installCallouts } from '../markdown/callout-plugin';
 import { installWikiLinks, installNoteTags, installTransclusions } from '../markdown/inline-tokens-plugin';
-import { renderYouTubeFence } from '../markdown/youtube-embed';
-import { detectDataSource } from '../../../shared/vega/data-binding';
-import { slugify } from '../../../shared/slug';
+import { installAnchors } from '../markdown/anchor-plugin';
+import { installFences } from '../markdown/fence-plugin';
 import { escapeAttr } from './text';
 import { resolveRelativeImagePath } from './image-paths';
 import { mediaKind } from '../../../shared/media';
-import { RUNNABLE_LANGUAGE_SET } from '../../../shared/compute/fences';
-import { findSourceFenceBefore, renderComputeOutput } from './compute-output-render';
+import type { PreviewMarkdownDeps } from './markdown-deps';
 
-export interface PreviewMarkdownDeps {
-    /** Per-fence collapse state, keyed by the fence's opening source line.
-     *  Shared by reference so a toggle-driven re-render reflects the change. */
-    collapsedFences: Set<number>;
-    /** Per-fence running state (disables the ▶ button while a cell is in
-     *  flight). Shared by reference. */
-    runningFences: Set<number>;
-    /** The transclusion path override — set while rendering an embedded
-     *  fragment so relative image paths resolve against the embedded note. */
-    getRenderPathOverride: () => string | null;
-    /** The note being rendered (used to resolve relative image paths). */
-    getNotePath: () => string | null;
-    /** Whether a runnable fence should show its ▶ button — i.e. the host wired
-     *  `onRunCell` + `onApplyCellOutputEdit` and a note path is known. */
-    getCanRun: () => boolean;
-}
-
-// Custom fence rendering (#994). The markdown-it fence rule computes the
-// shared context (token, 1-based source line) once, then dispatches on the
-// lowercased info string via `fenceRenderers`. Runnable fences (a
-// language-set membership test) and the default code-block wrapper (the
-// fallthrough) aren't keyable by a single info string, so they're
-// dispatched explicitly after the map lookup.
-interface FenceRenderArgs {
-    tok: Token;
-    tokens: Token[];
-    idx: number;
-    info: string;
-    openingLine: number | null;
-    /** Reproduce markdown-it's built-in fence output (the highlighted code
-     *  block) — used by the runnable + default renderers. */
-    renderDefault: () => string;
-}
+export type { PreviewMarkdownDeps } from './markdown-deps';
 
 export function createPreviewMarkdown(deps: PreviewMarkdownDeps): MarkdownItInstance {
     const md = new MarkdownIt({
@@ -99,102 +65,9 @@ export function createPreviewMarkdown(deps: PreviewMarkdownDeps): MarkdownItInst
     // element into view.
     md.use(mdFootnote);
 
-    // Give every heading an id derived from its text so [[note#heading]] anchor
-    // navigation can target it. Slugs must match the indexer's convention.
-    const defaultHeadingOpen = md.renderer.rules.heading_open;
-    md.renderer.rules.heading_open = (tokens, idx, options, env, self) => {
-        const inline = tokens[idx + 1];
-        const text = inline && inline.type === 'inline' ? inline.content : '';
-        const slug = slugify(text);
-        if (slug) tokens[idx]!.attrSet('id', slug);
-        return defaultHeadingOpen
-            ? defaultHeadingOpen(tokens, idx, options, env, self)
-            : self.renderToken(tokens, idx, options);
-    };
-
-    // Watch for block-id paragraphs (`^block-id` at paragraph end) and mirror
-    // them onto the rendered <p> so [[note#^id]] scrolls can find the target.
-    const BLOCK_ID_RE = /\s*\^([\w-]+)\s*$/;
-    const defaultParagraphOpen = md.renderer.rules.paragraph_open;
-    md.renderer.rules.paragraph_open = (tokens, idx, options, env, self) => {
-        const inline = tokens[idx + 1];
-        if (inline && inline.type === 'inline') {
-            const m = inline.content.match(BLOCK_ID_RE);
-            if (m) {
-                tokens[idx]!.attrSet('id', `^${m[1]}`);
-                // Strip the marker from what renders.
-                inline.content = inline.content.replace(BLOCK_ID_RE, '');
-                if (inline.children) {
-                    for (let i = inline.children.length - 1; i >= 0; i--) {
-                        const child = inline.children[i]!;
-                        if (child.type === 'text') {
-                            const stripped = child.content.replace(BLOCK_ID_RE, '');
-                            if (stripped !== child.content) {
-                                child.content = stripped;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return defaultParagraphOpen
-            ? defaultParagraphOpen(tokens, idx, options, env, self)
-            : self.renderToken(tokens, idx, options);
-    };
-
-    // Task-list items: when a list item starts with `[ ]` or `[x]`, render a
-    // live <input type="checkbox"> and stamp `data-task-line` with the source
-    // line (from the list_item_open token's `map`) so the click handler on
-    // the preview root knows which line to flip in the editor store (#127).
-    const TASK_ITEM_RE = /^\[([ xX])\]\s/;
-    const defaultListItemOpen = md.renderer.rules.list_item_open;
-    md.renderer.rules.list_item_open = (tokens, idx, options, env, self) => {
-        // Scan forward to the first inline token inside this list item (typical
-        // structure: list_item_open → paragraph_open → inline). Stop if we hit
-        // the matching close without finding one.
-        let k = idx + 1;
-        while (k < tokens.length && tokens[k]!.type !== 'inline' && tokens[k]!.type !== 'list_item_close') k++;
-        const inlineTok = k < tokens.length && tokens[k]!.type === 'inline' ? tokens[k]! : null;
-        if (inlineTok) {
-            const m = inlineTok.content.match(TASK_ITEM_RE);
-            if (m) {
-                const checked = m[1] === 'x' || m[1] === 'X';
-                // `map[0]` is 0-indexed within whatever source was passed to
-                // `md.render` — which is the frontmatter-stripped content below.
-                // Add the env-carried offset so the checkbox's data-task-line
-                // points at the line index in the original note.
-                const rawLine = tokens[idx]!.map?.[0] ?? -1;
-                const line = rawLine >= 0 ? rawLine + ((env as { lineOffset?: number })?.lineOffset ?? 0) : -1;
-                tokens[idx]!.attrSet('data-task-line', String(line));
-                tokens[idx]!.attrJoin('class', 'task-list-item');
-                // Strip the `[ ]` prefix from the inline's aggregate content and
-                // from its first text child so the rendered output doesn't repeat it.
-                inlineTok.content = inlineTok.content.replace(TASK_ITEM_RE, '');
-                if (inlineTok.children) {
-                    for (let i = 0; i < inlineTok.children.length; i++) {
-                        const child = inlineTok.children[i]!;
-                        if (child.type === 'text') {
-                            child.content = child.content.replace(TASK_ITEM_RE, '');
-                            break;
-                        }
-                    }
-                    // Inject the checkbox as an html_inline prefix on the inline tree.
-                    // Recover the Token constructor from the inline token itself so we
-                    // don't have to deep-import `markdown-it/lib/token.mjs` (#347).
-                    const TokenCtor = inlineTok.constructor as new (
-                        type: string, tag: string, nesting: -1 | 0 | 1,
-                    ) => Token;
-                    const cb = new TokenCtor('html_inline', '', 0);
-                    cb.content = `<input type="checkbox" data-task-line="${line}"${checked ? ' checked' : ''}> `;
-                    inlineTok.children.unshift(cb);
-                }
-            }
-        }
-        return defaultListItemOpen
-            ? defaultListItemOpen(tokens, idx, options, env, self)
-            : self.renderToken(tokens, idx, options);
-    };
+    // Heading/block/task-list addressability (id-for-anchor stamping +
+    // task-checkbox rendering) — see anchor-plugin.ts.
+    installAnchors(md);
 
     // Wiki-link plugin: [[type::target|display]], [[type::target]], [[target|display]], [[target]]
     installWikiLinks(md);
@@ -250,154 +123,9 @@ export function createPreviewMarkdown(deps: PreviewMarkdownDeps): MarkdownItInst
         return `<img class="local-image" data-rel="${escapeAttr(rel)}" alt="${escapeAttr(alt)}"${title} />`;
     };
 
-    // Compute-cell output blocks (#238). A ```output fence below an executable
-    // fence carries the JSON payload the executor produced; render it as a
-    // shape-specific artifact (table / error / text / pretty JSON) rather
-    // than as a generic highlighted code block. Users editing the note in
-    // source view still see the raw JSON and can delete the block to re-run.
-    function renderOutputFence(args: FenceRenderArgs): string {
-        const source = findSourceFenceBefore(args.tokens, args.idx);
-        return renderComputeOutput(args.tok.content, source);
-    }
-
-    function renderMermaidFence(args: FenceRenderArgs): string {
-        const { tok, openingLine } = args;
-        const escaped = (tok.content ?? '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
-        // Mermaid blocks get a collapse toggle (no run — they auto-render
-        // on view) so a long diagram can be tucked away when scrolling
-        // through the rest of the note.
-        if (openingLine !== null) {
-            const isCollapsed = deps.collapsedFences.has(openingLine);
-            return `<div class="fence-block fence-mermaid${isCollapsed ? ' fence-collapsed' : ''}" data-fence-line="${openingLine}">`
-                + `<div class="fence-toolbar"><span class="fence-lang">mermaid</span>`
-                + `<button class="fence-collapse-btn" data-fence-action="collapse" type="button" title="Collapse / expand">${isCollapsed ? '▸' : '▾'}</button>`
-                + `</div>`
-                + `<div class="fence-body"><div class="mermaid-block" data-mermaid-pending="1">${escaped}</div></div>`
-                + `</div>\n`;
-        }
-        return `<div class="mermaid-block" data-mermaid-pending="1">${escaped}</div>\n`;
-    }
-
-    function renderVegaFence(args: FenceRenderArgs): string {
-        const { tok, info, openingLine } = args;
-        const escaped = (tok.content ?? '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
-        const mode = info === 'vega' ? 'full' : 'lite';
-        // Like mermaid, charts auto-render on view (no run button) but get a
-        // collapse toggle so a tall chart can be tucked away. The lazy hydrator
-        // (vega-renderer.ts) swaps the placeholder for an embedded SVG chart.
-        const block = `<div class="vega-block" data-vega-pending="1" data-vega-mode="${mode}">${escaped}</div>`;
-        // A data-bound chart (#832 — `data.sparql` etc.) gets a refresh button so
-        // the user can re-run the query after the graph changes without editing
-        // the note. Inline charts don't need it. Cheap parse — charts are few.
-        let isBound = false;
-        try {
-            isBound = detectDataSource(JSON.parse(tok.content ?? '')) !== null;
-        } catch { /* not bound */
-        }
-        if (openingLine !== null) {
-            const isCollapsed = deps.collapsedFences.has(openingLine);
-            const refreshBtn = isBound
-                ? `<button class="fence-refresh-btn" data-fence-action="refresh-vega" type="button" title="Refresh chart data">⟳</button>`
-                : '';
-            return `<div class="fence-block fence-vega${isCollapsed ? ' fence-collapsed' : ''}" data-fence-line="${openingLine}">`
-                + `<div class="fence-toolbar"><span class="fence-lang">${info}</span>`
-                + refreshBtn
-                + `<button class="fence-collapse-btn" data-fence-action="collapse" type="button" title="Collapse / expand">${isCollapsed ? '▸' : '▾'}</button>`
-                + `</div>`
-                + `<div class="fence-body">${block}</div>`
-                + `</div>\n`;
-        }
-        return `${block}\n`;
-    }
-
-    // A `youtube` fence renders a click-to-open poster card (#904) — thumbnail
-    // + ▶, opens in the browser on click. No live iframe, so no CSP change; the
-    // card is self-explanatory, so it skips the code-fence toolbar wrapper.
-    function renderYouTubeFenceCard(args: FenceRenderArgs): string {
-        return `${renderYouTubeFence(args.tok.content ?? '')}\n`;
-    }
-
-    // Runnable fences (python / sparql / sql) get a toolbar with a ▶
-    // run button (when the host wired `onRunCell` + `onApplyCellOutputEdit`)
-    // and a collapse toggle. The default highlighted-code body is
-    // wrapped inside `.fence-body` so the toggle can hide it.
-    function renderRunnableFence(args: FenceRenderArgs, openingLine: number): string {
-        const { info, renderDefault } = args;
-        const isCollapsed = deps.collapsedFences.has(openingLine);
-        const isRunning = deps.runningFences.has(openingLine);
-        const canRun = deps.getCanRun();
-        const defaultRender = renderDefault();
-        const runBtn = canRun
-            ? `<button class="fence-run-btn" data-fence-action="run" type="button" title="Run cell" ${isRunning ? 'disabled' : ''}>${isRunning ? '⋯' : '▶'}</button>`
-            : '';
-        return `<div class="fence-block fence-runnable${isCollapsed ? ' fence-collapsed' : ''}" data-fence-line="${openingLine}" data-fence-lang="${info}">`
-            + `<div class="fence-toolbar">`
-            + `<span class="fence-lang">${info}</span>`
-            + runBtn
-            + `<button class="fence-collapse-btn" data-fence-action="collapse" type="button" title="Collapse / expand">${isCollapsed ? '▸' : '▾'}</button>`
-            + `</div>`
-            + `<div class="fence-body">${defaultRender}</div>`
-            + `</div>\n`;
-    }
-
-    function renderDefaultFence(args: FenceRenderArgs): string {
-        const { info, renderDefault } = args;
-        const rendered = renderDefault();
-        // Wrap non-runnable, non-mermaid fences in a code-block container
-        // carrying the language label (§8.5). Empty `info` (a bare ```)
-        // skips the wrapper so plain code blocks don't get a stray label.
-        if (info && info !== 'output') {
-            return `<div class="code-block" data-language="${info}">${rendered}</div>\n`;
-        }
-        return rendered;
-    }
-
-    const fenceRenderers: Record<string, (args: FenceRenderArgs) => string> = {
-        output: renderOutputFence,
-        mermaid: renderMermaidFence,
-        vega: renderVegaFence,
-        'vega-lite': renderVegaFence,
-        youtube: renderYouTubeFenceCard,
-    };
-
-    const defaultFence = md.renderer.rules.fence;
-    md.renderer.rules.fence = (tokens, idx, options, env, self) => {
-        const tok = tokens[idx]!;
-        const info = tok.info.trim().toLowerCase();
-        // tok.map is the [startLine, endLine] of the fence in the
-        // SOURCE-FED-TO-md.render — 0-indexed, and that source has had
-        // the YAML frontmatter stripped (see `renderContent` above).
-        // `findRunnableFences` operates on the FULL content (frontmatter
-        // intact). Add back `env.lineOffset` (the frontmatter line count)
-        // and switch to 1-based numbering so the two helpers agree on
-        // line numbers — without this the lookup in `runFenceAt` would
-        // miss every fence in any note that has frontmatter. tok.map is
-        // null when markdown-it can't determine the position (rare;
-        // toolbar falls back to "no run button").
-        const frontmatterOffset = (env as { lineOffset?: number } | undefined)?.lineOffset ?? 0;
-        const openingLine = tok.map ? tok.map[0] + 1 + frontmatterOffset : null;
-        const renderDefault = () => (defaultFence
-            ? defaultFence(tokens, idx, options, env, self)
-            : self.renderToken(tokens, idx, options));
-        const args: FenceRenderArgs = { tok, tokens, idx, info, openingLine, renderDefault };
-
-        const typeRenderer = fenceRenderers[info];
-        if (typeRenderer) return typeRenderer(args);
-
-        // Runnable fences render a toolbar (▶ run + collapse) only when the
-        // source line is known; otherwise they fall through to the default
-        // code-block wrapper.
-        if (RUNNABLE_LANGUAGE_SET.has(info) && openingLine !== null) {
-            return renderRunnableFence(args, openingLine);
-        }
-        return renderDefaultFence(args);
-    };
+    // Custom fence rendering (output blocks, mermaid, vega, youtube, runnable
+    // toolbar, default code-block wrap) — see fence-plugin.ts.
+    installFences(md, deps);
 
     // Query directive plugin: :::query-list ... :::
     md.block.ruler.before('fence', 'query_directive', (state: StateBlock, startLine: number, endLine: number, silent: boolean) => {

--- a/src/renderer/lib/preview/markdown-deps.ts
+++ b/src/renderer/lib/preview/markdown-deps.ts
@@ -1,0 +1,20 @@
+// The live component values `createPreviewMarkdown`'s renderer rules close
+// over. A leaf module (#1908) so both `markdown-config.ts` and the `install*`
+// plugins it composes (`fence-plugin.ts`) can depend on the type without
+// creating an import cycle between them.
+export interface PreviewMarkdownDeps {
+    /** Per-fence collapse state, keyed by the fence's opening source line.
+     *  Shared by reference so a toggle-driven re-render reflects the change. */
+    collapsedFences: Set<number>;
+    /** Per-fence running state (disables the ▶ button while a cell is in
+     *  flight). Shared by reference. */
+    runningFences: Set<number>;
+    /** The transclusion path override — set while rendering an embedded
+     *  fragment so relative image paths resolve against the embedded note. */
+    getRenderPathOverride: () => string | null;
+    /** The note being rendered (used to resolve relative image paths). */
+    getNotePath: () => string | null;
+    /** Whether a runnable fence should show its ▶ button — i.e. the host wired
+     *  `onRunCell` + `onApplyCellOutputEdit` and a note path is known. */
+    getCanRun: () => boolean;
+}


### PR DESCRIPTION
## Summary

Closes #1908. `createPreviewMarkdown` (`preview/markdown-config.ts`) already delegated 7 concerns to `installMath` / `installCallouts` / `installDoiAutolink` / `installHighlight` / `installWikiLinks` / `installNoteTags` / `installTransclusions`, but kept three more concerns inline: the heading/paragraph/list-item addressability rules, the six fence renderers, and the fence dispatcher.

Adds the two more `install*` functions the issue names, finishing the pattern:

- **`installAnchors(md)`** (`markdown/anchor-plugin.ts`) — `heading_open` (stamps a heading's id from its slug so `[[note#heading]]` can target it), `paragraph_open` (stamps `^block-id` markers the same way for `[[note#^id]]`), and `list_item_open` (task-checkbox rendering + `data-task-line`). None of the three need `PreviewMarkdownDeps` — matching every other `install*` function's zero-extra-arg signature.
- **`installFences(md, deps)`** (`markdown/fence-plugin.ts`) — the six fence renderers (output / mermaid / vega / vega-lite / youtube / runnable / default) plus the dispatcher. Needs `deps` (the collapse/running fence sets, the run-button gate), so its signature carries a second argument — matching the issue's own written signature for this one.

The image rule and the `:::query-…` block directive stay inline: the issue's own written signatures (`installFences(md, deps)` but `installAnchors(md)` — no deps) rule out folding the deps-needing image rule into `installAnchors`, and neither is named in the success criteria.

## The import-cycle wrinkle

Moved `PreviewMarkdownDeps` into its own leaf module, `preview/markdown-deps.ts`, rather than leaving it defined in `markdown-config.ts` where it originated. `fence-plugin.ts` needs the type, and `markdown-config.ts` needs `installFences` from `fence-plugin.ts` — a type import back into `markdown-config.ts` for the type would have created a genuine import cycle, caught by `tests/architecture/no-cycles.test.ts` (which doesn't special-case `import type` — the cycle exists in the module graph even though the type itself is erased at build time). `markdown-config.ts` re-exports the type from its original path so the two existing test files that import it from there (`markdown-config.test.ts`, `sanitize-note-html.test.ts`) are unaffected.

## Result

`createPreviewMarkdown` goes from 402 lines of inline logic to composition: 7 existing `install*` calls + 2 new ones + the image rule + the query directive. `markdown-config.ts` itself: 470 → 198 lines.

## Test plan

- [x] `pnpm lint` passes (`tsc`, `svelte-check`, `eslint`, including the import-cycle architecture test)
- [x] `markdown-config.test.ts` + `hydrate.test.ts` — 106 tests pass **unchanged**, per the issue's success criteria
- [x] `pnpm test` — 643 test files / 6986 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)