### PR TITLE
docs: record design decision — draft-kind family stays per-kind

### DIFF
--- a/src/shared/conversation-draft-base.ts
+++ b/src/shared/conversation-draft-base.ts
@@ -37,3 +37,66 @@ export interface ConversationToolDraft extends ConversationDraftBase {
    *  shown on the card header. */
   note: string;
 }
+
+/**
+ * Design decision (#1911): the draft-kind family stays as nine explicit
+ * channel pairs, not one parameterised pair. Recorded here because this file
+ * is the "half-built discriminant" the issue pointed at — the base type
+ * exists; the decision below is why it was never carried further into a
+ * generic dispatch.
+ *
+ * What's actually duplicated across the five layers (21 channel constants,
+ * matching `ChannelMap`/`EventMap` entries, ~19 preload passthroughs, the
+ * client interface, 11 main-process handlers, 9 approve + 9 discard store
+ * functions) was already measured and split into two categories before this
+ * issue was picked up:
+ *
+ *  - **Genuinely repeated LOGIC** — "file a write proposal and immediately
+ *    approve it" (main process) and "call the API, and on success drop the
+ *    card" (renderer store) — was real duplication and got extracted:
+ *    `fileAndApprove()` in `main/ipc/register-conversation-drafts.ts` (#1895)
+ *    and `approveFrom()` / `discardFrom()` in `stores/conversations.svelte.ts`
+ *    (#1896). That closed the actual repeated-logic gap.
+ *  - **What's left is mechanical SHAPE, not logic** — one channel constant,
+ *    one `ChannelMap` entry, one preload passthrough (literally
+ *    `x: (draft) => invoke(Channels.X, draft)`), one client interface method,
+ *    per kind. Each is one line, fully type-checked end-to-end via
+ *    `Parameters<ChannelMap[K]>`, and already about as low-risk as IPC wiring
+ *    gets.
+ *
+ * Collapsing the remaining shape into one `kind`-discriminated channel pair
+ * was evaluated and rejected:
+ *
+ *  1. It doesn't fit the same "no generic `<Payload, Outcome>`" reasoning
+ *     this file already recorded for the TYPE layer (#1090, above) — the
+ *     payload-construction logic inside each main-process handler and each
+ *     store approve function genuinely differs per kind (different
+ *     validation, different side effects, different result shapes), and
+ *     compute doesn't even follow the "approve" shape at all — it has RUN
+ *     and INSERT, not a single approve verb. A parameterised channel would
+ *     still need a `switch` dispatching to ~9 distinct implementations
+ *     inside one handler, which is strictly less legible than 9 separate,
+ *     independently-readable `handle()` registrations — not a reduction in
+ *     real complexity, just a relocation of it.
+ *  2. Preserving per-kind type safety through a single generic channel
+ *     requires either a call signature generic over a runtime `kind`
+ *     argument (unlike every other entry in `ChannelMap`, and real added
+ *     complexity to save four one-line entries) or a loosely-typed payload
+ *     narrowed at runtime — which is exactly the "weaken per-kind type
+ *     safety at the approval boundary" outcome the issue itself warned
+ *     against.
+ *  3. This is the LLM approve-and-apply surface (the Trust Principle's
+ *     enforcement point). Explicit per-kind channels are independently
+ *     greppable ("does `CONVERSATION_FILE_CLAIMS_DRAFT` reach
+ *     `approveProposal`? — right there") and independently testable (see
+ *     `tests/main/ipc/register-conversation-drafts.test.ts`, #1900). A bug in
+ *     a shared dispatch table would risk all nine kinds at once instead of
+ *     staying isolated to one — a worse failure mode at a trust boundary than
+ *     the file-count cost of the status quo.
+ *
+ * Net: status quo. Adding a tenth draft kind still touches on the order of
+ * five to seven files, but — thanks to #1895/#1896 — each touch is now a
+ * single obvious line rather than hand-copied logic. The ≤2-file target this
+ * issue posed was evaluated and knowingly not adopted; auditability at the
+ * approval boundary outweighs the file-count reduction here.
+ */


### PR DESCRIPTION
## Summary

Closes #1911. This issue explicitly asked for a **recorded design decision** — parameterised channel pair vs. status quo — not a mechanical sweep, and flagged the real risk clearly: this is the LLM approve-and-apply surface, so "a parameterised channel must not weaken per-kind type safety at the approval boundary."

**Decision: status quo.** Full rationale recorded in `src/shared/conversation-draft-base.ts` — the file the issue itself pointed at as "the half-built discriminant," and which already carried a directly analogous prior decision (rejecting a generic `<Payload, Outcome>` shape at the *type* layer, #1090).

## Why

Two things needed distinguishing, and conflating them is what made "seven-file change" look worse than it now is:

1. **Genuinely repeated LOGIC** — "file a write proposal and immediately approve it" (main process) and "call the API, and on success drop the card" (renderer store) — was real duplication, and it was already extracted *in this same effort, before this issue was picked up*: `fileAndApprove()` (#1895) and `approveFrom()`/`discardFrom()` (#1896).
2. **What's left across the five layers is mechanical SHAPE, not logic** — one channel constant, one `ChannelMap`/`EventMap` entry, one preload passthrough (literally `x: (draft) => invoke(Channels.X, draft)`), one client interface method, per kind. Each is one line and already fully type-checked end-to-end.

Collapsing that remaining shape into one `kind`-discriminated channel pair was evaluated and rejected:

- The per-kind payload-construction logic inside each handler/store function genuinely differs (different validation, different side effects, different result shapes) — and **compute doesn't even follow the "approve" shape at all** (it has RUN and INSERT, not one approve verb). A parameterised channel would still need a 9-way `switch` dispatching to distinct implementations inside one handler — a relocation of complexity, not a reduction.
- Preserving type safety through it requires either a call signature generic over a *runtime* `kind` argument (unlike every other `ChannelMap` entry, real complexity to save four one-line entries) or a loosely-typed payload narrowed at runtime — exactly the "weaken per-kind type safety" outcome the issue warned against.
- At the Trust Principle's enforcement point specifically, explicit per-kind channels are independently greppable ("does `CONVERSATION_FILE_CLAIMS_DRAFT` reach `approveProposal`? — right there") and independently testable (`register-conversation-drafts.test.ts`, #1900). A bug in a shared dispatch table risks all nine kinds at once instead of staying isolated to one.

Net: adding a tenth draft kind still touches on the order of five to seven files, but each touch is now a single obvious line rather than hand-copied logic, thanks to #1895/#1896. The ≤2-file target was evaluated and knowingly not adopted — auditability at the approval boundary outweighs the file-count reduction here.

## Test plan

- [x] No code changes — documentation only.
- [x] `pnpm lint` passes
- [x] `pnpm test` — 644 test files / 6996 tests pass, unchanged
- [x] Trust-path tests specifically verified: `register-conversation-drafts.test.ts` + `register-conversation-drafts-write-guard.test.ts` + `trust-integrity.test.ts` — 44 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)