### PR TITLE
fix: correct 83 client.ts subscription return types, fix a real listener leak (#1890)

### DIFF
--- a/src/renderer/lib/components/SourcesPanel.svelte
+++ b/src/renderer/lib/components/SourcesPanel.svelte
@@ -169,7 +169,12 @@
   // The main process broadcasts COLLECTIONS_CHANGED after any mutation
   // (including from other windows / direct file edits). Keep our tree
   // in sync without forcing the host to call refresh() explicitly.
-  sourceData.onCollectionsChanged(() => { void refreshCollections(); });
+  //
+  // This panel lives behind a {#if activePanel === 'sites'} in Sidebar.svelte
+  // — switching sidebar tabs destroys and recreates it — so the subscription
+  // MUST be torn down on unmount (#1890) or every tab switch leaks another
+  // listener, each firing refreshCollections() on the next change.
+  $effect(() => sourceData.onCollectionsChanged(() => { void refreshCollections(); }));
 
   async function refreshCollections(): Promise<void> {
     const data = await api.collections.list();

--- a/src/renderer/lib/ipc/client.ts
+++ b/src/renderer/lib/ipc/client.ts
@@ -58,9 +58,9 @@ export interface NotebaseApi {
   onFileChanged(cb: (path: string) => void): () => void;
   onFileCreated(cb: (path: string) => void): () => void;
   onFileDeleted(cb: (path: string) => void): () => void;
-  onRenamed(cb: (transitions: Array<{ old: string; new: string }>) => void): void;
+  onRenamed(cb: (transitions: Array<{ old: string; new: string }>) => void): () => void;
   onRewritten(cb: (paths: string[]) => void): () => void;
-  onHeadingRenameSuggested(cb: (candidate: HeadingRenameCandidate) => void): void;
+  onHeadingRenameSuggested(cb: (candidate: HeadingRenameCandidate) => void): () => void;
   renameAnchor(targetRelativePath: string, oldSlug: string, newSlug: string): Promise<{ rewrittenPaths: string[] }>;
   renameSource(oldId: string, newId: string): Promise<{ rewrittenPaths: string[] }>;
   renameExcerpt(oldId: string, newId: string): Promise<{ rewrittenPaths: string[] }>;
@@ -200,23 +200,23 @@ export interface TablesApi {
   query(sql: string): Promise<TablesQueryResult>;
   list(): Promise<TableInfo[]>;
   /** Fires when a CSV is registered/unregistered or the initial scan completes. */
-  onChanged(cb: () => void): void;
+  onChanged(cb: () => void): () => void;
   /** Fires when two CSVs derive the same DuckDB table name and the
    *  second was skipped (#354). Renderer surfaces a suppressible
    *  toast pointing at `table_name:` as the fix. */
-  onNameCollision(cb: (collision: import('../../../shared/types').CsvTableCollision) => void): void;
+  onNameCollision(cb: (collision: import('../../../shared/types').CsvTableCollision) => void): () => void;
 }
 
 /** File ▸ maintenance operations report progress + completion here (#1814);
  *  they run in main, kicked off from the native menu, so this event is the
  *  renderer's only view of them. */
 interface MaintenanceApi {
-  onProgress(cb: (p: MaintenanceProgress) => void): void;
+  onProgress(cb: (p: MaintenanceProgress) => void): () => void;
 }
 
 export interface EmbeddingsApi {
   /** Fires as the semantic-index backfill progresses; `running: false` on completion (#836). */
-  onBackfillProgress(cb: (p: { done: number; total: number; running: boolean }) => void): void;
+  onBackfillProgress(cb: (p: { done: number; total: number; running: boolean }) => void): () => void;
   /** Notes semantically related to `relativePath`, for the Related panel (#838). */
   related(relativePath: string, limit?: number): Promise<import('../../../shared/types').RelatedNotesResult>;
   /** Notes that semantically mention an object (by title/aliases) but don't link
@@ -622,9 +622,9 @@ export interface ConversationsApi {
   ): Promise<Conversation>;
   loadUIState(): Promise<import('../../../shared/conversation').ConversationsUIState>;
   saveUIState(state: import('../../../shared/conversation').ConversationsUIState): Promise<void>;
-  onAskUser(cb: (req: import('../../../shared/conversation-tools').AskUserRequest) => void): void;
+  onAskUser(cb: (req: import('../../../shared/conversation-tools').AskUserRequest) => void): () => void;
   askUserReply(questionId: string, answer: string): Promise<void>;
-  onStream(cb: (chunk: string) => void): void;
+  onStream(cb: (chunk: string) => void): () => void;
   cancel(): Promise<void>;
   setModel(conversationId: string, model: string | undefined): Promise<Conversation>;
   /** Per-conversation reasoning-effort override (#825). Pass undefined to
@@ -637,7 +637,7 @@ export interface ConversationsApi {
    *  conversation, archiving the original. */
   compact(conversationId: string): Promise<import('../../../shared/conversation').CompactResult>;
   /** Subscribe to drafts produced by the propose_notes tool. Drafts are scoped per conversation. */
-  onDraft(cb: (draft: import('../../../shared/conversation-drafts').ConversationDraft) => void): void;
+  onDraft(cb: (draft: import('../../../shared/conversation-drafts').ConversationDraft) => void): () => void;
   /** File a draft as a Proposal AND auto-approve it (the user already reviewed the inline card). */
   fileDraft(
     draft: import('../../../shared/conversation-drafts').ConversationDraft,
@@ -734,11 +734,11 @@ export interface ProposalsApi {
   expire(): Promise<number>;
   /** Fires when the pending-proposal set changes (in-app or routed from a
    *  CLI/MCP client) — the proposals store re-fetches on it (#1524). */
-  onChanged(cb: () => void): void;
+  onChanged(cb: () => void): () => void;
   /** Raise a native OS notification for an arrival while unfocused (#1541). */
   notifyArrival(arg: { count: number; proposer: string }): Promise<void>;
   /** Main → renderer: surface the Proposals panel (native notification clicked). */
-  onShowRequested(cb: () => void): void;
+  onShowRequested(cb: () => void): () => void;
 }
 
 export interface TabsApi {
@@ -833,7 +833,7 @@ export interface ToolsApi {
   execute(request: ToolExecutionRequest): Promise<ToolExecutionResult>;
   prepareConversation(request: ToolExecutionRequest): Promise<ConversationToolPayload>;
   cancel(): Promise<void>;
-  onStream(cb: (chunk: string) => void): void;
+  onStream(cb: (chunk: string) => void): () => void;
   getSettings(): Promise<import('../../../shared/tools/types').LLMSettingsView>;
   setSettings(update: import('../../../shared/tools/types').LLMSettingsUpdate): Promise<void>;
   getKeyStorage(): Promise<import('../../../shared/tools/types').ApiKeyStorage>;
@@ -845,7 +845,7 @@ export interface ToolsApi {
     candidateKey?: string,
     baseURL?: string,
   ): Promise<import('../../../shared/tools/types').ConnectionCheckResult>;
-  onInvoke(cb: (toolId: string) => void): void;
+  onInvoke(cb: (toolId: string) => void): () => void;
 }
 
 export interface TypesApi {
@@ -885,74 +885,74 @@ export interface SkillsApi {
 }
 
 export interface MenuApi {
-  onNewNote(cb: () => void): void;
-  onEditThoughtbaseDoc(cb: () => void): void;
-  onThoughtbaseProperties(cb: () => void): void;
-  onSave(cb: () => void): void;
-  onSaveAsTemplate(cb: () => void): void;
-  onSaveAsObjectType(cb: () => void): void;
-  onInsertTemplate(cb: () => void): void;
-  onToggleSidebar(cb: () => void): void;
-  onTogglePreview(cb: () => void): void;
-  onQuickOpen(cb: () => void): void;
-  onCycleTheme(cb: () => void): void;
-  onSetTheme(cb: (mode: ThemeMode) => void): void;
+  onNewNote(cb: () => void): () => void;
+  onEditThoughtbaseDoc(cb: () => void): () => void;
+  onThoughtbaseProperties(cb: () => void): () => void;
+  onSave(cb: () => void): () => void;
+  onSaveAsTemplate(cb: () => void): () => void;
+  onSaveAsObjectType(cb: () => void): () => void;
+  onInsertTemplate(cb: () => void): () => void;
+  onToggleSidebar(cb: () => void): () => void;
+  onTogglePreview(cb: () => void): () => void;
+  onQuickOpen(cb: () => void): () => void;
+  onCycleTheme(cb: () => void): () => void;
+  onSetTheme(cb: (mode: ThemeMode) => void): () => void;
   reportTheme(mode: ThemeMode): void;
   reportEditorState(state: MenuEditorState): void;
-  onSplitRight(cb: () => void): void;
-  onSplitDown(cb: () => void): void;
-  onFocusNextGroup(cb: () => void): void;
-  onFocusPrevGroup(cb: () => void): void;
-  onCloseGroup(cb: () => void): void;
-  onFontIncrease(cb: () => void): void;
-  onFontDecrease(cb: () => void): void;
-  onFontReset(cb: () => void): void;
-  onToggleRightSidebar(cb: () => void): void;
-  onToggleConversations(cb: () => void): void;
-  onNewConversation(cb: () => void): void;
-  onNavBack(cb: () => void): void;
-  onNavForward(cb: () => void): void;
-  onGotoLine(cb: () => void): void;
-  onFind(cb: () => void): void;
-  onFindReplace(cb: () => void): void;
-  onFindInNotes(cb: () => void): void;
-  onReplaceInNotes(cb: () => void): void;
-  onNewQuery(cb: () => void): void;
-  onOpenStockQuery(cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void): void;
-  onEditSavedQueries(cb: () => void): void;
-  onSortLines(cb: () => void): void;
-  onOpenSettings(cb: () => void): void;
-  onPrint(cb: () => void): void;
-  onAbout(cb: () => void): void;
-  onShortcuts(cb: () => void): void;
-  onOpenInDefault(cb: () => void): void;
-  onOpenInTerminal(cb: () => void): void;
-  onOpenProject(cb: () => void): void;
-  onNewProject(cb: () => void): void;
-  onInstallTutorial(cb: () => void): void;
-  onOpenRecentProject(cb: (path: string) => void): void;
-  onCloseProject(cb: () => void): void;
-  onClearRecent(cb: () => void): void;
-  onProjectOpened(cb: (meta: { rootPath: string; name: string }) => void): void;
-  onRefactorRename(cb: () => void): void;
-  onRefactorMove(cb: () => void): void;
-  onRefactorCopy(cb: () => void): void;
-  onRefactorExtract(cb: () => void): void;
-  onRefactorSplitHere(cb: () => void): void;
-  onRefactorSplitByHeading(cb: () => void): void;
-  onRefactorAutoTag(cb: () => void): void;
-  onRefactorAutoLink(cb: () => void): void;
-  onRefactorAutoLinkInbound(cb: () => void): void;
-  onRefactorDecompose(cb: () => void): void;
-  onFormat(cb: () => void): void;
-  onBibliography(cb: () => void): void;
-  onIngestUrl(cb: () => void): void;
-  onIngestIdentifier(cb: () => void): void;
-  onIngestFile(cb: () => void): void;
-  onExport(cb: (exporterId: string) => void): void;
-  onPublish(cb: () => void): void;
-  onImportBibtex(cb: () => void): void;
-  onImportZoteroRdf(cb: () => void): void;
+  onSplitRight(cb: () => void): () => void;
+  onSplitDown(cb: () => void): () => void;
+  onFocusNextGroup(cb: () => void): () => void;
+  onFocusPrevGroup(cb: () => void): () => void;
+  onCloseGroup(cb: () => void): () => void;
+  onFontIncrease(cb: () => void): () => void;
+  onFontDecrease(cb: () => void): () => void;
+  onFontReset(cb: () => void): () => void;
+  onToggleRightSidebar(cb: () => void): () => void;
+  onToggleConversations(cb: () => void): () => void;
+  onNewConversation(cb: () => void): () => void;
+  onNavBack(cb: () => void): () => void;
+  onNavForward(cb: () => void): () => void;
+  onGotoLine(cb: () => void): () => void;
+  onFind(cb: () => void): () => void;
+  onFindReplace(cb: () => void): () => void;
+  onFindInNotes(cb: () => void): () => void;
+  onReplaceInNotes(cb: () => void): () => void;
+  onNewQuery(cb: () => void): () => void;
+  onOpenStockQuery(cb: (payload: { query: string; language: 'sparql' | 'sql' }) => void): () => void;
+  onEditSavedQueries(cb: () => void): () => void;
+  onSortLines(cb: () => void): () => void;
+  onOpenSettings(cb: () => void): () => void;
+  onPrint(cb: () => void): () => void;
+  onAbout(cb: () => void): () => void;
+  onShortcuts(cb: () => void): () => void;
+  onOpenInDefault(cb: () => void): () => void;
+  onOpenInTerminal(cb: () => void): () => void;
+  onOpenProject(cb: () => void): () => void;
+  onNewProject(cb: () => void): () => void;
+  onInstallTutorial(cb: () => void): () => void;
+  onOpenRecentProject(cb: (path: string) => void): () => void;
+  onCloseProject(cb: () => void): () => void;
+  onClearRecent(cb: () => void): () => void;
+  onProjectOpened(cb: (meta: { rootPath: string; name: string }) => void): () => void;
+  onRefactorRename(cb: () => void): () => void;
+  onRefactorMove(cb: () => void): () => void;
+  onRefactorCopy(cb: () => void): () => void;
+  onRefactorExtract(cb: () => void): () => void;
+  onRefactorSplitHere(cb: () => void): () => void;
+  onRefactorSplitByHeading(cb: () => void): () => void;
+  onRefactorAutoTag(cb: () => void): () => void;
+  onRefactorAutoLink(cb: () => void): () => void;
+  onRefactorAutoLinkInbound(cb: () => void): () => void;
+  onRefactorDecompose(cb: () => void): () => void;
+  onFormat(cb: () => void): () => void;
+  onBibliography(cb: () => void): () => void;
+  onIngestUrl(cb: () => void): () => void;
+  onIngestIdentifier(cb: () => void): () => void;
+  onIngestFile(cb: () => void): () => void;
+  onExport(cb: (exporterId: string) => void): () => void;
+  onPublish(cb: () => void): () => void;
+  onImportBibtex(cb: () => void): () => void;
+  onImportZoteroRdf(cb: () => void): () => void;
 }
 
 /**
@@ -1124,7 +1124,7 @@ export interface SourcesApi {
     totalEntries: number;
   } | null>;
   /** Stream progress while a BibTeX import runs. */
-  onImportBibtexProgress(cb: (progress: { done: number; total: number; currentTitle: string }) => void): void;
+  onImportBibtexProgress(cb: (progress: { done: number; total: number; currentTitle: string }) => void): () => void;
   /** Open a .rdf picker and import a Zotero RDF export (#270). Returns null if cancelled. */
   importZoteroRdf(): Promise<{
     imported: Array<{ sourceId: string; title: string; pdfAttached: boolean }>;
@@ -1133,7 +1133,7 @@ export interface SourcesApi {
     totalItems: number;
   } | null>;
   /** Stream progress while a Zotero RDF import runs. */
-  onImportZoteroRdfProgress(cb: (progress: { done: number; total: number; currentTitle: string }) => void): void;
+  onImportZoteroRdfProgress(cb: (progress: { done: number; total: number; currentTitle: string }) => void): () => void;
   /** All indexed sources, sorted by title. */
   listAll(): Promise<import('../../../shared/types').SourceMetadata[]>;
   /** Delete a source + cascade-delete its excerpts. */
@@ -1196,7 +1196,7 @@ export interface SourcesApi {
    *  "resolved". (#107) */
   applyStubResolution(sourceId: string, doi: string): Promise<{ ok: boolean }>;
   /** Fires when a source is added, updated, or removed. */
-  onChanged(cb: () => void): void;
+  onChanged(cb: () => void): () => void;
   /** Create a `thought:Excerpt` from a highlighted passage. Idempotent by (sourceId, citedText). */
   createExcerpt(params: {
     sourceId: string;
@@ -1228,7 +1228,7 @@ export interface CollectionsApi {
   smartMembers(id: string): Promise<import('../../../shared/types').SourceMetadata[]>;
   /** Fires when a collection (manual or smart) is added, renamed,
    *  deleted, or its membership changes. */
-  onChanged(cb: () => void): void;
+  onChanged(cb: () => void): () => void;
 }
 
 declare global {

--- a/tests/architecture/file-size-budgets.test.ts
+++ b/tests/architecture/file-size-budgets.test.ts
@@ -57,7 +57,7 @@ const BUDGETS: Record<string, number> = {
   'src/renderer/App.svelte': 2075,
   'src/renderer/lib/components/Preview.svelte': 1299,
   'src/renderer/lib/components/SourceDetail.svelte': 1338,
-  'src/renderer/lib/components/SourcesPanel.svelte': 1293,
+  'src/renderer/lib/components/SourcesPanel.svelte': 1298,
   'src/renderer/lib/ipc/client.ts': 1240,
   'src/renderer/lib/stores/conversations.svelte.ts': 1179,
   'src/renderer/lib/components/Editor.svelte': 824,

--- a/tests/renderer/components/SourcesPanel.test.ts
+++ b/tests/renderer/components/SourcesPanel.test.ts
@@ -101,6 +101,22 @@ beforeEach(() => {
 });
 afterEach(() => { cleanup(); vi.clearAllMocks(); });
 
+describe('SourcesPanel — collections-changed subscription teardown (#1890)', () => {
+  it('unsubscribes from onCollectionsChanged when unmounted', async () => {
+    // The panel lives behind a sidebar {#if} — switching tabs destroys and
+    // recreates it. Before #1890 fixed onCollectionsChanged's return type to
+    // () => void, the component couldn't capture (or call) the unsubscriber,
+    // so every tab switch leaked another listener.
+    const unsubscribe = vi.fn();
+    h.sourceData.onCollectionsChanged.mockReturnValue(unsubscribe);
+    const { unmount } = render(SourcesPanel, props());
+    await waitFor(() => expect(h.sourceData.onCollectionsChanged).toHaveBeenCalledTimes(1));
+    expect(unsubscribe).not.toHaveBeenCalled();
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('SourcesPanel (baseline)', () => {
   it('renders the source list and the "All sources" count from listAll', async () => {
     render(SourcesPanel, props());


### PR DESCRIPTION
## Summary

Closes #1890 (dependency of #1920, which needs a correct baseline before the
compile-time contract check can be added). `client.ts` declared 83 of its 90
`on*` subscription methods as returning `void` (e.g. `onRenamed(...): void`);
only 7 declared the correct `() => void`. `preload.ts`'s `subscribe()`
returns `() => ipcRenderer.off(...)` from **all 98** call sites — the
mismatch meant 0 of 103 `api.*.on*` calls in `stores/` + `lib/app/` could
even type-check capturing the unsubscriber, whether or not a given call site
actually needed to.

Pure type widening (`void` → `() => void` is compatible with every existing
caller that ignored the return value), so `tsc`/`eslint`/`svelte-check` and
the full test suite pass unchanged **except** for the one real bug this
unblocked finding:

**`SourcesPanel.svelte`** called `sourceData.onCollectionsChanged(cb)` as a
bare top-level statement. The panel lives behind a
`{#if activePanel === 'sites'}` in `Sidebar.svelte` — switching sidebar tabs
destroys and recreates the component — so every tab switch registered a new
listener with no teardown, each one firing `refreshCollections()` on every
subsequent change. Fixed by wrapping the subscription in
`$effect(() => onCollectionsChanged(cb))`, whose returned cleanup Svelte now
calls on unmount (matching the existing pattern in `PdfViewer.svelte` /
`SourceDetail.svelte` for `onExcerptsChanged`, itself fixed for the same
reason in #1610).

Swept every other component-level `api.*.on*` call site
(`PdfViewer`/`SourceDetail`'s `onExcerptsChanged`, `PropertiesPanel`'s
`onRewritten`) and confirmed they already capture + call their unsubscriber
correctly. The store-level subscriptions
(conversations/history/inspections/proposals stores) are deliberately
session-lived singletons, subscribed once behind an idempotency guard for
the app's lifetime — already documented inline as "never torn down," and
correctly so, since nothing ever destroys these stores.

## Test plan

- [x] New regression test in `SourcesPanel.test.ts`: mount → subscribe once →
      unmount → unsubscriber called exactly once (mirrors the existing
      `PdfViewer.test.ts` #1610 pattern)
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 652 files / 7048 tests passed
- [x] `pnpm test tests/preload/preload-bridge.test.ts` — passes unchanged (no
      snapshot update needed; the runtime bridge shape is untouched, only
      `client.ts`'s TypeScript-only interface types changed)
- [x] `tests/architecture/file-size-budgets.test.ts` — raised
      `SourcesPanel.svelte`'s budget (+5 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)