### PR TITLE
test: cover the 7 near-zero-coverage LLM tool modules (#1935)

### DIFF
--- a/tests/main/llm/ask-user-tool.test.ts
+++ b/tests/main/llm/ask-user-tool.test.ts
@@ -1,0 +1,69 @@
+/**
+ * ask_user tool (#1935) — template-scoped: NOT in the default conversation
+ * toolset (only opted into by templates via `requiresTools: ['ask_user']`),
+ * but dispatchable by name via `executeNotebaseTool` regardless.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { executeNotebaseTool, NOTEBASE_TOOLS, type ToolContext } from '../../../src/main/llm/tools';
+
+const baseCtx: ToolContext = { rootPath: '/tmp/never-touched' };
+
+describe('ask_user tool execution', () => {
+  it('round-trips the question and choices to the callback and returns its reply', async () => {
+    const askUser = vi.fn().mockResolvedValue('yes');
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'ask_user',
+      { question: 'Proceed?', choices: ['yes', 'no'] },
+      { askUser },
+    );
+    expect(out.isError).toBe(false);
+    expect(out.content).toBe('yes');
+    expect(askUser).toHaveBeenCalledWith({ question: 'Proceed?', choices: ['yes', 'no'] });
+  });
+
+  it('trims the question and drops blank choice entries', async () => {
+    const askUser = vi.fn().mockResolvedValue('ok');
+    await executeNotebaseTool(
+      baseCtx,
+      'ask_user',
+      { question: '  Proceed?  ', choices: ['  a  ', '   ', 'b'] },
+      { askUser },
+    );
+    expect(askUser).toHaveBeenCalledWith({ question: 'Proceed?', choices: ['a', 'b'] });
+  });
+
+  it('omits choices when every entry is blank', async () => {
+    const askUser = vi.fn().mockResolvedValue('ok');
+    await executeNotebaseTool(baseCtx, 'ask_user', { question: 'Proceed?', choices: ['  ', ''] }, { askUser });
+    expect(askUser).toHaveBeenCalledWith({ question: 'Proceed?', choices: undefined });
+  });
+
+  it('omits choices when not provided', async () => {
+    const askUser = vi.fn().mockResolvedValue('ok');
+    await executeNotebaseTool(baseCtx, 'ask_user', { question: 'Proceed?' }, { askUser });
+    expect(askUser).toHaveBeenCalledWith({ question: 'Proceed?', choices: undefined });
+  });
+
+  it('errors when invoked without an askUser callback (no UI surface)', async () => {
+    const out = await executeNotebaseTool(baseCtx, 'ask_user', { question: 'Proceed?' });
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/no UI to render the question/);
+  });
+
+  it('rejects a non-object input', async () => {
+    const out = await executeNotebaseTool(baseCtx, 'ask_user', null, { askUser: vi.fn() });
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/must be an object/);
+  });
+
+  it('rejects a missing/blank question', async () => {
+    const out = await executeNotebaseTool(baseCtx, 'ask_user', { question: '  ' }, { askUser: vi.fn() });
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/non-empty `question`/);
+  });
+
+  it('is template-scoped: NOT in the default conversation toolset', () => {
+    expect(NOTEBASE_TOOLS.map((t) => t.name)).not.toContain('ask_user');
+  });
+});

--- a/tests/main/llm/describe-graph-schema-tool.test.ts
+++ b/tests/main/llm/describe-graph-schema-tool.test.ts
@@ -1,0 +1,26 @@
+/**
+ * describe_graph_schema tool (#1935) — returns the bundled core + thought
+ * ontology Turtle verbatim. No inputs, no I/O beyond the bundled `?raw` import.
+ */
+import { describe, it, expect } from 'vitest';
+import { executeNotebaseTool, NOTEBASE_TOOLS } from '../../../src/main/llm/tools';
+
+describe('describe_graph_schema tool execution', () => {
+  it('returns both ontologies, sectioned and never erroring', async () => {
+    const out = await executeNotebaseTool({ rootPath: '/tmp/never-touched' }, 'describe_graph_schema', {});
+    expect(out.isError).toBe(false);
+    expect(out.content).toContain('# Minerva Core Ontology (minerva:)');
+    expect(out.content).toContain('# Thought Ontology (thought:)');
+    expect(out.content.indexOf('# Minerva Core Ontology')).toBeLessThan(out.content.indexOf('# Thought Ontology'));
+  });
+
+  it('ignores whatever input it is given', async () => {
+    const out = await executeNotebaseTool({ rootPath: '/tmp/never-touched' }, 'describe_graph_schema', { anything: 'goes' });
+    expect(out.isError).toBe(false);
+    expect(out.content.length).toBeGreaterThan(0);
+  });
+
+  it('is registered in the default conversation toolset', () => {
+    expect(NOTEBASE_TOOLS.map((t) => t.name)).toContain('describe_graph_schema');
+  });
+});

--- a/tests/main/llm/fetch-properties-tool.test.ts
+++ b/tests/main/llm/fetch-properties-tool.test.ts
@@ -1,0 +1,57 @@
+/**
+ * fetch_properties tool (#1935) — read-only YAML frontmatter reader,
+ * symmetric with read_note. No approval gate: nothing is written.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { executeNotebaseTool, NOTEBASE_TOOLS } from '../../../src/main/llm/tools';
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-fetch-properties-'));
+});
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('fetch_properties tool execution', () => {
+  it('returns the frontmatter as JSON', async () => {
+    fs.writeFileSync(path.join(root, 'a.md'), '---\nstatus: done\ntags:\n  - x\n  - y\n---\n# A\n', 'utf-8');
+    const out = await executeNotebaseTool({ rootPath: root }, 'fetch_properties', { relative_path: 'a.md' });
+    expect(out.isError).toBe(false);
+    expect(JSON.parse(out.content)).toEqual({ status: 'done', tags: ['x', 'y'] });
+  });
+
+  it('returns {} for a note with no frontmatter', async () => {
+    fs.writeFileSync(path.join(root, 'plain.md'), '# Plain\nNo frontmatter here.\n', 'utf-8');
+    const out = await executeNotebaseTool({ rootPath: root }, 'fetch_properties', { relative_path: 'plain.md' });
+    expect(out.isError).toBe(false);
+    expect(JSON.parse(out.content)).toEqual({});
+  });
+
+  it('returns {} for malformed YAML frontmatter rather than throwing', async () => {
+    fs.writeFileSync(path.join(root, 'bad.md'), '---\n: not valid yaml: [\n---\n# Bad\n', 'utf-8');
+    const out = await executeNotebaseTool({ rootPath: root }, 'fetch_properties', { relative_path: 'bad.md' });
+    expect(out.isError).toBe(false);
+    expect(JSON.parse(out.content)).toEqual({});
+  });
+
+  it('requires a non-empty relative_path', async () => {
+    const out = await executeNotebaseTool({ rootPath: root }, 'fetch_properties', { relative_path: '' });
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/Tool fetch_properties failed: relative_path is required/);
+  });
+
+  it('surfaces a missing file as a tool error rather than throwing uncaught', async () => {
+    const out = await executeNotebaseTool({ rootPath: root }, 'fetch_properties', { relative_path: 'missing.md' });
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/Tool fetch_properties failed:/);
+  });
+
+  it('is registered in the default conversation toolset', () => {
+    expect(NOTEBASE_TOOLS.map((t) => t.name)).toContain('fetch_properties');
+  });
+});

--- a/tests/main/llm/propose-compute-tool.test.ts
+++ b/tests/main/llm/propose-compute-tool.test.ts
@@ -1,0 +1,132 @@
+/**
+ * propose_compute tool — server-side execution contract (#1935).
+ *
+ * Trust-principle parity with the other propose_* tools: the tool never
+ * executes the cell. It validates the input, runs the static red-flag scan
+ * (`scanComputeSafety`), and emits a ConversationComputeDraft for inline
+ * review — the user clicks Run/Insert/Discard.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { executeNotebaseTool, NOTEBASE_TOOLS, type ToolContext } from '../../../src/main/llm/tools';
+import type { ConversationComputeDraft } from '../../../src/shared/conversation-compute-drafts';
+
+const baseCtx: ToolContext = { rootPath: '/tmp/never-touched', conversationId: 'conv-test' };
+
+describe('propose_compute tool execution', () => {
+  it('emits a compute draft with no safety flags for benign SPARQL', async () => {
+    const onComputeDraft = vi.fn();
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_compute',
+      { language: 'sparql', code: 'SELECT ?n WHERE { ?n a minerva:Note }', rationale: 'count notes' },
+      { onComputeDraft },
+    );
+    expect(out.isError).toBe(false);
+    expect(onComputeDraft).toHaveBeenCalledTimes(1);
+
+    const draft = onComputeDraft.mock.calls[0][0] as ConversationComputeDraft;
+    expect(draft.draftId).toMatch(/^cmpdraft-/);
+    expect(draft.conversationId).toBe('conv-test');
+    expect(draft.language).toBe('sparql');
+    expect(draft.code).toBe('SELECT ?n WHERE { ?n a minerva:Note }');
+    expect(draft.rationale).toBe('count notes');
+    expect(draft.safetyFlags).toEqual([]);
+
+    const parsed = JSON.parse(out.content.split('\n\n')[0]) as { status: string; language: string; safetyFlags: string[] };
+    expect(parsed.status).toBe('drafted');
+    expect(parsed.language).toBe('sparql');
+    expect(parsed.safetyFlags).toEqual([]);
+    expect(out.content).toContain('(queued sparql draft)');
+  });
+
+  it('surfaces red-flag scan hits for a risky python cell', async () => {
+    const onComputeDraft = vi.fn();
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_compute',
+      { language: 'python', code: 'import subprocess\nsubprocess.run(["ls"])', rationale: 'list files' },
+      { onComputeDraft },
+    );
+    expect(out.isError).toBe(false);
+    const draft = onComputeDraft.mock.calls[0][0] as ConversationComputeDraft;
+    expect(draft.safetyFlags.length).toBeGreaterThan(0);
+  });
+
+  it('surfaces red-flag scan hits for a risky sql cell', async () => {
+    const onComputeDraft = vi.fn();
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_compute',
+      { language: 'sql', code: "COPY tbl TO 'out.csv'", rationale: 'export' },
+      { onComputeDraft },
+    );
+    expect(out.isError).toBe(false);
+    const draft = onComputeDraft.mock.calls[0][0] as ConversationComputeDraft;
+    expect(draft.safetyFlags.map((f) => f.id)).toContain('sql-copy-to');
+  });
+
+  it('errors when invoked without an onComputeDraft callback (no UI surface)', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_compute',
+      { language: 'sql', code: 'SELECT 1', rationale: 'x' },
+      // no callbacks
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/only available in conversation contexts/);
+  });
+
+  it('errors when the toolContext lacks a conversationId', async () => {
+    const out = await executeNotebaseTool(
+      { rootPath: '/tmp/whatever' },
+      'propose_compute',
+      { language: 'sql', code: 'SELECT 1', rationale: 'x' },
+      { onComputeDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/bound conversation id/);
+  });
+
+  it('rejects an unsupported language', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_compute',
+      { language: 'javascript', code: 'console.log(1)', rationale: 'x' },
+      { onComputeDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/must be one of "sparql", "sql", "python"/);
+  });
+
+  it('rejects blank code', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_compute',
+      { language: 'sql', code: '   ', rationale: 'x' },
+      { onComputeDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/`code` is required/);
+  });
+
+  it('rejects a blank rationale', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'propose_compute',
+      { language: 'sql', code: 'SELECT 1', rationale: '  ' },
+      { onComputeDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/`rationale` is required/);
+  });
+
+  it('rejects a non-object input', async () => {
+    const out = await executeNotebaseTool(baseCtx, 'propose_compute', 'not an object', { onComputeDraft: vi.fn() });
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/must be an object/);
+  });
+
+  it('is registered in the default conversation toolset', () => {
+    expect(NOTEBASE_TOOLS.map((t) => t.name)).toContain('propose_compute');
+  });
+});

--- a/tests/main/llm/query-graph-tool.test.ts
+++ b/tests/main/llm/query-graph-tool.test.ts
@@ -1,0 +1,66 @@
+/**
+ * query_graph tool (#1935) — thin wrapper over graph.queryGraph. Covers the
+ * three response shapes the tool maps to a ToolResult: bound rows, an empty
+ * "No bindings." result, and a SPARQL error pointing at describe_graph_schema.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { executeNotebaseTool, NOTEBASE_TOOLS } from '../../../src/main/llm/tools';
+import { initGraph, indexAllNotes } from '../../../src/main/graph/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-query-graph-'));
+  ctx = projectContext(root);
+  await initGraph(ctx);
+});
+afterEach(async () => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('query_graph tool execution', () => {
+  it('returns matching bindings as JSON', async () => {
+    fs.writeFileSync(path.join(root, 'a.md'), '---\ntitle: A\n---\n# A\n', 'utf-8');
+    await indexAllNotes(ctx);
+    const out = await executeNotebaseTool(
+      ctx,
+      'query_graph',
+      { sparql: 'SELECT ?n WHERE { ?n a minerva:Note }' },
+    );
+    expect(out.isError).toBe(false);
+    const rows = JSON.parse(out.content) as unknown[];
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('reports "No bindings." for a well-formed query with no matches', async () => {
+    const out = await executeNotebaseTool(
+      ctx,
+      'query_graph',
+      { sparql: 'SELECT ?n WHERE { ?n a minerva:NoSuchClass }' },
+    );
+    expect(out.isError).toBe(false);
+    expect(out.content).toBe('No bindings.');
+  });
+
+  it('surfaces a SPARQL error and points at describe_graph_schema', async () => {
+    const out = await executeNotebaseTool(ctx, 'query_graph', { sparql: 'this is not sparql' });
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/^SPARQL error:/);
+    expect(out.content).toMatch(/describe_graph_schema/);
+  });
+
+  it('requires a non-empty sparql string', async () => {
+    const out = await executeNotebaseTool(ctx, 'query_graph', { sparql: '  ' });
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/Tool query_graph failed: sparql is required/);
+  });
+
+  it('is registered in the default conversation toolset', () => {
+    expect(NOTEBASE_TOOLS.map((t) => t.name)).toContain('query_graph');
+  });
+});

--- a/tests/main/llm/search-notes-tool.test.ts
+++ b/tests/main/llm/search-notes-tool.test.ts
@@ -1,0 +1,65 @@
+/**
+ * search_notes tool (#1935) — thin wrapper over the MiniSearch full-text
+ * index. Covers a hit with a snippet, the "no results" message, and the
+ * missing-query error (thrown from the tool and wrapped by the dispatcher).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { executeNotebaseTool, NOTEBASE_TOOLS } from '../../../src/main/llm/tools';
+import * as search from '../../../src/main/search/index';
+import { projectContext, type ProjectContext } from '../../../src/main/project-context-types';
+
+let root: string;
+let ctx: ProjectContext;
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'minerva-search-notes-'));
+  fs.mkdirSync(path.join(root, '.minerva'), { recursive: true });
+  ctx = projectContext(root);
+  await search.initSearch(ctx);
+});
+afterEach(() => {
+  search.disposeProject(ctx);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('search_notes tool execution', () => {
+  it('returns ranked results with title, path, and a snippet', async () => {
+    fs.writeFileSync(path.join(root, 'cats.md'), '# Cats\nCats are feline animals that purr and hunt mice.\n', 'utf-8');
+    await search.indexAllNotes(ctx);
+
+    const out = await executeNotebaseTool(ctx, 'search_notes', { query: 'feline animals' });
+    expect(out.isError).toBe(false);
+    expect(out.content).toContain('Cats (cats.md)');
+    expect(out.content).toMatch(/^1\./);
+  });
+
+  it('honors the limit option', async () => {
+    fs.writeFileSync(path.join(root, 'a.md'), '# A\ngardening soil plants\n', 'utf-8');
+    fs.writeFileSync(path.join(root, 'b.md'), '# B\ngardening soil plants\n', 'utf-8');
+    await search.indexAllNotes(ctx);
+
+    const out = await executeNotebaseTool(ctx, 'search_notes', { query: 'gardening', limit: 1 });
+    expect(out.isError).toBe(false);
+    expect((out.content.match(/^\d+\. /gm) ?? []).length).toBe(1);
+  });
+
+  it('reports no results clearly', async () => {
+    await search.indexAllNotes(ctx);
+    const out = await executeNotebaseTool(ctx, 'search_notes', { query: 'zzz-not-present' });
+    expect(out.isError).toBe(false);
+    expect(out.content).toBe('No results for "zzz-not-present".');
+  });
+
+  it('requires a non-empty query', async () => {
+    const out = await executeNotebaseTool(ctx, 'search_notes', { query: '  ' });
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/Tool search_notes failed: query is required/);
+  });
+
+  it('is registered in the default conversation toolset', () => {
+    expect(NOTEBASE_TOOLS.map((t) => t.name)).toContain('search_notes');
+  });
+});

--- a/tests/main/llm/set-properties-tool.test.ts
+++ b/tests/main/llm/set-properties-tool.test.ts
@@ -1,0 +1,166 @@
+/**
+ * set_properties tool — server-side execution contract (#1935).
+ *
+ * Trust-principle parity with propose_notes / propose_compute: this tool
+ * MUST NOT write anything. It only emits a ConversationPropertyDraft; the
+ * actual frontmatter patch + approval-engine proposal is applied later by
+ * `applyPropertyUpdates` (covered separately in set-properties-apply.test.ts)
+ * once the user approves the draft card.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { executeNotebaseTool, NOTEBASE_TOOLS, type ToolContext } from '../../../src/main/llm/tools';
+import type { ConversationPropertyDraft } from '../../../src/shared/conversation-property-drafts';
+
+const baseCtx: ToolContext = { rootPath: '/tmp/never-touched', conversationId: 'conv-test' };
+
+describe('set_properties tool execution', () => {
+  it('emits a property draft and returns "drafted" without writing anything', async () => {
+    const onPropertyDraft = vi.fn();
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'set_properties',
+      {
+        note: 'Mark as done',
+        updates: [{ relativePath: 'notes/a.md', properties: { status: 'done' } }],
+      },
+      { onPropertyDraft },
+    );
+    expect(out.isError).toBe(false);
+    expect(onPropertyDraft).toHaveBeenCalledTimes(1);
+
+    const draft = onPropertyDraft.mock.calls[0][0] as ConversationPropertyDraft;
+    expect(draft.draftId).toMatch(/^propdraft-/);
+    expect(draft.conversationId).toBe('conv-test');
+    expect(draft.note).toBe('Mark as done');
+    expect(draft.updates).toEqual([{ relativePath: 'notes/a.md', properties: { status: 'done' } }]);
+
+    const parsed = JSON.parse(out.content.split('\n\n')[0]) as { status: string; updateCount: number; hint: string };
+    expect(parsed.status).toBe('drafted');
+    expect(parsed.updateCount).toBe(1);
+    expect(parsed.hint).toMatch(/do not call set_properties again/i);
+    expect(out.content).toContain('queued property draft: notes/a.md (1 key)');
+  });
+
+  it('pluralizes the key count in the summary for a multi-key update', async () => {
+    const onPropertyDraft = vi.fn();
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'set_properties',
+      {
+        note: 'x',
+        updates: [{ relativePath: 'notes/a.md', properties: { status: 'done', priority: 1 } }],
+      },
+      { onPropertyDraft },
+    );
+    expect(out.content).toContain('notes/a.md (2 keys)');
+  });
+
+  it('errors when invoked without an onPropertyDraft callback (no UI surface)', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'set_properties',
+      { note: 'x', updates: [{ relativePath: 'a.md', properties: { x: 1 } }] },
+      // no callbacks
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/only available in conversation contexts/);
+  });
+
+  it('errors when the toolContext lacks a conversationId', async () => {
+    const out = await executeNotebaseTool(
+      { rootPath: '/tmp/whatever' },
+      'set_properties',
+      { note: 'x', updates: [{ relativePath: 'a.md', properties: { x: 1 } }] },
+      { onPropertyDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/bound conversation id/);
+  });
+
+  it('rejects a missing/blank note', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'set_properties',
+      { note: '  ', updates: [{ relativePath: 'a.md', properties: { x: 1 } }] },
+      { onPropertyDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/`note` is required/);
+  });
+
+  it('rejects an empty updates array', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'set_properties',
+      { note: 'x', updates: [] },
+      { onPropertyDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/non-empty array/);
+  });
+
+  it('rejects an update missing relativePath', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'set_properties',
+      { note: 'x', updates: [{ properties: { x: 1 } }] },
+      { onPropertyDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/non-empty `relativePath`/);
+  });
+
+  it('rejects a relativePath that escapes the project root', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'set_properties',
+      { note: 'x', updates: [{ relativePath: '../etc/passwd', properties: { x: 1 } }] },
+      { onPropertyDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/must not contain '\.\.'/);
+  });
+
+  it('rejects an update with a non-object properties value', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'set_properties',
+      { note: 'x', updates: [{ relativePath: 'a.md', properties: [] }] },
+      { onPropertyDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/non-array object/);
+  });
+
+  it('rejects an update with an empty properties object', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'set_properties',
+      { note: 'x', updates: [{ relativePath: 'a.md', properties: {} }] },
+      { onPropertyDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/at least one key/);
+  });
+
+  it('rejects a property value that cannot round-trip through YAML', async () => {
+    const out = await executeNotebaseTool(
+      baseCtx,
+      'set_properties',
+      { note: 'x', updates: [{ relativePath: 'a.md', properties: { bad: undefined } }] },
+      { onPropertyDraft: vi.fn() },
+    );
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/not a YAML-encodable/);
+  });
+
+  it('rejects a non-object input', async () => {
+    const out = await executeNotebaseTool(baseCtx, 'set_properties', null, { onPropertyDraft: vi.fn() });
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatch(/must be an object/);
+  });
+
+  it('is registered in the default conversation toolset', () => {
+    expect(NOTEBASE_TOOLS.map((t) => t.name)).toContain('set_properties');
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -92,6 +92,26 @@ export default defineConfig({
           statements: 55,
           branches: 66,
         },
+        // The `tools/` subtree (the LLM tool-call surface itself) sat far
+        // below the `llm/**` aggregate above: 7 of its ~25 modules were
+        // effectively untested (#1935), including `set_properties` — an
+        // LLM-originated graph write whose write-guard fatality only holds
+        // on paths a test actually exercises. (`set_properties` here is the
+        // tool that emits the draft; the apply path it drafts for is
+        // `src/main/llm/set-properties.ts`, covered separately by
+        // `set-properties-apply.test.ts`.) Now covered by
+        // `set-properties-tool.test.ts`, `propose-compute-tool.test.ts`,
+        // `ask-user-tool.test.ts`, `query-graph-tool.test.ts`,
+        // `search-notes-tool.test.ts`, `fetch-properties-tool.test.ts`, and
+        // `describe-graph-schema-tool.test.ts`. Measured: 95.7% L / 100% F /
+        // 92.5% S / 84.2% B; floors ~8-10pts below so a refactor won't flap
+        // but a new untested tool fails.
+        'src/main/llm/tools/**': {
+          lines: 88,
+          functions: 90,
+          statements: 84,
+          branches: 74,
+        },
         // Security path — fs sandbox, write pipeline, rename/merge link rewrites.
         'src/main/notebase/**': {
           lines: 80,


### PR DESCRIPTION
## Summary
- Adds direct execution-contract tests for the 7 LLM tool modules flagged in #1935 as near-zero-coverage: `set_properties`, `propose_compute`, `ask_user`, `query_graph`, `search_notes`, `fetch_properties` (the issue's "get-properties.ts" — the file is actually named `fetch-properties.ts`, registering tool name `fetch_properties`), and `describe_graph_schema`.
- `set_properties` is the highest-priority target: it's an LLM-originated write-adjacent tool. Confirmed it never writes directly — it only emits a `ConversationPropertyDraft` via `onPropertyDraft`, matching the Trust Principle pattern used by `propose_notes`/`propose_compute`. The actual write/approval path (`applyPropertyUpdates` in `src/main/llm/set-properties.ts`, a *different* file) already has its own write-guard test coverage in `set-properties-apply.test.ts`; this PR adds the missing coverage for the tool-dispatch layer above it.
- Each new test file follows the existing sibling pattern (`propose-notes-tool.test.ts`, `grep-notes-tool.test.ts`, `search-related-tool.test.ts`): happy path, callback/context-missing errors, input-validation errors, and (where applicable) a "registered in the default toolset" check.
- Adds a new `src/main/llm/tools/**` coverage floor to `vitest.config.mts` (measured 95.7% L / 100% F / 92.5% S / 84.2% B; floors set ~8-10pts below) so this gap can't reopen silently.

## Test plan
- [x] `pnpm lint` — tsc, svelte-check, eslint all pass
- [x] `pnpm test` — 659 files / 7098 tests pass (1 pre-existing skip)
- [x] Confirmed no `window.api` surface touched (main-process-only tests) — no preload snapshot update needed
- [x] Confirmed no touched file crosses the file-size-budget threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)