### PR TITLE
fix: fan out sources/collections/excerpts changes to every window (#1916)

### DIFF
--- a/src/main/ipc/helpers.ts
+++ b/src/main/ipc/helpers.ts
@@ -160,6 +160,36 @@ export function broadcastInspectionsChanged(rootPath: string): void {
   }
 }
 
+/**
+ * Broadcast that `rootPath`'s source list changed (#1916). `register-sources.ts`
+ * used to target only the invoking window (`broadcast(win, …)`), so with two
+ * windows open on one thoughtbase, window B's Sources panel silently went
+ * stale after a mutation made in window A. Every other domain's broadcast
+ * (notes, proposals, history, inspections above) already fans out via
+ * `windowsForProject`; this brings sources/excerpts/collections in line.
+ */
+export function broadcastSourcesChanged(rootPath: string): void {
+  for (const targetWin of windowsForProject(rootPath)) {
+    broadcast(targetWin, Channels.SOURCES_CHANGED);
+  }
+}
+
+/** Broadcast that `rootPath`'s excerpts changed (#1916) — see
+ *  {@link broadcastSourcesChanged}. */
+export function broadcastExcerptsChanged(rootPath: string): void {
+  for (const targetWin of windowsForProject(rootPath)) {
+    broadcast(targetWin, Channels.EXCERPTS_CHANGED);
+  }
+}
+
+/** Broadcast that `rootPath`'s collections changed (#1916) — see
+ *  {@link broadcastSourcesChanged}. */
+export function broadcastCollectionsChanged(rootPath: string): void {
+  for (const targetWin of windowsForProject(rootPath)) {
+    broadcast(targetWin, Channels.COLLECTIONS_CHANGED);
+  }
+}
+
 export const hooks: WritePipelineHooks = {
   markPathHandled,
   broadcastRewritten,

--- a/src/main/ipc/register-sources.ts
+++ b/src/main/ipc/register-sources.ts
@@ -1,4 +1,4 @@
-import { dialog, BrowserWindow } from 'electron';
+import { dialog } from 'electron';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Channels } from '../../shared/channels';
@@ -40,8 +40,29 @@ import { importBibtex } from '../sources/import-bibtex';
 import { importZoteroRdf } from '../sources/import-zotero-rdf';
 import { getExcerptNoteFolder, setExcerptNoteFolder } from '../project-config';
 import { createExcerpt } from '../sources/create-excerpt';
-import { withRootPath, withRootPathOr, withRootPathWin, reindexFile, persistIndexes } from './helpers';
+import {
+  withRootPath, withRootPathOr, withRootPathWin, reindexFile, persistIndexes,
+  broadcastSourcesChanged, broadcastExcerptsChanged, broadcastCollectionsChanged,
+} from './helpers';
 import { handle } from './typed-ipc';
+
+/**
+ * Wraps a source-mutating handler (#1916): runs `fn`, reindexes, then
+ * broadcasts SOURCES_CHANGED to every window on the project — not just the
+ * one that made the change (see {@link broadcastSourcesChanged}). Collapses
+ * what used to be six handlers of identical
+ * mutate → persistIndexes → broadcast shape.
+ */
+function withSourceMutation<A extends unknown[], R>(
+  fn: (rootPath: string, ...args: A) => Promise<R>,
+): (e: Electron.IpcMainInvokeEvent, ...args: A) => Promise<R> {
+  return withRootPath(async (rootPath, ...args: A) => {
+    const result = await fn(rootPath, ...args);
+    await persistIndexes(rootPath);
+    broadcastSourcesChanged(rootPath);
+    return result;
+  });
+}
 
 export function registerSources(): void {
   handle(Channels.SOURCES_INGEST_URL, withRootPath(async (rootPath, url: string) => {
@@ -72,21 +93,15 @@ export function registerSources(): void {
     return await mineSourceReferences(rootPath, sourceId);
   }));
 
-  handle(Channels.SOURCES_CREATE_REFERENCE_STUBS, withRootPathWin(async (rootPath, win, params: { sourceId: string; refs: ParsedReference[] }) => {
-    const result = await createReferenceStubs(rootPath, params.sourceId, params.refs);
-    await persistIndexes(rootPath);
-    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
-    return result;
-  }));
+  handle(Channels.SOURCES_CREATE_REFERENCE_STUBS, withSourceMutation((rootPath, params: { sourceId: string; refs: ParsedReference[] }) =>
+    createReferenceStubs(rootPath, params.sourceId, params.refs)));
 
   handle(Channels.SOURCES_RESOLVE_STUB, withRootPath(async (rootPath, sourceId: string) => {
     return await resolveStub(rootPath, sourceId, { fetchImpl: privilegedFetch });
   }));
 
-  handle(Channels.SOURCES_APPLY_STUB_RESOLUTION, withRootPathWin(async (rootPath, win, params: { sourceId: string; doi: string }) => {
+  handle(Channels.SOURCES_APPLY_STUB_RESOLUTION, withSourceMutation(async (rootPath, params: { sourceId: string; doi: string }) => {
     const ok = await applyStubResolution(rootPath, params.sourceId, params.doi, { fetchImpl: privilegedFetch });
-    await persistIndexes(rootPath);
-    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
     return { ok };
   }));
 
@@ -180,34 +195,28 @@ export function registerSources(): void {
   // Finalise a scanned-PDF ingest: the renderer has run OCR and hands
   // back the per-page text. We rewrite body.md + stamp meta.ttl with
   // extractionMethod "ocr" (#95).
-  handle(Channels.SOURCES_FINISH_PDF_OCR, withRootPathWin(async (rootPath, win, sourceId: string, pages: string[]) => {
+  handle(Channels.SOURCES_FINISH_PDF_OCR, withSourceMutation(async (rootPath, sourceId: string, pages: string[]) => {
     await finishPdfOcrIngest(rootPath, sourceId, pages);
     await reindexFile(rootPath, `.minerva/sources/${sourceId}/meta.ttl`);
-    await persistIndexes(rootPath);
-    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
   }));
 
   handle(Channels.SOURCES_LIST_ALL, withRootPathOr([], (rootPath) =>
     graph.listAllSources(projectContext(rootPath))));
 
-  handle(Channels.SOURCES_DELETE, withRootPathWin(async (rootPath, win, sourceId: string) => {
+  handle(Channels.SOURCES_DELETE, withRootPath(async (rootPath, sourceId: string) => {
     const result = await deleteSource(rootPath, sourceId);
     await persistIndexes(rootPath);
-    if (!win.isDestroyed()) {
-      broadcast(win, Channels.SOURCES_CHANGED);
-      broadcast(win, Channels.EXCERPTS_CHANGED);
-    }
+    broadcastSourcesChanged(rootPath);
+    broadcastExcerptsChanged(rootPath);
     return result;
   }));
 
-  handle(Channels.SOURCES_MERGE, withRootPathWin(async (rootPath, win, params: { srcId: string; destId: string }) => {
+  handle(Channels.SOURCES_MERGE, withRootPath(async (rootPath, params: { srcId: string; destId: string }) => {
     try {
       const result = await mergeSources(rootPath, params.srcId, params.destId);
       await persistIndexes(rootPath);
-      if (!win.isDestroyed()) {
-        broadcast(win, Channels.SOURCES_CHANGED);
-        broadcast(win, Channels.EXCERPTS_CHANGED);
-      }
+      broadcastSourcesChanged(rootPath);
+      broadcastExcerptsChanged(rootPath);
       return result;
     } catch (err) {
       if (err instanceof MergeSourcesError) {
@@ -222,42 +231,25 @@ export function registerSources(): void {
   }));
 
   // ── Reading queue (#116) ──────────────────────────────────────────────────
-  handle(Channels.SOURCES_SET_READ_STATUS, withRootPathWin(async (rootPath, win, params: { sourceId: string; status: ReadStatus | null }) => {
-    await setSourceReadStatus(rootPath, params.sourceId, params.status);
-    await persistIndexes(rootPath);
-    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
-  }));
+  handle(Channels.SOURCES_SET_READ_STATUS, withSourceMutation((rootPath, params: { sourceId: string; status: ReadStatus | null }) =>
+    setSourceReadStatus(rootPath, params.sourceId, params.status)));
 
-  handle(Channels.SOURCES_SET_TITLE, withRootPathWin(async (rootPath, win, params: { sourceId: string; title: string }) => {
-    await setSourceTitle(rootPath, params.sourceId, params.title);
-    await persistIndexes(rootPath);
-    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
-  }));
+  handle(Channels.SOURCES_SET_TITLE, withSourceMutation((rootPath, params: { sourceId: string; title: string }) =>
+    setSourceTitle(rootPath, params.sourceId, params.title)));
 
-  handle(Channels.SOURCES_ADD_TAG, withRootPathWin(async (rootPath, win, params: { sourceId: string; tag: string }) => {
+  handle(Channels.SOURCES_ADD_TAG, withSourceMutation(async (rootPath, params: { sourceId: string; tag: string }) => {
     await addSourceTag(rootPath, params.sourceId, params.tag);
-    await persistIndexes(rootPath);
-    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
   }));
 
-  handle(Channels.SOURCES_REMOVE_TAG, withRootPathWin(async (rootPath, win, params: { sourceId: string; tag: string }) => {
+  handle(Channels.SOURCES_REMOVE_TAG, withSourceMutation(async (rootPath, params: { sourceId: string; tag: string }) => {
     await removeSourceTag(rootPath, params.sourceId, params.tag);
-    await persistIndexes(rootPath);
-    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
   }));
 
-  handle(Channels.SOURCES_SET_READ_DUE_BY, withRootPathWin(async (rootPath, win, params: { sourceId: string; dueBy: string | null }) => {
-    await setSourceReadDueBy(rootPath, params.sourceId, params.dueBy);
-    await persistIndexes(rootPath);
-    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
-  }));
+  handle(Channels.SOURCES_SET_READ_DUE_BY, withSourceMutation((rootPath, params: { sourceId: string; dueBy: string | null }) =>
+    setSourceReadDueBy(rootPath, params.sourceId, params.dueBy)));
 
-  handle(Channels.SOURCES_STRIP_UPSTREAM_TAGS, withRootPathWin(async (rootPath, win, sourceId: string) => {
-    const result = await stripUpstreamTags(rootPath, sourceId);
-    await persistIndexes(rootPath);
-    if (!win.isDestroyed()) broadcast(win, Channels.SOURCES_CHANGED);
-    return result;
-  }));
+  handle(Channels.SOURCES_STRIP_UPSTREAM_TAGS, withSourceMutation((rootPath, sourceId: string) =>
+    stripUpstreamTags(rootPath, sourceId)));
 
   handle(Channels.SOURCES_QUEUE_MEMBERS, withRootPathOr([], (rootPath, view: ReadingQueueView) => {
     const ctx = projectContext(rootPath);
@@ -267,59 +259,55 @@ export function registerSources(): void {
   }));
 
   // ── Collections (#470) ────────────────────────────────────────────────────
-  const broadcastCollectionsChanged = (win: BrowserWindow) => {
-    if (!win.isDestroyed()) broadcast(win, Channels.COLLECTIONS_CHANGED);
-  };
-
   handle(Channels.COLLECTIONS_LIST, withRootPathOr<[], { collections: never[] } | Promise<CollectionsFile>>({ collections: [] }, async (rootPath) => {
     return await loadCollections(rootPath);
   }));
 
-  handle(Channels.COLLECTIONS_CREATE, withRootPathWin(async (rootPath, win, args: { name: string; parent?: string | null }) => {
+  handle(Channels.COLLECTIONS_CREATE, withRootPath(async (rootPath, args: { name: string; parent?: string | null }) => {
     const result = await createCollection(rootPath, args);
-    broadcastCollectionsChanged(win);
+    broadcastCollectionsChanged(rootPath);
     return result;
   }));
 
-  handle(Channels.COLLECTIONS_RENAME, withRootPathWin(async (rootPath, win, args: { id: string; name: string }) => {
+  handle(Channels.COLLECTIONS_RENAME, withRootPath(async (rootPath, args: { id: string; name: string }) => {
     await renameCollection(rootPath, args.id, args.name);
-    broadcastCollectionsChanged(win);
+    broadcastCollectionsChanged(rootPath);
   }));
 
-  handle(Channels.COLLECTIONS_DELETE, withRootPathWin(async (rootPath, win, id: string) => {
+  handle(Channels.COLLECTIONS_DELETE, withRootPath(async (rootPath, id: string) => {
     await deleteCollection(rootPath, id);
-    broadcastCollectionsChanged(win);
+    broadcastCollectionsChanged(rootPath);
   }));
 
-  handle(Channels.COLLECTIONS_ADD_SOURCE, withRootPathWin(async (rootPath, win, args: { collectionId: string; sourceId: string }) => {
+  handle(Channels.COLLECTIONS_ADD_SOURCE, withRootPath(async (rootPath, args: { collectionId: string; sourceId: string }) => {
     await addSourceToCollection(rootPath, args.collectionId, args.sourceId);
-    broadcastCollectionsChanged(win);
+    broadcastCollectionsChanged(rootPath);
   }));
 
-  handle(Channels.COLLECTIONS_REMOVE_SOURCE, withRootPathWin(async (rootPath, win, args: { collectionId: string; sourceId: string }) => {
+  handle(Channels.COLLECTIONS_REMOVE_SOURCE, withRootPath(async (rootPath, args: { collectionId: string; sourceId: string }) => {
     await removeSourceFromCollection(rootPath, args.collectionId, args.sourceId);
-    broadcastCollectionsChanged(win);
+    broadcastCollectionsChanged(rootPath);
   }));
 
-  handle(Channels.COLLECTIONS_CREATE_SMART, withRootPathWin(async (rootPath, win, args: { name: string; predicate: SmartCollectionPredicate }) => {
+  handle(Channels.COLLECTIONS_CREATE_SMART, withRootPath(async (rootPath, args: { name: string; predicate: SmartCollectionPredicate }) => {
     const result = await createSmartCollection(rootPath, args);
-    broadcastCollectionsChanged(win);
+    broadcastCollectionsChanged(rootPath);
     return result;
   }));
 
-  handle(Channels.COLLECTIONS_RENAME_SMART, withRootPathWin(async (rootPath, win, args: { id: string; name: string }) => {
+  handle(Channels.COLLECTIONS_RENAME_SMART, withRootPath(async (rootPath, args: { id: string; name: string }) => {
     await renameSmartCollection(rootPath, args.id, args.name);
-    broadcastCollectionsChanged(win);
+    broadcastCollectionsChanged(rootPath);
   }));
 
-  handle(Channels.COLLECTIONS_DELETE_SMART, withRootPathWin(async (rootPath, win, id: string) => {
+  handle(Channels.COLLECTIONS_DELETE_SMART, withRootPath(async (rootPath, id: string) => {
     await deleteSmartCollection(rootPath, id);
-    broadcastCollectionsChanged(win);
+    broadcastCollectionsChanged(rootPath);
   }));
 
-  handle(Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, withRootPathWin(async (rootPath, win, args: { id: string; predicate: SmartCollectionPredicate }) => {
+  handle(Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, withRootPath(async (rootPath, args: { id: string; predicate: SmartCollectionPredicate }) => {
     await updateSmartCollectionPredicate(rootPath, args.id, args.predicate);
-    broadcastCollectionsChanged(win);
+    broadcastCollectionsChanged(rootPath);
   }));
 
   handle(Channels.COLLECTIONS_SMART_MEMBERS, withRootPathOr<[string], SourceMetadata[] | Promise<SourceMetadata[]>>([], async (rootPath, id: string) => {

--- a/tests/main/ipc/helpers.test.ts
+++ b/tests/main/ipc/helpers.test.ts
@@ -95,6 +95,9 @@ import {
   broadcastProposalsChanged,
   broadcastHistoryChanged,
   broadcastInspectionsChanged,
+  broadcastSourcesChanged,
+  broadcastExcerptsChanged,
+  broadcastCollectionsChanged,
   hooks,
   readJsonFileOr,
 } from '../../../src/main/ipc/helpers';
@@ -356,12 +359,41 @@ describe('broadcasts — fan out to every window on the project', () => {
     expect(win.webContents.send).toHaveBeenCalledWith(Channels.INSPECTIONS_CHANGED);
   });
 
+  // #1916: register-sources.ts used to broadcast SOURCES_CHANGED / EXCERPTS_CHANGED
+  // / COLLECTIONS_CHANGED to the invoking window only — with two windows open on
+  // one thoughtbase, a mutation in window A never reached window B, which sat
+  // stale until reopened. These three route through the same `windowsForProject`
+  // fan-out as every broadcast above; this is the regression test.
+  it('broadcastSourcesChanged reaches every window on the project, not just the one that mutated', () => {
+    broadcastSourcesChanged('/vault');
+    for (const w of [win, otherWin]) {
+      expect(w.webContents.send).toHaveBeenCalledWith(Channels.SOURCES_CHANGED);
+    }
+  });
+
+  it('broadcastExcerptsChanged reaches every window on the project', () => {
+    broadcastExcerptsChanged('/vault');
+    for (const w of [win, otherWin]) {
+      expect(w.webContents.send).toHaveBeenCalledWith(Channels.EXCERPTS_CHANGED);
+    }
+  });
+
+  it('broadcastCollectionsChanged reaches every window on the project', () => {
+    broadcastCollectionsChanged('/vault');
+    for (const w of [win, otherWin]) {
+      expect(w.webContents.send).toHaveBeenCalledWith(Channels.COLLECTIONS_CHANGED);
+    }
+  });
+
   it('a project with no open windows is a silent no-op, not a crash', () => {
     registry.windows = [];
     expect(() => {
       broadcastRewritten('/vault', ['notes/a.md']);
       broadcastProposalsChanged('/vault');
       broadcastInspectionsChanged('/vault');
+      broadcastSourcesChanged('/vault');
+      broadcastExcerptsChanged('/vault');
+      broadcastCollectionsChanged('/vault');
     }).not.toThrow();
   });
 });

--- a/tests/main/ipc/register-sources.test.ts
+++ b/tests/main/ipc/register-sources.test.ts
@@ -1,21 +1,26 @@
 /**
  * @vitest-environment node
  *
- * Main-process coverage for `register-sources.ts` (#1840).
+ * Main-process coverage for `register-sources.ts` (#1840, fan-out fixed #1916).
  *
  * At 343 lines this was the largest remaining untested registrar, and the one
  * with the most repetition: a dozen source mutations that all have to
- * `persistIndexes` and then broadcast `SOURCES_CHANGED` to a window that may
- * already have closed. Copy-paste is exactly where one of those steps goes
- * missing, so the repeated contract is asserted for every handler via a table
- * rather than trusted to review.
+ * `persistIndexes` and then announce the change. Copy-paste is exactly where
+ * one of those steps goes missing, so the repeated contract is asserted for
+ * every handler via a table rather than trusted to review.
  *
  * Beyond that it pins the parts with real logic:
  *
  *   - the #1631 project guard on every handler — throw vs each fallback's own
  *     legitimate empty value;
- *   - a closed window is never sent to: `isDestroyed()` is checked AFTER the
- *     await, which is the only reason that check exists at all;
+ *   - every mutation announces itself via `broadcastSourcesChanged` /
+ *     `broadcastExcerptsChanged` / `broadcastCollectionsChanged` (#1916) —
+ *     ONE per rootPath, fanned out to every window on the project, not just
+ *     the invoking one. The fan-out mechanism itself (multiple windows, a
+ *     destroyed one excluded) is `helpers.ts`'s job and is pinned in
+ *     `helpers.test.ts`; what matters here is that each handler calls the
+ *     right broadcast function, with the right rootPath, after the mutation
+ *     lands — not before, and not on failure;
  *   - `SOURCES_MERGE` carries a `MergeSourcesError`'s structured `code` across
  *     the IPC boundary (a plain rethrow loses it and the UI can no longer tell
  *     "you picked the same source twice" from a crash) while any other error
@@ -26,6 +31,11 @@
  *   - the reading-queue / smart-collection membership filters short-circuit
  *     instead of listing every source in the thoughtbase to intersect against
  *     an empty set.
+ *
+ * The BibTeX/Zotero import progress channels are unrelated to #1916 — they're
+ * per-operation progress for the window that opened the file picker, not a
+ * "something changed" signal other windows need, so they still target `win`
+ * directly and still check `isDestroyed()` themselves.
  *
  * `withRootPath*` are re-implemented in the helpers mock with the real
  * semantics (helpers.ts drags in electron + graph/search/vectors, so it can't
@@ -107,6 +117,9 @@ const h = vi.hoisted(() => {
     // helpers
     reindexFile: vi.fn(),
     persistIndexes: vi.fn(),
+    broadcastSourcesChanged: vi.fn(),
+    broadcastExcerptsChanged: vi.fn(),
+    broadcastCollectionsChanged: vi.fn(),
     // call-order log — ordering is load-bearing in the ingest/OCR handlers
     order: [] as string[],
   };
@@ -138,6 +151,9 @@ vi.mock('../../../src/main/ipc/helpers', () => ({
       },
   reindexFile: h.reindexFile,
   persistIndexes: h.persistIndexes,
+  broadcastSourcesChanged: h.broadcastSourcesChanged,
+  broadcastExcerptsChanged: h.broadcastExcerptsChanged,
+  broadcastCollectionsChanged: h.broadcastCollectionsChanged,
 }));
 
 vi.mock('../../../src/main/privileged-sites', () => ({ privilegedFetch: h.privilegedFetch }));
@@ -210,8 +226,24 @@ const call = (channel: string, ...args: unknown[]): unknown => h.handlers.get(ch
 /** Await a handler's answer whether it replied synchronously or with a promise. */
 const callAsync = (channel: string, ...args: unknown[]): Promise<unknown> =>
   Promise.resolve(call(channel, ...args));
-/** Every channel the handler broadcast to the project's window, in order. */
-const sent = (): unknown[] => h.win.webContents.send.mock.calls.map((c) => c[0]);
+/**
+ * Every "something changed" channel the handler announced, in call order
+ * (#1916 — these go through `broadcastSourcesChanged`/`broadcastExcerptsChanged`/
+ * `broadcastCollectionsChanged` now, each a separate mock, so ordering across
+ * them is reconstructed from vitest's own invocation-order counters rather
+ * than a single shared `webContents.send` log).
+ */
+const sent = (): unknown[] => {
+  const marks: Array<{ order: number; channel: string }> = [];
+  for (const [channel, fn] of [
+    [Channels.SOURCES_CHANGED, h.broadcastSourcesChanged],
+    [Channels.EXCERPTS_CHANGED, h.broadcastExcerptsChanged],
+    [Channels.COLLECTIONS_CHANGED, h.broadcastCollectionsChanged],
+  ] as const) {
+    for (const order of fn.mock.invocationCallOrder) marks.push({ order, channel });
+  }
+  return marks.sort((a, b) => a.order - b.order).map((m) => m.channel);
+};
 /** The ProjectContext the registrar builds from the root path. */
 const CTX = { rootPath: ROOT, _brand: 'ProjectContext' };
 
@@ -351,20 +383,15 @@ describe('register-sources — mutations persist their indexes and announce them
     [Channels.SOURCES_APPLY_STUB_RESOLUTION, [{ sourceId: 's1', doi: '10.1/x' }], () => { h.applyStubResolution.mockResolvedValue(true); }],
   ];
 
-  it.each(mutations)('%s persists the indexes and tells the window', async (channel, args, arrange) => {
+  it.each(mutations)('%s persists the indexes and announces the change by rootPath', async (channel, args, arrange) => {
     arrange();
     await callAsync(channel, ...args);
     expect(h.persistIndexes).toHaveBeenCalledWith(ROOT);
     expect(sent()).toContain(Channels.SOURCES_CHANGED);
-  });
-
-  it.each(mutations)('%s sends nothing to a window that closed mid-write', async (channel, args, arrange) => {
-    // `isDestroyed()` is checked after the await precisely because the user can
-    // close the window while the write is in flight; sending then throws.
-    arrange();
-    h.win.isDestroyed.mockReturnValue(true);
-    await callAsync(channel, ...args);
-    expect(h.win.webContents.send).not.toHaveBeenCalled();
+    // #1916: announced by rootPath (fans out to every window on the project),
+    // not the invoking window — the bug was targeting `win` directly, which
+    // left every OTHER window on the same thoughtbase stale.
+    expect(h.broadcastSourcesChanged).toHaveBeenCalledWith(ROOT);
   });
 
   it('SOURCES_DELETE also refreshes the excerpt panels — its excerpts went with it', async () => {
@@ -422,7 +449,7 @@ describe('register-sources — mutations persist their indexes and announce them
     h.setSourceTitle.mockRejectedValue(new Error('EACCES'));
     await expect(callAsync(Channels.SOURCES_SET_TITLE, { sourceId: 's1', title: 'T' })).rejects.toThrow('EACCES');
     expect(h.persistIndexes).not.toHaveBeenCalled();
-    expect(h.win.webContents.send).not.toHaveBeenCalled();
+    expect(sent()).toEqual([]);
   });
 });
 
@@ -444,7 +471,7 @@ describe('register-sources — SOURCES_MERGE error translation', () => {
     h.mergeSources.mockRejectedValue(new h.MergeSourcesError('no such source', 'not-found'));
     await expect(callAsync(Channels.SOURCES_MERGE, { srcId: 'a', destId: 'b' })).rejects.toThrow('no such source');
     expect(h.persistIndexes).not.toHaveBeenCalled();
-    expect(h.win.webContents.send).not.toHaveBeenCalled();
+    expect(sent()).toEqual([]);
   });
 
   it('lets a genuine crash through untouched', async () => {
@@ -678,17 +705,12 @@ describe('register-sources — collections', () => {
     [Channels.COLLECTIONS_UPDATE_SMART_PREDICATE, [{ id: 'sc1', predicate: { kind: 'tags', allOf: ['x'] } }], () => {}],
   ];
 
-  it.each(collectionMutations)('%s tells the sidebar the collections changed', async (channel, args, arrange) => {
+  it.each(collectionMutations)('%s announces the change by rootPath, to every window on the project', async (channel, args, arrange) => {
     arrange();
     await callAsync(channel, ...args);
     expect(sent()).toEqual([Channels.COLLECTIONS_CHANGED]);
-  });
-
-  it.each(collectionMutations)('%s sends nothing to a window that closed mid-write', async (channel, args, arrange) => {
-    arrange();
-    h.win.isDestroyed.mockReturnValue(true);
-    await callAsync(channel, ...args);
-    expect(h.win.webContents.send).not.toHaveBeenCalled();
+    // #1916: by rootPath, same as the source mutations above — not `win`.
+    expect(h.broadcastCollectionsChanged).toHaveBeenCalledWith(ROOT);
   });
 
   it('collection edits do not touch the source indexes', async () => {


### PR DESCRIPTION
## Summary

Closes #1916. `register-sources.ts` broadcast `SOURCES_CHANGED`,
`EXCERPTS_CHANGED`, and `COLLECTIONS_CHANGED` to the invoking window only
(`broadcast(win, ...)`), unlike every other domain (notes, proposals, history,
inspections), which already fan out via `windowsForProject(rootPath)` in
`helpers.ts`. **Symptom:** with two windows open on one thoughtbase, a
mutation made in window A never reached window B, which sat stale until
reopened.

Added `broadcastSourcesChanged`/`broadcastExcerptsChanged`/`broadcastCollectionsChanged`
to `helpers.ts`, matching the existing `broadcastRewritten`/`broadcastProposalsChanged`
pattern exactly, and routed every source/collection mutation through them.

- Added `withSourceMutation(fn)` — runs `fn`, persists indexes, then
  `broadcastSourcesChanged(rootPath)`. This collapses what the issue counted
  as six byte-identical handlers — actually **nine** once
  `SOURCES_CREATE_REFERENCE_STUBS`, `SOURCES_APPLY_STUB_RESOLUTION`, and
  `SOURCES_FINISH_PDF_OCR` are counted (identical shape, just not in the
  issue's line list).
- `SOURCES_DELETE` and `SOURCES_MERGE` broadcast both `SOURCES_CHANGED` and
  `EXCERPTS_CHANGED` — **also not named in the issue's line list** (it only
  cited `COLLECTIONS_CHANGED`'s definition site, not each of its 9 callers,
  and missed these two window-only broadcasts entirely). Converted directly
  since they don't fit `withSourceMutation`'s single-broadcast shape.
- All 9 `COLLECTIONS_*` handlers converted from `withRootPathWin` (`win` used
  only for the broadcast) to `withRootPath` + `broadcastCollectionsChanged(rootPath)`,
  replacing the local win-scoped closure that lived in this file.

`win` remains only for the two handlers that still need it for real: dialog
anchoring + BibTeX/Zotero import progress, which is intentionally
window-scoped (per-operation progress, not a project-wide "something
changed" signal) — left untouched.

## Test plan

- [x] `helpers.test.ts`: the three new broadcast functions reach **every**
      window on the project, mirroring the existing `broadcastRewritten`
      coverage — this is the actual multi-window regression test the issue's
      third success criterion asks for
- [x] `register-sources.test.ts`: reworked to assert each handler calls the
      right `broadcast*Changed(rootPath)` rather than inspecting a single
      window's `webContents.send` — the fan-out mechanism itself now lives in,
      and is tested by, `helpers.ts`. Removed the 21 "sends nothing to a
      window that closed mid-write" cases, since that check moved to
      `windowsForProject` (which, like the four pre-existing broadcast
      helpers, isn't independently re-tested at this layer)
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 648 files / 7002 tests passed
- [x] No `window.api` surface touched — preload bridge snapshot unaffected
- [x] No file-size-budgeted file crossed 600 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)