### PR TITLE
refactor: extract tab-session serialization from getEditorStore, memoize it (#1919)

### DIFF
--- a/src/renderer/lib/editor/tab-session.ts
+++ b/src/renderer/lib/editor/tab-session.ts
@@ -1,0 +1,227 @@
+/**
+ * Tab/layout session serialization, extracted from `getEditorStore` (#1919).
+ * Pure data mapping between the live `EditorGroup`/`Tab` shape and the
+ * persisted `SavedGroup`/`SavedTab`/`LayoutSession` shape — no autosave, no
+ * cursor/scroll tracking, no view-mode cycling, none of the store's other
+ * editor behavior. The store still owns the actual `$state` (`groups`,
+ * `activeGroupId`, `layout`) and the `api.tabs.save`/`load` IPC calls; this
+ * module only computes what to persist and how to turn persisted data back
+ * into live tabs.
+ */
+import type {
+  TabSession, SavedTab, SavedGroup, LayoutSession,
+} from '../../../shared/types';
+import { type LayoutNode, leaf, collectGroupIds, isLayoutNode } from './layout-tree';
+import {
+  type EditorGroup, type Tab, type ViewMode,
+  isNote, isQuery, isPdf, isGraph, isTypeView, isUnsupported,
+} from './tab-types';
+import { extensionOf } from '../../../shared/file-capability';
+import { api } from '../ipc/client';
+
+export function toSavedTab(t: Tab): SavedTab {
+  if (isNote(t)) {
+    return {
+      type: 'note',
+      relativePath: t.relativePath,
+      ...(t.plainText ? { plainText: true } : {}),
+      ...(t.cursorOffset !== undefined ? { cursorOffset: t.cursorOffset } : {}),
+      ...(t.scrollTop !== undefined ? { scrollTop: t.scrollTop } : {}),
+      ...(t.previewScrollTop !== undefined ? { previewScrollTop: t.previewScrollTop } : {}),
+    };
+  } else if (isUnsupported(t)) {
+    return { type: 'unsupported', relativePath: t.relativePath };
+  } else if (isQuery(t)) {
+    return { type: 'query', title: t.title, query: t.query, language: t.language };
+  } else if (isPdf(t)) {
+    return { type: 'pdf', sourceId: t.sourceId, page: t.page };
+  } else if (isGraph(t)) {
+    return { type: 'graph', relativePath: t.relativePath, depth: t.depth };
+  } else if (isTypeView(t)) {
+    return { type: 'type-view', typeId: t.typeId, layout: t.layout, sortColumn: t.sortColumn, sortDir: t.sortDir, columns: t.columns };
+  } else {
+    return {
+      type: 'source',
+      sourceId: t.sourceId,
+      ...(t.highlightExcerptId !== undefined ? { highlightExcerptId: t.highlightExcerptId } : {}),
+    };
+  }
+}
+
+/** Build the persisted session shape from the live editor-group state (#816). */
+export function buildSession(groups: EditorGroup[], activeGroupId: string, layout: LayoutNode): LayoutSession {
+  return {
+    version: 2,
+    activeGroupId,
+    groups: groups.map((g): SavedGroup => ({
+      id: g.id,
+      activeIndex: g.activeIndex,
+      viewMode: g.viewMode,
+      tabs: g.tabs.map(toSavedTab),
+    })),
+    layout,
+  };
+}
+
+/** Reconstruct a live tab from its persisted form. Notes read their file back
+ *  (returning null if it was deleted since last session, so the tab is
+ *  dropped); the other kinds rehydrate from saved fields. `nextQueryId`
+ *  shares the store's query-id counter so a restored query tab's id can
+ *  never collide with one opened fresh in the same session. */
+export async function reconstructTab(saved: SavedTab, nextQueryId: () => string): Promise<Tab | null> {
+  if (saved.type === 'note') {
+    try {
+      const text = await api.notebase.readFile(saved.relativePath);
+      const fileName = saved.relativePath.split('/').pop() ?? '';
+      return {
+        type: 'note',
+        relativePath: saved.relativePath,
+        fileName,
+        content: text,
+        savedContent: text,
+        ...(saved.plainText ? { plainText: true } : {}),
+        cursorOffset: saved.cursorOffset,
+        scrollTop: saved.scrollTop,
+        previewScrollTop: saved.previewScrollTop,
+      };
+    } catch {
+      return null; // file deleted since last session
+    }
+  } else if (saved.type === 'unsupported') {
+    const fileName = saved.relativePath.split('/').pop() ?? '';
+    return { type: 'unsupported', relativePath: saved.relativePath, fileName, ext: extensionOf(saved.relativePath) };
+  } else if (saved.type === 'query') {
+    return {
+      type: 'query',
+      id: nextQueryId(),
+      title: saved.title,
+      query: saved.query,
+      language: saved.language ?? 'sparql',
+      results: null,
+      columns: [],
+      error: null,
+      executing: false,
+      executionTime: null,
+    };
+  } else if (saved.type === 'pdf') {
+    return { type: 'pdf', sourceId: saved.sourceId, page: saved.page ?? 1 };
+  } else if (saved.type === 'graph') {
+    return { type: 'graph', relativePath: saved.relativePath, depth: saved.depth ?? 1 };
+  } else if (saved.type === 'type-view') {
+    return {
+      type: 'type-view',
+      typeId: saved.typeId,
+      layout: saved.layout ?? 'table',
+      sortColumn: saved.sortColumn ?? null,
+      sortDir: saved.sortDir ?? 'asc',
+      columns: saved.columns ?? null,
+    };
+  } else {
+    return { type: 'source', sourceId: saved.sourceId, highlightExcerptId: saved.highlightExcerptId };
+  }
+}
+
+export function asViewMode(v: unknown): ViewMode {
+  return v === 'preview' || v === 'editor-preview' || v === 'source' ? v : 'source';
+}
+
+/** Cross-pane identity of a persisted tab, for the forbid-duplicate dedup on
+ *  restore (#815). Queries have no shared-buffer identity (each is its own
+ *  scratch buffer), so they return null and are never deduped. */
+export function savedTabIdentity(t: SavedTab): string | null {
+  if (t.type === 'note') return `note:${t.relativePath}`;
+  if (t.type === 'source') return `source:${t.sourceId}`;
+  if (t.type === 'pdf') return `pdf:${t.sourceId}`;
+  if (t.type === 'type-view') return `type-view:${t.typeId}`;
+  return null;
+}
+
+/** Coerce whatever is on disk into the current multi-group shape. New
+ *  sessions pass through; a legacy flat `TabSession` migrates to a single
+ *  group (#816); anything else (null / empty / unrecognised) → null, so the
+ *  caller keeps the start-of-session empty group. */
+export function normalizeSession(raw: LayoutSession | TabSession | null, newGroupId: () => string): LayoutSession | null {
+  if (!raw || typeof raw !== 'object') return null;
+  if ('groups' in raw && Array.isArray(raw.groups)) {
+    return raw.groups.length > 0 ? raw : null;
+  }
+  if ('tabs' in raw && Array.isArray(raw.tabs)) {
+    if (raw.tabs.length === 0) return null;
+    const id = newGroupId();
+    return {
+      version: 2,
+      activeGroupId: id,
+      groups: [{ id, activeIndex: raw.activeIndex ?? 0, viewMode: 'source', tabs: raw.tabs }],
+      layout: { kind: 'leaf', groupId: id },
+    };
+  }
+  return null;
+}
+
+/**
+ * Turn a normalized session into the live groups/layout/activeGroupId to
+ * commit, dropping note tabs whose files have since vanished and any
+ * duplicate of a tab already restored in an earlier pane (#815) — even if
+ * the on-disk session was hand-edited or written by an older build. Falls
+ * back to merging every restored tab into one pane if the saved layout
+ * doesn't structurally match the restored groups (corrupt tree) rather than
+ * rendering a broken split or crashing. Returns null only in the defensive
+ * case of an empty group list (normalizeSession already rules this out for
+ * data it produces itself).
+ */
+export async function resolveRestoredSession(
+  session: LayoutSession,
+  nextQueryId: () => string,
+): Promise<{ groups: EditorGroup[]; layout: LayoutNode; activeGroupId: string } | null> {
+  const seen = new Set<string>();
+  const restored: EditorGroup[] = [];
+  for (const sg of session.groups) {
+    const tabs: Tab[] = [];
+    for (const saved of sg.tabs) {
+      const identity = savedTabIdentity(saved);
+      if (identity && seen.has(identity)) continue;
+      const tab = await reconstructTab(saved, nextQueryId);
+      if (tab) {
+        tabs.push(tab);
+        if (identity) seen.add(identity);
+      }
+    }
+    const activeIndex =
+      sg.activeIndex >= 0 && sg.activeIndex < tabs.length
+        ? sg.activeIndex
+        : tabs.length > 0 ? 0 : -1;
+    restored.push({ id: sg.id, tabs, activeIndex, viewMode: asViewMode(sg.viewMode) });
+  }
+  if (restored.length === 0) return null;
+
+  // The saved layout must structurally match the restored groups exactly
+  // (every leaf ↔ a live group, no orphans). If it doesn't, we can't trust
+  // the tree — recover by merging every restored tab into one pane rather
+  // than rendering a broken split or crashing.
+  const ids = new Set(restored.map((g) => g.id));
+  // SavedLayoutNode is structurally a LayoutNode; isLayoutNode still guards
+  // against a corrupt on-disk tree that doesn't match the declared shape.
+  const savedLayout = session.layout;
+  const layoutOk =
+    isLayoutNode(savedLayout) &&
+    (() => {
+      const leaves = collectGroupIds(savedLayout);
+      return leaves.length === ids.size && leaves.every((id) => ids.has(id));
+    })();
+
+  if (layoutOk) {
+    return {
+      groups: restored,
+      layout: savedLayout,
+      activeGroupId: ids.has(session.activeGroupId) ? session.activeGroupId : restored[0]!.id,
+    };
+  }
+  const merged: EditorGroup = {
+    id: restored[0]!.id,
+    tabs: restored.flatMap((g) => g.tabs),
+    activeIndex: -1,
+    viewMode: restored[0]!.viewMode,
+  };
+  merged.activeIndex = merged.tabs.length > 0 ? 0 : -1;
+  return { groups: [merged], layout: leaf(merged.id), activeGroupId: merged.id };
+}

--- a/src/renderer/lib/editor/tab-types.ts
+++ b/src/renderer/lib/editor/tab-types.ts
@@ -1,0 +1,129 @@
+/**
+ * Tab/editor-group type definitions, extracted from `stores/editor.svelte.ts`
+ * (#1919) so `editor/tab-session.ts` (the pure session-serialization module)
+ * can share them without importing the store itself — that would be a cycle,
+ * since the store imports the session module's functions. `editor.svelte.ts`
+ * re-exports everything here so existing `from '../stores/editor.svelte'`
+ * imports across the renderer are unaffected.
+ */
+
+export interface NoteTab {
+  type: 'note';
+  relativePath: string;
+  fileName: string;
+  content: string;
+  savedContent: string;
+  /** True when opened in plain-text mode — a non-markdown text file (#1130).
+   *  Drives the Editor's plain-text mode (markdown behaviors off). Omitted for
+   *  markdown files. */
+  plainText?: boolean | undefined;
+  cursorOffset?: number | undefined;
+  scrollTop?: number | undefined;
+  /** Preview-pane scroll offset. Separate from `scrollTop`: the editor and the
+   *  preview lay the same note out at different heights, so sharing one number
+   *  would land the reader in the wrong place. */
+  previewScrollTop?: number | undefined;
+  /**
+   * Serialised CodeMirror `EditorState` (doc + selection + history
+   * stacks) captured on Editor unmount. Used to restore undo/redo across
+   * tab switches — without this, switching tabs and back would give you
+   * a fresh editor with empty history (#167). Memory-only; not persisted
+   * to disk since session-restore is a separate concern.
+   */
+  historyJson?: unknown;
+}
+
+export type QueryLanguage = 'sparql' | 'sql';
+
+export interface QueryTab {
+  type: 'query';
+  id: string;
+  title: string;
+  query: string;
+  language: QueryLanguage;
+  results: Record<string, string>[] | null;
+  columns: string[];
+  error: string | null;
+  executing: boolean;
+  executionTime: number | null;
+}
+
+export interface SourceTab {
+  type: 'source';
+  sourceId: string;
+  /** If the user arrived via a [[quote::id]] click, highlight this excerpt in the detail view. */
+  highlightExcerptId?: string | undefined;
+}
+
+export interface PdfTab {
+  type: 'pdf';
+  sourceId: string;
+  /** 1-based current page; viewer updates this on navigation so
+   *  reopening the tab restores the user's place. */
+  page: number;
+}
+
+export interface GraphTab {
+  type: 'graph';
+  /** The note whose link neighborhood is shown (#847). */
+  relativePath: string;
+  /** Traversal depth (1–N). */
+  depth: number;
+}
+
+export interface UnsupportedTab {
+  type: 'unsupported';
+  relativePath: string;
+  fileName: string;
+  /** Lowercased extension (with dot) or '' — drives the "no preview for `.xyz`" copy. */
+  ext: string;
+}
+
+/** Multi-view over all instances of a typed-object type (#1070). */
+export type TypeViewLayout = 'list' | 'table' | 'gallery';
+/** The view's mutable projection state — layout + sort + visible columns.
+ *  Carried on the tab (persisted across sessions) and captured into a saved
+ *  view (#1072). */
+export interface TypeViewState {
+  layout: TypeViewLayout;
+  /** Sort key: a property name, `__title`, or null for the intrinsic order. */
+  sortColumn: string | null;
+  sortDir: 'asc' | 'desc';
+  /** Visible property names (table); null = every declared column. */
+  columns: string[] | null;
+}
+export interface TypeViewTab extends TypeViewState {
+  type: 'type-view';
+  /** The type whose instances are shown (e.g. `book`). */
+  typeId: string;
+}
+
+export type Tab = NoteTab | QueryTab | SourceTab | PdfTab | GraphTab | TypeViewTab | UnsupportedTab;
+
+/**
+ * Source / preview view mode. `'editor-preview'` = source editor + rendered
+ * preview side by side (#818). Lives per editor group (#811) — moved off the
+ * App.svelte global so each split pane can carry its own mode.
+ */
+export type ViewMode = 'source' | 'preview' | 'editor-preview';
+
+/**
+ * One editor group — an independent pane owning its own tab strip, active tab,
+ * and view mode (#811). Until pane-splitting lands (#813+) there is exactly one
+ * group, so every "active group" delegate below reproduces the old singleton
+ * behavior bit-for-bit.
+ */
+export interface EditorGroup {
+  id: string;
+  tabs: Tab[];
+  activeIndex: number;
+  viewMode: ViewMode;
+}
+
+export function isNote(tab: Tab): tab is NoteTab { return tab.type === 'note'; }
+export function isQuery(tab: Tab): tab is QueryTab { return tab.type === 'query'; }
+export function isSource(tab: Tab): tab is SourceTab { return tab.type === 'source'; }
+export function isPdf(tab: Tab): tab is PdfTab { return tab.type === 'pdf'; }
+export function isGraph(tab: Tab): tab is GraphTab { return tab.type === 'graph'; }
+export function isTypeView(tab: Tab): tab is TypeViewTab { return tab.type === 'type-view'; }
+export function isUnsupported(tab: Tab): tab is UnsupportedTab { return tab.type === 'unsupported'; }

--- a/src/renderer/lib/stores/editor.svelte.ts
+++ b/src/renderer/lib/stores/editor.svelte.ts
@@ -1,5 +1,4 @@
 import { api } from '../ipc/client';
-import type { TabSession, SavedTab, SavedGroup, LayoutSession } from '../../../shared/types';
 import { fileCapability, extensionOf } from '../../../shared/file-capability';
 import { normalizeSqlRows, unionColumns } from '../editor/sql-result';
 import {
@@ -9,134 +8,24 @@ import {
   splitLeaf,
   removeLeaf,
   collectGroupIds,
-  isLayoutNode,
 } from '../editor/layout-tree';
+import {
+  type EditorGroup, type Tab, type ViewMode, type TypeViewState, type TypeViewTab,
+  type NoteTab, type QueryTab, type QueryLanguage, type SourceTab, type PdfTab, type GraphTab, type UnsupportedTab,
+  isNote, isQuery, isSource, isPdf, isGraph, isTypeView, isUnsupported,
+} from '../editor/tab-types';
+import { buildSession, normalizeSession, resolveRestoredSession } from '../editor/tab-session';
 import { logger } from '../../../shared/logger';
 
 // ── Tab types ───────────────────────────────────────────────────────────────
-
-export interface NoteTab {
-  type: 'note';
-  relativePath: string;
-  fileName: string;
-  content: string;
-  savedContent: string;
-  /** True when opened in plain-text mode — a non-markdown text file (#1130).
-   *  Drives the Editor's plain-text mode (markdown behaviors off). Omitted for
-   *  markdown files. */
-  plainText?: boolean | undefined;
-  cursorOffset?: number | undefined;
-  scrollTop?: number | undefined;
-  /** Preview-pane scroll offset. Separate from `scrollTop`: the editor and the
-   *  preview lay the same note out at different heights, so sharing one number
-   *  would land the reader in the wrong place. */
-  previewScrollTop?: number | undefined;
-  /**
-   * Serialised CodeMirror `EditorState` (doc + selection + history
-   * stacks) captured on Editor unmount. Used to restore undo/redo across
-   * tab switches — without this, switching tabs and back would give you
-   * a fresh editor with empty history (#167). Memory-only; not persisted
-   * to disk since session-restore is a separate concern.
-   */
-  historyJson?: unknown;
-}
-
-export type QueryLanguage = 'sparql' | 'sql';
-
-export interface QueryTab {
-  type: 'query';
-  id: string;
-  title: string;
-  query: string;
-  language: QueryLanguage;
-  results: Record<string, string>[] | null;
-  columns: string[];
-  error: string | null;
-  executing: boolean;
-  executionTime: number | null;
-}
-
-export interface SourceTab {
-  type: 'source';
-  sourceId: string;
-  /** If the user arrived via a [[quote::id]] click, highlight this excerpt in the detail view. */
-  highlightExcerptId?: string | undefined;
-}
-
-export interface PdfTab {
-  type: 'pdf';
-  sourceId: string;
-  /** 1-based current page; viewer updates this on navigation so
-   *  reopening the tab restores the user's place. */
-  page: number;
-}
-
-export interface GraphTab {
-  type: 'graph';
-  /** The note whose link neighborhood is shown (#847). */
-  relativePath: string;
-  /** Traversal depth (1–N). */
-  depth: number;
-}
-
-export interface UnsupportedTab {
-  type: 'unsupported';
-  relativePath: string;
-  fileName: string;
-  /** Lowercased extension (with dot) or '' — drives the "no preview for `.xyz`" copy. */
-  ext: string;
-}
-
-/** Multi-view over all instances of a typed-object type (#1070). */
-export type TypeViewLayout = 'list' | 'table' | 'gallery';
-/** The view's mutable projection state — layout + sort + visible columns.
- *  Carried on the tab (persisted across sessions) and captured into a saved
- *  view (#1072). */
-export interface TypeViewState {
-  layout: TypeViewLayout;
-  /** Sort key: a property name, `__title`, or null for the intrinsic order. */
-  sortColumn: string | null;
-  sortDir: 'asc' | 'desc';
-  /** Visible property names (table); null = every declared column. */
-  columns: string[] | null;
-}
-export interface TypeViewTab extends TypeViewState {
-  type: 'type-view';
-  /** The type whose instances are shown (e.g. `book`). */
-  typeId: string;
-}
-
-export type Tab = NoteTab | QueryTab | SourceTab | PdfTab | GraphTab | TypeViewTab | UnsupportedTab;
-
-/**
- * Source / preview view mode. `'editor-preview'` = source editor + rendered
- * preview side by side (#818). Lives per editor group (#811) — moved off the
- * App.svelte global so each split pane can carry its own mode.
- */
-export type ViewMode = 'source' | 'preview' | 'editor-preview';
-
-/**
- * One editor group — an independent pane owning its own tab strip, active tab,
- * and view mode (#811). Until pane-splitting lands (#813+) there is exactly one
- * group, so every "active group" delegate below reproduces the old singleton
- * behavior bit-for-bit.
- */
-export interface EditorGroup {
-  id: string;
-  tabs: Tab[];
-  activeIndex: number;
-  viewMode: ViewMode;
-}
-
-// ── Helpers ─────────────────────────────────────────────────────────────────
-
-function isNote(tab: Tab): tab is NoteTab { return tab.type === 'note'; }
-function isQuery(tab: Tab): tab is QueryTab { return tab.type === 'query'; }
-function isSource(tab: Tab): tab is SourceTab { return tab.type === 'source'; }
-function isPdf(tab: Tab): tab is PdfTab { return tab.type === 'pdf'; }
-function isGraph(tab: Tab): tab is GraphTab { return tab.type === 'graph'; }
-function isTypeView(tab: Tab): tab is TypeViewTab { return tab.type === 'type-view'; }
-function isUnsupported(tab: Tab): tab is UnsupportedTab { return tab.type === 'unsupported'; }
+// Moved to ../editor/tab-types.ts (#1919) so the session-serialization module
+// below can share them without importing this store (which would cycle back
+// into it). Re-exported here so existing `from '../stores/editor.svelte'`
+// imports across the renderer are unaffected.
+export type {
+  NoteTab, QueryLanguage, QueryTab, SourceTab, PdfTab, GraphTab, UnsupportedTab,
+  TypeViewLayout, TypeViewState, TypeViewTab, Tab, ViewMode, EditorGroup,
+} from '../editor/tab-types';
 
 let queryCounter = 0;
 let groupCounter = 0;
@@ -165,7 +54,19 @@ let onAutoSaved: (() => void) | null = null;
 const AUTO_SAVE_DELAY = 1000;
 const TAB_PERSIST_DELAY = 500;
 
+/**
+ * Memoized (#1919): `groups`/`activeGroupId`/`layout` above are already
+ * module-level `$state`, so every call used to rebuild an identical closure
+ * set over the same shared state — wasted work, and a shape that invites the
+ * (false) assumption that a fresh call gets fresh state. One instance, built
+ * on first call.
+ */
+let editorStore: ReturnType<typeof buildEditorStore> | undefined;
 export function getEditorStore() {
+  return editorStore ??= buildEditorStore();
+}
+
+function buildEditorStore() {
   function activeGroup(): EditorGroup {
     return groups.find((g) => g.id === activeGroupId) ?? groups[0]!;
   }
@@ -670,33 +571,11 @@ export function getEditorStore() {
     }, TAB_PERSIST_DELAY);
   }
 
-  function toSavedTab(t: Tab): SavedTab {
-    if (isNote(t)) {
-      return {
-        type: 'note',
-        relativePath: t.relativePath,
-        ...(t.plainText ? { plainText: true } : {}),
-        ...(t.cursorOffset !== undefined ? { cursorOffset: t.cursorOffset } : {}),
-        ...(t.scrollTop !== undefined ? { scrollTop: t.scrollTop } : {}),
-        ...(t.previewScrollTop !== undefined ? { previewScrollTop: t.previewScrollTop } : {}),
-      };
-    } else if (isUnsupported(t)) {
-      return { type: 'unsupported', relativePath: t.relativePath };
-    } else if (isQuery(t)) {
-      return { type: 'query', title: t.title, query: t.query, language: t.language };
-    } else if (isPdf(t)) {
-      return { type: 'pdf', sourceId: t.sourceId, page: t.page };
-    } else if (isGraph(t)) {
-      return { type: 'graph', relativePath: t.relativePath, depth: t.depth };
-    } else if (isTypeView(t)) {
-      return { type: 'type-view', typeId: t.typeId, layout: t.layout, sortColumn: t.sortColumn, sortDir: t.sortDir, columns: t.columns };
-    } else {
-      return {
-        type: 'source',
-        sourceId: t.sourceId,
-        ...(t.highlightExcerptId !== undefined ? { highlightExcerptId: t.highlightExcerptId } : {}),
-      };
-    }
+  /** `nextQueryId` shared with `openQuery` below so a restored query tab's id
+   *  can never collide with one opened fresh in the same session. */
+  function nextQueryId(): string {
+    queryCounter++;
+    return `query-${queryCounter}-${Date.now()}`;
   }
 
   function persistTabs() {
@@ -705,183 +584,33 @@ export function getEditorStore() {
     //
     // Snapshot the whole session rather than just `layout` (which was already
     // snapshotted for the reason below). Defence in depth, not a known break:
-    // `toSavedTab` copies some fields off `$state` tabs by reference — a
+    // `buildSession` copies some fields off `$state` tabs by reference — a
     // type-view tab's `columns`, for one — and whether such a value comes back
     // as a Svelte Proxy is subtle enough that it isn't worth betting session
     // restore on. The structured-clone IPC boundary rejects a Proxy outright,
     // and one slipping through would silently lose the whole save.
-    const session: LayoutSession = {
-      version: 2,
-      activeGroupId,
-      groups: groups.map((g): SavedGroup => ({
-        id: g.id,
-        activeIndex: g.activeIndex,
-        viewMode: g.viewMode,
-        tabs: g.tabs.map(toSavedTab),
-      })),
-      layout,
-    };
+    const session = buildSession(groups, activeGroupId, layout);
     // Surfacing beats a silent `void`: a rejected save means the session won't
     // come back next launch, and losing that quietly is how this went unseen.
     void api.tabs.save($state.snapshot(session))
       .catch((e: unknown) => { logger('tabs').error('failed to persist session:', e); });
   }
 
-  /** Reconstruct a live tab from its persisted form. Notes read their file
-   *  back (returning null if it was deleted since last session, so the tab is
-   *  dropped); the other kinds rehydrate from saved fields. */
-  async function reconstructTab(saved: SavedTab): Promise<Tab | null> {
-    if (saved.type === 'note') {
-      try {
-        const text = await api.notebase.readFile(saved.relativePath);
-        const fileName = saved.relativePath.split('/').pop() ?? '';
-        return {
-          type: 'note',
-          relativePath: saved.relativePath,
-          fileName,
-          content: text,
-          savedContent: text,
-          ...(saved.plainText ? { plainText: true } : {}),
-          cursorOffset: saved.cursorOffset,
-          scrollTop: saved.scrollTop,
-          previewScrollTop: saved.previewScrollTop,
-        };
-      } catch {
-        return null; // file deleted since last session
-      }
-    } else if (saved.type === 'unsupported') {
-      const fileName = saved.relativePath.split('/').pop() ?? '';
-      return { type: 'unsupported', relativePath: saved.relativePath, fileName, ext: extensionOf(saved.relativePath) };
-    } else if (saved.type === 'query') {
-      queryCounter++;
-      return {
-        type: 'query',
-        id: `query-${queryCounter}-${Date.now()}`,
-        title: saved.title,
-        query: saved.query,
-        language: saved.language ?? 'sparql',
-        results: null,
-        columns: [],
-        error: null,
-        executing: false,
-        executionTime: null,
-      };
-    } else if (saved.type === 'pdf') {
-      return { type: 'pdf', sourceId: saved.sourceId, page: saved.page ?? 1 };
-    } else if (saved.type === 'graph') {
-      return { type: 'graph', relativePath: saved.relativePath, depth: saved.depth ?? 1 };
-    } else if (saved.type === 'type-view') {
-      return {
-        type: 'type-view',
-        typeId: saved.typeId,
-        layout: saved.layout ?? 'table',
-        sortColumn: saved.sortColumn ?? null,
-        sortDir: saved.sortDir ?? 'asc',
-        columns: saved.columns ?? null,
-      };
-    } else {
-      return { type: 'source', sourceId: saved.sourceId, highlightExcerptId: saved.highlightExcerptId };
-    }
-  }
-
-  function asViewMode(v: unknown): ViewMode {
-    return v === 'preview' || v === 'editor-preview' || v === 'source' ? v : 'source';
-  }
-
-  /** Cross-pane identity of a persisted tab, for the forbid-duplicate dedup on
-   *  restore (#815). Queries have no shared-buffer identity (each is its own
-   *  scratch buffer), so they return null and are never deduped. */
-  function savedTabIdentity(t: SavedTab): string | null {
-    if (t.type === 'note') return `note:${t.relativePath}`;
-    if (t.type === 'source') return `source:${t.sourceId}`;
-    if (t.type === 'pdf') return `pdf:${t.sourceId}`;
-    if (t.type === 'type-view') return `type-view:${t.typeId}`;
-    return null;
-  }
-
-  /** Coerce whatever is on disk into the current multi-group shape. New
-   *  sessions pass through; a legacy flat `TabSession` migrates to a single
-   *  group (#816); anything else (null / empty / unrecognised) → null, so the
-   *  caller keeps the start-of-session empty group. */
-  function normalizeSession(raw: LayoutSession | TabSession | null): LayoutSession | null {
-    if (!raw || typeof raw !== 'object') return null;
-    if ('groups' in raw && Array.isArray(raw.groups)) {
-      return raw.groups.length > 0 ? raw : null;
-    }
-    if ('tabs' in raw && Array.isArray(raw.tabs)) {
-      if (raw.tabs.length === 0) return null;
-      const id = newGroupId();
-      return {
-        version: 2,
-        activeGroupId: id,
-        groups: [{ id, activeIndex: raw.activeIndex ?? 0, viewMode: 'source', tabs: raw.tabs }],
-        layout: { kind: 'leaf', groupId: id },
-      };
-    }
-    return null;
-  }
-
   async function restoreTabs() {
-    const session = normalizeSession(await api.tabs.load());
+    const session = normalizeSession(await api.tabs.load(), newGroupId);
     if (!session) return; // nothing saved or corrupt → keep the default empty group
 
-    // Rebuild each group, dropping note tabs whose files have since vanished
-    // and any duplicate of a tab already restored in an earlier pane — the
-    // forbid-duplicate-open invariant (#815) must hold even if the on-disk
-    // session was hand-edited or written by an older build.
-    const seen = new Set<string>();
-    const restored: EditorGroup[] = [];
-    for (const sg of session.groups) {
-      const tabs: Tab[] = [];
-      for (const saved of sg.tabs) {
-        const identity = savedTabIdentity(saved);
-        if (identity && seen.has(identity)) continue;
-        const tab = await reconstructTab(saved);
-        if (tab) {
-          tabs.push(tab);
-          if (identity) seen.add(identity);
-        }
-      }
-      const activeIndex =
-        sg.activeIndex >= 0 && sg.activeIndex < tabs.length
-          ? sg.activeIndex
-          : tabs.length > 0 ? 0 : -1;
-      restored.push({ id: sg.id, tabs, activeIndex, viewMode: asViewMode(sg.viewMode) });
-    }
-    if (restored.length === 0) return;
-
-    // The saved layout must structurally match the restored groups exactly
-    // (every leaf ↔ a live group, no orphans). If it doesn't, we can't trust
-    // the tree — recover by merging every restored tab into one pane rather
-    // than rendering a broken split or crashing.
-    const ids = new Set(restored.map((g) => g.id));
-    // SavedLayoutNode is structurally a LayoutNode; isLayoutNode still guards
-    // against a corrupt on-disk tree that doesn't match the declared shape.
-    const savedLayout = session.layout;
-    const layoutOk =
-      isLayoutNode(savedLayout) &&
-      (() => {
-        const leaves = collectGroupIds(savedLayout);
-        return leaves.length === ids.size && leaves.every((id) => ids.has(id));
-      })();
+    // Rebuild each group (dropping vanished files + forbid-duplicate-open
+    // dedup, #815) and validate the saved layout against it, falling back to
+    // one merged pane if the tree doesn't structurally match — see
+    // `resolveRestoredSession` in editor/tab-session.ts.
+    const resolved = await resolveRestoredSession(session, nextQueryId);
+    if (!resolved) return;
 
     groups.length = 0;
-    if (layoutOk) {
-      groups.push(...restored);
-      layout = savedLayout;
-      activeGroupId = ids.has(session.activeGroupId) ? session.activeGroupId : restored[0]!.id;
-    } else {
-      const merged: EditorGroup = {
-        id: restored[0]!.id,
-        tabs: restored.flatMap((g) => g.tabs),
-        activeIndex: -1,
-        viewMode: restored[0]!.viewMode,
-      };
-      merged.activeIndex = merged.tabs.length > 0 ? 0 : -1;
-      groups.push(merged);
-      layout = leaf(merged.id);
-      activeGroupId = merged.id;
-    }
+    groups.push(...resolved.groups);
+    layout = resolved.layout;
+    activeGroupId = resolved.activeGroupId;
 
     // `groupCounter` reset to 0 at launch; restored ids came from disk. Advance
     // it past the highest restored `group-N` so a later split can't re-mint an

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -61,7 +61,7 @@ const BUDGETS: Record<string, number> = {
   'src/renderer/lib/ipc/client.ts': 1240,
   'src/renderer/lib/stores/conversations.svelte.ts': 1179,
   'src/renderer/lib/components/Editor.svelte': 824,
-  'src/renderer/lib/stores/editor.svelte.ts': 1184,
+  'src/renderer/lib/stores/editor.svelte.ts': 913,
     'src/renderer/lib/components/right-sidebar/PropertiesPanel.svelte': 1156,
   'src/main/menu.ts': 1020,
   'src/main/graph/indexers.ts': 724,

--- a/tests/renderer/editor/tab-session.test.ts
+++ b/tests/renderer/editor/tab-session.test.ts
@@ -1,0 +1,220 @@
+/**
+ * `editor/tab-session.ts` (#1919) — the tab/layout serialization seam
+ * extracted from `getEditorStore`. Pure data mapping, tested directly rather
+ * than only indirectly through the store's persist/restore integration tests
+ * (`editor-store-panes.test.ts`, `editor-store-tabs.test.ts`), which still
+ * cover the end-to-end save→load round trip through the real store.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { EditorGroup, Tab, NoteTab, QueryTab } from '../../../src/renderer/lib/editor/tab-types';
+import type { LayoutSession, TabSession } from '../../../src/shared/types';
+import { leaf } from '../../../src/renderer/lib/editor/layout-tree';
+
+const h = vi.hoisted(() => ({
+  readFile: vi.fn(async (p: string) => `# ${p}\nbody`),
+}));
+
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
+  api: { notebase: { readFile: h.readFile } },
+}));
+
+import {
+  toSavedTab, buildSession, reconstructTab, asViewMode, savedTabIdentity,
+  normalizeSession, resolveRestoredSession,
+} from '../../../src/renderer/lib/editor/tab-session';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.readFile.mockImplementation(async (p: string) => `# ${p}\nbody`);
+});
+
+const noteTab: NoteTab = {
+  type: 'note', relativePath: 'a.md', fileName: 'a.md', content: 'x', savedContent: 'x',
+};
+const queryTab: QueryTab = {
+  type: 'query', id: 'query-1', title: 'Query 1', query: 'SELECT *', language: 'sparql',
+  results: null, columns: [], error: null, executing: false, executionTime: null,
+};
+
+describe('toSavedTab', () => {
+  it('drops runtime-only note fields not meant for the saved shape', () => {
+    const withHistory: NoteTab = { ...noteTab, historyJson: { fake: true }, cursorOffset: 5 };
+    const saved = toSavedTab(withHistory);
+    expect(saved).toEqual({ type: 'note', relativePath: 'a.md', cursorOffset: 5 });
+    expect(saved).not.toHaveProperty('historyJson');
+    expect(saved).not.toHaveProperty('content');
+  });
+
+  it('carries a query tab\'s editable fields, not its runtime result state', () => {
+    const ran: QueryTab = { ...queryTab, results: [{ a: '1' }], columns: ['a'], executing: true };
+    expect(toSavedTab(ran)).toEqual({ type: 'query', title: 'Query 1', query: 'SELECT *', language: 'sparql' });
+  });
+});
+
+describe('buildSession', () => {
+  it('snapshots every group\'s tabs, active index, and view mode, plus the layout', () => {
+    const groups: EditorGroup[] = [{ id: 'group-1', tabs: [noteTab], activeIndex: 0, viewMode: 'source' }];
+    const session = buildSession(groups, 'group-1', leaf('group-1'));
+    expect(session).toEqual({
+      version: 2,
+      activeGroupId: 'group-1',
+      groups: [{ id: 'group-1', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'a.md' }] }],
+      layout: leaf('group-1'),
+    });
+  });
+});
+
+describe('reconstructTab', () => {
+  it('reads a note tab\'s content back from disk', async () => {
+    h.readFile.mockResolvedValue('# A\nbody');
+    const tab = await reconstructTab({ type: 'note', relativePath: 'a.md' }, () => 'unused') as NoteTab;
+    expect(tab).toMatchObject({ type: 'note', relativePath: 'a.md', content: '# A\nbody', savedContent: '# A\nbody' });
+  });
+
+  it('drops a note tab whose file was deleted since the last session', async () => {
+    h.readFile.mockRejectedValue(new Error('ENOENT'));
+    expect(await reconstructTab({ type: 'note', relativePath: 'gone.md' }, () => 'unused')).toBeNull();
+  });
+
+  it('mints a query tab id via the shared counter, not a fixed value', async () => {
+    const tab = await reconstructTab(
+      { type: 'query', title: 'Q', query: 'SELECT *' },
+      () => 'query-42-123',
+    ) as QueryTab;
+    expect(tab.id).toBe('query-42-123');
+    expect(tab).toMatchObject({ results: null, executing: false });
+  });
+
+  it('rehydrates a pdf tab, defaulting an absent page to 1', async () => {
+    const tab = await reconstructTab({ type: 'pdf', sourceId: 's1' }, () => 'unused');
+    expect(tab).toEqual({ type: 'pdf', sourceId: 's1', page: 1 });
+  });
+});
+
+describe('asViewMode', () => {
+  it('passes through a recognised mode', () => {
+    expect(asViewMode('preview')).toBe('preview');
+    expect(asViewMode('editor-preview')).toBe('editor-preview');
+  });
+
+  it('falls back to source for anything unrecognised', () => {
+    expect(asViewMode('nonsense')).toBe('source');
+    expect(asViewMode(undefined)).toBe('source');
+  });
+});
+
+describe('savedTabIdentity', () => {
+  it('identifies note/source/pdf/type-view tabs for forbid-duplicate dedup (#815)', () => {
+    expect(savedTabIdentity({ type: 'note', relativePath: 'a.md' })).toBe('note:a.md');
+    expect(savedTabIdentity({ type: 'source', sourceId: 's1' })).toBe('source:s1');
+    expect(savedTabIdentity({ type: 'pdf', sourceId: 's1' })).toBe('pdf:s1');
+    expect(savedTabIdentity({ type: 'type-view', typeId: 'book' })).toBe('type-view:book');
+  });
+
+  it('a query tab has no shared-buffer identity — never deduped', () => {
+    expect(savedTabIdentity({ type: 'query', title: 'Q', query: 'x' })).toBeNull();
+  });
+});
+
+describe('normalizeSession', () => {
+  it('passes a modern multi-group session through unchanged', () => {
+    const session: LayoutSession = {
+      version: 2, activeGroupId: 'g1',
+      groups: [{ id: 'g1', activeIndex: 0, viewMode: 'source', tabs: [] }],
+      layout: leaf('g1'),
+    };
+    expect(normalizeSession(session, () => 'unused')).toBe(session);
+  });
+
+  it('migrates a legacy flat TabSession into a single group (#816)', () => {
+    const legacy: TabSession = { tabs: [{ type: 'note', relativePath: 'a.md' }], activeIndex: 0 };
+    const migrated = normalizeSession(legacy, () => 'group-9');
+    expect(migrated).toEqual({
+      version: 2,
+      activeGroupId: 'group-9',
+      groups: [{ id: 'group-9', activeIndex: 0, viewMode: 'source', tabs: legacy.tabs }],
+      layout: { kind: 'leaf', groupId: 'group-9' },
+    });
+  });
+
+  it('returns null for null, an empty legacy session, or an unrecognised shape', () => {
+    expect(normalizeSession(null, () => 'x')).toBeNull();
+    expect(normalizeSession({ tabs: [], activeIndex: 0 }, () => 'x')).toBeNull();
+    expect(normalizeSession({} as TabSession, () => 'x')).toBeNull();
+  });
+
+  it('an empty modern session (groups: []) is treated the same as none', () => {
+    expect(normalizeSession({ version: 2, activeGroupId: 'g1', groups: [], layout: leaf('g1') }, () => 'x')).toBeNull();
+  });
+});
+
+describe('resolveRestoredSession', () => {
+  const nextQueryId = () => 'query-1-0';
+
+  it('restores every group with a matching layout, keeping the saved activeGroupId', async () => {
+    const session: LayoutSession = {
+      version: 2,
+      activeGroupId: 'g1',
+      groups: [
+        { id: 'g1', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'a.md' }] },
+      ],
+      layout: leaf('g1'),
+    };
+    const resolved = await resolveRestoredSession(session, nextQueryId);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.groups).toHaveLength(1);
+    expect(resolved!.groups[0]!.tabs).toEqual([
+      expect.objectContaining({ type: 'note', relativePath: 'a.md' }),
+    ]);
+    expect(resolved!.layout).toEqual(leaf('g1'));
+    expect(resolved!.activeGroupId).toBe('g1');
+  });
+
+  it('drops a note whose file vanished, and dedupes a tab restored in an earlier pane (#815)', async () => {
+    h.readFile.mockImplementation(async (p: string) => {
+      if (p === 'gone.md') throw new Error('ENOENT');
+      return `# ${p}`;
+    });
+    const session: LayoutSession = {
+      version: 2,
+      activeGroupId: 'g1',
+      groups: [
+        { id: 'g1', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'a.md' }, { type: 'note', relativePath: 'gone.md' }] },
+        { id: 'g2', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'a.md' }] }, // duplicate of g1's tab
+      ],
+      layout: { kind: 'split', direction: 'horizontal', children: [leaf('g1'), leaf('g2')], sizes: [0.5, 0.5] },
+    };
+    const resolved = await resolveRestoredSession(session, nextQueryId);
+    expect(resolved!.groups[0]!.tabs.map((t: Tab) => (t as NoteTab).relativePath)).toEqual(['a.md']);
+    expect(resolved!.groups[1]!.tabs).toEqual([]); // its only tab was a dupe of g1's
+  });
+
+  it('falls back to one merged pane when the saved layout does not structurally match the restored groups', async () => {
+    const session: LayoutSession = {
+      version: 2,
+      activeGroupId: 'g1',
+      groups: [
+        { id: 'g1', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'a.md' }] },
+        { id: 'g2', activeIndex: 0, viewMode: 'source', tabs: [{ type: 'note', relativePath: 'b.md' }] },
+      ],
+      // Corrupt: layout only references g1, not g2 — leaves.length !== ids.size.
+      layout: leaf('g1'),
+    };
+    const resolved = await resolveRestoredSession(session, nextQueryId);
+    expect(resolved!.groups).toHaveLength(1);
+    expect(resolved!.groups[0]!.tabs.map((t: Tab) => (t as NoteTab).relativePath)).toEqual(['a.md', 'b.md']);
+    expect(resolved!.layout).toEqual(leaf(resolved!.groups[0]!.id));
+    expect(resolved!.activeGroupId).toBe(resolved!.groups[0]!.id);
+  });
+
+  it('falls back to the first restored group when the saved activeGroupId no longer exists', async () => {
+    const session: LayoutSession = {
+      version: 2,
+      activeGroupId: 'ghost',
+      groups: [{ id: 'g1', activeIndex: 0, viewMode: 'source', tabs: [] }],
+      layout: leaf('g1'),
+    };
+    const resolved = await resolveRestoredSession(session, nextQueryId);
+    expect(resolved!.activeGroupId).toBe('g1');
+  });
+});

--- a/tests/renderer/stores/editor-store-panes.test.ts
+++ b/tests/renderer/stores/editor-store-panes.test.ts
@@ -1,5 +1,12 @@
 /**
- * Editor store — editor-group model (#811).
+ * Editor store — pane/split-layout model (#811, #813, #814, #815, #817).
+ *
+ * Renamed from `tests/renderer/editor-store.test.ts` (#1919) — its
+ * near-identical name and different directory next to
+ * `editor-store-tabs.test.ts` (per-tab-kind behavior) was a navigation
+ * hazard. This file owns the group/pane/split-layout half of the store:
+ * one-group parity, group-scoped mutations, split/collapse/drag-to-split,
+ * forbid-duplicate-open, and multi-group session persistence.
  *
  * Phase 1 of #810 promotes the `tabs[]` / `activeIndex` / `viewMode` singleton
  * into a collection of editor groups. These tests pin (a) one-group parity —
@@ -7,7 +14,7 @@
  * new group-scoped mutation surface.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { LayoutSession } from '../../src/shared/types';
+import type { LayoutSession } from '../../../src/shared/types';
 
 const h = vi.hoisted(() => ({
   readFile: vi.fn(async (p: string) => `# ${p}\nbody`),
@@ -16,7 +23,7 @@ const h = vi.hoisted(() => ({
   tabsLoad: vi.fn(async (): Promise<unknown> => null),
 }));
 
-vi.mock('../../src/renderer/lib/ipc/client', () => ({
+vi.mock('../../../src/renderer/lib/ipc/client', () => ({
   api: {
     notebase: { readFile: h.readFile, writeFile: h.writeFile },
     tabs: { save: h.tabsSave, load: h.tabsLoad },
@@ -25,8 +32,8 @@ vi.mock('../../src/renderer/lib/ipc/client', () => ({
   },
 }));
 
-import { getEditorStore } from '../../src/renderer/lib/stores/editor.svelte';
-import { collectGroupIds } from '../../src/renderer/lib/editor/layout-tree';
+import { getEditorStore } from '../../../src/renderer/lib/stores/editor.svelte';
+import { collectGroupIds } from '../../../src/renderer/lib/editor/layout-tree';
 
 const editor = getEditorStore();
 

--- a/tests/renderer/stores/editor-store-tabs.test.ts
+++ b/tests/renderer/stores/editor-store-tabs.test.ts
@@ -1,9 +1,15 @@
 /**
- * Editor store — coverage for the paths the group-model suite
- * (`tests/renderer/editor-store.test.ts`) doesn't exercise: query tabs,
- * neighborhood/pdf/source tabs, autosave/persist timers, dirty tracking +
- * reload-from-disk, non-markdown (plain-text / unsupported) opens, source-tab
- * teardown, and the query/pdf/graph/source round-trips through save + restore.
+ * Editor store — per-tab-kind behavior. Renamed from
+ * `tests/renderer/stores/editor-store.test.ts` (#1919) — its near-identical
+ * name next to `tests/renderer/editor-store.test.ts` (the group/pane-layout
+ * suite, itself renamed + moved here as `editor-store-panes.test.ts`) was a
+ * navigation hazard.
+ *
+ * Covers the paths the pane/layout suite (`editor-store-panes.test.ts`)
+ * doesn't exercise: query tabs, neighborhood/pdf/source tabs, autosave/persist
+ * timers, dirty tracking + reload-from-disk, non-markdown (plain-text /
+ * unsupported) opens, source-tab teardown, and the query/pdf/graph/source
+ * round-trips through save + restore.
  *
  * Same mock pattern as the sibling suite: `window.api` (`../ipc/client`) is
  * replaced with configurable slices, the singleton store is driven directly,
@@ -41,6 +47,13 @@ beforeEach(() => {
   h.readFile.mockImplementation(async (p: string) => `# ${p}\nbody`);
   editor.onAutoSaved = null;
   editor.clear(); // collapse to a single empty group
+});
+
+describe('getEditorStore memoization (#1919)', () => {
+  it('returns the same instance on every call, not a fresh closure set', () => {
+    expect(getEditorStore()).toBe(editor);
+    expect(getEditorStore()).toBe(getEditorStore());
+  });
 });
 
 // ── Query tabs ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #1919. `getEditorStore` (1,017-line function body) was the largest
single function in the codebase — a genuine god-object, unlike the long
registrars/factories elsewhere that are mostly repetition. The tab/layout
serialisation block was the clean seam: pure data mapping over
`EditorGroup`/`Tab` with no editor behavior in it (no autosave, no
cursor/scroll tracking, no view-mode cycling).

Extracted two new leaf modules under `src/renderer/lib/editor/`:
- **`tab-types.ts`**: the Tab-family interfaces (`NoteTab`/`QueryTab`/.../`EditorGroup`)
  and their type guards, pulled out first because both `editor.svelte.ts` and
  the new session module need them — importing types from `editor.svelte.ts`
  into the session module would have been a cycle, since `editor.svelte.ts`
  also imports the session module's functions.
- **`tab-session.ts`**: `toSavedTab`, `buildSession`, `reconstructTab`,
  `asViewMode`, `savedTabIdentity`, `normalizeSession`, and
  `resolveRestoredSession` (which composes the group-rebuild +
  forbid-duplicate dedup + layout-validation logic previously inlined in
  `restoreTabs`). The store still owns the actual `$state`
  (`groups`/`activeGroupId`/`layout`) and the `api.tabs.save`/`load` IPC
  calls; `editor.svelte.ts`'s `persistTabs`/`restoreTabs` are now thin
  wrappers that compute what to persist / how to turn persisted data into
  live tabs by calling into this module, then commit the result.

`editor.svelte.ts` re-exports every type now living in `tab-types.ts`, so the
19 other files importing from `stores/editor.svelte` are unaffected. The
factory body shrank from 1,017 to 845 lines; the whole file from 1,184 to 913.

**`getEditorStore()` is now memoised**: it was called at 19 sites, none of
them needing a fresh instance (`groups`/`activeGroupId`/`layout` are already
module-level `$state`), so every call rebuilt an identical closure set over
the same shared state — wasted work, and a shape that invited the false
assumption that a fresh call gets fresh state.

**Renamed + moved the two near-identically-named test files** (a navigation
hazard, not actual duplicates — they cover different halves of the store):
`tests/renderer/editor-store.test.ts` (pane/split-layout mechanics, #811-#817)
→ `tests/renderer/stores/editor-store-panes.test.ts`; the existing
`tests/renderer/stores/editor-store.test.ts` (per-tab-kind behavior) →
`editor-store-tabs.test.ts`, both now living together under `stores/`.

## Test plan

- [x] New `tests/renderer/editor/tab-session.test.ts` — 19 tests directly
      exercising the extracted module's pure functions (dedup, layout
      fallback, legacy-session migration, vanished-file handling, ...)
- [x] Memoization test added to `editor-store-tabs.test.ts`
- [x] Both renamed/moved test files — 104 pre-existing tests, unchanged and
      passing through the extraction
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 652 files / 7047 tests passed
- [x] `tests/architecture/no-cycles.test.ts` — no cycle from the new
      cross-module type sharing
- [x] `tests/architecture/file-size-budgets.test.ts` — lowered
      `editor.svelte.ts`'s budget (1184 → 913)
- [x] No `window.api` surface touched — preload bridge snapshot unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)