### PR TITLE
refactor: hoist duplicated pure helpers into src/shared/ (#1917)

### DIFF
--- a/src/main/embeddings/chunk.ts
+++ b/src/main/embeddings/chunk.ts
@@ -14,6 +14,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { stripFrontmatter } from '../../shared/frontmatter-strip';
 
 export interface Chunk {
   /** 0-based position of this chunk within the note (stable ordering). */
@@ -107,10 +108,6 @@ function splitLong(text: string, maxChars: number): string[] {
   }
   if (buf) out.push(buf);
   return out;
-}
-
-function stripFrontmatter(content: string): string {
-  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
 }
 
 function sha256(s: string): string {

--- a/src/main/notebase/merge.ts
+++ b/src/main/notebase/merge.ts
@@ -5,6 +5,7 @@ import { rewriteWikiLinks, normalizePath as normalizeLinkPath } from './link-rew
 import * as graph from '../graph/index';
 import { projectContext } from '../project-context-types';
 import { isIndexable } from './indexable-files';
+import { stripFrontmatter } from '../../shared/frontmatter-strip';
 
 /**
  * Merge note (#464). Append the source note's body to a target note,
@@ -20,8 +21,6 @@ import { isIndexable } from './indexable-files';
  * the project in whatever state the partial writes produced — recovery
  * is `git reset --hard HEAD` per Minerva's git-as-undo model.
  */
-
-const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
 
 export interface MergePreview {
   /** Number of wiki-link occurrences across the project that will be
@@ -221,10 +220,6 @@ export async function mergeNotes(
     rewrittenPaths,
     deletedSource: sourceRelPath,
   };
-}
-
-function stripFrontmatter(content: string): string {
-  return content.replace(FRONTMATTER_RE, '');
 }
 
 function countLines(s: string): number {

--- a/src/main/publish/csl/renderer.ts
+++ b/src/main/publish/csl/renderer.ts
@@ -15,6 +15,7 @@
 
 import CSL, { Engine as CslEngine } from 'citeproc';
 import type { CslItem } from './source-to-csl';
+import { escapeHtmlFull as escapeHtml } from '../../../shared/text-escape';
 
 export interface RenderedBibliography {
   entries: string[];
@@ -215,11 +216,3 @@ export class CitationRenderer {
   }
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}

--- a/src/main/publish/csl/source-to-csl.ts
+++ b/src/main/publish/csl/source-to-csl.ts
@@ -9,6 +9,7 @@
  * `family` / `given` because APA-style inline marks need the family
  * name alone: "(Brooks, 1987)" rather than "(Frederick P. Brooks, 1987)").
  */
+import { escapeRegex } from '../../../shared/text-escape';
 
 export interface CslName {
   family?: string | undefined;
@@ -124,10 +125,6 @@ function extractIri(ttl: string, predicate: string): string | null {
   const re = new RegExp(`${escapeRegex(predicate)}\\s+<([^>]+)>`);
   const m = ttl.match(re);
   return m ? m[1]! : null;
-}
-
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // ── Author-name heuristics ─────────────────────────────────────────────────

--- a/src/main/publish/exporters/annotated-reading/index.ts
+++ b/src/main/publish/exporters/annotated-reading/index.ts
@@ -17,6 +17,7 @@ import { resolveAnnotatedReading } from './resolve';
 import { renderAnnotatedReading } from './render';
 import type { Exporter, ExportPlanFile } from '../../types';
 import { isIgnoredEntry } from '../../../notebase/ignored-dirs';
+import { slugifyId } from '../../../../shared/slug';
 
 export const annotatedReadingExporter: Exporter = {
   id: 'annotated-reading-html',
@@ -127,5 +128,5 @@ function titleFromContent(content: string, fallbackName: string): string {
 }
 
 function slugify(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'source';
+  return slugifyId(s) || 'source';
 }

--- a/src/main/publish/exporters/annotated-reading/render.ts
+++ b/src/main/publish/exporters/annotated-reading/render.ts
@@ -18,6 +18,7 @@
 import MarkdownIt from 'markdown-it';
 import type { CitationRenderer } from '../../csl';
 import type { AnnotatedReadingData, AnnotatedExcerpt } from './resolve';
+import { escapeHtmlFull as escapeHtml, escapeHtmlFull as escapeAttr } from '../../../../shared/text-escape';
 
 export interface RenderedReading {
   /** Self-contained HTML document. */
@@ -184,16 +185,6 @@ function wrapHighlights(
 function noteHrefFor(relativePath: string): string {
   return relativePath;
 }
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-function escapeAttr(s: string): string { return escapeHtml(s); }
 
 const ANNOTATED_READING_STYLE = `
 :root {

--- a/src/main/publish/exporters/note-html/render.ts
+++ b/src/main/publish/exporters/note-html/render.ts
@@ -26,6 +26,8 @@ import { resolveTransclusions } from '../../transclusion-resolve';
 import { linkifyLocalMedia } from '../../media-export';
 import type { ExportPlanFile, ExportPlan } from '../../types';
 import type { CitationRenderer } from '../../csl';
+import { escapeHtmlFull as escapeHtml, escapeHtmlFull as escapeAttr } from '../../../../shared/text-escape';
+import { stripFrontmatter } from '../../../../shared/frontmatter-strip';
 
 /**
  * Returns the rendered body HTML — just the article content, no `<html>`
@@ -438,10 +440,6 @@ function mimeForExt(ext: string): string {
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-function stripFrontmatter(content: string): string {
-  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
-}
-
 function findTitle(target: string, titleByTarget: Map<string, string>): string | null {
   return (
     titleByTarget.get(target) ??
@@ -455,15 +453,3 @@ function stripMd(p: string): string {
   return p.replace(/\.md$/i, '');
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function escapeAttr(s: string): string {
-  return escapeHtml(s);
-}

--- a/src/main/publish/exporters/note-html/shell.ts
+++ b/src/main/publish/exporters/note-html/shell.ts
@@ -4,6 +4,7 @@
 
 import { NOTE_HTML_STYLE } from './style';
 import { bodyHasKatex, getKatexStyle } from './katex-css';
+import { escapeHtmlFull as escapeHtml } from '../../../../shared/text-escape';
 
 export interface HtmlShellInput {
   title: string;
@@ -69,11 +70,3 @@ ${input.body}
 `;
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}

--- a/src/main/publish/exporters/note-pdf/options.ts
+++ b/src/main/publish/exporters/note-pdf/options.ts
@@ -112,6 +112,14 @@ function clamp(n: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, n));
 }
 
+// Deliberately NOT hoisted to `shared/text-escape.ts` (#1917): this is a
+// third, genuinely distinct escaping behavior (&, <, >, " — no apostrophe),
+// used nowhere else. Neither `escapeHtml` (3-char) nor `escapeHtmlFull`
+// (5-char, WITH apostrophe) in the shared module matches it, and this
+// function has no other call site to reconcile with — it isn't duplication,
+// just a third case. Merging it into either shared variant would silently
+// change this file's escaping behavior for the one thing #1917 explicitly
+// warns against.
 function escapeHtml(s: string): string {
   return s
     .replace(/&/g, '&amp;')

--- a/src/main/publish/exporters/static-site/render.ts
+++ b/src/main/publish/exporters/static-site/render.ts
@@ -18,6 +18,7 @@ import { noteUrl, type SiteIndex } from './site-data';
 import { renderFootnotesSection } from '../note-html';
 import { extractPublish, type PublishMeta } from './publish-meta';
 import { type SidebarNode, subtreeContains } from './sidebar';
+import { escapeHtmlFull as escapeHtml, escapeHtmlFull as escapeAttr } from '../../../../shared/text-escape';
 
 export interface RenderPageInput {
   note: ExportPlanFile;
@@ -380,16 +381,6 @@ function extractTagList(note: ExportPlanFile): string[] {
   }
   return [];
 }
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-function escapeAttr(s: string): string { return escapeHtml(s); }
 
 // Suppress unused-helper warnings for `path` import — used by future
 // asset-copy code; left so the module's expected import shape stays

--- a/src/main/publish/exporters/tree-html/index.ts
+++ b/src/main/publish/exporters/tree-html/index.ts
@@ -26,6 +26,7 @@ import { renderFootnotesSection } from '../note-html';
 import { NOTE_HTML_STYLE } from '../note-html/style';
 import { bodyHasKatex, getKatexStyle } from '../note-html/katex-css';
 import type { Exporter, ExportOutput, ExportPlan, ExportPlanFile } from '../../types';
+import { escapeHtmlFull as escapeHtml, escapeHtmlFull as escapeAttr } from '../../../../shared/text-escape';
 
 export const treeHtmlExporter: Exporter = {
   id: 'tree-html',
@@ -170,16 +171,6 @@ function renderSidebar(
   });
   return `<nav class="bundle-tree"><h2 class="bundle-tree-heading">Pages</h2><ol>${items.join('')}</ol></nav>`;
 }
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-function escapeAttr(s: string): string { return escapeHtml(s); }
 
 const BUNDLE_NAV_STYLE = `
 /* Tree-html bundle: shared stylesheet + sidebar nav (#292). */

--- a/src/main/publish/exporters/tree-markdown.ts
+++ b/src/main/publish/exporters/tree-markdown.ts
@@ -20,6 +20,7 @@ import {
   rewriteWikiLinksInContent,
 } from '../link-resolver';
 import type { Exporter, ExportPlan, ExportPlanFile } from '../types';
+import { slugifyId } from '../../../shared/slug';
 
 export const treeMarkdownExporter: Exporter = {
   id: 'tree-markdown',
@@ -84,11 +85,7 @@ export const treeMarkdownExporter: Exporter = {
 };
 
 function slugify(s: string): string {
-  return s
-    .toLowerCase()
-    .replace(/\.md$/i, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '') || 'tree';
+  return slugifyId(s.replace(/\.md$/i, '')) || 'tree';
 }
 
 // Re-export the type so the exporter's `run` signature hangs together

--- a/src/main/publish/exporters/tree-pdf.ts
+++ b/src/main/publish/exporters/tree-pdf.ts
@@ -22,6 +22,8 @@ import { resolveRenderOptions, toPrintToPdfArgs } from './note-pdf/options';
 import { renderPdfFromHtml } from './note-pdf/electron-render';
 import { NOTE_HTML_STYLE } from './note-html/style';
 import type { Exporter, ExportOutput, ExportPlan, ExportPlanFile } from '../types';
+import { escapeHtml, escapeRegex } from '../../../shared/text-escape';
+import { slugifyId } from '../../../shared/slug';
 
 export interface BuildTreePdfHtmlResult {
   html: string;
@@ -173,19 +175,8 @@ function rewriteInterChapterLinks(
   return out;
 }
 
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 function slugify(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'document';
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+  return slugifyId(s) || 'document';
 }
 
 const TREE_PDF_EXTRA_STYLE = `

--- a/src/main/skills/parse.ts
+++ b/src/main/skills/parse.ts
@@ -14,6 +14,7 @@ import {
   type SkillSource,
 } from '../../shared/skills/types';
 import { validateTemplate } from './template';
+import { slugifyId as slugify } from '../../shared/slug';
 
 const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
 
@@ -32,10 +33,6 @@ export interface ParseResult {
   errors: string[];
   /** Best-effort label for error reporting even when the skill is rejected. */
   label: string;
-}
-
-function slugify(s: string): string {
-  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
 function asString(v: unknown): string | undefined {

--- a/src/main/sources/about-note.ts
+++ b/src/main/sources/about-note.ts
@@ -9,6 +9,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { slugifyId } from '../../shared/slug';
 
 export interface AboutNoteParams {
   sourceId: string;
@@ -45,12 +46,7 @@ export async function createAboutNote(
 
 /** Filename-safe, lowercase, hyphenated stem from a free-text title. */
 export function slugifyTitle(title: string): string {
-  return title
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 60);
+  return slugifyId(title).slice(0, 60);
 }
 
 /** `<stem>.md`, or `<stem>-2.md`, `<stem>-3.md`, … if earlier ones exist. */

--- a/src/main/types/parse.ts
+++ b/src/main/types/parse.ts
@@ -5,6 +5,7 @@
  * malformed type can't break the rest of the catalog (mirrors skills/parse.ts).
  */
 import YAML from 'yaml';
+import { slugifyId as slugify } from '../../shared/slug';
 import {
   PROPERTY_TYPES,
   pascalCase,
@@ -22,10 +23,6 @@ export interface ParseTypeResult {
   errors: string[];
   /** Best-effort label for error reporting even when the type is rejected. */
   label: string;
-}
-
-function slugify(s: string): string {
-  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
 function asString(v: unknown): string | undefined {

--- a/src/main/types/write.ts
+++ b/src/main/types/write.ts
@@ -7,6 +7,7 @@
 import YAML from 'yaml';
 import * as notebaseFs from '../notebase/fs';
 import type { PropertyDef } from '../../shared/objects/type-def';
+import { slugifyId } from '../../shared/slug';
 
 export interface SaveTypeInput {
   label: string;
@@ -27,7 +28,7 @@ export interface SaveTypeInput {
 }
 
 export function slugify(s: string): string {
-  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return slugifyId(s);
 }
 
 /** Serialize to a type-definition markdown file (frontmatter only; the body —

--- a/src/renderer/lib/app/text-helpers.ts
+++ b/src/renderer/lib/app/text-helpers.ts
@@ -3,14 +3,14 @@
  * no DOM, no reactivity — just string and NoteFile-tree functions, so they're
  * trivially unit-testable and don't belong inline in the root component.
  */
-import { slugify } from '../../../shared/slug';
+import { slugify, slugifyId } from '../../../shared/slug';
 import { isNotePath } from '../../../shared/note-extensions';
 import type { NoteFile } from '../../../shared/types';
 
 /** Cheap slug for path placeholders (e.g. onboarding system-prompt paths).
  *  Callers may override; this is just a sensible default. */
 export function slugifyForPath(s: string): string {
-  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'overview';
+  return slugifyId(s).slice(0, 40) || 'overview';
 }
 
 /** Byte offset of the heading/block-id anchor within `text`, or null.

--- a/src/renderer/lib/editor/formatting.ts
+++ b/src/renderer/lib/editor/formatting.ts
@@ -1,5 +1,6 @@
 import { EditorView } from '@codemirror/view';
 import { LINK_TYPES, type LinkType } from '../../../shared/link-types';
+import { escapeRegex } from '../../../shared/text-escape';
 import {
   HIGHLIGHT_PALETTE,
   scanHighlights,
@@ -228,10 +229,6 @@ function makeLinePrefixToggle(prefix: string, numbered = false): Command {
     view.dispatch({ changes });
     return true;
   };
-}
-
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 export const toggleH1: Command = makeLinePrefixToggle('# ');

--- a/src/renderer/lib/editor/note-preview.ts
+++ b/src/renderer/lib/editor/note-preview.ts
@@ -10,6 +10,7 @@
  */
 import { resolveWikiLinkTarget } from '../../../shared/wiki-link-resolver';
 import { parseTransclusionTarget, sliceTransclusion } from '../../../shared/transclusion';
+import { stripFrontmatter } from '../../../shared/frontmatter-strip';
 
 export interface NotePreview {
   /** Resolved relativePath of the target note. */
@@ -106,6 +107,3 @@ function truncate(text: string): string {
   return clipped ? `${out}…` : out;
 }
 
-function stripFrontmatter(content: string): string {
-  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
-}

--- a/src/renderer/lib/markdown/callout-plugin.ts
+++ b/src/renderer/lib/markdown/callout-plugin.ts
@@ -28,6 +28,7 @@ import type { MarkdownIt } from 'markdown-it';
 import type { StateCore } from 'markdown-it';
 import type { Token } from 'markdown-it';
 import { TRAILING_ID_RE } from '../../../shared/flashcards/cards';
+import { escapeHtml, escapeAttr } from '../../../shared/text-escape';
 
 /**
  * First-line marker. Title whitespace is restricted to spaces/tabs so a
@@ -244,13 +245,3 @@ function capitalize(s: string): string {
   return s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1);
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
-function escapeAttr(s: string): string {
-  return escapeHtml(s).replace(/"/g, '&quot;');
-}

--- a/src/renderer/lib/markdown/mermaid-renderer.ts
+++ b/src/renderer/lib/markdown/mermaid-renderer.ts
@@ -17,6 +17,7 @@
 import { getEffectiveTheme, getThemeMode } from '../theme';
 import { normalizeColor } from '../utils/oklch';
 import { sanitizeDiagramSvg } from './sanitize-diagram-svg';
+import { escapeHtml } from '../../../shared/text-escape';
 
 type MermaidApi = {
   initialize: (config: Record<string, unknown>) => void;
@@ -179,11 +180,4 @@ export function invalidateMermaidTheme(): void {
 
 function renderErrorHtml(msg: string): string {
   return `<div class="mermaid-error" role="alert"><strong>Mermaid error</strong><pre>${escapeHtml(msg)}</pre></div>`;
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
 }

--- a/src/renderer/lib/markdown/vega-renderer.ts
+++ b/src/renderer/lib/markdown/vega-renderer.ts
@@ -47,6 +47,7 @@ import {
   type VegaRows,
 } from '../../../shared/vega/data-binding';
 import { findCellOutput } from '../../../shared/compute/cell-output';
+import { escapeHtml } from '../../../shared/text-escape';
 
 type VegaView = { finalize: () => void };
 type VegaEmbed = (
@@ -377,13 +378,6 @@ function renderErrorHtml(msg: string): string {
 function renderNoticeHtml(title: string, body: string): string {
   // `body` already contains escaped interpolations; the literal copy is safe.
   return `<div class="vega-notice" role="note"><strong>${escapeHtml(title)}</strong><p>${body}</p></div>`;
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
 }
 
 // Exported for unit tests — the spec-scan and JSON guardrail are the security

--- a/src/renderer/lib/markdown/youtube-embed.ts
+++ b/src/renderer/lib/markdown/youtube-embed.ts
@@ -16,6 +16,7 @@
  */
 
 import { parseYouTubeUrl, thumbnailUrl } from '../../../shared/youtube/youtube';
+import { escapeHtml, escapeAttr } from '../../../shared/text-escape';
 
 /** Build the poster-card HTML for a `youtube` fence body, or an inline error
  *  if the URL doesn't parse as a YouTube video. */
@@ -52,13 +53,3 @@ export function renderYouTubeFence(body: string): string {
     + `</a>`;
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
-function escapeAttr(s: string): string {
-  return escapeHtml(s).replace(/"/g, '&quot;');
-}

--- a/src/renderer/lib/preview/text.ts
+++ b/src/renderer/lib/preview/text.ts
@@ -3,19 +3,14 @@
  * Preview.svelte (#672). No DOM, no reactivity — just string transforms,
  * so they're trivially unit-testable and shared by the other preview
  * modules.
+ *
+ * `escapeHtml`/`escapeAttr`/`stripFrontmatter` moved to `src/shared/` (#1917)
+ * — this file re-exports them so existing imports of `preview/text` are
+ * unaffected. `countFrontmatterLines` stays local: it's specific to this
+ * module's line-counting need, not one of the duplicated helpers.
  */
-
-export function escapeHtml(str: string): string {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-
-export function escapeAttr(str: string): string {
-  return escapeHtml(str).replace(/"/g, '&quot;');
-}
-
-export function stripFrontmatter(text: string): string {
-  return text.replace(/^---\n[\s\S]*?\n---\n?/, '');
-}
+export { escapeHtml, escapeAttr } from '../../../shared/text-escape';
+export { stripFrontmatter } from '../../../shared/frontmatter-strip';
 
 export function countFrontmatterLines(text: string): number {
   const m = text.match(/^---\n[\s\S]*?\n---\n?/);

--- a/src/shared/formatter/rules/content/auto-correct-common-misspellings.ts
+++ b/src/shared/formatter/rules/content/auto-correct-common-misspellings.ts
@@ -1,5 +1,6 @@
 import { registerRule } from '../../registry';
 import { transformUnprotected } from '../helpers';
+import { escapeRegex } from '../../../text-escape';
 
 interface Config {
   /**
@@ -94,7 +95,3 @@ registerRule<Config>({
     );
   },
 });
-
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}

--- a/src/shared/frontmatter-strip.ts
+++ b/src/shared/frontmatter-strip.ts
@@ -1,0 +1,12 @@
+/**
+ * Strip a leading `---\n...\n---\n` YAML frontmatter block, if present.
+ * Hoisted from 6 duplicated copies (#1917). Five already agreed on the
+ * CRLF-aware pattern below; `renderer/lib/preview/text.ts`'s copy was the
+ * odd one out (`\n` only, no `\r?`), meaning it silently failed to strip
+ * frontmatter from a note saved with Windows line endings — a latent bug,
+ * not a deliberate difference, so this adopts the CRLF-aware pattern as
+ * canonical rather than preserving the narrower one.
+ */
+export function stripFrontmatter(content: string): string {
+  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+}

--- a/src/shared/markdown/math-plugin.ts
+++ b/src/shared/markdown/math-plugin.ts
@@ -23,6 +23,7 @@ import type { MarkdownIt } from 'markdown-it';
 import type { StateInline } from 'markdown-it';
 import type { StateBlock } from 'markdown-it';
 import katex from 'katex';
+import { escapeHtml, escapeAttr } from '../text-escape';
 
 export function installMath(md: MarkdownIt): void {
   md.inline.ruler.before('escape', 'math_inline', mathInline);
@@ -47,13 +48,6 @@ function renderTex(tex: string, displayMode: boolean): string {
     const msg = err instanceof Error ? err.message : String(err);
     return `<span class="katex-error" title="${escapeAttr(msg)}">${escapeHtml(tex)}</span>`;
   }
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-function escapeAttr(s: string): string {
-  return escapeHtml(s).replace(/"/g, '&quot;');
 }
 
 /**

--- a/src/shared/refactor/bundle-link-fixup.ts
+++ b/src/shared/refactor/bundle-link-fixup.ts
@@ -14,6 +14,7 @@
  */
 
 import { WIKI_LINK_RE, parseWikiInner, reassembleWikiLink } from '../wiki-link';
+import { slugifyId } from '../slug';
 
 export interface BundleNote {
   relativePath: string;
@@ -43,10 +44,7 @@ function stemOf(relativePath: string): string {
 
 /** Lowercase, replace non-alphanumeric with `-`, collapse runs, trim hyphens. */
 export function slugifyForLink(s: string): string {
-  return s
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  return slugifyId(s);
 }
 
 function buildIndex(notes: BundleNote[]): SiblingIndex {

--- a/src/shared/slug.ts
+++ b/src/shared/slug.ts
@@ -23,6 +23,25 @@ export function slugify(text: string): string {
 }
 
 /**
+ * Plain ASCII kebab-case identifier: lowercase, non-alphanumeric runs
+ * collapsed to a single `-`, leading/trailing dashes trimmed. Hoisted from
+ * ~8 duplicated copies (#1917) that all did exactly this — some with a
+ * redundant leading `.trim()` (subsumed by the dash-collapsing regexes: a
+ * leading/trailing run of whitespace becomes a leading/trailing run of `-`,
+ * which the final trim already strips, so pre-trimming changes nothing).
+ *
+ * Distinct from {@link slugify} above: this is for filenames/ids/URL
+ * segments, not a wiki-link/anchor slug — `slugify` deliberately preserves
+ * `_` and the `^blockid` marker, which this strips. Callers needing a length
+ * cap or an empty-result fallback word apply it to this result rather than
+ * reimplementing the substitution (see e.g. `about-note.ts`'s
+ * `slugifyTitle`, or the local `slugify` wrappers in the publish exporters).
+ */
+export function slugifyId(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+/**
  * Split a wiki-link target at the first `#` into its path and anchor parts.
  * `anchor` is the text AFTER the `#` (no leading hash). For block-id links,
  * the returned anchor still begins with `^` so callers can distinguish.

--- a/src/shared/text-escape.ts
+++ b/src/shared/text-escape.ts
@@ -1,0 +1,43 @@
+/**
+ * Escaping helpers duplicated across ~25 call sites (#1917): every markdown
+ * plugin, publish exporter, and formatter rule that builds HTML or a RegExp
+ * from arbitrary text had its own copy. Hoisted here as the one definition —
+ * but only where the implementations were actually the same behavior. Two
+ * genuinely different HTML-escaping conventions existed side by side (see
+ * below); both are kept, distinctly named, rather than silently picking one
+ * and changing every exporter's byte-for-byte output.
+ */
+
+/** Escapes `&`, `<`, `>` — the minimum needed for safe HTML text-node
+ *  content. Does NOT escape quotes; use {@link escapeAttr} for a
+ *  double-quoted attribute value. */
+export function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** {@link escapeHtml} plus double-quote escaping — safe to interpolate into
+ *  a double-quoted HTML attribute. Does not escape a bare apostrophe: every
+ *  caller wraps attributes in double quotes, so a literal `'` cannot break
+ *  out. */
+export function escapeAttr(s: string): string {
+  return escapeHtml(s).replace(/"/g, '&quot;');
+}
+
+/**
+ * Escapes `&`, `<`, `>`, `"`, `'` — full escaping for the publish exporters
+ * that historically reused ONE function for both text content and attribute
+ * interpolation. Escaping quotes in plain text is harmless (renders
+ * identically once parsed as HTML) but changes the literal HTML source, so
+ * this stays a distinct export rather than folding into {@link escapeHtml}
+ * above — merging them would silently change every one of those exporters'
+ * byte-for-byte output.
+ */
+export function escapeHtmlFull(s: string): string {
+  return escapeAttr(s).replace(/'/g, '&#39;');
+}
+
+/** Escapes RegExp metacharacters so `s` matches itself literally when spliced
+ *  into a `new RegExp(...)` source string. */
+export function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/shared/transclusion.ts
+++ b/src/shared/transclusion.ts
@@ -13,6 +13,7 @@
  */
 
 import { slugify } from './slug';
+import { stripFrontmatter } from './frontmatter-strip';
 
 export interface TransclusionTarget {
   /** The note name / path (no `#heading` or `^blockid`, no `.md`). */
@@ -110,6 +111,3 @@ function sliceBlock(body: string, blockId: string): SliceResult {
   return { ok: false, text: '', reason: `block "^${blockId}" not found` };
 }
 
-function stripFrontmatter(content: string): string {
-  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
-}

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -76,7 +76,7 @@ const BUDGETS: Record<string, number> = {
   'src/shared/ipc-contract.ts': 720,
   'src/shared/channels.ts': 701,
   'src/renderer/lib/app/note-ops.ts': 687,
-  'src/renderer/lib/editor/formatting.ts': 671,
+  'src/renderer/lib/editor/formatting.ts': 668,
   'src/main/sources/tables.ts': 661,
   'src/renderer/lib/components/FindInNotesDialog.svelte': 601,
   'src/preload/preload.ts': 614,

--- a/tests/shared/frontmatter-strip.test.ts
+++ b/tests/shared/frontmatter-strip.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonical `stripFrontmatter` (#1917), hoisted from 6 duplicated copies.
+ * CRLF-aware — see the module docstring for why that's the canonical
+ * behavior rather than the narrower LF-only variant one copy had.
+ */
+import { describe, it, expect } from 'vitest';
+import { stripFrontmatter } from '../../src/shared/frontmatter-strip';
+
+describe('stripFrontmatter (#1917)', () => {
+  it('strips a leading frontmatter block', () => {
+    expect(stripFrontmatter('---\ntitle: X\n---\nBody text.\n')).toBe('Body text.\n');
+  });
+
+  it('strips a CRLF frontmatter block', () => {
+    expect(stripFrontmatter('---\r\ntitle: X\r\n---\r\nBody text.\r\n')).toBe('Body text.\r\n');
+  });
+
+  it('leaves content with no frontmatter untouched', () => {
+    expect(stripFrontmatter('# Just a note\n\nNo frontmatter here.\n')).toBe('# Just a note\n\nNo frontmatter here.\n');
+  });
+
+  it('does not strip a --- that is not at the very start', () => {
+    expect(stripFrontmatter('Body first.\n---\ntitle: X\n---\n')).toBe('Body first.\n---\ntitle: X\n---\n');
+  });
+
+  it('handles a frontmatter block with no trailing newline after the closing ---', () => {
+    expect(stripFrontmatter('---\ntitle: X\n---')).toBe('');
+  });
+});

--- a/tests/shared/slug.test.ts
+++ b/tests/shared/slug.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { slugify, splitAnchor } from '../../src/shared/slug';
+import { slugify, slugifyId, splitAnchor } from '../../src/shared/slug';
 
 describe('slugify', () => {
   it('lowercases and hyphenates spaces', () => {
@@ -23,6 +23,39 @@ describe('slugify', () => {
 
   it('keeps underscores and numeric chars (word chars)', () => {
     expect(slugify('foo_bar 42')).toBe('foo_bar-42');
+  });
+});
+
+describe('slugifyId (#1917)', () => {
+  it('lowercases and hyphenates spaces', () => {
+    expect(slugifyId('Hello World')).toBe('hello-world');
+  });
+
+  it('treats punctuation and underscores as separators, unlike slugify', () => {
+    // slugify() strips these to nothing (`foo_bar` → `foo_bar`, keeps the
+    // underscore, drops the apostrophe entirely: "dont-stop"); slugifyId
+    // treats every non-alphanumeric run — underscore included — as a
+    // separator instead.
+    expect(slugifyId('foo_bar 42')).toBe('foo-bar-42');
+    expect(slugifyId("Don't stop!")).toBe('don-t-stop');
+  });
+
+  it('collapses repeated separators and trims edges', () => {
+    expect(slugifyId('  foo   bar  ')).toBe('foo-bar');
+    expect(slugifyId('--foo--bar--')).toBe('foo-bar');
+  });
+
+  it('does not preserve a block-id caret (unlike slugify)', () => {
+    expect(slugifyId('^p4')).toBe('p4');
+  });
+
+  it('returns empty for input with no alphanumeric characters', () => {
+    expect(slugifyId('!!!')).toBe('');
+    expect(slugifyId('   ')).toBe('');
+  });
+
+  it('leading/trailing whitespace needs no separate trim() — the dash-collapse already absorbs it', () => {
+    expect(slugifyId('  Hello World  ')).toBe(slugifyId('Hello World'));
   });
 });
 

--- a/tests/shared/text-escape.test.ts
+++ b/tests/shared/text-escape.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Canonical escaping helpers (#1917), hoisted from ~25 duplicated copies.
+ * `escapeHtml` and `escapeHtmlFull` are genuinely different behaviors kept
+ * side by side — see the module docstring — so both are pinned here.
+ */
+import { describe, it, expect } from 'vitest';
+import { escapeHtml, escapeAttr, escapeHtmlFull, escapeRegex } from '../../src/shared/text-escape';
+
+describe('escapeHtml', () => {
+  it('escapes &, <, >', () => {
+    expect(escapeHtml('<a href="x">Tom & Jerry</a>')).toBe('&lt;a href="x"&gt;Tom &amp; Jerry&lt;/a&gt;');
+  });
+
+  it('leaves quotes untouched', () => {
+    expect(escapeHtml(`it's "fine"`)).toBe(`it's "fine"`);
+  });
+});
+
+describe('escapeAttr', () => {
+  it('escapes &, <, >, " but not a bare apostrophe', () => {
+    expect(escapeAttr(`Tom & Jerry's "Show"`)).toBe('Tom &amp; Jerry\'s &quot;Show&quot;');
+  });
+});
+
+describe('escapeHtmlFull', () => {
+  it('escapes &, <, >, ", and \'', () => {
+    expect(escapeHtmlFull(`Tom & Jerry's "Show"`)).toBe('Tom &amp; Jerry&#39;s &quot;Show&quot;');
+  });
+});
+
+describe('escapeRegex', () => {
+  it('escapes every RegExp metacharacter', () => {
+    const literal = '.*+?^${}()|[]\\';
+    const escaped = escapeRegex(literal);
+    expect(new RegExp(escaped).test(literal)).toBe(true);
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(escapeRegex('plain text 123')).toBe('plain text 123');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1917. `escapeHtml` (14 copies), the `slugify` family (11),
`escapeAttr` (8), `stripFrontmatter` (6), and `escapeRegex` (4) were each
redefined across renderer markdown plugins, main publish exporters, and
shared formatter rules. Consolidated into three new/extended shared modules,
each with unit tests.

- **`src/shared/text-escape.ts`**: `escapeHtml`, `escapeAttr`, `escapeRegex`
  — plus `escapeHtmlFull`, a genuinely distinct behavior kept separate rather
  than silently merged (see below).
- **`src/shared/frontmatter-strip.ts`**: `stripFrontmatter`.
- **`src/shared/slug.ts`**: added `slugifyId` alongside the existing `slugify`.

## Semantics checked before merging — two surprises

The issue's own caution ("check semantics before merging the slug
variants — some are deliberately different") turned out to apply to
`escapeHtml` too, not just slugs:

- **`escapeHtml` had THREE distinct behaviors**, not one: a 3-char variant
  (`&`,`<`,`>`) used by 7 sites for text-node content; a 5-char variant
  (`&`,`<`,`>`,`"`,`'`) used by 6 publish exporters that reuse one function
  for both content and attribute interpolation; and a **unique** 4-char
  variant (`&`,`<`,`>`,`"` — no apostrophe) in `note-pdf/options.ts`, used
  nowhere else. The first two are now `escapeHtml`/`escapeHtmlFull` in
  shared; the third stays local, documented inline as a deliberate
  non-merge — folding it into either shared variant would have silently
  changed that file's escaping.
- **The slugify family**: 3 of 11 were byte-identical (`types/parse.ts`,
  `types/write.ts`, `skills/parse.ts`) and merged directly into the new
  `slugifyId`. The other 7 (`slugifyForPath`, `slugifyForLink`,
  `slugifyTitle`, and the local `slugify` in `tree-markdown`/`tree-pdf`/
  `annotated-reading`) each add their own length cap, empty-result fallback
  word, or `.md`-suffix stripping on top of the same core substitution —
  proven algebraically equivalent minus those additions (a leading
  `.trim()` some had is redundant: the dash-collapse regexes already absorb
  leading/trailing whitespace). Each keeps its own exported name and now
  delegates to `slugifyId` instead of reimplementing the regex.
  `slugifyTableName` (SQL-identifier-safe, case-preserving, underscore-based)
  is genuinely unrelated and untouched.

`stripFrontmatter` also had a real (if minor) **bug hiding in the
duplication**: 5 of 6 copies already agreed on a CRLF-aware pattern
(`\r?\n`); only `renderer/lib/preview/text.ts`'s copy — the one the issue
cited as the "already correct" example — was LF-only, silently failing to
strip frontmatter from a note saved with Windows line endings. Adopted the
CRLF-aware pattern as canonical (majority behavior, a strict superset of
correctness) rather than preserving the narrower one.

`preview/text.ts` becomes a thin re-export of the shared functions so its
two existing consumers (`inline-tokens-plugin.ts`, `Preview.svelte`) are
unaffected; `countFrontmatterLines` stays local since it isn't one of the
duplicated helpers.

## Test plan

- [x] New unit tests: `tests/shared/text-escape.test.ts`,
      `tests/shared/frontmatter-strip.test.ts`, extended
      `tests/shared/slug.test.ts`
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 650 files / 7019 tests passed, no change to any existing
      exporter/preview test's expected output
- [x] `tests/architecture/file-size-budgets.test.ts` — lowered the one
      budget that shrank (`editor/formatting.ts`)
- [x] `tests/architecture/no-cycles.test.ts` — no new import cycles
- [x] No `window.api` surface touched — preload bridge snapshot unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)